### PR TITLE
chat: per-message scrollAnchor render hint

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -8,6 +8,8 @@ import { ChatMessageListSkeleton } from "./chat-message-skeleton"
 import { DotsLoaderIcon } from "../icons-v2-generated"
 import { CyclingPhrase } from "./cycling-phrase"
 import type { ChatMessageListProps } from "./types"
+import { SCROLL_ANCHOR } from "./types/message.types"
+import type { MessageContent } from "./types/message.types"
 
 // Flamingo-themed cycling words shown next to the streaming indicator
 // (Claude-Code-style activity hint). Mix of classic AI verbs, flamingo
@@ -56,6 +58,35 @@ const STREAMING_WORDS = [
  * — pass them directly as `ref={scrollRef}` / `ref={contentRef}`.
  */
 
+/** Whether a `Message.content` (string OR `MessageSegment[]`) carries
+ *  visible text. The top-anchor effect uses this to skip the metadata-
+ *  only commit (empty assistant bubble) and wait until the body chunk
+ *  has landed in the DOM. */
+function hasNonEmptyContent(content: MessageContent): boolean {
+  if (typeof content === 'string') return content.length > 0
+  if (!Array.isArray(content)) return false
+  return content.some((s) => s.type === 'text' && s.text.length > 0)
+}
+
+/** Async-growth watcher installed by the top-anchor effect for the 2s
+ *  settle window. Single owner is `anchorWatcherRef`; the helper below
+ *  is the only place that knows how to tear one down. */
+interface AnchorWatcher {
+  id: string
+  ro: ResizeObserver
+  timer: ReturnType<typeof setTimeout>
+}
+
+/** Idempotent tear-down for an `AnchorWatcher`. Used by both the
+ *  inline supersede path (new top-anchor turn arrives mid-window) and
+ *  the component-unmount cleanup. Caller owns the surrounding ref
+ *  null-out — the helper itself doesn't touch the ref. */
+function disposeAnchorWatcher(w: AnchorWatcher | null): void {
+  if (!w) return
+  w.ro.disconnect()
+  clearTimeout(w.timer)
+}
+
 const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
   (
     {
@@ -87,7 +118,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     // effect below owns first-paint positioning so re-opening a chat
     // with prior history lands at the bottom without a smooth-scroll
     // animation playing over the cold-paint.
-    const { scrollRef, contentRef, scrollToBottom } = useStickToBottom({
+    const { scrollRef, contentRef, scrollToBottom, stopScroll } = useStickToBottom({
       resize: 'smooth',
       initial: false,
     })
@@ -201,6 +232,111 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       }
     }, [messages, scrollRef])
 
+    // ---- Per-message scrollAnchor (server-driven) --------------------
+    // Server emits `scrollAnchor: 'top'` on the metadata leading frame
+    // for display-action answers; default tail behaviour is preserved
+    // for every other path that omits the field.
+    //
+    // Per-id memoized ref callbacks preserve callback identity across
+    // the token-streaming re-renders that React.memo lets through —
+    // a fresh closure each render would detach/reattach the ref on
+    // every commit and could race the useLayoutEffect's element lookup.
+    const messageElsRef = useRef<Map<string, HTMLElement>>(new Map())
+    const refCallbacksRef = useRef<Map<string, (el: HTMLElement | null) => void>>(new Map())
+
+    const getRegisterMessageEl = (id: string): (el: HTMLElement | null) => void => {
+      let cb = refCallbacksRef.current.get(id)
+      if (cb) return cb
+      cb = (el) => {
+        if (el) {
+          messageElsRef.current.set(id, el)
+        } else {
+          messageElsRef.current.delete(id)
+          refCallbacksRef.current.delete(id)
+        }
+      }
+      refCallbacksRef.current.set(id, cb)
+      return cb
+    }
+
+    // Lazy-init: seed ONLY messages whose content is populated. Persisted
+    // reload has full bodies → all ids seeded → no scroll-replay on cold
+    // paint. A fresh turn's empty assistant placeholder (appended by
+    // useChat before streaming) is intentionally excluded so the top-
+    // anchor effect can fire when its body lands.
+    const scrolledIdsRef = useRef<Set<string> | null>(null)
+    if (scrolledIdsRef.current === null) {
+      scrolledIdsRef.current = new Set(
+        messages.filter((m) => hasNonEmptyContent(m.content)).map((m) => m.id),
+      )
+    }
+
+    // Active async-growth watcher. Stored in a ref (NOT in the effect's
+    // cleanup) so subsequent `messages` mutations during the 2s settle
+    // window don't tear it down. Cleared only when a new top-anchor turn
+    // supersedes it, or on component unmount.
+    const anchorWatcherRef = useRef<AnchorWatcher | null>(null)
+
+    useLayoutEffect(() => {
+      if (!autoScroll) return
+      const last = messages[messages.length - 1]
+      if (!last || last.role !== 'assistant' || last.scrollAnchor !== SCROLL_ANCHOR.TOP) return
+      // Metadata frame arrives BEFORE body. Wait for content so we don't
+      // snap an empty bubble and burn the one-shot.
+      if (!hasNonEmptyContent(last.content)) return
+      const seen = scrolledIdsRef.current!
+      if (seen.has(last.id)) return
+      const node = messageElsRef.current.get(last.id)
+      const container = scrollRef.current
+      if (!node || !node.isConnected || !container) return
+      seen.add(last.id)
+      // `stopScroll` MUST precede scrollIntoView — the imperative scrollTop
+      // write is what the library's geometry tracker uses to flip
+      // `escapedFromLock`, so any in-flight scrollToBottom spring is
+      // first cancelled.
+      stopScroll()
+      // Instant (not smooth): the markdown body contains async <img>
+      // children whose loads race a 300ms smooth animation and leave
+      // the viewport mid-article. Instant snap dodges the race; the
+      // ResizeObserver below re-anchors any post-snap growth.
+      node.scrollIntoView({ block: 'start' })
+
+      // Tear down any prior watcher (rapid back-to-back display turns).
+      disposeAnchorWatcher(anchorWatcherRef.current)
+      // Re-anchor on async growth for ~2s. Bail if the user scrolls
+      // meaningfully past the baseline so we don't fight their reading
+      // position. NOTE: the watcher lives in a ref, not in the effect's
+      // cleanup, so subsequent `messages` mutations during streaming
+      // don't kill it.
+      const baselineScrollTop = container.scrollTop
+      const ro = new ResizeObserver(() => {
+        if (!node.isConnected) {
+          ro.disconnect()
+          return
+        }
+        if (container.scrollTop > baselineScrollTop + 200) {
+          ro.disconnect()
+          return
+        }
+        node.scrollIntoView({ block: 'start' })
+      })
+      ro.observe(node)
+      const timer = setTimeout(() => {
+        ro.disconnect()
+        // Guard against nulling a successor watcher mid-flight.
+        if (anchorWatcherRef.current?.id === last.id) {
+          anchorWatcherRef.current = null
+        }
+      }, 2000)
+      anchorWatcherRef.current = { id: last.id, ro, timer }
+    }, [messages, autoScroll, stopScroll, scrollRef])
+
+    // Component-unmount cleanup for the active watcher.
+    useEffect(() => () => {
+      disposeAnchorWatcher(anchorWatcherRef.current)
+      anchorWatcherRef.current = null
+    }, [])
+
     // ---- Load-more (infinite-scroll UP) ------------------------------
     // Distinct from stick-to-bottom; uses its own IntersectionObserver
     // on the top sentinel.
@@ -308,6 +444,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
             {messages.map((message, index) => (
               <ChatMessageEnhanced
                 key={message.id}
+                ref={getRegisterMessageEl(message.id)}
                 role={message.role}
                 name={message.name}
                 content={message.content}

--- a/openframe-frontend-core/src/components/chat/types/message.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/message.types.ts
@@ -29,6 +29,19 @@ export const MESSAGE_TYPE = {
 
 export type MessageType = typeof MESSAGE_TYPE[keyof typeof MESSAGE_TYPE]
 
+// ========== Scroll Anchor (per-message render hint) ==========
+
+/** Per-message viewport-positioning hint sent on the per-turn metadata
+ *  leading frame at the START of every assistant response. The chat
+ *  message-list reads it to override the default `use-stick-to-bottom`
+ *  tail behaviour for a single message. Field is OPTIONAL — when omitted
+ *  (or set to `'bottom'`) the chat tails as today. Only `'top'` opts in
+ *  to the alternative behaviour (used by display-action answers whose
+ *  body is a long article and should be read top-down). */
+export const SCROLL_ANCHOR = { TOP: 'top', BOTTOM: 'bottom' } as const
+
+export type ScrollAnchor = typeof SCROLL_ANCHOR[keyof typeof SCROLL_ANCHOR]
+
 // ========== Tool Execution Types ==========
 
 export interface ToolExecutionData {
@@ -313,4 +326,11 @@ export interface Message {
    *  user messages and legacy turns omit this field. The host's
    *  `renderEntityCard` callback resolves keys to inline components. */
   chatRefs?: Record<string, MessageChatRef>
+  /** Per-message viewport-positioning hint. OPTIONAL — when omitted (the
+   *  default for every LLM Q&A / browse / search / find / Discuss path)
+   *  the chat tails as today via `use-stick-to-bottom`. Only `'top'` opts
+   *  in to the alternative top-anchor behaviour (display-action answers
+   *  whose body is a long article). The server is the sole decision-
+   *  maker — set on the metadata leading frame. */
+  scrollAnchor?: ScrollAnchor
 }


### PR DESCRIPTION
## Summary

- Adds an optional `Message.scrollAnchor?: 'top' | 'bottom'` field + `SCROLL_ANCHOR` const enum to the chat message types
- `ChatMessageList` reads the field from the most recent message and, when `'top'`, snaps the message into view via `scrollIntoView({block:'start'})` plus a 2s ResizeObserver settle window to re-anchor against async growth (inline-card images, lazy markdown blocks)
- Default tail behaviour is preserved 1:1 for every existing path: non-display callers omit the field on the wire, and the new effect's guard chain short-circuits

## Why

The hub's display-action slash command (`/<cmd> display "<value>"`) returns a long markdown article. Without a per-message scroll hint, the user lands at the *bottom* of the article and has to scroll up to read it. Putting the decision on the server (a per-message field on the existing metadata leading frame) keeps the client a read-only consumer: no client-side branching on which command was typed.

## Design notes

- `scrollAnchor` is OPTIONAL at every layer. Wire bytes for LLM responses are byte-identical to today — they emit no `scrollAnchor`, and the client treats absent/undefined/`'bottom'` as default tail.
- `anchorWatcherRef` (ref outside the effect's cleanup) survives token-streaming `messages` mutations during the 2s settle window. The earlier draft tied the ResizeObserver to the effect's cleanup, which killed the window after one frame.
- Mount-seeded `scrolledIdsRef` is filtered by non-empty content so the in-flight assistant placeholder (appended by `useChat` before streaming) is NOT seeded — otherwise the effect would early-return when `scrollAnchor` eventually arrives.
- Helper `disposeAnchorWatcher` is the single tear-down site, called from both the inline supersede path (back-to-back display turns) and the component-unmount cleanup.
- Uses INSTANT `scrollIntoView` (no `behavior: 'smooth'`) — a 300ms smooth animation races async image loads and leaves the viewport mid-article when the snap finally lands.

## Test plan

- [x] Type-check clean (no new errors vs baseline)
- [x] Live: `/getting-started display "Connect Slack..."` → title at viewport top (`msgTopRelToScroller: 0`)
- [x] Live: `/getting-started display "Connect Your PSA..."` → title at viewport top
- [x] Live: `/getting-started display "Connect HubSpot..."` → title at viewport top
- [x] Live: regular question (`what is openframe?`) → tails (`distFromBottom: 1`)
- [ ] Verify rapid back-to-back display turns don't leak watchers (supersede path)
- [ ] Verify persisted-reload doesn't re-scroll old display messages on cold paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)