### PR TITLE
feat(contexts): EndpointsRuntimeContext for embeddable lib usage

### DIFF
--- a/openframe-frontend-core/docs/EMBEDDING.md
+++ b/openframe-frontend-core/docs/EMBEDDING.md
@@ -1,0 +1,233 @@
+# Embedding `@flamingo-stack/openframe-frontend-core` in a non-Next.js React app
+
+This guide shows how to embed lib components (`<AnnouncementBar>`, contact form
+hook, access-code hook, chat panel) into a third-party React app — typically
+served behind a reverse proxy that rewrites `/api/<your-prefix>/*` to the
+hub's `/api/*`.
+
+The lib exposes runtime configuration through two React Contexts:
+
+- **`EndpointsRuntimeContext`** — API endpoint URLs (`AnnouncementBar`, contact
+  form, access codes).
+- **`ChatRuntimeContext`** — chat-panel endpoints + a `mode: 'host' | 'embed'`
+  discriminator that controls click behavior.
+
+The hub mounts a `<HubRuntimeProvider>` that supplies defaults for both;
+embedded apps mount their own provider(s) with overrides.
+
+---
+
+## 1. Install
+
+```bash
+npm install @flamingo-stack/openframe-frontend-core
+```
+
+Peer dependencies (install whichever your components touch): `react`,
+`react-dom`, `@tanstack/react-query`, `@radix-ui/react-use-controllable-state`.
+
+---
+
+## 2. Mount the runtime providers at your app's root
+
+Define a small wrapper that builds **memoized** runtime values and provides both contexts.
+Non-memoized values churn references on every render and cause downstream
+effect-dep churn.
+
+```tsx
+// src/runtime-providers.tsx
+import { useMemo, type ReactNode } from 'react'
+import {
+  EndpointsRuntimeContext,
+  type EndpointsRuntime,
+} from '@flamingo-stack/openframe-frontend-core/contexts'
+// ChatRuntimeContext is currently in the hub source tree; once the chat
+// panel migrates into oss-lib (see MIGRATING_COMPONENTS.md), the import
+// will resolve here. For now, the embedded app uses ONLY the endpoints
+// runtime unless you also vendor the chat panel.
+import {
+  ChatRuntimeContext,
+  type ChatRuntime,
+} from '@flamingo-stack/openframe-frontend-core/contexts' // <- when chat migrates
+
+const PROXY_PREFIX = '/api/mingo-guide' // your reverse-proxy prefix
+const CONTENT_HOST = 'https://hub.openframe.ai' // where chat links should resolve
+
+export function EmbeddedRuntimeProvider({ children }: { children: ReactNode }) {
+  const endpoints = useMemo<EndpointsRuntime>(() => ({
+    announcementsUrl: `${PROXY_PREFIX}/announcements/active`,
+    accessCode: {
+      validateUrl: `${PROXY_PREFIX}/validate-access-code`,
+      consumeUrl: `${PROXY_PREFIX}/consume-access-code`,
+    },
+    contactUrl: `${PROXY_PREFIX}/contact`,
+  }), [])
+
+  const chat = useMemo<ChatRuntime>(() => ({
+    endpoints: {
+      chatStreamUrl: `${PROXY_PREFIX}/docs/chat`,
+      approvalToolUrl: `${PROXY_PREFIX}/chat/agent/confirm-tool`,
+      commandsUrl: `${PROXY_PREFIX}/docs/commands`,
+      buildListUrl: (type, ids) => `${PROXY_PREFIX}/${type}?ids=${ids.join(',')}`,
+    },
+    navigation: {
+      mode: 'embed',                          // forces new-tab + absolute URLs on every chat click
+      defaultContentOrigin: CONTENT_HOST,     // used when target platform can't be inferred
+      // Optional analytics hook. MUST be synchronous (popup-blocker).
+      openExternal: (href) => {
+        navigator.sendBeacon('/analytics/click', JSON.stringify({ href, t: Date.now() }))
+        window.open(href, '_blank', 'noopener,noreferrer')
+      },
+    },
+  }), [])
+
+  return (
+    <ChatRuntimeContext.Provider value={chat}>
+      <EndpointsRuntimeContext.Provider value={endpoints}>
+        {children}
+      </EndpointsRuntimeContext.Provider>
+    </ChatRuntimeContext.Provider>
+  )
+}
+```
+
+Wrap your tree at the root:
+
+```tsx
+// src/main.tsx
+import { EmbeddedRuntimeProvider } from './runtime-providers'
+
+createRoot(document.getElementById('root')!).render(
+  <EmbeddedRuntimeProvider>
+    <App />
+  </EmbeddedRuntimeProvider>
+)
+```
+
+---
+
+## 3. Use the features
+
+### Announcement bar
+
+```tsx
+import { AnnouncementBar } from '@flamingo-stack/openframe-frontend-core/components'
+
+<AnnouncementBar />
+```
+
+Polls `endpoints.announcementsUrl` every 5 minutes. When the URL is undefined
+(no provider mounted), the bar still renders any cached announcement but
+skips the fetch and the polling timer entirely.
+
+### Contact form submission
+
+```tsx
+import { useContactSubmission } from '@flamingo-stack/openframe-frontend-core/hooks'
+
+function ContactForm() {
+  const { submit, isSubmitting, isSuccess } = useContactSubmission({
+    successRedirectUrl: '/thank-you',
+    successToastMessage: 'We will be in touch.',
+  })
+  // submit(formData) — POSTs to endpoints.contactUrl
+}
+```
+
+Throws if no provider is mounted — wrap in `<EmbeddedRuntimeProvider>` (or your
+own `<EndpointsRuntimeContext.Provider>`).
+
+### Access code validation
+
+```tsx
+import { useAccessCodeIntegration } from '@flamingo-stack/openframe-frontend-core/hooks'
+
+function RegisterForm() {
+  const { validate, consume, validateAndConsume, isProcessing } = useAccessCodeIntegration()
+  // validate(email, code) — POST endpoints.accessCode.validateUrl
+  // consume(email, code) — POST endpoints.accessCode.consumeUrl
+}
+```
+
+For non-React callers (e.g. server scripts, edge functions), the pure helpers
+under `@flamingo-stack/openframe-frontend-core/utils` accept the endpoints
+explicitly:
+
+```ts
+import {
+  validateAccessCode,
+  type AccessCodeEndpoints,
+} from '@flamingo-stack/openframe-frontend-core/utils'
+
+const endpoints: AccessCodeEndpoints = {
+  validateUrl: '/api/mingo-guide/validate-access-code',
+  consumeUrl: '/api/mingo-guide/consume-access-code',
+}
+await validateAccessCode(email, code, endpoints)
+```
+
+### Chat panel (when migrated)
+
+The chat panel currently lives in the hub source tree (`components/shared/global-ask-ai.tsx`)
+and migrates into oss-lib in a follow-up. When it lands, usage is:
+
+```tsx
+import { useState } from 'react'
+import { GlobalAskAI } from '@flamingo-stack/openframe-frontend-core/components/chat'
+
+function Shell() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button onClick={() => setOpen(true)}>Open chat</button>
+      <GlobalAskAI
+        open={open}
+        onOpenChange={setOpen}
+        showInternalTrigger={false}   // hide the hub's built-in floating button
+      />
+    </>
+  )
+}
+```
+
+Every link click inside the chat opens in a new tab against the absolute
+content host (`navigation.defaultContentOrigin` or per-platform resolution).
+
+---
+
+## 4. Verification checklist
+
+Open devtools, then:
+
+| Action | Expected |
+|---|---|
+| App boot | Network requests go to `<PROXY_PREFIX>/*` — never directly to `hub.openframe.ai` |
+| Send chat message | `POST <PROXY_PREFIX>/docs/chat` (streaming) |
+| Type `/` in chat input | `GET <PROXY_PREFIX>/docs/commands` |
+| Click source chip in chat | New tab opens at absolute `https://hub.openframe.ai/...` (or other source platform) |
+| `localStorage.setItem('nav-trace','true')` + click chip | Console: `reason=override:embed-mode` |
+| Approval card → approve | `POST <PROXY_PREFIX>/chat/agent/confirm-tool` |
+| Announcement bar visible | `GET <PROXY_PREFIX>/announcements/active` every 5 min |
+| Submit contact form | `POST <PROXY_PREFIX>/contact` |
+
+---
+
+## 5. Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `createContext is not a function` during SSR | An oss-lib `utils/` export pulled `contexts/` transitively | Never re-export `hooks/` or `contexts/` from `utils/index.ts` — see [contexts/index.ts JSDoc](../src/contexts/index.ts) |
+| `[chat-runtime] hook called outside <ChatRuntimeContext.Provider>` | Chat component rendered above the provider | Lift `<EmbeddedRuntimeProvider>` higher |
+| Click opens against embedder origin (wrong host) | Source URL was relative and platform couldn't be inferred AND `defaultContentOrigin` is unset | Set `navigation.defaultContentOrigin` in embed mode |
+| Safari blocks the new-tab open | `openExternal` did async work before `window.open` | Make `openExternal` synchronous — use `sendBeacon` for fire-and-forget analytics |
+| Chat re-fetches every render | Runtime value rebuilt inline | Wrap the runtime value(s) in `useMemo(() => ({...}), [])` |
+| Mid-session provider value swap remounts chat | Branch-based mount (not the lib's outer-forward pattern) | Mount the provider unconditionally at root; only its `value` should change |
+
+---
+
+## Reference
+
+- [`endpoints-runtime-context.tsx`](../src/contexts/endpoints-runtime-context.tsx) — full type definitions for `EndpointsRuntime`.
+- [`access-code-client.ts`](../src/utils/access-code-client.ts) — pure helpers + `AccessCodeEndpoints` type.
+- [`use-access-code-integration.ts`](../src/hooks/use-access-code-integration.ts) — runtime-binding React hook.
+- [`announcement-bar.tsx`](../src/components/announcement-bar.tsx) — the consumer that demonstrates the optional-runtime + cached-paint pattern.

--- a/openframe-frontend-core/docs/MIGRATING_COMPONENTS.md
+++ b/openframe-frontend-core/docs/MIGRATING_COMPONENTS.md
@@ -1,0 +1,267 @@
+# Migrating components from the hub into `openframe-frontend-core`
+
+This guide walks through moving a component (and its hook/util dependencies)
+from `multi-platform-hub` into the shared oss-lib. The working example is
+**blog-posts** — moving the blog detail card + list view + the data-fetch
+hook + any utility helpers.
+
+The pattern generalizes; the checklist at the end applies to any component.
+
+---
+
+## Mental model: three layers, two bundles
+
+Every file in this lib lives in one of three layers:
+
+| Layer | Folder | tsup bundle | `'use client'` | What goes here |
+|---|---|---|---|---|
+| **Server-safe utils** | `src/utils/` | server bundle (treeshake on) | No | Pure functions, types, constants. **No React imports, no `createContext()`, no `useContext()`** |
+| **Client hooks** | `src/hooks/` | client bundle (`"use client"` banner) | Implicit | React hooks. Free to read context, call `useState`/`useEffect` |
+| **Client components** | `src/components/...` | client bundle (`"use client"` banner) | Implicit | React components |
+
+**The cardinal rule:** anything that calls `createContext()` at module top
+level OR uses `useContext()` lives in the client bundle. If `utils/index.ts`
+re-exports a file that pulls a context, every server-rendered page that
+imports anything from `utils/` will crash on SSR with
+`createContext is not a function`. This is the trap fixed in the
+`use-access-code-integration` extraction — see
+[`src/contexts/index.ts`](../src/contexts/index.ts) for the convention.
+
+---
+
+## Worked example: migrating blog posts
+
+Assume the hub has:
+
+```
+multi-platform-hub/
+├── components/shared/blog-card.tsx          # <BlogCard>
+├── components/shared/blog-list.tsx          # <BlogList>
+├── hooks/use-blog-posts.ts                  # data-fetch hook (calls /api/blog/posts)
+├── lib/utils/blog-card-props.ts             # pure prop-mapping helper
+└── lib/data/blog-utils.ts                   # SERVER-ONLY (uses Supabase) → STAYS in hub
+```
+
+We want `<BlogCard>` / `<BlogList>` / `useBlogPosts` in oss-lib.
+`lib/data/blog-utils.ts` stays in the hub because it imports the Supabase
+admin client.
+
+### Step 1 — audit what crosses the boundary
+
+```bash
+# What does each file import?
+grep -rn "^import" components/shared/blog-card.tsx hooks/use-blog-posts.ts \
+  lib/utils/blog-card-props.ts
+```
+
+Sort imports into three buckets:
+
+1. **Already in oss-lib** — `@flamingo-stack/openframe-frontend-core/...` — fine
+2. **Pure helpers in hub** — small utilities, types — **migrate alongside** the component
+3. **Hub-only services** — auth, Supabase admin, route handlers — **must NOT move**
+
+If you see a hub-only service in the chain (e.g. `@/lib/supabase-server`), the
+component depends on the hub and can't migrate as-is. Either:
+- The component talks to an API endpoint instead (good) — that endpoint becomes
+  part of `EndpointsRuntime` (see step 4).
+- Refactor first to remove the hub coupling, then migrate.
+
+### Step 2 — pick the new home in oss-lib
+
+| Hub file | New oss-lib location |
+|---|---|
+| `components/shared/blog-card.tsx` | `src/components/blog/blog-card.tsx` |
+| `components/shared/blog-list.tsx` | `src/components/blog/blog-list.tsx` |
+| `hooks/use-blog-posts.ts` | `src/hooks/use-blog-posts.ts` |
+| `lib/utils/blog-card-props.ts` | `src/utils/blog-card-props.ts` (server-safe — no React imports) |
+
+If `blog-card-props.ts` does NOT call `useContext()` or `createContext()`, put
+it in `utils/`. If it does (a hook-shaped helper), put it in `hooks/`.
+
+### Step 3 — copy + adjust imports
+
+Move the files. Inside each, rewrite imports:
+
+```ts
+// Before (hub):
+import { Card } from '@flamingo-stack/openframe-frontend-core/components/ui'
+import { formatDate } from '@/lib/utils/format-date'
+import type { BlogPost } from '@/types/blog'
+
+// After (in oss-lib):
+import { Card } from '../ui/card'                  // local
+import { formatDate } from '../../utils/format-date'
+import type { BlogPost } from '../../types/blog'
+```
+
+Use **relative paths inside oss-lib** — don't import from
+`@flamingo-stack/openframe-frontend-core/...` within the lib itself (creates a
+self-reference and breaks tsup splitting).
+
+### Step 4 — extract any hardcoded API paths into `EndpointsRuntime`
+
+If `useBlogPosts` calls `fetch('/api/blog/posts')`, extend `EndpointsRuntime`:
+
+```ts
+// src/contexts/endpoints-runtime-context.tsx
+export interface EndpointsRuntime {
+  announcementsUrl: string
+  accessCode: { ... }
+  contactUrl: string
+  blog: {
+    listUrl: string  // GET /api/blog/posts
+    detailUrl: (slug: string) => string  // GET /api/blog/posts/[slug]
+  }
+}
+```
+
+Then in the hub default ([`hub-runtime-provider.tsx`](../../multi-platform-hub/components/providers/hub-runtime-provider.tsx)):
+
+```tsx
+const endpointsValue = useOuterOrDefault<EndpointsRuntime>(EndpointsRuntimeContext, () => ({
+  // ...existing...
+  blog: {
+    listUrl: '/api/blog/posts',
+    detailUrl: (slug) => `/api/blog/posts/${slug}`,
+  },
+}))
+```
+
+And in `useBlogPosts`:
+
+```ts
+import { useRequiredEndpointsRuntime } from '../contexts/endpoints-runtime-context'
+
+export function useBlogPosts() {
+  const { blog } = useRequiredEndpointsRuntime()
+  // useQuery(['blog'], () => fetch(blog.listUrl).then(r => r.json()))
+}
+```
+
+### Step 5 — barrel exports
+
+Add the new files to the right barrel(s):
+
+```ts
+// src/components/index.ts
+export * from './blog/blog-card'
+export * from './blog/blog-list'
+
+// src/hooks/index.ts
+export * from './use-blog-posts'
+
+// src/utils/index.ts (only if blog-card-props.ts is server-safe)
+export * from './blog-card-props'
+```
+
+### Step 6 — tsup config: do you need a new subpath export?
+
+For most components, the existing `./components` / `./hooks` / `./utils`
+subpath exports are enough — you only need a new entry if you want
+consumers to import via a finer-grained path like
+`@flamingo-stack/openframe-frontend-core/components/blog`.
+
+If you DO want a finer path:
+
+```ts
+// tsup.config.ts (in the client entries block — anything with React belongs here)
+entry: {
+  // ...existing...
+  'components/blog/index': 'src/components/blog/index.ts',
+}
+```
+
+And in `package.json`:
+
+```json
+{
+  "exports": {
+    "./components/blog": {
+      "types": "./dist/components/blog/index.d.ts",
+      "import": "./dist/components/blog/index.js",
+      "require": "./dist/components/blog/index.cjs",
+      "default": "./dist/components/blog/index.js"
+    }
+  }
+}
+```
+
+Don't forget the matching `src/components/blog/index.ts` barrel.
+
+### Step 7 — update the hub to import from oss-lib
+
+Replace local imports with lib imports:
+
+```tsx
+// Before:
+import { BlogCard } from '@/components/shared/blog-card'
+
+// After:
+import { BlogCard } from '@flamingo-stack/openframe-frontend-core/components'
+// or with finer-grained subpath:
+import { BlogCard } from '@flamingo-stack/openframe-frontend-core/components/blog'
+```
+
+Then delete the now-unused hub files.
+
+### Step 8 — build + verify
+
+```bash
+# In oss-lib:
+npm run build         # full tsup build
+yalc push             # ship to local consumers
+
+# In hub:
+npx tsc --noEmit      # type-check
+npm run build         # production build
+```
+
+Smoke-test in the dev server (`npm run dev:openframe` etc.) — confirm the
+blog page still loads, still fetches via the runtime URL, still styled
+correctly with ODS tokens.
+
+---
+
+## Checklist (any component)
+
+- [ ] Audit imports — no hub-only services in the call graph (Supabase admin,
+      route handlers, hub auth helpers).
+- [ ] Pick the right oss-lib home: `utils/` (server-safe), `hooks/` (React, may
+      use context), or `components/...` (React UI).
+- [ ] Move files; rewrite imports to relative paths.
+- [ ] If the component fetches: extract endpoint paths into `EndpointsRuntime`
+      (or add a new runtime context if it's a new concern); read via
+      `useRequiredEndpointsRuntime()` (throws) or `useEndpointsRuntime()`
+      (null fallback for optional consumers).
+- [ ] Add hub defaults in
+      [`hub-runtime-provider.tsx`](../../multi-platform-hub/components/providers/hub-runtime-provider.tsx).
+- [ ] Update barrel(s): `components/index.ts`, `hooks/index.ts`, `utils/index.ts`.
+- [ ] (Optional) New subpath export — `tsup.config.ts` entry + `package.json`
+      `exports` block.
+- [ ] Switch hub call sites to lib imports; delete the hub copies.
+- [ ] `npm run build` in oss-lib, then `yalc push`.
+- [ ] `npx tsc --noEmit` + `npm run build` in hub.
+- [ ] Manual smoke test in dev for the touched feature.
+- [ ] Smoke-test on a non-chat page too (to ensure no SSR `createContext`
+      regression from a stray `utils/` import that now pulls a context
+      transitively).
+
+---
+
+## Anti-patterns to avoid
+
+- **Re-exporting a hook or context module from `utils/index.ts`.** Even
+  one accidental `export * from './my-hook'` in the server bundle blows up
+  SSR. The fix is the bundle-split convention documented in
+  [`src/contexts/index.ts`](../src/contexts/index.ts).
+- **Importing from `@flamingo-stack/openframe-frontend-core/...` inside the lib
+  itself.** Use relative paths. The package alias is for consumers.
+- **Building the runtime value inline at the provider site.** Memoize
+  with `useMemo(() => ({...}), [])` so consumer effect-dep arrays stay
+  stable across embedder re-renders.
+- **Hub-aliased imports (`@/...`) in lib files.** Lib files import only
+  from `react`, `react-dom`, other peer deps, and relative paths. Any
+  `@/` import is a port-the-file-into-the-lib smell, not a real dep.
+- **`'use client'` directive at the top of an individual file.** tsup
+  injects the banner per-bundle (client entries only). Per-file
+  directives get stripped during bundling. Trust the config.

--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -18,6 +18,12 @@
       "require": "./dist/index.cjs",
       "default": "./dist/index.js"
     },
+    "./contexts": {
+      "types": "./dist/contexts/index.d.ts",
+      "import": "./dist/contexts/index.js",
+      "require": "./dist/contexts/index.cjs",
+      "default": "./dist/contexts/index.js"
+    },
     "./components": {
       "types": "./dist/components/index.d.ts",
       "import": "./dist/components/index.js",

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -12,6 +12,7 @@ import {
 } from '../utils/announcement-storage';
 import { Announcement } from '../types/announcement';
 import { getAppType } from '../utils/app-config';
+import { useEndpointsRuntime } from '../contexts/endpoints-runtime-context';
 
 // Helper that defers to renderSvgIcon so we don't need local icon imports
 const getSvgIcon = (
@@ -33,6 +34,15 @@ export function AnnouncementBar() {
   // Get the platform type for platform-specific localStorage keys
   const platform = getAppType();
 
+  // Optional endpoint runtime: when no provider is mounted (e.g. on a
+  // bare React-tree page that doesn't wrap with HubRuntimeProvider),
+  // the bar silently skips its fetch instead of throwing. Apps that DO
+  // mount the provider get the configured URL — typically
+  // '/api/announcements/active' in the hub, or a proxied path in an
+  // embedded host.
+  const endpoints = useEndpointsRuntime();
+  const announcementsUrl = endpoints?.announcementsUrl;
+
   // Helper to determine dismissal key for localStorage
   const getDismissKey = (id: string) => `${platform}-announcement-${id}-dismissed`;
   
@@ -41,9 +51,12 @@ export function AnnouncementBar() {
 
   // Fetch active announcement from API and update state + LS
   const fetchActiveAnnouncement = async () => {
+    // No provider mounted → no URL configured → skip fetch silently.
+    // Cached announcement from previous sessions still renders if present.
+    if (!announcementsUrl) return;
     try {
       // Server-side platform injection - no URL parameter needed
-      const response = await fetch(`/api/announcements/active`);
+      const response = await fetch(announcementsUrl);
       
       if (response.ok) {
         const data = await response.json();
@@ -92,13 +105,22 @@ export function AnnouncementBar() {
       setIsVisible(!isDismissed);
     }
 
+    // No provider mounted → no URL → no fetch / no polling. Cached
+    // announcement still painted above. Skip scheduling the 5-min
+    // interval entirely to avoid an idle timer + repeated short-circuit
+    // calls.
+    if (!announcementsUrl) return;
+
     // Always fetch latest on mount
     fetchActiveAnnouncement();
 
-    // Schedule refresh every 5 minutes
+    // Schedule refresh every 5 minutes. When announcementsUrl flips
+    // (e.g. provider value swap), the effect re-runs and restarts the
+    // interval against the new URL — no stale captured fetch.
     const interval = setInterval(fetchActiveAnnouncement, 300_000);
     return () => clearInterval(interval);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [announcementsUrl]);
 
   // helpers
   const handleDismiss = () => {

--- a/openframe-frontend-core/src/contexts/endpoints-runtime-context.tsx
+++ b/openframe-frontend-core/src/contexts/endpoints-runtime-context.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+/**
+ * Endpoints runtime — sibling of ChatRuntime. Carries the API path
+ * literals consumed by oss-lib components/hooks/utils so a host
+ * application can override them (e.g. when running behind a reverse
+ * proxy as `user1.openframe.ai` → `/api/mingo-guide/*`).
+ *
+ * The hub mounts `<HubRuntimeProvider>` at root with the
+ * canonical hub paths; an embedded app mounts its own provider with
+ * remapped paths. The pattern mirrors ChatRuntimeContext exactly:
+ *
+ *   - `useEndpointsRuntime()` returns null when no provider is mounted.
+ *     For optional consumers that should gracefully no-op without one.
+ *   - `useRequiredEndpointsRuntime()` throws on missing provider — for
+ *     hooks/components that cannot function without endpoints.
+ *
+ * IMPORTANT for embedders: memoize the value passed to
+ * `<EndpointsRuntimeContext.Provider value={...}>` (e.g. React.useMemo).
+ * Reference changes invalidate downstream effect dependency arrays and
+ * trigger unnecessary re-fetches.
+ */
+
+import { createContext, useContext } from 'react'
+
+export interface EndpointsRuntime {
+  /** GET active announcement (used by `<AnnouncementBar>` polling). */
+  announcementsUrl: string
+  accessCode: {
+    /** POST validate access code. */
+    validateUrl: string
+    /** POST consume / redeem access code after registration. */
+    consumeUrl: string
+  }
+  /** POST contact-form submission. */
+  contactUrl: string
+}
+
+export const EndpointsRuntimeContext = createContext<EndpointsRuntime | null>(null)
+
+/**
+ * Optional read — returns null when no provider is mounted. Use for
+ * surfaces that should silently skip the fetch (e.g. announcement
+ * polling on a page rendered outside the provider tree).
+ */
+export function useEndpointsRuntime(): EndpointsRuntime | null {
+  return useContext(EndpointsRuntimeContext)
+}
+
+/**
+ * Strict variant — throws on missing provider. Use for consumers that
+ * cannot function without an endpoint (form submission, code
+ * validation). In tests/Storybook, wrap with the hub's
+ * `<HubRuntimeProvider>` or a stub
+ * `<EndpointsRuntimeContext.Provider value={mockedEndpoints}>`.
+ */
+export function useRequiredEndpointsRuntime(): EndpointsRuntime {
+  const v = useContext(EndpointsRuntimeContext)
+  if (!v) {
+    throw new Error(
+      '[endpoints-runtime] hook called outside an <EndpointsRuntimeContext.Provider>. ' +
+        'Hub: mount <HubRuntimeProvider> in your providers tree. ' +
+        'Embedded app: mount your own provider with proxied URLs at the tree root. ' +
+        'Tests/Storybook: wrap render() in <EndpointsRuntimeContext.Provider value={mocked}>.',
+    )
+  }
+  return v
+}

--- a/openframe-frontend-core/src/contexts/index.ts
+++ b/openframe-frontend-core/src/contexts/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Runtime contexts for embeddable oss-lib components.
+ *
+ * BUNDLE-SPLIT CONVENTION — read before adding new files here:
+ *   Every module in `src/contexts/` calls `createContext()` at module
+ *   top level. The tsup config builds this directory under the CLIENT
+ *   bundle (with `"use client"` banner). Importing anything from here
+ *   into a SERVER-bundled module (`utils/index.ts` and its `export *`
+ *   transitive closure) crashes SSR with
+ *   `createContext is not a function`.
+ *
+ *   Rule of thumb when adding a runtime-aware helper:
+ *     - Pure functions that take endpoints/runtime as args → `utils/`.
+ *     - React hooks that READ the runtime via useContext → `hooks/`
+ *       (with `'use client'` at the top of the file).
+ *     - Never re-export from `utils/*` anything that pulls
+ *       `src/contexts/*` transitively.
+ *
+ *   The split between `utils/access-code-client.ts` (pure) and
+ *   `hooks/use-access-code-integration.ts` (runtime-aware) is the
+ *   reference example.
+ */
+
+export {
+  EndpointsRuntimeContext,
+  useEndpointsRuntime,
+  useRequiredEndpointsRuntime,
+  type EndpointsRuntime,
+} from './endpoints-runtime-context'

--- a/openframe-frontend-core/src/hooks/index.ts
+++ b/openframe-frontend-core/src/hooks/index.ts
@@ -18,3 +18,9 @@ export * from './nats/use-nats-client'
 
 // Viewport / lazy-mount primitive (shared IO singleton)
 export * from './use-near-viewport'
+
+// Access code integration — pairs with the standalone helpers in
+// `utils/access-code-client`. Lives in `hooks/` so the createContext
+// pulled in via EndpointsRuntimeContext doesn't end up in the
+// server-safe utils bundle.
+export * from './use-access-code-integration'

--- a/openframe-frontend-core/src/hooks/use-access-code-integration.ts
+++ b/openframe-frontend-core/src/hooks/use-access-code-integration.ts
@@ -1,0 +1,107 @@
+'use client'
+
+/**
+ * Access Code Integration Hook
+ *
+ * React-side wrapper around the pure `access-code-client` utilities.
+ * Lives in `hooks/` (client bundle) so the `createContext()` call in
+ * `endpoints-runtime-context` doesn't get pulled into the server-safe
+ * `utils/index` bundle.
+ *
+ * The pure standalone functions (`validateAccessCode`,
+ * `consumeAccessCode`, `validateAndConsumeAccessCode`) remain importable
+ * from `@flamingo-stack/openframe-frontend-core/utils` — they take the
+ * endpoints object as an argument. This hook binds those endpoints from
+ * `EndpointsRuntimeContext` so React callers don't have to plumb URLs.
+ */
+
+import React from 'react'
+
+import { useRequiredEndpointsRuntime } from '../contexts/endpoints-runtime-context'
+import {
+  validateAccessCode,
+  consumeAccessCode,
+  validateAndConsumeAccessCode,
+} from '../utils/access-code-client'
+
+/**
+ * Resolves access-code endpoints from `EndpointsRuntimeContext` (throws
+ * if no provider is mounted) and exposes loading-state-aware wrappers
+ * around the standalone helpers in `utils/access-code-client`.
+ *
+ * @returns the following fields. The `validate` / `consume` /
+ *   `validateAndConsume` functions and the returned object identity are
+ *   NOT memoized — they're re-created each render. Wrap with
+ *   `useCallback` / `useMemo` at the call site if downstream effect
+ *   dep arrays depend on stable identities.
+ *   - `validate(email, code)`: validates only.
+ *   - `consume(email, code)`: consumes only.
+ *   - `validateAndConsume(email, code)`: one-step validate-then-consume.
+ *   - `isValidating: boolean`: a validate call is in flight.
+ *   - `isConsuming: boolean`: a consume call is in flight.
+ *   - `isProcessing: boolean`: convenience — `isValidating || isConsuming`.
+ *     Use this for a single "in-flight" indicator on UI affordances that
+ *     should disable during both phases.
+ *
+ * @example
+ * const { validate, consume, isProcessing } = useAccessCodeIntegration();
+ *
+ * const handleRegistration = async (formData) => {
+ *   const validation = await validate(formData.email, formData.accessCode);
+ *   if (!validation.valid) {
+ *     setError(validation.message);
+ *     return;
+ *   }
+ *
+ *   // Process registration...
+ *   const registrationResult = await registerUser(formData);
+ *
+ *   if (registrationResult.success) {
+ *     await consume(formData.email, formData.accessCode);
+ *   }
+ * };
+ */
+export function useAccessCodeIntegration() {
+  const runtime = useRequiredEndpointsRuntime()
+  const endpoints = runtime.accessCode
+  const [isValidating, setIsValidating] = React.useState(false)
+  const [isConsuming, setIsConsuming] = React.useState(false)
+
+  const validate = async (email: string, code: string) => {
+    setIsValidating(true)
+    try {
+      return await validateAccessCode(email, code, endpoints)
+    } finally {
+      setIsValidating(false)
+    }
+  }
+
+  const consume = async (email: string, code: string) => {
+    setIsConsuming(true)
+    try {
+      return await consumeAccessCode(email, code, endpoints)
+    } finally {
+      setIsConsuming(false)
+    }
+  }
+
+  const validateAndConsume = async (email: string, code: string) => {
+    setIsValidating(true)
+    setIsConsuming(true)
+    try {
+      return await validateAndConsumeAccessCode(email, code, endpoints)
+    } finally {
+      setIsValidating(false)
+      setIsConsuming(false)
+    }
+  }
+
+  return {
+    validate,
+    consume,
+    validateAndConsume,
+    isValidating,
+    isConsuming,
+    isProcessing: isValidating || isConsuming,
+  }
+}

--- a/openframe-frontend-core/src/hooks/use-contact-submission.ts
+++ b/openframe-frontend-core/src/hooks/use-contact-submission.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useToast } from "./use-toast";
 import { useRouter } from 'next/navigation';
+import { useRequiredEndpointsRuntime } from '../contexts/endpoints-runtime-context';
 
 interface ContactSubmissionOptions {
   userId?: string;
@@ -44,6 +45,9 @@ export function useContactSubmission(options: ContactSubmissionOptions = {}) {
   const { userId, successRedirectUrl, successToastMessage, onSuccess } = options;
   const { toast } = useToast();
   const router = useRouter();
+  // Endpoint URL injected via context — hub provides hub default, embedded
+  // app provides its proxied path. Throws if no provider is mounted.
+  const { contactUrl } = useRequiredEndpointsRuntime();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSuccess, setIsSuccess] = useState(false);
 
@@ -53,7 +57,7 @@ export function useContactSubmission(options: ContactSubmissionOptions = {}) {
     setIsSubmitting(true);
 
     try {
-      const response = await fetch('/api/contact', {
+      const response = await fetch(contactUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ 
@@ -90,7 +94,7 @@ export function useContactSubmission(options: ContactSubmissionOptions = {}) {
     } finally {
       setIsSubmitting(false);
     }
-  }, [isSubmitting, toast, userId, successToastMessage]);
+  }, [isSubmitting, toast, userId, successToastMessage, contactUrl]);
 
   // Handle redirect after success
   useEffect(() => {

--- a/openframe-frontend-core/src/utils/access-code-client.ts
+++ b/openframe-frontend-core/src/utils/access-code-client.ts
@@ -1,16 +1,31 @@
 /**
- * Access Code Client Utilities
+ * Access Code Client Utilities — pure standalone functions.
  *
- * Simple client-side utilities for integrating access code validation
- * and consumption into registration forms.
+ * Endpoint paths are NOT hardcoded — every function takes an
+ * `endpoints` argument. The React-side wrapper that binds them from
+ * `EndpointsRuntimeContext` lives separately at
+ * `hooks/use-access-code-integration.ts` (`useAccessCodeIntegration`).
+ *
+ * Keep this file **free of React imports** — it lives in the
+ * server-safe `utils/index` tsup bundle. Any module-top-level call
+ * into `createContext()` (which the runtime context file does) would
+ * be pulled into the server bundle and crash SSR with
+ * `createContext is not a function`.
  */
 
-import React from 'react';
 import {
   AccessCodeValidation,
   AccessCodeValidationResponse,
   AccessCodeConsumptionResponse
 } from '../types/access-code-cohorts';
+
+/** Endpoints required by the standalone client utilities. The
+ *  `useAccessCodeIntegration` hook (in `hooks/`) resolves these from
+ *  `EndpointsRuntimeContext.accessCode` automatically. */
+export interface AccessCodeEndpoints {
+  validateUrl: string
+  consumeUrl: string
+}
 
 /**
  * Validate an access code for a given email
@@ -31,10 +46,11 @@ import {
  */
 export async function validateAccessCode(
   email: string,
-  code: string
+  code: string,
+  endpoints: AccessCodeEndpoints,
 ): Promise<AccessCodeValidationResponse> {
   try {
-    const response = await fetch('/api/validate-access-code', {
+    const response = await fetch(endpoints.validateUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -77,10 +93,11 @@ export async function validateAccessCode(
  */
 export async function consumeAccessCode(
   email: string,
-  code: string
+  code: string,
+  endpoints: AccessCodeEndpoints,
 ): Promise<AccessCodeConsumptionResponse> {
   try {
-    const response = await fetch('/api/consume-access-code', {
+    const response = await fetch(endpoints.consumeUrl, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -125,17 +142,18 @@ export async function consumeAccessCode(
  */
 export async function validateAndConsumeAccessCode(
   email: string,
-  code: string
+  code: string,
+  endpoints: AccessCodeEndpoints,
 ): Promise<AccessCodeValidationResponse & { consumed?: boolean }> {
   // First validate
-  const validation = await validateAccessCode(email, code);
+  const validation = await validateAccessCode(email, code, endpoints);
 
   if (!validation.valid) {
     return validation;
   }
 
   // If valid, consume the code
-  const consumption = await consumeAccessCode(email, code);
+  const consumption = await consumeAccessCode(email, code, endpoints);
 
   return {
     ...validation,
@@ -146,67 +164,6 @@ export async function validateAndConsumeAccessCode(
   };
 }
 
-/**
- * Access Code Integration Hook (for React components)
- *
- * @example
- * const { validate, consume, isValidating, isConsuming } = useAccessCodeIntegration();
- *
- * const handleRegistration = async (formData) => {
- *   const validation = await validate(formData.email, formData.accessCode);
- *   if (!validation.valid) {
- *     setError(validation.message);
- *     return;
- *   }
- *
- *   // Process registration...
- *   const registrationResult = await registerUser(formData);
- *
- *   if (registrationResult.success) {
- *     await consume(formData.email, formData.accessCode);
- *   }
- * };
- */
-export function useAccessCodeIntegration() {
-  const [isValidating, setIsValidating] = React.useState(false);
-  const [isConsuming, setIsConsuming] = React.useState(false);
-
-  const validate = async (email: string, code: string) => {
-    setIsValidating(true);
-    try {
-      return await validateAccessCode(email, code);
-    } finally {
-      setIsValidating(false);
-    }
-  };
-
-  const consume = async (email: string, code: string) => {
-    setIsConsuming(true);
-    try {
-      return await consumeAccessCode(email, code);
-    } finally {
-      setIsConsuming(false);
-    }
-  };
-
-  const validateAndConsume = async (email: string, code: string) => {
-    setIsValidating(true);
-    setIsConsuming(true);
-    try {
-      return await validateAndConsumeAccessCode(email, code);
-    } finally {
-      setIsValidating(false);
-      setIsConsuming(false);
-    }
-  };
-
-  return {
-    validate,
-    consume,
-    validateAndConsume,
-    isValidating,
-    isConsuming,
-    isProcessing: isValidating || isConsuming,
-  };
-}
-
+// `useAccessCodeIntegration` (the React-side wrapper) lives in
+// `hooks/use-access-code-integration.ts`. It binds the endpoints from
+// `EndpointsRuntimeContext` so React callers don't have to plumb URLs.

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -56,6 +56,7 @@ export default defineConfig([
       'components/icons-v2-generated/index': 'src/components/icons-v2-generated/index.ts',
       'components/navigation/index': 'src/components/navigation/index.ts',
       'hooks/index': 'src/hooks/index.ts',
+      'contexts/index': 'src/contexts/index.ts',
     },
     format: ['esm', 'cjs'],
     dts: false,


### PR DESCRIPTION
## Summary

- Adds `EndpointsRuntimeContext` so host applications inject API URLs at the provider level. `<AnnouncementBar>`, `useContactSubmission`, and `useAccessCodeIntegration` now read endpoints from the runtime instead of hardcoding hub paths — required for embedding the lib behind a reverse proxy (e.g. `user1.openframe.ai → /api/mingo-guide/*`).
- Pairs with the matching changes on the hub side (see the multi-platform-hub PR): the hub mounts `<HubRuntimeProvider>` at root with the canonical hub URLs; embedded apps mount their own provider with proxied URLs.
- Two docs added under `docs/`: `EMBEDDING.md` (vanilla React walkthrough) and `MIGRATING_COMPONENTS.md` (how to migrate further hub components, with blog posts as a worked example).

## What's new

### New runtime context
- `src/contexts/endpoints-runtime-context.tsx` — `EndpointsRuntime` interface + two hooks:
  - `useEndpointsRuntime()` returns `null` when no provider is mounted (for optional consumers like `<AnnouncementBar>` that should silently skip their fetch).
  - `useRequiredEndpointsRuntime()` throws with an actionable message (for hooks that cannot function without endpoints).
- `src/contexts/index.ts` — barrel + top-of-file JSDoc documenting the **bundle-split convention** (the SSR `createContext is not a function` trap and how the `utils/` vs `hooks/` split prevents it).

### Refactored consumers
- `src/components/announcement-bar.tsx` — reads `announcementsUrl` from the runtime; when no provider is mounted, paints cached announcement and skips the polling timer entirely.
- `src/hooks/use-contact-submission.ts` — reads `contactUrl` via `useRequiredEndpointsRuntime`.
- `src/utils/access-code-client.ts` — pure standalone helpers (`validateAccessCode`, `consumeAccessCode`, `validateAndConsumeAccessCode`) now take an `AccessCodeEndpoints` arg. No defaults, no module-level React imports — safe in the server tsup bundle.
- `src/hooks/use-access-code-integration.ts` — **NEW**. Extracts the React hook out of `utils/access-code-client.ts` so the `createContext()` call doesn't leak into the server bundle. The hook binds the standalone helpers to the runtime via `useRequiredEndpointsRuntime()`. Re-exported via `src/hooks/index.ts`.

### Build / packaging
- `package.json` — new `./contexts` subpath export.
- `tsup.config.ts` — `contexts/index` added to the client entry block (receives the `"use client"` banner).

### Docs
- `docs/EMBEDDING.md` — vanilla React app embedding (install → mount provider → use components → verification + failure-mode table).
- `docs/MIGRATING_COMPONENTS.md` — three-layer mental model (`utils/` vs `hooks/` vs `components/`), worked migration walkthrough using blog-posts as the example, full checklist + anti-patterns.

## Why the access-code hook moved

The first build of this work put `useContext(EndpointsRuntimeContext)` inside `utils/access-code-client.ts`. `utils/index.ts` re-exports `* from './access-code-client'`, so the server bundle ended up calling `createContext()` at module top level on SSR → `createContext is not a function`. The cleanest fix is to keep `utils/` React-free and house any runtime-reading helper in `hooks/`. The convention is now documented at the top of `contexts/index.ts` so future contributors don't re-hit the trap.

## Test plan

- [ ] Build: `npm run build` succeeds.
- [ ] Verify dist artifacts: `dist/contexts/index.{js,cjs,d.ts}` exist after build.
- [ ] yalc push to the hub worktree; hub `npm run build` succeeds; no SSR `createContext` errors.
- [ ] Smoke-test in hub dev: announcement bar polls (5-min interval), contact form submits to `/api/contact`, access-code hook works on registration flow.
- [ ] Smoke-test with an override: mount a `<EndpointsRuntimeContext.Provider value={mockedRuntime}>` in a debug page; confirm announcement bar fetches the mocked URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)