### PR TITLE
fix(tickets): cache slot is FindTicketResponse-shaped — hotfix for #1053 t.map runtime error

### DIFF
--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -40,7 +40,7 @@ import { useTicketsList } from './hooks/use-tickets-list'
 import { useTicketActions } from './hooks/use-ticket-actions'
 import { HelpCenterCard } from './help-center-card'
 import { HelpCenterCreateForm, HelpCenterCreateFormSkeleton } from './help-center-create-form'
-import type { AnyTicket, OptimisticTicket, TicketData } from './types'
+import type { AnyTicket, OptimisticTicket, TicketsCacheSlot } from './types'
 import { isOptimistic } from './types'
 
 export interface HelpCenterListProps {
@@ -175,9 +175,21 @@ function HelpCenterListAuthed({
       // Every cache slot under the ['tickets'] prefix — the queryKey
       // includes search + status + page + pageSize segments so a bare
       // write would miss most slots.
-      queryClient.setQueriesData<TicketData[] | undefined>(
+      //
+      // Cache slot is `TicketsCacheSlot` (`{ tickets, count, … }`), NOT
+      // a bare `TicketData[]`. The previous version called `.filter()`
+      // directly on the object — silently crashing only on the rare
+      // TICKET_NOT_FOUND path; the prod regression that landed
+      // 2026-05-29 surfaced the same shape mismatch in the
+      // close/reopen optimistic-update path. Project, filter, reassemble.
+      queryClient.setQueriesData<TicketsCacheSlot | undefined>(
         { queryKey: ['tickets'] },
-        (prev) => (prev ?? []).filter((t) => t.id !== ticketId),
+        (prev) => {
+          if (!prev || !Array.isArray(prev.tickets)) return prev
+          const nextTickets = prev.tickets.filter((t) => t.id !== ticketId)
+          if (nextTickets.length === prev.tickets.length) return prev
+          return { ...prev, tickets: nextTickets }
+        },
       )
       setExpandedTicketId((prev) => (prev === ticketId ? null : prev))
     },

--- a/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
@@ -39,6 +39,7 @@ import {
   type OptimisticTicket,
   type TicketActionErrorCode,
   type TicketData,
+  type TicketsCacheSlot,
   TOAST_COPY,
 } from '../types'
 
@@ -455,17 +456,25 @@ export function useTicketActions(options: UseTicketActionsOptions): UseTicketAct
           const statusUpdate =
             (serverArgs as { status?: 'OPEN' | 'CLOSED' }).status ?? null
           if (statusUpdate) {
-            queryClient.setQueriesData<TicketData[] | undefined>(
+            // The `useTicketsList` query (in `use-tickets-list.ts`)
+            // returns `FindTicketResponse` — an OBJECT shape
+            // `{ tickets: TicketData[], count, page, totalPages, ... }` —
+            // NOT a bare `TicketData[]`. The previous version of this
+            // callback assumed an array and crashed at runtime with
+            // `t.map is not a function` on every close/reopen
+            // (reported 2026-05-29 in prod). Project the nested
+            // tickets array, map, and reassemble the wrapper.
+            queryClient.setQueriesData<TicketsCacheSlot | undefined>(
               { queryKey: ['tickets'] },
               (prev) => {
-                if (!prev) return prev
+                if (!prev || !Array.isArray(prev.tickets)) return prev
                 let mutated = false
-                const next = prev.map((t) => {
+                const nextTickets = prev.tickets.map((t) => {
                   if (t.id !== ticket.id || t.status === statusUpdate) return t
                   mutated = true
                   return { ...t, status: statusUpdate }
                 })
-                return mutated ? next : prev
+                return mutated ? { ...prev, tickets: nextTickets } : prev
               },
             )
           }
@@ -722,9 +731,20 @@ function cacheContainsTicket(
   queryClient: ReturnType<typeof useQueryClient>,
   expectedTicketId: string,
 ): boolean {
-  const entries = queryClient.getQueriesData<TicketData[] | undefined>({ queryKey: ['tickets'] })
+  // Cache slot is `TicketsCacheSlot` (`{ tickets, count, … }`), NOT a
+  // bare `TicketData[]`. The previous code's `Array.isArray(data)` guard
+  // silently fell through to `return false` on real responses — the
+  // post-create watcher therefore NEVER detected the real row arriving
+  // early and always waited the full timeout. Project the nested array.
+  const entries = queryClient.getQueriesData<TicketsCacheSlot | undefined>({
+    queryKey: ['tickets'],
+  })
   for (const [, data] of entries) {
-    if (Array.isArray(data) && data.some((t) => t.external_id === expectedTicketId)) {
+    if (
+      data &&
+      Array.isArray(data.tickets) &&
+      data.tickets.some((t) => t.external_id === expectedTicketId)
+    ) {
       return true
     }
   }

--- a/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
@@ -444,8 +444,15 @@ function ReopenAction({
   onActionCollapsed: TicketDetailDrawerProps['onActionCollapsed']
 }) {
   const handleReopen = async () => {
-    const ok = await onReopen(ticketRef)
-    if (ok) onActionCollapsed()
+    // Intentionally do NOT call `onActionCollapsed()` here. Pre-PR #1053
+    // every reopen was followed by a full list refetch which removed
+    // the (now-OPEN) row from a `?status=closed` view, so collapsing
+    // the drawer hid the disappearance flash. After #1053+#1055 the
+    // row stays in the list with the optimistic in-place status
+    // update — collapsing the drawer now actively dismisses the
+    // ticket the user is working on. Keep it mounted; the badge flip
+    // is enough feedback. (Reported 2026-05-29.)
+    void (await onReopen(ticketRef))
   }
   return (
     <div className="flex justify-end">
@@ -501,9 +508,14 @@ function OpenActions({
 
   const confirmClose = async () => {
     setCloseDialogOpen(false)
-    const ok = await onClose(ticketRef, resolution.trim() || undefined)
+    await onClose(ticketRef, resolution.trim() || undefined)
     setResolution('')
-    if (ok) onActionCollapsed()
+    // Intentionally do NOT call `onActionCollapsed()` here. See the
+    // matching comment in ReopenActions.handleReopen above — collapsing
+    // the drawer after a successful close now dismisses the ticket the
+    // user is actively working on, which is the exact UX bug PR #1053
+    // set out to fix. The optimistic in-place status update keeps the
+    // row mounted with the new badge; that's the only feedback needed.
   }
 
   return (

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -140,6 +140,29 @@ export function isOptimistic(t: AnyTicket): t is OptimisticTicket {
 }
 
 /**
+ * Shape of a single `['tickets', …]` TanStack-Query cache slot.
+ * Mirrors `FindTicketResponse` in `hooks/use-tickets-list.ts` — kept
+ * here because the cache-mutation call sites in `useTicketActions` and
+ * `<HelpCenterList>` would otherwise have to redeclare the shape inline.
+ *
+ * A 2026-05-29 prod regression (`t.map is not a function` on
+ * close/reopen) was caused by assuming the cache held a bare
+ * `TicketData[]` instead of this wrapper — every helper that calls
+ * `queryClient.setQueriesData` / `getQueriesData` on `['tickets']`
+ * MUST type the value through this shape and project / reassemble
+ * `tickets` explicitly.
+ */
+export interface TicketsCacheSlot {
+  tickets?: TicketData[]
+  count?: number
+  totalCount?: number
+  page?: number
+  pageSize?: number
+  totalPages?: number
+  scope?: 'self' | 'all'
+}
+
+/**
  * Stable server-side error codes the ticket-action helpers route
  * through `mapTicketActionError`. Anything else is treated as a generic
  * server error.


### PR DESCRIPTION
## Summary

**Hotfix for [#1053](https://github.com/flamingo-stack/openframe-oss-lib/pull/1053).** Prod regression: every close or reopen showed a toast "Could not [re]open ticket — `t.map is not a function`" even though the underlying ticket-action API succeeded.

Screenshot from reporter: error appears immediately after the HTTP 200 response from `/api/chat/agent/ticket-action`.

## Root cause

`useTicketsList` (in `hooks/use-tickets-list.ts`) returns `FindTicketResponse` — an OBJECT shape `{ tickets: TicketData[], count, page, totalCount, pageSize, totalPages, scope }` — NOT a bare `TicketData[]`.

Three call sites assumed `TicketData[]`:

1. **`updateTicket` optimistic in-place status update** (#1053) — `prev.map(...)` crashed at runtime because `prev` is the wrapper object, not the array. The toast caught the throw and surfaced "Could not [re]open ticket".
2. **`removeTicketFromCache`** (pre-existing) — `(prev ?? []).filter(...)` on the wrapper object. Silently broken on the rare TICKET_NOT_FOUND error path.
3. **`cacheContainsTicket`** (pre-existing) — `Array.isArray(data)` guard silently returned false on every real response. The post-create mirror-sync watcher therefore never short-circuited and always waited the full 30s timeout.

## Fix

New `TicketsCacheSlot` interface exported from `types.ts` mirrors the real cache shape. All three call sites project `data.tickets`, operate on the array, and reassemble the wrapper.

## Test plan

- [ ] Open a ticket in the drawer → click Close → toast says "Ticket closed", drawer stays open, badge flips to CLOSED, no `t.map is not a function` error.
- [ ] Click Reopen → drawer stays open, badge flips to OPEN.
- [ ] Send a message in the drawer → composer clears, new message appears in timeline.
- [ ] Optimistic create flow → placeholder drops as soon as the real row arrives (was previously waiting the full 30s due to #3).
- [ ] TICKET_NOT_FOUND error path → row drops from list without throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
