### PR TITLE
fix(tickets): suppress redundant 'Original message' when engagement timeline already has it

### DIFF
--- a/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
@@ -203,6 +203,32 @@ function TicketTimelinePanel({ ticket }: { ticket: AnyTicket }) {
     ? ticket.body.split(TURN_SEPARATOR_RE).map((t) => t.trim()).filter(Boolean)
     : []
 
+  // Suppress `bodyTurns[0]` ("Original message") when the engagement
+  // timeline already has a customer-authored message whose body
+  // matches it. The channel-first create path in the hub writes the
+  // customer's message body BOTH into `hubspot_tickets.content` AND
+  // into the first `hubspot_ticket_conversation_messages` row — pre-
+  // 2026-05-29 the bot-intake-burst filter on the server dropped the
+  // first-customer message from engagements, so `bodyTurns[0]` was
+  // the only render. With channel-first, the engagement survives and
+  // both surfaces render the same text. Drop the redundant
+  // "Original message" turn when we detect that overlap.
+  //
+  // Only `bodyTurns[0]` is conditional. Subsequent turns ("Update N",
+  // "[Resolution]") come from `update_ticket.content_addendum` and
+  // are NEVER customer-written, so the engagement timeline can't
+  // match them. Leave their indices intact so `Update 1` still
+  // labels as such when `bodyTurns[0]` is suppressed.
+  const customerEngagementBodies = new Set<string>(
+    engagements
+      .filter((e) => e.authorRole === 'customer')
+      .map((e) => (e.body ?? '').trim())
+      .filter(Boolean),
+  )
+  const suppressBodyTurnZero =
+    bodyTurns.length > 0 &&
+    customerEngagementBodies.has(bodyTurns[0])
+
   // Customer name resolution precedence:
   //   1. LIVE chat identity (`identity.user.name`) — when the viewer
   //      is the ticket's own customer. Always fresh.
@@ -259,6 +285,10 @@ function TicketTimelinePanel({ ticket }: { ticket: AnyTicket }) {
           manually-entered description and engagements show subsequent
           replies — same flow, no duplication. */}
       {bodyTurns.map((turn, i) => {
+        // Drop the redundant first turn when the engagement timeline
+        // below already renders the same customer-authored body. See
+        // `suppressBodyTurnZero` derivation above for the rationale.
+        if (i === 0 && suppressBodyTurnZero) return null
         const isResolution = turn.startsWith('[Resolution]')
         const role =
           i === 0 ? 'Original message' : isResolution ? 'Resolution' : `Update ${i}`


### PR DESCRIPTION
## Summary

**User-facing bug:** customer opens a ticket from `/tickets` — the drawer shows the body text TWICE, once as "Original message" at the top of the drawer and again as the first "REPLY" in the engagement timeline below.

Reported 2026-05-29 with screenshot showing ticket #45618831404.

## Root cause

The channel-first create path (hub PR #564) writes the customer's message body into BOTH:

- `hubspot_tickets.content` — rendered by the drawer as `bodyTurns[0]` labeled **"Original message"**
- the first `hubspot_ticket_conversation_messages` row — rendered as the first **"REPLY"** in the engagement timeline

Pre-channel-first, the server's bot-intake-burst filter dropped the customer's first conversation message from engagements when the ticket originated via the HubSpot Custom Channel bot intake, so `bodyTurns[0]` was the only render. With channel-first the engagement survives and we get the duplication.

## Why Option B (drawer-side filter) rather than Option A (skip the content write)

Keeping `hubspot_tickets.content` populated is useful for:
- `find-ticket` previews (the chat agent surfaces previews from `content`).
- Admin views.
- HubSpot's own ticket UI where `content` is the canonical description field.

Stripping it from the mirror would degrade those surfaces. Filtering in the drawer is the minimum-impact fix.

## What this does

After computing `bodyTurns` from `ticket.body`, build a Set of trimmed customer-authored engagement bodies. If `bodyTurns[0]` matches one of them, skip rendering it (`return null` in the map, preserving indices so "Update N" labels stay correct on any later turns).

Only `bodyTurns[0]` is conditional. Subsequent turns ("Update N", "[Resolution]") come from `update_ticket.content_addendum` and are never customer-written, so the engagement timeline can't match them — they always render.

## Test plan

- [ ] Open `/tickets` → open an existing channel-first ticket. The body should appear **only once**, as the first reply in the engagement timeline (with attachment chips intact, agent replies below it).
- [ ] Open a ticket created by an agent on HubSpot's side (no customer first message). The "Original message" label at the top should still render (engagement timeline doesn't have a matching customer body).
- [ ] Send a customer reply via the drawer composer. It should appear as a new reply in the timeline without affecting how the "original" is rendered.
- [ ] Use `update_ticket` with a `content_addendum` → confirm "Update 1" still labels correctly even when `bodyTurns[0]` is suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
