### PR TITLE
Use grey PowerShell logo in ShellTypeBadge

### DIFF
--- a/openframe-frontend-core/src/components/platform/ShellTypeBadge.tsx
+++ b/openframe-frontend-core/src/components/platform/ShellTypeBadge.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react'
-import { PowershellLogoIcon } from '../icons-v2-generated/brand-logos/powershell-logo-icon'
+import { PowershellLogoGreyIcon } from '../icons-v2-generated/brand-logos/powershell-logo-grey-icon'
 import { PythonLogoIcon } from '../icons-v2-generated/brand-logos/python-logo-icon'
 
 import { ShellType, ShellTypeValues } from '../../types/shell.types'
@@ -34,7 +34,7 @@ interface ShellIconConfig {
  */
 const shellIconMap: Record<ShellType, ShellIconConfig> = {
   [ShellTypeValues.POWERSHELL]: {
-    icon: PowershellLogoIcon,
+    icon: PowershellLogoGreyIcon,
     props: { size: 16, className: 'text-ods-text-secondary' }
   },
   [ShellTypeValues.CMD]: {


### PR DESCRIPTION
## Summary
- Swap `PowershellLogoIcon` for `PowershellLogoGreyIcon` in `ShellTypeBadge` so the PowerShell entry uses the grey variant, consistent with the `text-ods-text-secondary` treatment applied to other shell badges.

## Test plan
- [ ] Render `ShellTypeBadge` with `ShellTypeValues.POWERSHELL` and confirm the grey PowerShell logo is displayed
- [ ] Verify other shell types (CMD, Python, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)