### PR TITLE
fix(blog-card): restore view count in default footer

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/blog-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/blog-card.tsx
@@ -19,6 +19,7 @@
  */
 
 import React, { useState } from 'react'
+import { Eye } from 'lucide-react'
 import Image from '../../../embed-shims/next-image'
 import { StatusBadge } from '../../ui/status-badge'
 import { cn } from '../../../utils/cn'
@@ -235,22 +236,30 @@ export function BlogCard({
             </p>
           </div>
 
-          {/* Footer: author + date (simplified — no hub BlogMeta dep). */}
-          <div className="mt-auto flex items-center gap-2 text-sm text-ods-text-secondary">
-            {post.author_avatar ? (
-              <Image
-                src={post.author_avatar}
-                alt={post.author_name || ''}
-                width={32}
-                height={32}
-                className="rounded-full"
-                unoptimized
-              />
-            ) : null}
-            <span className="truncate">
-              {post.author_name || 'Anonymous'}
-              {dateStr ? <> · {dateStr}</> : null}
-            </span>
+          <div className="mt-auto flex items-center justify-between gap-2 text-sm text-ods-text-secondary">
+            <div className="flex items-center gap-2 min-w-0">
+              {post.author_avatar ? (
+                <Image
+                  src={post.author_avatar}
+                  alt={post.author_name || ''}
+                  width={32}
+                  height={32}
+                  className="rounded-full shrink-0"
+                  unoptimized
+                />
+              ) : null}
+              <span className="truncate">
+                {post.author_name || 'Anonymous'}
+                {dateStr ? <> · {dateStr}</> : null}
+              </span>
+            </div>
+            <div
+              className="flex items-center gap-1 shrink-0"
+              aria-label={`View count: ${(post.view_count ?? 0).toLocaleString('en-US')} views`}
+            >
+              <Eye className="w-4 h-4 shrink-0" />
+              <span>{(post.view_count ?? 0).toLocaleString('en-US')}</span>
+            </div>
           </div>
         </div>
       </a>


### PR DESCRIPTION
## Summary
- Default-size `<BlogCard>` footer dropped the view-count meta during the OSS-lib consolidation (commit `ea73c47e`, comment "simplified — no hub BlogMeta dep"). `BlogPostSummary.view_count` still flows through from the hub SSR (`lib/data/blog-catalog-ssr.ts:63`), so no data wiring was needed.
- Footer restructured to `justify-between`: author + avatar + date on the left (unchanged), view count with lucide `Eye` icon on the right. The `sm` (chat-inline) variant is untouched.

Reported missing on https://www.flamingo.run/blog — the admin card (`components/admin/blog-card-admin.tsx`) still rendered view count via the hub's `<BlogMeta>`, but the public card lost it in the lib swap.

## Test plan
- [ ] On `flamingo.run/blog` locally: view count visible on each card with eye icon
- [ ] Cards with 0 views render `0` (not blank)
- [ ] Long author + date strings still truncate without pushing the view count off-screen
- [ ] Chat-inline compact `<BlogCard size="sm">` unchanged
- [ ] OpenMSP / TMCG / OpenFrame blog pages still render footer correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)