### PR TITLE
fix(tickets): drawer stays open on close/reopen — optimistic in-place row update

### DIFF
--- a/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
@@ -426,13 +426,55 @@ export function useTicketActions(options: UseTicketActionsOptions): UseTicketAct
             ticket_id: ticket.external_id,
           } as unknown as Record<string, unknown>)
           toast(successCopy)
-          // Invalidate BOTH ticket list (status / pipeline may have
-          // changed) AND engagements (comments + attachments produce a
-          // new Note that the timeline must pick up).
-          await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ['tickets'] }),
-            queryClient.invalidateQueries({ queryKey: ['ticket-engagements'] }),
-          ])
+
+          // OPTIMISTIC in-place row update on the tickets cache.
+          //
+          // Previously this code called
+          // `queryClient.invalidateQueries({ queryKey: ['tickets'] })`
+          // which forced a full refetch. When the user is on a
+          // filtered view (e.g. ?status=open) and CLOSES a ticket from
+          // its drawer, the refetched list excludes the now-closed
+          // row, the parent `<HelpCenterCard>` for that row unmounts,
+          // and the inline drawer dies with it — user-facing bug
+          // "close button refreshes the whole page and dismisses the
+          // ticket I was working on" (reported 2026-05-29).
+          //
+          // The mutation already knows what changed (status, content
+          // addendum, attachments) — apply those fields in place
+          // across every `['tickets']` cache slot. The row stays in
+          // the list with the new badge; React doesn't reconcile away
+          // the card; the drawer stays mounted and the user can
+          // continue working.
+          //
+          // Filter-mismatch trade-off: a row that no longer matches a
+          // slot's filter (e.g. CLOSED row in ?status=open cache)
+          // stays visually until next manual refetch (filter change,
+          // page nav, manual reload). Acceptable — the user opted into
+          // the action; carrying their drawer through it is more
+          // important than instantly hiding the row.
+          const statusUpdate =
+            (serverArgs as { status?: 'OPEN' | 'CLOSED' }).status ?? null
+          if (statusUpdate) {
+            queryClient.setQueriesData<TicketData[] | undefined>(
+              { queryKey: ['tickets'] },
+              (prev) => {
+                if (!prev) return prev
+                let mutated = false
+                const next = prev.map((t) => {
+                  if (t.id !== ticket.id || t.status === statusUpdate) return t
+                  mutated = true
+                  return { ...t, status: statusUpdate }
+                })
+                return mutated ? next : prev
+              },
+            )
+          }
+
+          // Engagements ALWAYS need to refetch — the addendum / new
+          // attachment / status-change-note must land in the timeline.
+          // Scoped to the engagements query only; doesn't touch the
+          // list cache.
+          await queryClient.invalidateQueries({ queryKey: ['ticket-engagements'] })
           return true
         })
       } catch (err) {


### PR DESCRIPTION
## Summary

User-facing bug reported 2026-05-29 during prod verification of #1051:

> "When I click Close or Reopen on a ticket, the whole screen refreshes and closes the ticket I'm working on. It should just refresh that one ticket and keep the drawer open."

## Root cause

`updateTicket()` in `use-ticket-actions.ts` called `queryClient.invalidateQueries({queryKey:['tickets']})` after every mutation. That forces the list to refetch with the current filter. When the user is on the default `?status=open` view and closes a ticket:

1. Server-side refetch returns the list WITHOUT the closed ticket (filter mismatch).
2. `merged` array in `<HelpCenterList>` drops the row.
3. `<HelpCenterCard key={ticket.id}>` for that row is no longer in the JSX.
4. React unmounts the card AND its inline drawer.
5. User sees the drawer disappear + the list jump.

## Fix

Replace the bulk `invalidateQueries` with an optimistic in-place row update across every `['tickets']` cache slot. The mutation already knows the new status — apply it directly to the cached row without refetching. The card stays in the list, the drawer stays mounted, the badge updates immediately.

`['ticket-engagements']` invalidation stays — the timeline still needs to refetch to pick up the new addendum / attachment / status-change-note.

## Trade-off

A row that no longer matches a slot's filter (e.g. CLOSED row visible in `?status=open` cache) stays visually until next manual refetch (filter change, page nav, manual reload). Acceptable — the user opted into the action; carrying their drawer through it is more important than instantly hiding the row.

## Test plan

- [ ] Open a ticket in the drawer (`/tickets` with default `?status=open`).
- [ ] Click Close → drawer stays open, status badge updates to CLOSED, timeline shows the close event.
- [ ] Click Reopen → drawer stays open, badge flips back to OPEN.
- [ ] Send a message via composer → drawer stays open, new message appears in timeline (engagements refetch).
- [ ] Switch filter from `open` → `closed` → see only closed tickets (no stale rows from earlier session — fresh refetch).
- [ ] Navigate to a different page + back → list refetches cleanly with current filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
