### PR TITLE
fix(mux-origins): extract Mux CDN constants to server-safe module

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -78,6 +78,12 @@
       "require": "./dist/components/features/index.cjs",
       "default": "./dist/components/features/index.js"
     },
+    "./components/features/mux-origins": {
+      "types": "./dist/components/features/mux-origins.d.ts",
+      "import": "./dist/components/features/mux-origins.js",
+      "require": "./dist/components/features/mux-origins.cjs",
+      "default": "./dist/components/features/mux-origins.js"
+    },
     "./components/toast": {
       "types": "./dist/components/toast/index.d.ts",
       "import": "./dist/components/toast/index.js",

--- a/openframe-frontend-core/src/components/features/mux-origins.ts
+++ b/openframe-frontend-core/src/components/features/mux-origins.ts
@@ -1,0 +1,27 @@
+/**
+ * Mux CDN origin constants — single source of truth, server-safe.
+ *
+ * Lives in its own NON-`'use client'` module so server-side hub
+ * modules (webhook handlers, URL builders, hostname comparisons in
+ * `lib/config/mux-config.ts`) can import these strings without
+ * tripping Next.js's client-reference poisoning. Re-exported from
+ * `use-video-warmup.ts` for backward-compat with client-side callers.
+ *
+ * Bug history (2026-05-29): when these constants lived in
+ * `use-video-warmup.ts` (which is `'use client'`), the hub's
+ * server-side `new URL(MUX_STREAM_ORIGIN).hostname` evaluation crashed
+ * at Vercel build with `TypeError: Invalid URL` — Next.js had
+ * replaced the constant with a client-function stub that throws
+ * "Attempted to call ... from the server" when stringified. Splitting
+ * the constants into this module restores the server-safe path.
+ *
+ * These hostnames are part of Mux's public API contract and are
+ * stable. A future change to the Mux CDN architecture (extremely
+ * unlikely) would be a single-line edit here.
+ */
+
+/** HLS playback (`/{playback_id}.m3u8` + segments + per-asset MP4 renditions). */
+export const MUX_STREAM_ORIGIN = 'https://stream.mux.com'
+
+/** Server-generated thumbnails (`/{playback_id}/thumbnail.jpg`). */
+export const MUX_IMAGE_ORIGIN = 'https://image.mux.com'

--- a/openframe-frontend-core/src/components/features/use-video-warmup.ts
+++ b/openframe-frontend-core/src/components/features/use-video-warmup.ts
@@ -39,10 +39,14 @@ import { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { useNearViewport } from '../../hooks/use-near-viewport'
 import { useChatRuntime } from '../../contexts/chat-runtime-context'
-
-/** Public Mux CDN hostnames — stable, part of Mux's API contract. */
-export const MUX_STREAM_ORIGIN = 'https://stream.mux.com'
-export const MUX_IMAGE_ORIGIN = 'https://image.mux.com'
+// Re-export from the server-safe `mux-origins.ts` module so the
+// constants are NOT bound to this `'use client'` file. See the
+// JSDoc in `mux-origins.ts` for the bug history. Backward-compat:
+// existing imports that read `MUX_STREAM_ORIGIN` from
+// `@flamingo-stack/openframe-frontend-core/components/features`
+// continue to resolve through this re-export.
+export { MUX_STREAM_ORIGIN, MUX_IMAGE_ORIGIN } from './mux-origins'
+import { MUX_STREAM_ORIGIN, MUX_IMAGE_ORIGIN } from './mux-origins'
 
 /**
  * Preconnect-only variant — fires the three video-bearing origin

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -36,6 +36,14 @@ export default defineConfig([
       // BOTH the lib's `<ContactForm>` for validation AND the hub's
       // server-side /api/contact + admin routes for payload validation.
       'schemas/contact-schema': 'src/schemas/contact-schema.ts',
+      // Mux CDN origins — string constants, no React, no browser APIs.
+      // Server-safe so hub server-side modules (mux-config, webhook
+      // handlers, URL parsers) can import without Next.js client-
+      // reference poisoning. The `'use client'` `use-video-warmup.ts`
+      // module re-exports these for backward-compat with client-side
+      // callers; new server-side callers should import from this
+      // subpath directly.
+      'components/features/mux-origins': 'src/components/features/mux-origins.ts',
     },
     format: ['esm', 'cjs'],
     dts: false,


### PR DESCRIPTION
## Summary

- Split `MUX_STREAM_ORIGIN` / `MUX_IMAGE_ORIGIN` into a NEW non-client module `src/components/features/mux-origins.ts` (no \`'use client'\`).
- `use-video-warmup.ts` re-exports them for backward compat with client-side callers — zero churn for existing client imports.
- New subpath export \`@flamingo-stack/openframe-frontend-core/components/features/mux-origins\` for server-side callers (hub \`lib/config/mux-config.ts\`, webhook handlers, URL parsers).
- Added tsup entry on the server/universal build (no \`'use client'\` banner) — confirmed: \`dist/components/features/mux-origins.js\` has no banner.

## Why

multi-platform-hub#565's Vercel build failed with \`TypeError: Invalid URL\` on \`new URL(MUX_STREAM_ORIGIN).hostname\` at \`lib/config/mux-config.ts:35\`. The constant came from \`use-video-warmup.ts\` (a \`'use client'\` file), so Next.js replaced it with a client-function stub at the server boundary that threw "Attempted to call MUX_STREAM_ORIGIN() from the server but MUX_STREAM_ORIGIN is on the client" when stringified.

The constants are pure strings — there's no actual React/browser-API content. They lived in \`use-video-warmup.ts\` for narrative locality. This PR makes that locality explicit (re-export) while moving the source of truth to a server-safe file.

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`dist/components/features/mux-origins.js\` has NO \`'use client'\` directive (confirmed via grep)
- [ ] Verify multi-platform-hub#565 Vercel build passes after consuming this snapshot (next step)