### PR TITLE
feat(frontend-core): StatusBadge singleLine + PlatformRecord chat fields

### DIFF
--- a/openframe-frontend-core/src/components/ui/status-badge.tsx
+++ b/openframe-frontend-core/src/components/ui/status-badge.tsx
@@ -39,6 +39,13 @@ export interface StatusBadgeProps
   extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof statusBadgeVariants> {
   text: string;
+  /**
+   * When true, renders `text` verbatim on a single line, bypassing the
+   * default multi-word vertical-stack behavior used by `variant="button"`.
+   * Use this for compact inline contexts (e.g. chat-inline roadmap cards)
+   * where the stamp-like stacked layout is undesirable.
+   */
+  singleLine?: boolean;
 }
 
 function StatusBadge({
@@ -46,6 +53,7 @@ function StatusBadge({
   variant,
   colorScheme,
   className,
+  singleLine,
   ...props
 }: StatusBadgeProps) {
   // Outer element is `<span>` so the badge is HTML-valid in any inline
@@ -53,7 +61,13 @@ function StatusBadge({
   // or inside an `<a>`). The `inline-flex` base class in
   // `statusBadgeVariants` keeps the layout identical to the previous
   // `<div>` outer — only the element name changed.
+  //
+  // Escape hatch: callers can pass `singleLine` to opt out of the
+  // multi-word stacking applied for `variant="button"`. This is needed
+  // for compact inline contexts (chat-inline roadmap cards) where the
+  // default stamp-like vertical stack ("TO" / "DO") breaks layout.
   const renderText = () => {
+    if (singleLine) return text;
     if (variant === 'button' && text.includes(' ')) {
       const words = text.split(' ');
       return (

--- a/openframe-frontend-core/src/types/platform.ts
+++ b/openframe-frontend-core/src/types/platform.ts
@@ -11,6 +11,15 @@ export interface PlatformRecord {
   description?: string;
   is_active: boolean;
   is_internal: boolean; // Whether this is an internal admin platform vs public-facing
+  // Chat (Ask AI) wiring — populated only for platforms that host a chat surface.
+  // `chat_source_id` is the doc-source binding (`chat_admin_personas.chat_source_id`).
+  // `chat_source_rag_tables_version` is the per-platform RAG-table override version
+  //   bumped by the `replace_chat_source_rag_tables` RPC; used for cross-Lambda
+  //   cache invalidation in `lib/data/doc-source-config-utils.ts`.
+  // `chat_enabled` is the platform-wide chat kill switch (NOT NULL DEFAULT true).
+  chat_source_id?: string | null;
+  chat_source_rag_tables_version?: number | null;
+  chat_enabled?: boolean | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Two surgical changes the hub depends on:

- **StatusBadge `singleLine` prop** — the `variant="button"` branch currently splits multi-word `text` on spaces and stacks each word vertically (stamp-style render used on the roadmap detail page). For chat-inline compact cards this breaks badges like "TO DO" onto two lines. New optional `singleLine` opts out, leaving the text as a single horizontal line. Default behavior unchanged for every existing caller.
- **PlatformRecord chat fields** — extend the type with `chat_source_id`, `chat_source_rag_tables_version`, `chat_enabled`. These columns already exist on the DB but weren't in the TypeScript type, so the hub had to cast inline whenever it touched them.

## Test plan

- [x] tsc clean inside \`openframe-frontend-core/\`
- [x] No regression on existing StatusBadge callers — grep across consumer (hub) confirms zero existing callers pass \`singleLine\`, so all retain stacked-word behavior.
- [ ] Manual: render an existing roadmap-page StatusBadge ("TO DO") without \`singleLine\` and confirm vertical stack still shows.
- [ ] Manual: hub PR consumer renders "TO DO" inline on chat-inline roadmap card with \`singleLine\` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)