### PR TITLE
feat(chat-inline): thread placeholderUrl through chat-card dispatch

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
@@ -117,6 +117,15 @@ export interface ChatCardDispatchExtras {
   buildProductReleaseCardProps?: (
     release: any,
   ) => Omit<ProductReleaseCardProps, 'size' | 'title' | 'summary' | 'version' | 'anchorProps'>
+  /** Build a branded OG placeholder URL from an entity title. Compact chat-
+   *  inline cards (`size='sm'` for blog/case-study/customer-interview/
+   *  investor-update/onboarding-guide) pass the result as `placeholderUrl`
+   *  so the card's image slot renders the OG fallback instead of an empty
+   *  span when the entity has no `featured_image`. Hub callers wire
+   *  `buildOgPlaceholderUrl` from `lib/utils/entity-image.ts`. Optional —
+   *  when omitted, the compact cards keep the existing empty-slot
+   *  behavior. */
+  buildOgPlaceholderUrl?: (title: string) => string | null
 }
 
 /** Per-card render options threaded through from the chat shell. */
@@ -676,6 +685,7 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
         size="sm"
         href={chatRef.url ?? ''}
         targetPlatform={chatRef.targetPlatform ?? null}
+        placeholderUrl={opts?.extras?.buildOgPlaceholderUrl?.(item?.title ?? '') ?? null}
         {...newTabAnchorAttrs(opts.isNewTab)}
         hasEmbeddedVideo={chatRef.metadata?.hasEmbeddedVideo === true}
       />
@@ -692,6 +702,7 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
         size="sm"
         href={chatRef.url ?? ''}
         targetPlatform={chatRef.targetPlatform ?? null}
+        placeholderUrl={opts?.extras?.buildOgPlaceholderUrl?.(item?.title ?? '') ?? null}
         {...newTabAnchorAttrs(opts.isNewTab)}
       />
     ),
@@ -707,6 +718,7 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
         size="sm"
         href={chatRef.url ?? ''}
         targetPlatform={chatRef.targetPlatform ?? null}
+        placeholderUrl={opts?.extras?.buildOgPlaceholderUrl?.(item?.title ?? '') ?? null}
         {...newTabAnchorAttrs(opts.isNewTab)}
       />
     ),
@@ -747,6 +759,7 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
         size="sm"
         href={chatRef.url ?? ''}
         targetPlatform={chatRef.targetPlatform ?? null}
+        placeholderUrl={opts?.extras?.buildOgPlaceholderUrl?.(item?.title ?? '') ?? null}
         {...newTabAnchorAttrs(opts.isNewTab)}
       />
     ),
@@ -763,6 +776,7 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
         size="sm"
         href={chatRef.url ?? ''}
         targetPlatform={chatRef.targetPlatform ?? null}
+        placeholderUrl={opts?.extras?.buildOgPlaceholderUrl?.(item?.title ?? '') ?? null}
         {...newTabAnchorAttrs(opts.isNewTab)}
       />
     ),


### PR DESCRIPTION
Compact chat-inline cards (size='sm' for blog/case-study/customer-interview/investor-update/onboarding-guide) accept a `placeholderUrl` prop that renders an OG fallback when the entity has no featured_image. But `dispatch.tsx` wasn't passing it — so chat references to entities without cover images showed an empty image slot.

Adds `buildOgPlaceholderUrl?: (title: string) => string | null` to `ChatCardDispatchExtras` (same opts.extras pattern that already threads `buildProductReleaseCardProps` and `programConfigs`). Each card's render branch in `CHAT_CARD_REGISTRY` now calls it with `item.title` and passes the result as `placeholderUrl`. ProductReleaseCard has internal Package-icon fallback so it doesn't need this.

When the host doesn't wire the builder, the lib falls back to the existing empty-slot behavior — no regression for non-Next embedders.

**Companion hub PR follow-up:** after this merges + republishes, a hub PR will:
1. Bump `@flamingo-stack/openframe-frontend-core` version
2. Wire `buildOgPlaceholderUrl` from `lib/utils/entity-image.ts` into `ChatCardDispatchExtras` (via the chat runtime extras passed to dispatch)

## Test plan

- [ ] After republish + hub bump, ask chat to reference a blog/case-study/etc with no featured_image
- [ ] Confirm the compact card image slot shows a branded OG placeholder instead of being empty
- [ ] Confirm entities WITH featured_image continue to render the real image unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)