### PR TITLE
navigation-sidebar: close tablet overlay after navigation

### DIFF
--- a/openframe-frontend-core/src/components/navigation/navigation-sidebar.tsx
+++ b/openframe-frontend-core/src/components/navigation/navigation-sidebar.tsx
@@ -83,7 +83,9 @@ export function NavigationSidebar({ config, disabled = false }: NavigationSideba
     } else if (item.path) {
       config.onNavigate?.(item.path)
     }
-  }, [config])
+
+    if (isTablet) setTabletMinimized(true)
+  }, [config, isTablet])
 
   const { primaryItems, secondaryItems } = useMemo(() => ({
     primaryItems: config.items.filter(item => item.section !== 'secondary'),


### PR DESCRIPTION
## Summary
- On tablet viewports the sidebar opens as a floating overlay. Previously, after clicking a navigation item the overlay stayed open over the new page.
- After a nav item click (path navigation or custom `onClick`), the tablet overlay now auto-minimizes so the user lands on the destination unobstructed.
- Desktop and mobile behavior unchanged.

## Test plan
- [ ] On a tablet-width viewport (md but not lg): open the sidebar via the toggle, click a nav item — overlay closes and content is visible.
- [ ] Same flow for an item with a custom `onClick` (no `path`) — overlay still closes.
- [ ] Desktop (lg+): clicking a nav item does not collapse the sidebar.
- [ ] Mobile (<md): sidebar hidden as before, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)