### PR TITLE
chat: thread targetPlatform on ChatRef + pass modifier event to Searc…

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-ref.types.ts
+++ b/openframe-frontend-core/src/components/chat/chat-ref.types.ts
@@ -27,6 +27,13 @@ export interface ChatRef {
   title: string
   /** Resolved external URL — null when the entity has no public link. */
   url: string | null
+  /** Platform that owns the destination at `url` — sourced by the host's
+   *  RAG mapper from the row's `platforms` junction (or the rag-config's
+   *  default). Threaded through to the host's nav hook so the same-app-
+   *  vs-cross-app routing decision is deterministic (no origin guess in
+   *  dev where every platform shares localhost). Null when `url` is
+   *  external/unknown or the mapper didn't supply it (backward-compat). */
+  targetPlatform?: string | null
   /** ISO date for the entity's canonical time. Optional. */
   date?: string
   /** PII-sanitized hover preview text. Optional. */

--- a/openframe-frontend-core/src/components/ui/search-input.tsx
+++ b/openframe-frontend-core/src/components/ui/search-input.tsx
@@ -46,8 +46,18 @@ export interface SearchInputProps {
   results?: SearchResult[]
   /** Whether results are loading */
   isLoading?: boolean
-  /** Called when a result row is selected */
-  onResultSelect?: (result: SearchResult) => void
+  /** Called when a result row is selected.
+   *
+   *  `modifiers` carries the click event's modifier-key state when the
+   *  user picked the row via mouse — pass through so the consumer can
+   *  honor cmd/ctrl/shift/middle-click for background-tab navigation
+   *  (the row is a `<div role="option">` rather than an `<a>`, so the
+   *  browser doesn't background-tab natively even with `target="_blank"`).
+   *  Empty `{}` when the row was selected via keyboard Enter. */
+  onResultSelect?: (
+    result: SearchResult,
+    modifiers?: { metaKey?: boolean; ctrlKey?: boolean; shiftKey?: boolean; altKey?: boolean; button?: number },
+  ) => void
   /** Debounce delay in ms. 0 disables debounce. Default 300 */
   debounceMs?: number
   /** Custom renderer for a single result row */
@@ -245,8 +255,22 @@ export function SearchInput({
     inputRef.current?.focus()
   }
 
-  const handleResultClick = (result: SearchResult) => {
-    onResultSelect?.(result)
+  const handleResultClick = (
+    result: SearchResult,
+    e?: React.MouseEvent,
+  ) => {
+    onResultSelect?.(
+      result,
+      e
+        ? {
+            metaKey: e.metaKey,
+            ctrlKey: e.ctrlKey,
+            shiftKey: e.shiftKey,
+            altKey: e.altKey,
+            button: e.button,
+          }
+        : undefined,
+    )
     setIsOpen(false)
   }
 
@@ -331,7 +355,7 @@ export function SearchInput({
           isHighlighted && "bg-ods-bg-hover",
           !isHighlighted && "hover:bg-ods-bg-hover"
         )}
-        onClick={() => handleResultClick(result)}
+        onClick={(e) => handleResultClick(result, e)}
         onMouseEnter={() => setHighlightedIndex(index)}
       >
         {renderResult ? renderResult(result, isHighlighted) : defaultRenderResult(result, isHighlighted)}

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -4,7 +4,7 @@ export { cn, formatDate, formatNumber, formatPrice, formatBytes, getAllPlatformB
 export { PLAY_ICON_PATH } from '../components/icons-v2-generated/media-playback/play-icon'
 export { getPlatformAccentColor, getCurrentPlatform, type ColorCategory } from './ods-color-utils'
 export { delay, generateRandomString, truncateString, deepClone, getSlackCommunityJoinUrl } from './common'
-export { getBaseUrl } from '../utils/cn'
+export { getBaseUrl, getPlatformProductionUrl } from '../utils/cn'
 
 export * from './platform-config'
 export * from './os-platforms'


### PR DESCRIPTION
…hInput onResultSelect

ChatRef carries the destination's `targetPlatform` so chat-source chips and inline cards can hand it to the host app's `useNavLink` — keeps the same-tab/new-tab decision deterministic in dev where every platform shares localhost.

SearchInput's `onResultSelect` callback now receives a second `modifiers` arg ({metaKey, ctrlKey, shiftKey, altKey, button}) capturing the click event's modifier-key state so consumers can honor cmd/ctrl- click for background-tab navigation — the row is `<div role="option">`, not an `<a>`, so the browser doesn't background-tab natively. Empty when the row was selected via keyboard Enter.

## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 
