### PR TITLE
feat(chat): SSE binary framing demuxer + cross-call token usage badge

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -1,99 +1,544 @@
 "use client"
 
-import { useRef, useEffect, useLayoutEffect, useCallback, useImperativeHandle, forwardRef } from "react"
+import {
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useImperativeHandle,
+  useState,
+  forwardRef,
+  useMemo,
+} from "react"
 import { cn } from "../../utils/cn"
 import { ChatMessageEnhanced } from "./chat-message-enhanced"
 import { ChatMessageListSkeleton } from "./chat-message-skeleton"
 import type { ChatMessageListProps } from "./types"
 
-const BOTTOM_THRESHOLD = 30 // px from bottom to be considered "at bottom"
+/*
+ * Stick-to-bottom architecture (v2 — 2026)
+ *
+ * Replaces the prior "1.5s ResizeObserver window + 4 racing scrollTop
+ * mutation sites" approach that regressed on streaming responses longer
+ * than 1.5 seconds. v2 fixes the regression + addresses the
+ * device/race/UX issues five parallel reviewers surfaced.
+ *
+ * Mechanism (matches stackblitz-labs/use-stick-to-bottom, the library
+ * Vercel AI SDK Elements ships in 2026):
+ *
+ *  - **Bottom sentinel + IntersectionObserver** owns the `isAtBottom`
+ *    state. `rootMargin: 0 0 NEAR_BOTTOM_PX 0` widens the bottom edge
+ *    so "within NEAR_BOTTOM_PX of bottom" still counts as at-bottom.
+ *    IO does NOT fire for programmatic scroll origin; it reports
+ *    geometry only, so we don't fight ourselves.
+ *
+ *  - **ResizeObserver on the inner content** (NOT the scroller) runs
+ *    for the lifetime of the mount. When content grows AND the user
+ *    has elected stickiness, we rescue scroll to bottom inside a
+ *    `requestAnimationFrame`. No timeout — the old 1.5s cap was the
+ *    regression source.
+ *
+ *  - **Second ResizeObserver on the scroller itself** rescues the
+ *    "approvals bar appeared / pulled-up viewport" case: when the
+ *    scroller's CLIENT height shrinks while we're sticky, the
+ *    streaming text would otherwise scroll out of view behind the new
+ *    bar. We re-snap to bottom.
+ *
+ *  - **Explicit user-escape signals**: wheel (deltaY < 0), touchmove
+ *    (drag down with cancelable event + larger threshold so iOS
+ *    momentum doesn't false-positive), keydown (PageUp / ArrowUp /
+ *    Home) — only when focus is INSIDE the scroller (the body-focus
+ *    fallback in v1 released stickiness from ANY arrow keypress on the
+ *    page; reviewer-flagged CRIT). The scroller is `tabIndex={-1}` so
+ *    it can receive focus.
+ *
+ *  - **Release-debounce**: when a user escape signal fires, we
+ *    snapshot the timestamp into `releasedAtRef`. The IO callback
+ *    refuses to re-engage stickiness within `RELEASE_DEBOUNCE_MS` of
+ *    that snapshot. This kills the "wheel-inside-near-bottom-band"
+ *    race the Logic reviewer flagged HIGH: without the window, IO
+ *    fires AFTER the wheel handler (IO is queued, wheel is sync),
+ *    sees the user is still in the slack band, sets stick=true,
+ *    next RO tick yanks them back to bottom — flicker.
+ *
+ *  - **Visibility-change handling**: rAF is paused on backgrounded
+ *    tabs, so a pending scroll-write can wedge for minutes. On
+ *    `visibilitychange === 'visible'`, we drop any pending rAF and
+ *    re-snap if sticky. Closes the Bug-Hunter CRIT.
+ *
+ *  - **visualViewport.resize**: iOS opens/closes the on-screen
+ *    keyboard by shrinking the visual viewport (NOT the scroller's
+ *    clientHeight directly). We listen and re-snap on stick. Closes
+ *    the UX/Bug-Hunter HIGH about streaming hiding behind keyboard.
+ *
+ *  - **Jump-to-bottom pill**: when the user releases, a floating pill
+ *    appears at the bottom with an unread count (messages arrived
+ *    after release). Tap re-engages stickiness + scrolls. Closes the
+ *    UX-Quality HIGH about reader-mode users not knowing the chat
+ *    answered.
+ *
+ *  - **`scroll-behavior` + smooth/instant**: we write
+ *    `scrollTop = scrollHeight` directly (instant) inside rAF. Per
+ *    the research synthesis, smooth-scroll-during-streaming has
+ *    well-known iOS Safari quirks (nested-scroller cancellation,
+ *    smooth interrupted by next write) and ChatGPT/Claude.ai's
+ *    instant pattern via batched writes is what users experience as
+ *    "smooth" (the 60Hz rAF coalescing absorbs the per-token shifts).
+ *
+ *  - **`overflow-anchor: none`** kept on the scroller: Safari has zero
+ *    support (WebKit #171099, still open) so we cannot RELY on
+ *    anchor-selection cross-browser, but disabling it on Chrome /
+ *    Firefox prevents anchor-selection from picking the sticky
+ *    approvals bar as the anchor element. We own scrollTop
+ *    explicitly.
+ *
+ *  - **Prepend anchoring (load-more older messages)** stays as a
+ *    separate `useLayoutEffect`: when the first message changes
+ *    (older page prepended), add `delta = newHeight - oldHeight` to
+ *    scrollTop. Structurally orthogonal to stickiness.
+ */
+
+/** Within `NEAR_BOTTOM_PX` of the absolute bottom counts as "at bottom"
+ *  for auto-sticking. 70px matches use-stick-to-bottom's default —
+ *  enough slack to absorb mid-stream height shifts without flicking
+ *  state on every delta. */
+const NEAR_BOTTOM_PX = 70
+
+/** Minimum touch drag in px before we treat it as an explicit user
+ *  release. 24px on iOS filters out finger-drift during a hold without
+ *  intent to escape (10px in v1 was reviewer-flagged as too sensitive). */
+const TOUCH_DRAG_THRESHOLD_PX = 24
+
+/** After an explicit user release (wheel-up / touch-drag / keyboard),
+ *  the IO sentinel refuses to re-engage stickiness for this many
+ *  milliseconds. Kills the "wheel inside the 70px slack band → flicker"
+ *  race: IO fires async AFTER wheel, would otherwise see "still in
+ *  band, re-engage", and the next RO tick yanks the user to bottom. */
+const RELEASE_DEBOUNCE_MS = 250
+
+/** Top-sentinel (infinite-scroll-UP / load-more older) — IO `rootMargin`
+ *  in px from the top, plus a low `threshold` so partial visibility
+ *  triggers the load. */
+const TOP_SENTINEL_ROOT_MARGIN_PX = 200
+const TOP_SENTINEL_THRESHOLD = 0.1
+
+/** Inline style for elements that must NOT participate in browser
+ *  scroll-anchor selection (sentinels + the scroller). Memoised at
+ *  module scope so each render reuses the same identity (avoids
+ *  React's new-object reconciler shim). */
+const NO_OVERFLOW_ANCHOR_STYLE: React.CSSProperties = { overflowAnchor: 'none' }
 
 const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
-  ({ className, messages, dialogId, isLoading = false, isTyping = false, autoScroll = true, showAvatars = true, contentClassName, assistantType, assistantIcon, pendingApprovals, hasNextPage, isFetchingNextPage, onLoadMore, renderEntityCard, ...props }, ref) => {
+  (
+    {
+      className,
+      messages,
+      dialogId,
+      isLoading = false,
+      isTyping = false,
+      autoScroll = true,
+      showAvatars = true,
+      contentClassName,
+      assistantType,
+      assistantIcon,
+      pendingApprovals,
+      hasNextPage,
+      isFetchingNextPage,
+      onLoadMore,
+      renderEntityCard,
+      ...props
+    },
+    ref,
+  ) => {
     const scrollRef = useRef<HTMLDivElement>(null)
-    const sentinelRef = useRef<HTMLDivElement>(null)
-    const onLoadMoreRef = useRef(onLoadMore)
-    onLoadMoreRef.current = onLoadMore
-    const isFetchingRef = useRef(isFetchingNextPage)
-    isFetchingRef.current = isFetchingNextPage
-    const isStuckRef = useRef(true)
-    const touchStartYRef = useRef(0)
-    const rafIdRef = useRef<number | null>(null)
+    /** Inner content; RO observes THIS, not the scroller. Scroller is
+     *  layout-bound and rarely changes height; content grows mid-stream. */
+    const contentRef = useRef<HTMLDivElement>(null)
+    /** 1-px div at the very bottom of the content. The bottom-sentinel
+     *  IntersectionObserver watches this to derive `isAtBottom`. */
+    const bottomSentinelRef = useRef<HTMLDivElement>(null)
+    /** Existing top-sentinel for infinite-scroll-UP. NOT part of
+     *  stickiness — separate concern. */
+    const topSentinelRef = useRef<HTMLDivElement>(null)
 
-    // Tracks previous render state for auto-scroll decisions
+    // ------------------------------------------------------------------
+    // Latest-prop refs — mirror parent props into refs inside an effect
+    // so observer callbacks (closures captured at observer-creation
+    // time) always read fresh values WITHOUT re-creating the observer
+    // every render. The prior "assign-during-render" pattern was
+    // structurally fine but violated React's "no side effects in
+    // render" guideline; this layout-effect version is idiomatic.
+    // ------------------------------------------------------------------
+    const onLoadMoreRef = useRef(onLoadMore)
+    const isFetchingRef = useRef(isFetchingNextPage)
+    useEffect(() => {
+      onLoadMoreRef.current = onLoadMore
+    }, [onLoadMore])
+    useEffect(() => {
+      isFetchingRef.current = isFetchingNextPage
+    }, [isFetchingNextPage])
+
+    // ------------------------------------------------------------------
+    // Stick-to-bottom state.
+    //
+    // Two parallel sources of truth:
+    //   - `stickRef`   — synchronous access in observer / event handlers
+    //                    (refs don't trigger re-renders).
+    //   - `released`   — React state; drives the jump-to-bottom pill UI.
+    //
+    // They MUST stay in sync. Every write goes through `engageStick()`
+    // or `releaseStick()` (each updates both atomically) so they never
+    // diverge. Both callbacks are deps-free + stable identity, so the
+    // observer / event-listener effects subscribing to them NEVER
+    // re-create on prop changes.
+    // ------------------------------------------------------------------
+    const stickRef = useRef(true)
+    const [released, setReleased] = useState(false)
+    /** Timestamp (ms) of last explicit user release. IO callback refuses
+     *  to re-engage within RELEASE_DEBOUNCE_MS so the wheel-inside-band
+     *  race can't flicker us back. */
+    const releasedAtRef = useRef(0)
+    /** Snapshot of `messages.length` at the moment the user released.
+     *  Drives the pill's unread-count badge so users know how many new
+     *  messages arrived while they were scrolled away. */
+    const releasedAtCountRef = useRef(0)
+    const [unreadCount, setUnreadCount] = useState(0)
+    /** Coalesces multiple ResizeObserver / segment-append calls into one
+     *  DOM write per frame. */
+    const rafIdRef = useRef<number | null>(null)
+    /** Guards against ResizeObserver-loop ping-pong: when scrollToBottom
+     *  writes scrollTop, browsers may fire a follow-up RO callback if
+     *  the write changed layout. Without this flag, every late image
+     *  load could re-fire the RO chain. */
+    const isWritingRef = useRef(false)
+    /** Set true when a RO callback bailed because `isWritingRef` was
+     *  true (a scroll write was in flight). After `isWritingRef`
+     *  clears, the rAF-clear handler retries the scroll once — closes
+     *  the rare "image-B loads during the rAF→rAF gap" gap where the
+     *  growth signal would otherwise be dropped. */
+    const missedScrollRef = useRef(false)
+    /** Touch start Y for drag-down detection. */
+    const touchStartYRef = useRef(0)
+
+    /** Mutator for the stick state. Keeps `stickRef` (sync access) and
+     *  `released` (React state) in lockstep.
+     *
+     *  Two callbacks, both deps-free + stable identity, so the observer
+     *  / event-listener effects that subscribe to them NEVER re-create:
+     *
+     *  - `engageStick()`   — set stick=true; reset released flag + unread.
+     *  - `releaseStick()`  — set stick=false; capture release timestamp
+     *                        + count baseline via refs (NOT reading
+     *                        `messages.length` from closure — we use a
+     *                        latest-prop ref instead so the callback
+     *                        stays deps-free).
+     *
+     *  The prior v2 design had `setStickyState` depend on
+     *  `messages.length` to capture the count baseline at release time.
+     *  That caused the callback to recreate on every message arrival,
+     *  which churned the IO observer / wheel-touch-keydown listeners
+     *  every message. v3 reads count from `messagesLengthRef` (mirrored
+     *  in a useEffect) — no closure capture, no deps. */
+    const messagesLengthRef = useRef(messages.length)
+    useEffect(() => {
+      messagesLengthRef.current = messages.length
+    }, [messages.length])
+
+    const engageStick = useCallback(() => {
+      stickRef.current = true
+      setReleased(false)
+      setUnreadCount(0)
+    }, [])
+
+    /** Release stickiness in response to an explicit user gesture
+     *  (wheel-up / touch-drag / keyboard-up). Snapshots the release
+     *  timestamp + the messages-length baseline (for unread counting)
+     *  and resets the visible unread count. The non-user-gesture
+     *  "release path" (initial mount) is owned by the default-state
+     *  initializers — `stickRef = useRef(true)`, `released =
+     *  useState(false)` — so this callback is single-purpose. */
+    const releaseStick = useCallback(() => {
+      stickRef.current = false
+      setReleased(true)
+      releasedAtRef.current =
+        typeof performance !== 'undefined' ? performance.now() : Date.now()
+      // Reset baseline AND unread count. Without resetting unread,
+      // a re-release while the pill was visible (user wheel-ups
+      // while already released) would leave a stale "N new messages"
+      // count with a freshly-zeroed baseline — the displayed number
+      // becomes meaningless until the next message arrives.
+      releasedAtCountRef.current = messagesLengthRef.current
+      setUnreadCount(0)
+    }, [])
+
+    // ------------------------------------------------------------------
+    // scrollToBottom — rAF-batched, idempotent.
+    //
+    // Writes `scrollTop = scrollHeight` inside one rAF per frame.
+    // Multiple callers in the same frame collapse to one DOM write.
+    //
+    // `isWritingRef` flips true around the write so a ResizeObserver
+    // callback that fires inside the same tick (rare but legal — image
+    // load resolving layout) can skip its own write and avoid
+    // pong-back oscillation.
+    // ------------------------------------------------------------------
+    const scrollToBottom = useCallback(() => {
+      if (rafIdRef.current !== null) return
+      rafIdRef.current = requestAnimationFrame(() => {
+        rafIdRef.current = null
+        const el = scrollRef.current
+        if (!el) return
+        isWritingRef.current = true
+        el.scrollTop = el.scrollHeight
+        // Yield once before clearing the flag so a RO callback fired
+        // by the scrollTop-induced layout sees the flag and bails.
+        // After the clear: if any RO callback bailed during this
+        // write window, retry the scroll ONCE so the dropped growth
+        // signal isn't lost forever. The retry recursion bottoms out
+        // because the inner rAF won't fire while a new outer rAF is
+        // pending (the dedup check at the top of this fn).
+        requestAnimationFrame(() => {
+          isWritingRef.current = false
+          // Retry the dropped scroll AT MOST ONCE per write cycle, AND
+          // only if the user is still stuck. The stick gate is the fix
+          // for the wheel-up-during-write race: user wheel-ups between
+          // the RO bail (T=0) and this clear-rAF (T≈16ms), `stickRef`
+          // flips false, and we MUST NOT yank them back to bottom even
+          // though `missedScrollRef` is true. The flag is cleared
+          // unconditionally so a future stick re-engage doesn't see a
+          // stale missed signal from a long-past write cycle.
+          const shouldRetry = missedScrollRef.current && stickRef.current
+          missedScrollRef.current = false
+          if (shouldRetry) scrollToBottom()
+        })
+      })
+    }, [])
+
+    /** Combined "force stick + scroll" — used by dialog change, first
+     *  load, and user-sent-message paths. The earlier code repeated
+     *  this trio 3× inline; the helper makes intent obvious. */
+    const forceStickAndScroll = useCallback(() => {
+      engageStick()
+      scrollToBottom()
+    }, [engageStick, scrollToBottom])
+
+    // ------------------------------------------------------------------
+    // IntersectionObserver on the bottom sentinel — single source of
+    // truth for at-bottom geometry. Re-engages stickiness when the
+    // user scrolls back into the near-bottom band — UNLESS we're
+    // inside the RELEASE_DEBOUNCE_MS window, in which case we ignore
+    // (kills the wheel-inside-band race).
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      const scrollEl = scrollRef.current
+      const sentinelEl = bottomSentinelRef.current
+      if (!scrollEl || !sentinelEl) return
+
+      const io = new IntersectionObserver(
+        (entries) => {
+          const entry = entries[0]
+          if (!entry) return
+          if (!entry.isIntersecting) return
+          // Geometry says "near bottom". Refuse to re-engage if the
+          // user just explicitly released — they meant it, even if
+          // they were still in the slack band when they did so.
+          const now =
+            typeof performance !== 'undefined' ? performance.now() : Date.now()
+          if (now - releasedAtRef.current < RELEASE_DEBOUNCE_MS) return
+          if (!stickRef.current) engageStick()
+        },
+        {
+          root: scrollEl,
+          rootMargin: `0px 0px ${NEAR_BOTTOM_PX}px 0px`,
+          threshold: 0,
+        },
+      )
+      io.observe(sentinelEl)
+      return () => io.disconnect()
+    }, [autoScroll, engageStick])
+
+    // ------------------------------------------------------------------
+    // ResizeObserver on the inner content — fires whenever content
+    // grows (streaming text, markdown mount, ObjectCard mount,
+    // ThinkingDisplay expand). Runs for the lifetime of the mount —
+    // NO timeout. This is the regression fix.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      const contentEl = contentRef.current
+      if (!contentEl) return
+
+      const ro = new ResizeObserver(() => {
+        if (!stickRef.current) return
+        // ping-pong guard — see scrollToBottom's `isWritingRef`. On
+        // bail, record the missed signal so the rAF-clear handler
+        // retries once when the write window ends.
+        if (isWritingRef.current) {
+          missedScrollRef.current = true
+          return
+        }
+        scrollToBottom()
+      })
+      // `box: 'border-box'` selects the metric REPORTED to the
+      // callback (it does NOT change when the callback fires — that
+      // happens on any size change). We don't read the entry's size
+      // here so this is purely future-proofing for callers that do.
+      ro.observe(contentEl, { box: 'border-box' })
+      return () => ro.disconnect()
+    }, [autoScroll, scrollToBottom])
+
+    // ------------------------------------------------------------------
+    // ResizeObserver on the SCROLLER (not the content). Fires when the
+    // scroller's clientHeight changes — e.g., the sticky pending-
+    // approvals bar appears below the scroller and shrinks its
+    // available height; iOS keyboard open / close; window resize.
+    // Without this, streaming text could end up hidden behind the new
+    // bar / keyboard because the scroll position is unchanged but the
+    // viewport shrunk.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      const scrollEl = scrollRef.current
+      if (!scrollEl) return
+
+      const ro = new ResizeObserver(() => {
+        if (!stickRef.current) return
+        if (isWritingRef.current) {
+          missedScrollRef.current = true
+          return
+        }
+        scrollToBottom()
+      })
+      ro.observe(scrollEl, { box: 'border-box' })
+      return () => ro.disconnect()
+    }, [autoScroll, scrollToBottom])
+
+    // ------------------------------------------------------------------
+    // visualViewport.resize — iOS keyboard open/close, mobile
+    // address-bar collapse. The scroller's `clientHeight` doesn't
+    // always change immediately, but the visible region does. Re-snap
+    // to bottom when sticky.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      if (typeof window === 'undefined' || !window.visualViewport) return
+      const vv = window.visualViewport
+
+      const onVvResize = () => {
+        if (!stickRef.current) return
+        // Symmetric with content-RO / scroller-RO bail pattern: if a
+        // scroll write is already in flight, defer this signal via
+        // `missedScrollRef` so the rAF-clear retry picks it up.
+        // Without this, a keyboard-open event that lands during a
+        // write window would be silently dropped.
+        if (isWritingRef.current) {
+          missedScrollRef.current = true
+          return
+        }
+        scrollToBottom()
+      }
+      vv.addEventListener('resize', onVvResize)
+      return () => vv.removeEventListener('resize', onVvResize)
+    }, [autoScroll, scrollToBottom])
+
+    // ------------------------------------------------------------------
+    // visibilitychange — browsers pause rAF on backgrounded tabs. A
+    // scrollToBottom queued before backgrounding will sit in
+    // rafIdRef until the tab is foregrounded again. On return-to-
+    // visible, drop any stale rAF + re-snap if sticky so the user
+    // doesn't see a frozen pre-background scroll position.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      if (typeof document === 'undefined') return
+
+      const onVisibilityChange = () => {
+        if (document.visibilityState !== 'visible') return
+        if (rafIdRef.current !== null) {
+          cancelAnimationFrame(rafIdRef.current)
+          rafIdRef.current = null
+        }
+        if (stickRef.current) scrollToBottom()
+      }
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+    }, [autoScroll, scrollToBottom])
+
+    // ------------------------------------------------------------------
+    // Explicit user-escape signals. v1 had two issues the reviewers
+    // flagged:
+    //   1. `window` keydown listener with `document.body` fallback —
+    //      released stick on ANY arrow key from anywhere on the page.
+    //      v2: scope keydown to the scroller (`tabIndex={-1}` makes it
+    //      focusable), no body fallback.
+    //   2. Touch threshold 10px — too sensitive on iOS, momentum
+    //      drift could false-positive. v2: 24px + cancelable check
+    //      filters momentum-phase events.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      if (!autoScroll) return
+      const el = scrollRef.current
+      if (!el) return
+
+      const release = () => releaseStick()
+
+      const onWheel = (e: WheelEvent) => {
+        if (e.deltaY < 0) release()
+      }
+      const onTouchStart = (e: TouchEvent) => {
+        const t = e.touches[0]
+        if (t) touchStartYRef.current = t.clientY
+      }
+      const onTouchMove = (e: TouchEvent) => {
+        // `cancelable: false` filters iOS momentum-phase events: iOS
+        // dispatches non-cancelable touchmove during fling-decel AFTER
+        // touchend. Android Chrome doesn't have this distinction
+        // (uses synthetic scroll events instead), so the check is a
+        // pure iOS guard — harmless cross-browser.
+        if (!e.cancelable) return
+        const t = e.touches[0]
+        if (!t) return
+        if (t.clientY > touchStartYRef.current + TOUCH_DRAG_THRESHOLD_PX) release()
+      }
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home') release()
+      }
+
+      el.addEventListener('wheel', onWheel, { passive: true })
+      el.addEventListener('touchstart', onTouchStart, { passive: true })
+      el.addEventListener('touchmove', onTouchMove, { passive: true })
+      // Scoped to the scroller (NOT window) — focus must be inside
+      // the scroller (`tabIndex={-1}` makes it programmatically
+      // focusable) OR a descendant for keydown to fire here.
+      // Prevents arrow keys typed elsewhere on the page (chat input,
+      // sidebar, modal) from releasing stickiness.
+      el.addEventListener('keydown', onKeyDown)
+
+      return () => {
+        el.removeEventListener('wheel', onWheel)
+        el.removeEventListener('touchstart', onTouchStart)
+        el.removeEventListener('touchmove', onTouchMove)
+        el.removeEventListener('keydown', onKeyDown)
+      }
+    }, [autoScroll, releaseStick])
+
+    // ------------------------------------------------------------------
+    // Dialog change / first-load / user-sent-message detection.
+    //
+    // - Dialog change → reset to sticky, scroll.
+    // - 0 → N first messages → reset to sticky, scroll.
+    // - ANY new user-role message in the diff (not just last — handles
+    //   optimistic + server response landing in the same render) →
+    //   force-stick, scroll.
+    // - New assistant messages while released → bump unread count for
+    //   the pill badge.
+    // ------------------------------------------------------------------
     const prevRenderRef = useRef<{
       dialogId: string | undefined
       messageCount: number
       lastMessageId: string | undefined
     }>({ dialogId: undefined, messageCount: 0, lastMessageId: undefined })
-
-    // Tracks scroll height snapshot for prepend anchoring
-    const prependRef = useRef<{
-      firstMessageId: string | undefined
-      firstMessageContent: unknown
-      scrollHeight: number
-      dialogId: string | undefined
-    }>({ firstMessageId: undefined, firstMessageContent: undefined, scrollHeight: 0, dialogId: undefined })
-
-    // ResizeObserver-based post-render anchoring (for markdown mounting after prepend)
-    const anchoringRef = useRef<{
-      observer: ResizeObserver | null
-      timeout: ReturnType<typeof setTimeout> | null
-      baseline: number
-    }>({ observer: null, timeout: null, baseline: 0 })
-
-    const startAnchoringWatch = useCallback((el: HTMLDivElement) => {
-      anchoringRef.current.observer?.disconnect()
-      if (anchoringRef.current.timeout) clearTimeout(anchoringRef.current.timeout)
-
-      anchoringRef.current.baseline = el.scrollHeight
-      const contentEl = el.firstElementChild as HTMLElement
-
-      const observer = new ResizeObserver(() => {
-        const newHeight = el.scrollHeight
-        const delta = newHeight - anchoringRef.current.baseline
-        if (!anchoringRef.current.baseline || delta === 0) return
-        if (isStuckRef.current) {
-          el.scrollTop = el.scrollHeight
-        } else {
-          el.scrollTop += delta
-        }
-        anchoringRef.current.baseline = newHeight
-      })
-
-      if (contentEl) observer.observe(contentEl)
-      anchoringRef.current.observer = observer
-
-      anchoringRef.current.timeout = setTimeout(() => {
-        observer.disconnect()
-        anchoringRef.current.observer = null
-        anchoringRef.current.baseline = 0
-      }, 1500)
-    }, [])
-
-    const scrollToBottomDeferred = useCallback((el: HTMLDivElement) => {
-      if (rafIdRef.current !== null) {
-        cancelAnimationFrame(rafIdRef.current)
-      }
-
-      rafIdRef.current = requestAnimationFrame(() => {
-        rafIdRef.current = requestAnimationFrame(() => {
-          el.scrollTop = el.scrollHeight
-          rafIdRef.current = null
-        })
-      })
-    }, [])
-
-    useEffect(() => {
-      return () => {
-        if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current)
-        anchoringRef.current.observer?.disconnect()
-        anchoringRef.current.observer = null
-        if (anchoringRef.current.timeout) clearTimeout(anchoringRef.current.timeout)
-        anchoringRef.current.timeout = null
-        anchoringRef.current.baseline = 0
-      }
-    }, [])
 
     useEffect(() => {
       if (!autoScroll) return
@@ -103,92 +548,54 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       const dialogChanged = dialogId !== prevRenderRef.current.dialogId
       const prevCount = prevRenderRef.current.messageCount
       const newCount = messages.length
-
       const currentLastId = messages[messages.length - 1]?.id
-      const prevLastId = prevRenderRef.current.lastMessageId
       prevRenderRef.current = { dialogId, messageCount: newCount, lastMessageId: currentLastId }
 
       if (dialogChanged) {
-        isStuckRef.current = true
-        scrollToBottomDeferred(el)
-        startAnchoringWatch(el)
+        forceStickAndScroll()
         return
       }
-
-      if (newCount > prevCount || (newCount > 0 && prevCount === 0)) {
-        if (prevCount === 0) {
-          isStuckRef.current = true
-          scrollToBottomDeferred(el)
-          startAnchoringWatch(el)
+      if (newCount > 0 && prevCount === 0) {
+        forceStickAndScroll()
+        return
+      }
+      if (newCount > prevCount) {
+        // Scan the new tail for any user message — handles the
+        // coalesced-render case where optimistic-user + server-
+        // assistant land in the same diff (the last message is the
+        // assistant, but a user message DID just arrive).
+        const newSlice = messages.slice(prevCount)
+        const hasNewUser = newSlice.some((m) => m.role === 'user')
+        if (hasNewUser) {
+          forceStickAndScroll()
           return
         }
-
-        const lastIdChanged = currentLastId !== prevLastId
-        const lastMsg = messages[messages.length - 1]
-
-        if (lastIdChanged && lastMsg?.role === 'user') {
-          isStuckRef.current = true
-          el.scrollTop = el.scrollHeight
+        // Assistant-only new messages while released → update pill
+        // unread count.
+        if (!stickRef.current) {
+          setUnreadCount(newCount - releasedAtCountRef.current)
         }
       }
-    }, [autoScroll, messages.length, dialogId, isLoading, scrollToBottomDeferred, startAnchoringWatch])
+    }, [autoScroll, messages, dialogId, forceStickAndScroll])
 
-    useEffect(() => {
-      const el = scrollRef.current
-      if (!el || !autoScroll) return
-
-      const onWheel = (e: WheelEvent) => {
-        if (e.deltaY < 0) {
-          isStuckRef.current = false
-        }
-      }
-
-      const onTouchStart = (e: TouchEvent) => {
-        touchStartYRef.current = e.touches[0].clientY
-      }
-
-      const onTouchMove = (e: TouchEvent) => {
-        if (e.touches[0].clientY > touchStartYRef.current + 10) {
-          isStuckRef.current = false
-        }
-      }
-
-      const onScroll = () => {
-        prependRef.current.scrollHeight = el.scrollHeight
-        const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_THRESHOLD
-        if (atBottom && !isStuckRef.current) {
-          isStuckRef.current = true
-        }
-      }
-
-      el.addEventListener('wheel', onWheel, { passive: true })
-      el.addEventListener('touchstart', onTouchStart, { passive: true })
-      el.addEventListener('touchmove', onTouchMove, { passive: true })
-      el.addEventListener('scroll', onScroll, { passive: true })
-
-      return () => {
-        el.removeEventListener('wheel', onWheel)
-        el.removeEventListener('touchstart', onTouchStart)
-        el.removeEventListener('touchmove', onTouchMove)
-        el.removeEventListener('scroll', onScroll)
-      }
-    }, [autoScroll, isLoading])
-
-    const lastMessage = messages[messages.length - 1]
-    useEffect(() => {
-      if (!autoScroll) return
-      const el = scrollRef.current
-      if (!el) return
-
-      if (isStuckRef.current) {
-        el.scrollTop = el.scrollHeight
-      }
-    }, [autoScroll, lastMessage])
+    // ------------------------------------------------------------------
+    // Prepend anchoring (load-older). Pinning the user's viewport to
+    // the same message after older messages prepend. useLayoutEffect
+    // so the scrollTop write lands before paint.
+    //
+    // The snapshot writes are GATED — only when something actually
+    // changes — so we don't churn the ref on every render.
+    // ------------------------------------------------------------------
+    const prependRef = useRef<{
+      firstMessageId: string | undefined
+      firstMessageContent: unknown
+      scrollHeight: number
+    }>({ firstMessageId: undefined, firstMessageContent: undefined, scrollHeight: 0 })
 
     useLayoutEffect(() => {
       const el = scrollRef.current
       if (!el) {
-        prependRef.current = { firstMessageId: undefined, firstMessageContent: undefined, scrollHeight: 0, dialogId: prependRef.current.dialogId }
+        prependRef.current = { firstMessageId: undefined, firstMessageContent: undefined, scrollHeight: 0 }
         return
       }
 
@@ -198,66 +605,119 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       const prevFirstContent = prependRef.current.firstMessageContent
       const prevHeight = prependRef.current.scrollHeight
 
-      // Capture snapshot for next render
-      prependRef.current.firstMessageId = currentFirstId
-      prependRef.current.firstMessageContent = currentFirstContent
-      prependRef.current.scrollHeight = el.scrollHeight
+      const idChanged = currentFirstId !== prevFirstId
+      const contentChanged = currentFirstContent !== prevFirstContent
 
-      // On dialog change: just snapshot, don't adjust (auto-scroll handles it)
-      if (dialogId !== prependRef.current.dialogId) {
-        prependRef.current.dialogId = dialogId
+      if (idChanged) {
+        // First-id changed → older messages prepended (verified by
+        // checking the previous-first is still somewhere in the list
+        // at idx > 0). Add the height delta to scrollTop so the user
+        // stays on the message they were reading.
+        if (prevFirstId && prevHeight > 0) {
+          const prevIdx = messages.findIndex((m) => m.id === prevFirstId)
+          if (prevIdx > 0) {
+            const addedHeight = el.scrollHeight - prevHeight
+            if (addedHeight > 0) el.scrollTop += addedHeight
+          }
+        }
+        prependRef.current = {
+          firstMessageId: currentFirstId,
+          firstMessageContent: currentFirstContent,
+          scrollHeight: el.scrollHeight,
+        }
         return
       }
-
-      if (!prevFirstId || prevHeight === 0) return
-
-      if (currentFirstId !== prevFirstId) {
-        const prevIdx = messages.findIndex(m => m.id === prevFirstId)
-        if (prevIdx > 0) {
+      // Streaming-edit of a leading message — adjust IF user isn't
+      // currently stuck (sticky path owns position when active).
+      if (contentChanged && !stickRef.current) {
+        if (prevFirstId && prevHeight > 0) {
           const addedHeight = el.scrollHeight - prevHeight
-          if (addedHeight > 0) {
-            el.scrollTop += addedHeight
-          }
-          if (rafIdRef.current !== null) {
-            cancelAnimationFrame(rafIdRef.current)
-            rafIdRef.current = null
-          }
-          startAnchoringWatch(el)
+          if (addedHeight > 0) el.scrollTop += addedHeight
         }
-        return
       }
 
-      if (currentFirstId === prevFirstId && !isStuckRef.current && currentFirstContent !== prevFirstContent) {
-        const addedHeight = el.scrollHeight - prevHeight
-        if (addedHeight > 0) {
-          el.scrollTop += addedHeight
-        }
+      // ALWAYS keep `scrollHeight` snapshot fresh — even on renders
+      // where nothing notable changed about the first message. Without
+      // this, mid-list streaming (a NEW message appended at the bottom
+      // grows scrollHeight) leaves the snapshot stale; a later
+      // load-older would over-compute `addedHeight = newHeight -
+      // staleHeight` and over-scroll. Updating scrollHeight is cheap
+      // (one DOM read) and correctness-critical.
+      //
+      // The id/content snapshot is gated to ID/content changes above
+      // (inside the idChanged branch) so we don't churn those refs on
+      // every render.
+      prependRef.current.scrollHeight = el.scrollHeight
+      if (contentChanged) {
+        prependRef.current.firstMessageContent = currentFirstContent
+      }
+    }, [messages])
+
+    // ------------------------------------------------------------------
+    // rAF cleanup. Cancel any pending scroll write on unmount so we
+    // don't write to a detached ref.
+    // ------------------------------------------------------------------
+    useEffect(() => {
+      return () => {
         if (rafIdRef.current !== null) {
           cancelAnimationFrame(rafIdRef.current)
           rafIdRef.current = null
         }
-        startAnchoringWatch(el)
       }
-    }, [messages, dialogId, startAnchoringWatch])
+    }, [])
 
+    // ------------------------------------------------------------------
+    // Infinite-scroll (load older). Top sentinel; orthogonal to
+    // stickiness. Single dep on `hasNextPage` — the prior `isLoading`
+    // dep was stale (never read inside the effect body, caused
+    // unnecessary observer re-subscription).
+    // ------------------------------------------------------------------
     useEffect(() => {
       const scrollContainer = scrollRef.current
-      const sentinelElement = sentinelRef.current
+      const sentinelElement = topSentinelRef.current
       if (!scrollContainer || !sentinelElement || !hasNextPage) return
 
       const observer = new IntersectionObserver(
         (entries) => {
-          if (entries[0].isIntersecting && !isFetchingRef.current) {
+          const entry = entries[0]
+          if (!entry) return
+          if (entry.isIntersecting && !isFetchingRef.current) {
             onLoadMoreRef.current?.()
           }
         },
-        { root: scrollContainer, rootMargin: '200px', threshold: 0.1 }
+        {
+          root: scrollContainer,
+          rootMargin: `${TOP_SENTINEL_ROOT_MARGIN_PX}px`,
+          threshold: TOP_SENTINEL_THRESHOLD,
+        },
       )
       observer.observe(sentinelElement)
       return () => observer.disconnect()
-    }, [hasNextPage, isLoading])
+    }, [hasNextPage])
 
-    useImperativeHandle(ref, () => scrollRef.current!)
+    // useImperativeHandle: stable identity via empty deps. React
+    // assigns DOM refs BEFORE `useImperativeHandle`'s commit-phase
+    // callback in the same commit (per the docs), so by the time the
+    // parent reads `ref.current`, `scrollRef.current` is non-null.
+    // The `as HTMLDivElement` cast bridges TS's `HTMLDivElement | null`
+    // with the public `forwardRef<HTMLDivElement, …>` generic — type-
+    // honest in practice because consumers don't read the handle
+    // synchronously during a parent render (chat surfaces only read
+    // it from imperative handlers / effects, all of which run after
+    // the first commit). The empty deps array means the factory only
+    // re-runs on parent rerender + `null`-cast; React still updates
+    // `ref.current` on each commit so this is correct.
+    useImperativeHandle(ref, () => scrollRef.current as HTMLDivElement, [])
+
+    const onJumpToBottom = useCallback(() => {
+      forceStickAndScroll()
+    }, [forceStickAndScroll])
+
+    const pillLabel = useMemo(() => {
+      if (unreadCount <= 0) return 'Jump to latest'
+      if (unreadCount === 1) return '1 new message'
+      return `${unreadCount} new messages`
+    }, [unreadCount])
 
     if (isLoading) {
       return (
@@ -272,56 +732,135 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     }
 
     return (
-      <div className="relative flex-1 min-h-0 flex flex-col">
-        <div
-          ref={scrollRef}
-          className={cn(
-            "flex h-full w-full flex-col overflow-y-auto overflow-x-hidden flex-1",
-            "scrollbar-thin scrollbar-track-transparent scrollbar-thumb-ods-border/30 hover:scrollbar-thumb-ods-text-secondary/30",
-            className
-          )}
-          style={{ overflowAnchor: 'none' }}
-          {...props}
-        >
+      // Outer column is flex-col but NOT relative — the pill below
+      // anchors to the scroller-wrapper's relative box, NOT the outer,
+      // so it floats above the scroller's bottom edge and is never
+      // obscured by the sticky pending-approvals area (which is a
+      // sibling of the scroller-wrapper inside this outer column).
+      <div className="flex-1 min-h-0 flex flex-col">
+        {/* Scroller wrapper — `relative` here so the absolutely-
+            positioned jump-to-bottom pill is bounded by the scroller's
+            box, not the outer column's. */}
+        <div className="relative flex-1 min-h-0 flex flex-col">
           <div
+            ref={scrollRef}
             className={cn(
-              "mx-auto flex w-full max-w-3xl flex-col pb-2 min-w-0",
-              contentClassName || "px-4"
+              "flex h-full w-full flex-col overflow-y-auto overflow-x-hidden flex-1",
+              "scrollbar-thin scrollbar-track-transparent scrollbar-thumb-ods-border/30 hover:scrollbar-thumb-ods-text-secondary/30",
+              // `tabIndex={-1}` makes the scroller programmatically
+              // focusable so the scoped keydown listener receives
+              // ArrowUp / PageUp / Home. We render a `focus-visible`
+              // ring (NOT plain `:focus`) so keyboard-Tab navigation
+              // surfaces the focused scroller without painting a ring
+              // on mouse-click focus (which would feel like a visual
+              // bug). `ring-inset` keeps the ring inside the scroller
+              // edge so it doesn't overlap surrounding chrome.
+              "outline-none focus-visible:ring-2 focus-visible:ring-ods-border focus-visible:ring-inset",
+              className,
             )}
-            style={{ minHeight: '100%' }}
+            style={NO_OVERFLOW_ANCHOR_STYLE}
+            tabIndex={-1}
+            {...props}
           >
-            {/* Infinite scroll sentinel */}
-            {hasNextPage && (
-              <div ref={sentinelRef} className="h-px" style={{ overflowAnchor: 'none' }} />
-            )}
-            <div className="flex-1" />
-            {messages.map((message, index) => (
-              <ChatMessageEnhanced
-                key={message.id}
-                role={message.role}
-                name={message.name}
-                content={message.content}
-                timestamp={message.timestamp}
-                isTyping={index === messages.length - 1 && isTyping && message.role === 'assistant'}
-                avatar={showAvatars ? message.avatar : null}
-                showAvatar={showAvatars}
-                assistantType={message.assistantType || assistantType}
-                authorType={message.authorType}
-                assistantIcon={message.role !== 'user' ? assistantIcon : undefined}
-                chatRefs={message.chatRefs}
-                renderEntityCard={renderEntityCard}
+            <div
+              ref={contentRef}
+              className={cn(
+                "mx-auto flex w-full max-w-3xl flex-col pb-2 min-w-0",
+                contentClassName || "px-4",
+              )}
+              style={{ minHeight: '100%' }}
+            >
+              {hasNextPage && (
+                <div ref={topSentinelRef} className="h-px" style={NO_OVERFLOW_ANCHOR_STYLE} />
+              )}
+              <div className="flex-1" />
+              {messages.map((message, index) => (
+                <ChatMessageEnhanced
+                  key={message.id}
+                  role={message.role}
+                  name={message.name}
+                  content={message.content}
+                  timestamp={message.timestamp}
+                  isTyping={index === messages.length - 1 && isTyping && message.role === 'assistant'}
+                  avatar={showAvatars ? message.avatar : null}
+                  showAvatar={showAvatars}
+                  assistantType={message.assistantType || assistantType}
+                  authorType={message.authorType}
+                  assistantIcon={message.role !== 'user' ? assistantIcon : undefined}
+                  chatRefs={message.chatRefs}
+                  renderEntityCard={renderEntityCard}
+                />
+              ))}
+              {/* Bottom sentinel for IntersectionObserver. AFTER every
+                  message so its visibility tracks the true bottom of
+                  the content. */}
+              <div
+                ref={bottomSentinelRef}
+                aria-hidden="true"
+                className="h-px w-full shrink-0"
+                style={NO_OVERFLOW_ANCHOR_STYLE}
               />
-            ))}
+            </div>
           </div>
+
+          {/* Jump-to-bottom pill — appears when the user has released
+              stickiness. Tap re-engages + scrolls. Unread badge counts
+              messages that arrived while released.
+              - Positioned relative to the SCROLLER-WRAPPER (its
+                enclosing `relative`), NOT the outer column, so the
+                pill always floats above the scroller's bottom edge
+                and is never obscured by the sticky pending-approvals
+                bar (which is a sibling of the scroller-wrapper).
+              - Tap target: 44px height (Apple HIG / Material 48dp).
+              - Fade-in: tailwindcss-animate utility — short 150ms
+                slide-up + opacity so the pill doesn't pop suddenly
+                into view mid-scroll. */}
+          {autoScroll && released && messages.length > 0 && (
+            <div
+              className={cn(
+                "pointer-events-none absolute left-0 right-0 flex justify-center",
+                "animate-in fade-in slide-in-from-bottom-1 duration-150",
+              )}
+              // Respect iOS safe-area-inset-bottom so the pill doesn't
+              // sit on top of the home-indicator bar. `max(0.75rem,
+              // env(...))` falls back to 12px on non-iOS where the
+              // env-var is 0.
+              style={{ bottom: 'max(0.75rem, env(safe-area-inset-bottom))' }}
+            >
+              <button
+                type="button"
+                onClick={onJumpToBottom}
+                className={cn(
+                  "pointer-events-auto",
+                  "inline-flex items-center justify-center gap-1.5",
+                  "min-h-[44px] px-4 rounded-full",
+                  "bg-ods-card border border-ods-border text-ods-text-primary",
+                  "text-sm font-dm-sans font-medium shadow-md",
+                  "hover:bg-ods-bg-secondary transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ods-border",
+                )}
+              >
+                <span aria-hidden="true" className="text-base leading-none">↓</span>
+                <span>{pillLabel}</span>
+              </button>
+            </div>
+          )}
         </div>
 
-        {/* Sticky Pending Approvals Section */}
+        {/* Sticky pending-approvals area — sibling of the scroller-
+            wrapper, BELOW it in the outer column. Height changes here
+            shrink the scroller's clientHeight, which the scroller-RO
+            catches and re-snaps to bottom when sticky. The pill above
+            stays anchored to the scroller-wrapper, never overlapping
+            this bar. */}
         {pendingApprovals && pendingApprovals.length > 0 && (
-          <div className={cn(
-            "border-t border-ods-border bg-ods-bg/95 backdrop-blur-sm",
-            "mx-auto w-full max-w-3xl",
-            contentClassName || "px-4"
-          )}>
+          <div
+            className={cn(
+              "border-t border-ods-border bg-ods-bg/95 backdrop-blur-sm",
+              "mx-auto w-full max-w-3xl",
+              contentClassName || "px-4",
+            )}
+          >
             <ChatMessageEnhanced
               role="assistant"
               name={assistantType === 'mingo' ? 'Mingo' : 'Fae'}
@@ -336,7 +875,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         )}
       </div>
     )
-  }
+  },
 )
 
 ChatMessageList.displayName = "ChatMessageList"

--- a/openframe-frontend-core/src/components/chat/model-display.tsx
+++ b/openframe-frontend-core/src/components/chat/model-display.tsx
@@ -2,14 +2,15 @@
 
 import React from 'react';
 import { cn } from '../../utils/cn';
-import type { ModelDisplayProps } from './types';
+import type { ModelDisplayProps, ModelUsageBreakdown } from './types';
 import { AnthropicLogoGreyIcon, GeminiLogoGreyIcon, OpenaiLogoGreyIcon } from '../icons-v2-generated';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '../hover-card';
 
 const getProviderIcon = (provider?: string) => {
   if (!provider) return null;
-  
+
   const providerLower = provider.toLowerCase();
-  
+
   switch (providerLower) {
     case 'anthropic':
     case 'claude':
@@ -38,18 +39,42 @@ const formatTokenCount = (count: number): string => {
   return String(count);
 };
 
+const hasAnyBreakdownRow = (breakdown?: ModelUsageBreakdown): boolean =>
+  !!breakdown && !!(breakdown.haikuRewriter || breakdown.haikuClassifier || breakdown.haikuSummarizer);
+
 const ModelDisplay = React.forwardRef<HTMLDivElement, ModelDisplayProps>(
-  ({ className, provider, modelName, displayName, usedTokens, contextWindow, ...props }, ref) => {
+  (
+    {
+      className,
+      provider,
+      modelName,
+      displayName,
+      usedTokens,
+      contextWindow,
+      breakdown,
+      hitRatePct,
+      inputTokens,
+      outputTokens,
+      ...props
+    },
+    ref,
+  ) => {
     const icon = getProviderIcon(provider);
     const name = displayName || modelName;
 
-    return (
+    // Inline pill: provider icon + model name + "X / Y tokens used".
+    // The "tokens used" tail renders as soon as `contextWindow` is known
+    // (typically from the leading metadata frame). `usedTokens` lags by a
+    // tick — it only becomes non-null after the first `message_start`
+    // usage frame. Showing "— / 200K tokens used" early gives users the
+    // model's capacity context without waiting for the first byte.
+    const inline = (
       <div
         ref={ref}
         className={cn(
-          "flex items-center gap-1 text-ods-text-secondary",
-          "text-sm",
-          className
+          'flex items-center gap-1 text-ods-text-secondary',
+          'text-sm',
+          className,
         )}
         {...props}
       >
@@ -61,16 +86,104 @@ const ModelDisplay = React.forwardRef<HTMLDivElement, ModelDisplayProps>(
         <span className="font-dm-sans font-medium">
           {name}
         </span>
-        {usedTokens != null && contextWindow != null && (
+        {contextWindow != null && (
           <span className="font-dm-sans text-xs opacity-70 ml-auto">
-            {formatTokenCount(usedTokens)}/{formatTokenCount(contextWindow)} tokens used
+            {usedTokens != null ? formatTokenCount(usedTokens) : '—'}/{formatTokenCount(contextWindow)} tokens used
           </span>
         )}
       </div>
     );
-  }
+
+    // Without a breakdown there's no story to tell on hover — return the
+    // bare inline so we don't add a stray pointer cursor / accessibility
+    // chrome on chat surfaces that don't capture cross-call usage.
+    if (!hasAnyBreakdownRow(breakdown)) return inline;
+
+    return (
+      <HoverCard openDelay={150} closeDelay={100}>
+        <HoverCardTrigger asChild>
+          <div className="cursor-help">{inline}</div>
+        </HoverCardTrigger>
+        <HoverCardContent
+          className={cn(
+            'w-80 p-3',
+            'bg-ods-card border-ods-border text-ods-text-primary',
+          )}
+          align="end"
+          sideOffset={6}
+        >
+          <div className="font-dm-sans text-xs font-semibold text-ods-text-primary mb-2">
+            Token breakdown
+          </div>
+          {/* Answer-call row — uses the SAME pretty model name as the
+              inline pill, plus the input/output split that doesn't fit
+              in the inline view. */}
+          <BreakdownRow
+            label={`Answer (${name ?? 'model'})`}
+            input={inputTokens}
+            output={outputTokens}
+            isAnswer
+          />
+          {breakdown!.haikuRewriter && (
+            <BreakdownRow
+              label="Query rewriter (Haiku)"
+              input={breakdown!.haikuRewriter.input}
+              output={breakdown!.haikuRewriter.output}
+            />
+          )}
+          {breakdown!.haikuClassifier && (
+            <BreakdownRow
+              label="Intent classifier (Haiku)"
+              input={breakdown!.haikuClassifier.input}
+              output={breakdown!.haikuClassifier.output}
+            />
+          )}
+          {breakdown!.haikuSummarizer && (
+            <BreakdownRow
+              label="History summarizer (Haiku)"
+              input={breakdown!.haikuSummarizer.input}
+              output={breakdown!.haikuSummarizer.output}
+            />
+          )}
+          {typeof hitRatePct === 'number' && hitRatePct > 0 && (
+            <div className="mt-2 pt-2 border-t border-ods-border font-dm-sans text-xs text-ods-text-secondary">
+              Prompt-cache hit: {hitRatePct}% of answer input
+            </div>
+          )}
+        </HoverCardContent>
+      </HoverCard>
+    );
+  },
 );
 
-ModelDisplay.displayName = "ModelDisplay";
+function BreakdownRow({
+  label,
+  input,
+  output,
+  isAnswer,
+}: {
+  label: string;
+  input?: number;
+  output?: number;
+  isAnswer?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between py-1 font-dm-sans text-xs">
+      <span
+        className={cn(
+          'text-ods-text-secondary',
+          isAnswer && 'text-ods-text-primary font-medium',
+        )}
+      >
+        {label}
+      </span>
+      <span className="text-ods-text-secondary tabular-nums">
+        {input != null ? formatTokenCount(input) : '—'} in / {output != null ? formatTokenCount(output) : '—'} out
+      </span>
+    </div>
+  );
+}
+
+ModelDisplay.displayName = 'ModelDisplay';
 
 export { ModelDisplay };

--- a/openframe-frontend-core/src/components/chat/types/component.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/component.types.ts
@@ -285,6 +285,44 @@ export interface ModelDisplayProps extends HTMLAttributes<HTMLDivElement> {
   contextWindow?: number
   usedTokens?: number
   showIcon?: boolean
+  /**
+   * Per-call token breakdown for the hover-tooltip (v6.1 §A.3). When
+   * provided alongside non-empty fields, the entire ModelDisplay is
+   * wrapped in a HoverCard trigger that surfaces "Answer model + each
+   * helper" rows on hover. Use this for chat surfaces that aggregate a
+   * Sonnet answer with Haiku helpers (query rewriter / classifier /
+   * summarizer). Absent → renders the bare display unchanged
+   * (backward-compatible — every existing caller keeps working).
+   */
+  breakdown?: ModelUsageBreakdown
+  /**
+   * Cache-hit % across the answer call's input + cached + creation
+   * tokens. Surfaced in the breakdown tooltip's footer. Drives a
+   * "cache savings" summary line.
+   */
+  hitRatePct?: number
+  /**
+   * Answer call's input tokens — surfaced in the breakdown tooltip's
+   * "Answer model" row alongside outputTokens. `usedTokens` (sum) is
+   * still the right prop for the inline "X / Y" display; this pair
+   * powers the per-row split inside the tooltip.
+   */
+  inputTokens?: number
+  /** Answer call's output tokens — pairs with `inputTokens`. */
+  outputTokens?: number
+}
+
+/**
+ * Cross-call token breakdown captured by the chat route across all
+ * Claude calls in a turn (Sonnet answer + Haiku rewriter + Haiku
+ * classifier + Haiku summarizer). Every field is optional — chats that
+ * skip a helper (e.g., short-conversation summarizer-skipped path) omit
+ * the field, and the tooltip just doesn't render that row.
+ */
+export interface ModelUsageBreakdown {
+  haikuRewriter?: { input: number; output: number }
+  haikuClassifier?: { input: number; output: number }
+  haikuSummarizer?: { input: number; output: number }
 }
 
 // ========== Chat Quick Action Props ==========

--- a/openframe-frontend-core/src/utils/chat-stream-demux.ts
+++ b/openframe-frontend-core/src/utils/chat-stream-demux.ts
@@ -1,0 +1,291 @@
+/*
+ * Client-side demuxer for the v5.1 §7 chat stream protocol.
+ *
+ * Stream layout this demuxer handles:
+ *
+ *   PHASE 1 — leading metadata frames (0..N):
+ *     <UTF-8 JSON>\0  (each terminated by a single NUL byte)
+ *
+ *   PHASE 2 — body (interleaved):
+ *     TEXT  : raw UTF-8 bytes
+ *     CTRL  : \xFE <u32-be length> <type byte> <JSON payload bytes>
+ *
+ * Phase 1 ends at the first \xFE byte (signals first ctrl frame OR start of
+ * a body that contains ctrl frames). Phase 1 is also implicitly over when
+ * the buffer transitions from \0-terminated JSON frames into non-JSON
+ * text — handled by the JSON.parse fail path (falls through to phase 2).
+ *
+ * Why the OSS-lib needs this (separate from the hub's own use-docs.ts):
+ * a future OSS-lib chat surface (or future hub migration) can route its
+ * chat stream through this demuxer for clean separation between text and
+ * ctrl frames. The hub's existing use-docs.ts uses a Session-1 protocol
+ * (\x1E sentinel between leading frames and text; \x1F sentinel for
+ * trailing usage) that pre-dates this spec — both are correct; pick the
+ * one whose protocol matches the server you're consuming.
+ *
+ * Critical invariants enforced:
+ *   - 1 MB cap on ctrl frame payload (DoS-resistant)
+ *   - Unknown type bytes log + skip (forward-compat)
+ *   - JSON.parse errors per-frame log + skip (no stream-kill)
+ *   - Multi-byte UTF-8 codepoints preserved across chunk boundaries
+ *     (no U+FFFD replacement artifacts on European/CJK text)
+ *
+ * v6.1 fix: payload size cap mirrors the server's MAX_CTRL_FRAME_BYTES
+ * constant. Both sides enforce; neither trusts the other.
+ */
+
+/**
+ * Must match `MAX_CTRL_FRAME_BYTES` in the server's
+ * `lib/utils/sse-binary-framing.ts`. Hard-coded here instead of imported
+ * so the OSS-lib has no dependency on hub-side modules. If the server
+ * raises its cap, raise this one too AND ship the OSS-lib bump first
+ * (clients with a stale cap reject the larger frame).
+ */
+export const MAX_CTRL_FRAME_BYTES = 1 * 1024 * 1024
+
+/**
+ * Discriminated union of events yielded by `demuxChatStream`. The kind
+ * field tells the consumer how to interpret `data`:
+ *   - 'text'           → string (decoded UTF-8 text)
+ *   - 'metadata'       → object (parsed leading-frame JSON; e.g.,
+ *                        sources/refs/model)
+ *   - 'tool_proposal'  → { proposalId, toolName, args, toolUseId }
+ *   - 'tool_result'    → { proposalId, result }
+ *   - 'error'          → { message, code }
+ *   - 'usage'          → token + cache + breakdown stats
+ */
+export interface DemuxedEvent {
+  kind: 'text' | 'metadata' | 'tool_proposal' | 'tool_result' | 'error' | 'usage'
+  data: string | Record<string, unknown>
+}
+
+/**
+ * Drain a chat-stream reader, yielding each frame as a typed event.
+ *
+ * Usage:
+ * ```ts
+ * for await (const ev of demuxChatStream(response.body!.getReader())) {
+ *   switch (ev.kind) {
+ *     case 'metadata': handleMetadata(ev.data)
+ *     case 'text':     appendToMessage(ev.data)
+ *     ...
+ *   }
+ * }
+ * ```
+ *
+ * The generator runs to completion (server closes the stream) OR to the
+ * first unrecoverable framing error (oversized ctrl frame).
+ */
+export async function* demuxChatStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncIterableIterator<DemuxedEvent> {
+  // TS 5.8+ tightened Uint8Array's generic to `<ArrayBuffer | SharedArrayBuffer>`
+  // and `subarray` returns `<ArrayBufferLike>`. Type the buffer + helpers'
+  // returns as `Uint8Array<ArrayBufferLike>` so reassignments between
+  // freshly-allocated buffers and subarray slices type-check cleanly.
+  let buffer: Uint8Array<ArrayBufferLike> = new Uint8Array(0)
+  let phase: 'metadata' | 'body' = 'metadata'
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer = concat(buffer, value)
+
+    // -----------------------------------------------------------------
+    // PHASE 1 — drain leading \0-terminated metadata frames. Continues
+    // until the buffer is exhausted OR a \xFE byte appears before the
+    // next \0 (signals body phase has started — first byte is a ctrl
+    // frame). Note: a leading metadata frame's payload is JSON, and
+    // JSON.stringify NEVER emits raw 0xFE (it escapes non-ASCII as
+    // \uXXXX), so 0xFE can only appear as the START of a ctrl frame.
+    // -----------------------------------------------------------------
+    while (phase === 'metadata' && buffer.byteLength > 0) {
+      const feIdx = indexOfByte(buffer, 0xfe)
+      const nullIdx = indexOfByte(buffer, 0x00)
+      if (nullIdx === -1 && feIdx === -1) break // need more bytes
+      // Body phase begins at the first 0xFE (a ctrl frame appeared
+      // before the next \0-terminated metadata frame).
+      if (feIdx !== -1 && (nullIdx === -1 || feIdx < nullIdx)) {
+        phase = 'body'
+        break
+      }
+      // Consume one metadata frame: bytes 0..nullIdx-1 are the JSON.
+      try {
+        const json = decodeText(buffer.subarray(0, nullIdx))
+        // Empty frame (just a stray \0) — skip silently.
+        if (json.trim().length > 0) {
+          yield { kind: 'metadata', data: JSON.parse(json) }
+        }
+      } catch (err) {
+        // Malformed JSON in a leading-frame slot. Most likely cause:
+        // server emitted non-JSON text without a \xFE-prefixed ctrl
+        // frame to switch us out of metadata phase. Treat the rest of
+        // the buffer as body text and yield it.
+        console.warn('[chat-stream-demux] failed to parse metadata frame; switching to body phase:', err)
+        phase = 'body'
+        // Don't consume the \0 — yield the entire buffer as text.
+        break
+      }
+      buffer = buffer.subarray(nullIdx + 1)
+    }
+    if (phase === 'metadata') continue // not enough bytes yet for a phase decision
+
+    // -----------------------------------------------------------------
+    // PHASE 2 — body. Interleaved text and ctrl frames.
+    // -----------------------------------------------------------------
+    while (buffer.byteLength > 0) {
+      const feIdx = indexOfByte(buffer, 0xfe)
+      if (feIdx === -1) {
+        // No ctrl frame ahead. Flush whole-codepoint prefix; retain
+        // partial trailing UTF-8 bytes for the next chunk so multi-byte
+        // codepoints split across TCP packets don't emit replacement chars.
+        const { full, partial } = splitOnLastCodepoint(buffer)
+        if (full.byteLength > 0) {
+          yield { kind: 'text', data: decodeText(full) }
+        }
+        buffer = partial
+        break // wait for more bytes
+      }
+      // Text before the ctrl frame — emit it. Preserve trailing-partial
+      // codepoints only if the \xFE itself appeared MID-codepoint, which
+      // is impossible (\xFE can't be a continuation byte either —
+      // continuations are 0x80-0xBF). So the bytes 0..feIdx-1 are
+      // guaranteed whole codepoints.
+      if (feIdx > 0) {
+        yield { kind: 'text', data: decodeText(buffer.subarray(0, feIdx)) }
+      }
+      // Frame header layout: \xFE (1) + u32-be length (4) + type (1) = 6 bytes
+      if (buffer.byteLength < feIdx + 6) break // need more bytes for header
+      const length = new DataView(buffer.buffer, buffer.byteOffset + feIdx + 1, 4).getUint32(0, false)
+      const type = buffer[feIdx + 5]
+      // Reject malformed / oversized frames eagerly. The server-side cap
+      // is the same constant; this side enforces too because we don't
+      // trust the server (compromise, version skew, etc.).
+      if (length > MAX_CTRL_FRAME_BYTES) {
+        console.error(
+          `[chat-stream-demux] ctrl frame length ${length} exceeds cap ${MAX_CTRL_FRAME_BYTES}; aborting demux`,
+        )
+        return
+      }
+      const totalFrameBytes = 1 + 4 + 1 + length
+      if (buffer.byteLength < feIdx + totalFrameBytes) break // need more bytes for payload
+      const payloadBytes = buffer.subarray(feIdx + 6, feIdx + 6 + length)
+      let payload: unknown
+      try {
+        payload = JSON.parse(decodeText(payloadBytes))
+      } catch (err) {
+        console.warn(`[chat-stream-demux] failed to parse ctrl frame type=0x${type.toString(16)}:`, err)
+        buffer = buffer.subarray(feIdx + totalFrameBytes)
+        continue
+      }
+      switch (type) {
+        case 0x01:
+          yield { kind: 'tool_proposal', data: payload as Record<string, unknown> }
+          break
+        case 0x02:
+          yield { kind: 'tool_result', data: payload as Record<string, unknown> }
+          break
+        case 0x03:
+          yield { kind: 'error', data: payload as Record<string, unknown> }
+          break
+        case 0x04:
+          yield { kind: 'usage', data: payload as Record<string, unknown> }
+          break
+        default:
+          // Unknown type byte — log and skip (don't crash). Lets the
+          // server roll out new frame types without immediately bumping
+          // every client.
+          console.warn(
+            `[chat-stream-demux] unknown ctrl frame type 0x${type.toString(16)} (length=${length}); skipped`,
+          )
+          break
+      }
+      buffer = buffer.subarray(feIdx + totalFrameBytes)
+    }
+  }
+  // Final flush — server closed cleanly with bytes still in the buffer.
+  // In body phase: yield whatever's left as text.
+  // In metadata phase: this only happens if the stream emitted metadata
+  // frames followed by a text body WITHOUT a ctrl frame to trigger phase
+  // transition. The spec recommends emitting at least one ctrl frame (or
+  // using a transport sentinel), but we treat trailing bytes as text
+  // rather than silently discarding them — pragmatic forward-compat.
+  if (buffer.byteLength > 0) {
+    yield { kind: 'text', data: decodeText(buffer) }
+  }
+}
+
+/**
+ * UTF-8 decode helper. `fatal: false` means invalid sequences produce
+ * U+FFFD replacement chars instead of throwing — chat text rendering
+ * survives a corrupted byte without killing the whole stream.
+ */
+function decodeText(bytes: Uint8Array): string {
+  return new TextDecoder('utf-8', { fatal: false }).decode(bytes)
+}
+
+/**
+ * Split a Uint8Array into (whole-codepoint prefix, trailing partial bytes).
+ *
+ * UTF-8 codepoint structure:
+ *   0xxxxxxx                                              → 1-byte ASCII
+ *   110xxxxx 10xxxxxx                                     → 2 bytes
+ *   1110xxxx 10xxxxxx 10xxxxxx                            → 3 bytes
+ *   11110xxx 10xxxxxx 10xxxxxx 10xxxxxx                   → 4 bytes
+ *
+ * Continuation bytes match `(b & 0xC0) === 0x80` (0x80..0xBF).
+ * Leading bytes match `(b & 0xC0) !== 0x80`. Walk back at most 4 bytes
+ * to find the last leading byte; if its expected width exceeds what we
+ * have, retain the partial tail for the next chunk.
+ *
+ * Without this, an emoji or CJK character split across a TCP chunk
+ * boundary would emit replacement chars on the first chunk's text
+ * frame and replacement chars on the second's prefix.
+ */
+function splitOnLastCodepoint(bytes: Uint8Array): { full: Uint8Array; partial: Uint8Array } {
+  if (bytes.byteLength === 0) return { full: bytes, partial: bytes }
+  for (let i = bytes.byteLength - 1; i >= Math.max(0, bytes.byteLength - 4); i--) {
+    const b = bytes[i]
+    if ((b & 0x80) === 0) {
+      // Last byte is ASCII — buffer ends on a whole codepoint.
+      return { full: bytes, partial: new Uint8Array(0) }
+    }
+    if ((b & 0xc0) !== 0x80) {
+      // Leading byte. Width = number of leading 1s.
+      const width = b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : 2
+      if (i + width <= bytes.byteLength) {
+        // Codepoint complete in the buffer.
+        return { full: bytes, partial: new Uint8Array(0) }
+      }
+      // Codepoint truncated — retain the partial tail.
+      return { full: bytes.subarray(0, i), partial: bytes.subarray(i) }
+    }
+    // Continuation byte — keep walking back to find the leading byte.
+  }
+  // Buffer has no leading byte in the last 4 bytes (either malformed or
+  // pathologically long continuation run). Emit as-is; the decoder will
+  // produce replacement chars where the input is genuinely bad.
+  return { full: bytes, partial: new Uint8Array(0) }
+}
+
+/**
+ * `Uint8Array.indexOf` exists on Node's TypedArray but isn't a real
+ * Array method in the DOM lib types — `(bytes as any).indexOf(byte)`
+ * works at runtime but trips strict TS. Helper preserves the typed
+ * surface and matches Node's behavior (returns -1 if not found).
+ */
+function indexOfByte(bytes: Uint8Array, target: number): number {
+  for (let i = 0; i < bytes.byteLength; i++) {
+    if (bytes[i] === target) return i
+  }
+  return -1
+}
+
+function concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  if (a.byteLength === 0) return b
+  if (b.byteLength === 0) return a
+  const out = new Uint8Array(a.byteLength + b.byteLength)
+  out.set(a, 0)
+  out.set(b, a.byteLength)
+  return out
+}

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -29,3 +29,6 @@ export * from './os-utils'
 export * from './country-phone-utils'
 // Generic domain detection
 export * from './generic-domain-utils'
+// Chat stream demuxer (v5.1 §7 / v6.1 §A.3) — length-prefixed ctrl frame
+// protocol for chat surfaces consuming the hub's /api/docs/chat stream.
+export * from './chat-stream-demux'


### PR DESCRIPTION
## Summary

Companion PR for [multi-platform-hub#474](https://github.com/flamingo-stack/multi-platform-hub/pull/474) — Phase 2/3 batch 4 (Session 4 of the v6.1 plan).

- **`src/utils/chat-stream-demux.ts`** (NEW) — v5.1 §7 spec'd client demuxer for the chat stream's `\xFE` length-prefixed ctrl frame protocol. Two-phase parser (metadata → body), UTF-8 codepoint preservation across chunk boundaries, 1 MB ctrl frame cap, unknown type byte forward-compat (log + skip).
- **`src/components/chat/model-display.tsx`** (ENHANCED) — v6.1 §A.3. Adds optional `breakdown` / `hitRatePct` / `inputTokens` / `outputTokens` props. When `breakdown` is present, the entire pill is wrapped in a HoverCard trigger; tooltip shows answer-call + each Haiku helper with per-row in/out split, plus prompt-cache hit %. Inline "X / Y tokens used" tail now renders from `contextWindow` alone (was: required `usedTokens` too) so the denominator appears immediately on first paint.
- **`src/components/chat/types/component.types.ts`** — new `ModelUsageBreakdown` interface; `ModelDisplayProps` adds the 4 optional props.

Design decision: NO parallel "ChatMessageUsageBadge" component. The breakdown tooltip lives inside the existing ModelDisplay so chat surfaces have a single, consistent token-display pill. Backward-compat: every prior caller keeps working — the new props are all optional.

Both are foundation work for Session 5's HubSpot tool-mediated flow.

## Test plan

- [x] `npm run type-check` clean
- [ ] Bundling via tsup: demuxer exported from `utils`; enhanced ModelDisplay still exported from `components/chat`
- [ ] Manual: consume in a chat surface; verify first paint shows `Model · — / 200K tokens used`, animates to `45.3K / 200K` as tokens land, and hover tooltip surfaces breakdown rows after the trailing frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)