### PR TITLE
feat(react-embedding-example): reference embed app + generic URL-routing plan

### DIFF
--- a/openframe-frontend-core/src/components/shared/legal-document/use-legal-docs.ts
+++ b/openframe-frontend-core/src/components/shared/legal-document/use-legal-docs.ts
@@ -86,7 +86,11 @@ export function useLegalDocs(
       setData(result);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-      console.error(`Error fetching ${docType} document:`, err);
+      // `docType` is externally controlled (URL path segment in embedders), so it must NOT sit in
+      // console.error's FIRST (format-string) argument — Node interprets %s/%j/%o there
+      // (CodeQL js/tainted-format-string). Keep the format string constant; pass docType + err as
+      // plain trailing args.
+      console.error('Error fetching legal document:', docType, err);
       setError(errorMessage);
     } finally {
       setIsLoading(false);

--- a/react-embedding-example/.env.example
+++ b/react-embedding-example/.env.example
@@ -1,0 +1,20 @@
+# ─── Proxy (SERVER-ONLY — never shipped to the browser) ──────────────────────
+# Where the proxy forwards /content/api/* → ${HUB_ORIGIN}/api/* .
+HUB_ORIGIN=http://localhost:3000
+
+# Shared chat secret. MUST equal the hub deployment's CHAT_PROXY_SECRET.
+# If empty, the hub returns 503 CHAT_PROXY_SECRET_NOT_CONFIGURED and chat errors.
+CHAT_PROXY_SECRET=
+
+# Fixed identity the proxy injects (X-Chat-Act-As / -First-Name / -Last-Name / -Avatar-Url).
+# The hub impersonates / auto-provisions this user, so the chat greets them with no client auth.
+ACT_AS_EMAIL=michael@flamingo.cx
+ACT_AS_FIRST_NAME=Michael
+ACT_AS_LAST_NAME=Assraf
+ACT_AS_AVATAR_URL=https://www.imatest.com/wp-content/uploads/2022/05/Imatest-User-Profile-Brian-Deegan.png
+
+# ─── Client (VITE_-prefixed — these ARE bundled into the browser) ────────────
+# Public hub origin for new-tab "open the full content" links the chat/surfaces render.
+VITE_HUB_ORIGIN=http://localhost:3000
+# Chat source — must match the target hub's currentPlatform() so doc-search scopes correctly.
+VITE_CHAT_SOURCE=openframe

--- a/react-embedding-example/.gitignore
+++ b/react-embedding-example/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.local
+*.log
+.DS_Store

--- a/react-embedding-example/GENERIC_ROUTING_PLAN.md
+++ b/react-embedding-example/GENERIC_ROUTING_PLAN.md
@@ -1,0 +1,299 @@
+# Plan: Generic, embedder-configurable URL routing & navigation
+
+> Fourth revision (after three source-verified review panels). Net architecture: **don't touch
+> the hub's content resolvers**; single-source only the list-URL table (the one thing an embedder
+> can't replicate); deliver internal browsing through the **existing** `composeContentUrl` seam +
+> a lib default suffix table; and fix the one raw-`<a>` view card by switching it to the lib's
+> **existing embed-shim `Link`** (no new component). Verified per-type shapes inline.
+
+## Context (source-verified)
+
+The lib is embedded in a non-hub host (the `react-embedding-example` is the reference). Two bugs +
+the internal-browsing need all come from URL/nav logic an embedder must reverse-engineer and can't
+replicate.
+
+**Bug #2 — chat entity cards don't display.** Fetch-mode cards: `dispatch.tsx` →
+`useChatCardItem(fetchEntry.contentRefType, id)` → `runtime.endpoints.buildListUrl(contentRefType,[id])`
+→ `fetch`; `enabled: !!url`, so null URL ⇒ no fetch ⇒ `ChatCardLoader` renders nothing. The embedder
+can't write a correct `buildListUrl`: key is **`contentRefType`** (blog fetches as
+`blog_post_existing`; hub un-aliases to `blog_post`); per-type shapes live in **14 mapper closures**
+(`lib/config/rag-mappers/*.ts`) and differ (`task_ids` vs `ids`, `pageSize`, `limit&filter=all`);
+some are **null** (no-fetch: `github_*`, `slack_message`); `marketing_campaign` is **non-RAG**. My
+example's `chat-meta.ts` used wrong keys (`roadmap` not `roadmap_item`) + a `?ids=` guess ⇒ null ⇒
+roadmap/delivery/onboarding cards render nothing.
+
+**Bug #1 — identity/commands "canceled".** React StrictMode dev double-mount aborts the first fetch;
+both hooks already swallow `AbortError` (`use-chat-identity.ts`, the commands effect). Cosmetic dev
+noise; **not** nav-related (in-chat clicks `preventDefault` via `ChatCardNavWrap`). Document, don't fix.
+
+**Internal-browsing gap.** The only lib view card that renders a **raw `<a href>`** (full-page nav)
+and is mounted on a host route is `onboarding-guide-card.tsx` (used by `OnboardingGuidesCatalogView`/
+`OnboardingGuideDetailView` + related rail). Today it deep-links via `runtime.composeContentUrl` or
+`build-default-href`, and the example makes it navigate in-app only via a document-level click
+interceptor (`app-shell.tsx`). (Verified non-issues: `RoadmapCard`'s grid/`default` variant renders a
+`<div>` with no anchor — `RoadmapGrid` doesn't navigate; `delivery-row.tsx` already uses the
+**embed-shim `Link`**, which the example registers to react-router via `embed-router-bridge`, so it
+already soft-navigates. So roadmap/delivery need no card conversion.)
+
+## Goal
+
+Overarching rule (see §5): **every page-level surface an embedder renders is the same fully-shared,
+parameterized lib component the hub renders** — no hub-coupled views, no example stubs/forks. The
+scoped changes below make that achievable; **the hub's content resolvers stay untouched**:
+1. One shared **list-URL builder** in the lib (the only un-replicable piece) — fixes bug #2 for every
+   type; base-configurable (`/api` hub, `/content/api` embedder); the 14 mapper closures delegate to
+   it (single source, byte-parity test).
+2. **Internal-browsing overrides via the existing `composeContentUrl` seam** + a lib default suffix
+   table — the embedder wires one `composeContentUrl` from a lib helper; no hand-rolled suffix map,
+   no hub change.
+3. The one raw-`<a>` view card (`onboarding-guide-card`) renders via the **existing embed-shim
+   `Link`** instead of `<a>`; the host already registers `Link`→its router, so the example deletes
+   its interceptor. No new component.
+
+End state: the example holds no per-type URL tables, no hand-rolled `buildListUrl`, no interceptor —
+just a base, a small overrides object, and one `composeContentUrl` line.
+
+## Design
+
+### 1. Shared list-URL builder (fixes bug #2; single source)
+
+`src/utils/list-url.ts` (pure, server-safe — obeys the `contexts/index.ts` bundle-split rule;
+hub mappers already import from `@flamingo-stack/openframe-frontend-core/utils` server-side):
+```ts
+const ALIASES: Record<string, string> = { blog_post_existing: 'blog_post' } // mirrors hub LEGACY_TYPE_ALIASES
+// One builder per fetch-mode contentRefType. base='' → '/api/...'; base='/content' → '/content/api/...'.
+// Bodies are copied VERBATIM from each mapper's current `listApi` (raw, unencoded `join(',')`;
+// exact param names). ABSENT key ⇒ no-fetch (null) — do NOT enumerate github_*/slack as null keys.
+const BUILDERS: Record<string, (ids: string[], base: string) => string> = {
+  roadmap_item:  (ids, b) => `${b}/api/roadmap?task_ids=${ids.join(',')}`,
+  delivery_item: (ids, b) => `${b}/api/delivery?task_ids=${ids.join(',')}`,
+  internal_task: (ids, b) => `${b}/api/internal-tasks?task_ids=${ids.join(',')}`,
+  blog_post:     (ids, b) => `${b}/api/blog/posts?ids=${ids.join(',')}&pageSize=${ids.length}`,
+  webinar:       (ids, b) => `${b}/api/programs/webinars?ids=${ids.join(',')}&limit=${ids.length}&filter=all`,
+  podcast:       (ids, b) => `${b}/api/programs/podcasts?ids=${ids.join(',')}&limit=${ids.length}&filter=all`,
+  event:         (ids, b) => `${b}/api/programs/events?ids=${ids.join(',')}&limit=${ids.length}&filter=all`,
+  onboarding_guide: (ids, b) => `${b}/api/onboarding-guides?ids=${ids.join(',')}&limit=${ids.length}`,
+  case_study:    (ids, b) => `${b}/api/case-studies?ids=${ids.join(',')}&limit=${ids.length}`,
+  product_release: (ids, b) => `${b}/api/releases?ids=${ids.join(',')}&limit=${ids.length}`,
+  customer_interview: (ids, b) => `${b}/api/customer-interviews?ids=${ids.join(',')}&limit=${ids.length}`, // list path ≠ detail suffix 'interviews'
+  investor_update: (ids, b) => `${b}/api/investor-updates?ids=${ids.join(',')}&limit=${ids.length}`,
+}
+// marketing_campaign stays a LITERAL case (admin-only, non-RAG) — keep the hub's static-switch
+// shape so CodeQL still proves no user-controlled dynamic dispatch; embedders can't hit /api/admin.
+export function buildListUrl(contentRefType: string, ids: string[], base = ''): string | null {
+  if (ids.length === 0) return null
+  const key = ALIASES[contentRefType] ?? contentRefType
+  if (key === 'marketing_campaign') return `${base}/api/admin/marketing/campaigns?ids=${ids.join(',')}&pageSize=${ids.length}`
+  const fn = BUILDERS[key]
+  return fn ? fn(ids, base) : null
+}
+```
+- **The builder bodies are copied verbatim from the real mappers** (the snippet reflects the verified
+  shapes, but the implementer copies each `listApi` string). The 14 mapper `listApi` then **delegate**
+  (`listApi: (ids) => buildListUrl('<type>', ids)`), so there's one source. **KEEP**
+  `entity-list-api.ts`'s `LEGACY_TYPE_ALIASES` un-rename: its callers (the chat dispatcher's
+  `endpoints.buildListUrl`, `related-content-card`, `app/api/chat/entity-list/route`) pass
+  `blog_post_existing` and rely on it to reach the `blog_post` mapper before the RAG lookup; the
+  delegating mapper closures pass the **canonical** type, so they never exercise it. The lib
+  `buildListUrl` carries its OWN `ALIASES` for direct lib/embedder callers. So both entry points
+  un-alias (correct) — the "alias in one place" goal is dropped (it would require rewiring
+  `entity-list-api.buildListUrl` to delegate to the lib, which is out of scope).
+- **Embedder:** `endpoints.buildListUrl = (t, ids) => buildListUrl(t, ids, '/content')`.
+- **Parity gate (required, all types incl. the `blog_post_existing` alias + `marketing_campaign`):**
+  FIRST capture each mapper's current `listApi(['a','b'])` output into a test fixture (snapshot the
+  baseline strings), THEN assert `buildListUrl(type, ['a','b'])` byte-equals that fixture (and that
+  `entity-list-api.buildListBasePath`, which probes `buildListUrl`, is unchanged). Convert **all 12
+  mappers in the same change** (no half-migrated two-source state). Guards the path/param drift the
+  panels caught.
+
+`useChatCardItem` is unchanged; both hub + embedder set `buildListUrl` to a correct builder → every
+fetch-mode card resolves a real URL; null types stay no-fetch. `ChatRef.url` (server `resolveUrl`)
+remains authoritative for the card's link — this governs only the row fetch.
+
+### 2. Internal-browsing overrides via the existing `composeContentUrl` seam (the user's ask)
+
+Leave the hub's `buildContentURL`/`resolveUrl`/`buildDevSectionUrl`/`getPlatformDomain` alone. Give
+embedders a lib helper + default suffix table to wire the **existing** `runtime.composeContentUrl`
+seam without duplicating the hub's suffix map.
+
+`src/utils/content-href.ts` (pure, server-safe):
+```ts
+// type -> in-app route suffix. Public-hostable subset; mirrors the public entries of the hub's
+// PUBLIC_URL_PATHS (hub keeps its own copy; this is the embedder default, must stay in sync).
+// NO slug-vs-id field: the composeContentUrl seam receives an already-resolved id STRING, so the
+// CALLER passes the right id (the onboarding views pass guide.slug).
+export const DEFAULT_CONTENT_SUFFIXES: Record<string, string> = {
+  onboarding_guide: 'onboarding-guides', product_release: 'releases', blog_post: 'blog',
+  case_study: 'case-studies', customer_interview: 'interviews', investor_update: 'investor-updates',
+  webinar: 'webinars', podcast: 'podcasts', event: 'events',
+}
+export interface ContentHrefOptions {
+  hostedTypes: ReadonlySet<string>   // types THIS host serves in-app → relative href
+  contentOrigin: string              // hub origin for everything else
+  suffixes?: Record<string, string>  // defaults to DEFAULT_CONTENT_SUFFIXES
+  overrides?: Record<string, (slug: string) => { href: string; targetPlatform: string | null }>
+}
+// ALWAYS returns a tuple (NEVER null) — the composeContentUrl seam type is non-nullable and the two
+// onboarding views read `.href` unconditionally. Internal-vs-hub is decided by `hostedTypes`
+// membership (NOT platform equality — embedders have a free-form source). Unknown type with no
+// suffix ⇒ hub origin with the raw type as a last resort.
+export function makeComposeContentUrl(opts: ContentHrefOptions):
+  (type: string, slug: string, platforms?: Array<{ name?: string }>) => { href: string; targetPlatform: string | null }
+```
+Resolution: `overrides[type]` → else `const seg = suffixes[type] ?? type` (never `/undefined/…`);
+if `hostedTypes.has(type)` return relative `/<seg>/<slug>` (in-app) else
+`${contentOrigin}/<seg>/<slug>` (hub, opens out). The caller passes the correct identifier as
+`slug` (the onboarding views pass `guide.slug`).
+
+- **Embedder** wires the existing seam in one line:
+  `composeContentUrl: makeComposeContentUrl({ hostedTypes: new Set(['onboarding_guide','product_release']), contentOrigin: VITE_HUB_ORIGIN })` (only the types the example actually routes; everything else opens the hub).
+  Deletes `content-routes.ts`. (Roadmap/delivery `overrides` are optional + **forward-looking**:
+  `composeContentUrl` is consumed only by the two onboarding views today; roadmap/delivery cards get
+  their href from `ChatRef.url`/grid props, so add overrides only when a view composes those hrefs.)
+- **Hub:** unchanged.
+
+### 3. The one raw-`<a>` view card → existing embed-shim `Link`
+
+`onboarding-guide-card.tsx` (all 3 variants) currently renders `<a href target rel>`. Switch it to
+the lib's existing `embed-shims/next-link` `Link` (the same primitive `delivery-row.tsx` already
+uses), passing the card's existing `href` prop, the `{ target, rel }` from `useEntityCardLink`
+(that hook returns only `target`/`rel` — `href` is the card's own prop), and **`prefetch={false}`**
+(match `delivery-row`; otherwise next/link prefetches all dozens of catalog cards on the hub). Effects:
+- **Embedder:** it registers `Link`→react-router (`embed-router-bridge`), so catalog/detail/related
+  onboarding cards soft-navigate in-app — and the example **deletes** its `app-shell` document
+  interceptor + `router-nav.ts`.
+- **Hub:** registers `Link`→`next/link`, so behavior is unchanged.
+- **In chat:** the card stays wrapped by `ChatCardNavWrap` (whose `onClickCapture` `preventDefault`s
+  and routes through `runtime.navigation`), so chat nav is unaffected regardless of `<a>` vs `Link`.
+- No new `<ContentLink>` component; no chat coupling added to non-chat cards. roadmap-card/delivery
+  are **not** converted (grid roadmap card has no anchor; delivery already uses `Link`).
+- **Gate (explicit checklist, not a grep caveat):** the example registers `Link`→react-router, so
+  any lib surface already on the embed-shim `Link` keeps soft-navigating after the interceptor is
+  removed. Before deleting `app-shell`'s interceptor + `router-nav.ts`, confirm **each** lib view
+  surface the example mounts is either on the embed-shim `Link` or routes via `runtime.navigation`:
+  | Surface | mounted by | nav today | action |
+  |---|---|---|---|
+  | onboarding-guide-card (catalog/sm/default) | catalog + detail views | raw `<a>` | **convert to `Link`** |
+  | onboarding detail back-link | detail view | embed-shim `Link` | none (already `Link`) |
+  | onboarding related-rail cards | detail view | = onboarding-guide-card | covered by the conversion |
+  | DocSearchBar result rows | catalog view | `useDocSearch` → react-router push | none |
+  | RoadmapGrid / RoadmapCard (grid) | `/roadmap` | no anchor (vote card) | none |
+  | DeliveryTable / delivery-row | `/delivery` | embed-shim `Link` | none |
+  | ReleaseDetailPage, LegalDocumentPage, ContactForm, HelpCenterList, AnnouncementBar | their routes | internal `Link`/own fetch, no host `/…` `<a>` | none |
+  Delete the interceptor only once every row is "none" or converted. (The example's own JSX has zero
+  raw `<a href>`.)
+
+### 4. Bug #1 — document only
+
+StrictMode dev-only canceled-request noise (AbortError already swallowed in both hooks). No nav fix.
+Optionally drop `<React.StrictMode>` in the example dev entry to silence it (cosmetic).
+
+### 5. Rule of thumb — every page-level surface is a fully-shared, parameterized lib component
+
+**Principle (applies to ALL surfaces, not just releases):** an embedder must render the *same*
+lib component the hub renders. No hub-coupled page/list/detail view, and no example stub or fork.
+If a surface today lives hub-side (imports `@/…`) or the example hand-rolls it, that surface must
+be **lifted into the lib and parameterized** so hub + every embedder share one implementation. The
+decoupling recipe is uniform (already established by §1–§3 and the existing shared views):
+- **data** via props (server-fetched, like `OnboardingGuidesCatalogView.initialGuides`) or a
+  configurable endpoint — never a hard-wired hub hook;
+- **card props** via the lib default (e.g. `defaultBuildProductReleaseCardProps`) overridable
+  through the existing `extras.*` seam — never a hub-only `@/lib/utils/*` builder;
+- **nav** via `runtime.composeContentUrl` (§2) + embed-shim `Link`/`useEntityCardLink` (§3) —
+  never `@/lib/utils/use-nav-link` / `currentPlatform`;
+- **chrome** via already-lib primitives (`PersistentPaginationWrapper`, `EmptyState`,
+  `DevSectionPage`, embed-shim `useSearchParams`).
+
+**Audit (do this as part of the work):** for every surface the example mounts, confirm it imports a
+lib component, not a hub-local one or an example stub. Known violators today:
+
+| Surface | Lib list/view export today | Status |
+|---|---|---|
+| Onboarding | `OnboardingGuidesCatalogView` | ✅ shared |
+| Roadmap | `RoadmapGrid` | ✅ shared |
+| Delivery | `DeliveryLists` | ✅ shared |
+| Legal / Contact / Tickets / Announcements | `LegalDocumentPage` / `ContactForm` / `HelpCenterList` / `AnnouncementBar` | ✅ shared |
+| **Product releases (LIST)** | ❌ only `ProductReleaseCard` + `ReleaseDetailPage` — **no list view** | **lift (below)** |
+
+**Worked instance — lift `ReleasesList` → lib `ProductReleasesView`.** The releases LIST lives
+hub-side at `multi-platform-hub/components/releases/product-releases-tab-content.tsx` (`ReleasesList`),
+coupled to `@/hooks/api/use-product-releases`, `@/lib/utils/product-release-card-props`,
+`@/lib/utils/use-nav-link`, `@/lib/platform-utils-shared`; the example currently ships a hand-rolled
+slug-input stub (`pages/releases.tsx`) instead — the discrepancy vs the hub/testing app. Lift it as
+`ProductReleasesView` per the recipe above (props-driven rows + `defaultBuildProductReleaseCardProps`
++ `composeContentUrl`/embed-shim `Link` + the already-lib `PersistentPaginationWrapper`/`EmptyState`).
+Then the hub's `ReleasesList` becomes a thin wrapper (or is replaced) and the example renders
+`<ProductReleasesView items={…} />` — all list pages share one component. Apply the same lift to any
+other violator the audit surfaces.
+
+## Precedence (unambiguous)
+
+- **Chat inline card link:** `ChatRef.url` (server `resolveUrl`) — authoritative, unchanged.
+- **Chat card row fetch:** `runtime.endpoints.buildListUrl` = lib `buildListUrl(type, ids, base)`.
+- **View content link (onboarding catalog/detail/related):** `runtime.composeContentUrl(...)`
+  (embedder wires via `makeComposeContentUrl`, always returns a tuple) `?? build-default-href` (fires
+  only when the composer is absent). Hub keeps its own `composeContentUrl`.
+
+## Files
+
+**Lib (`openframe-frontend-core`)**
+- new `src/utils/list-url.ts` + `src/utils/content-href.ts`; export from `utils/index.ts`.
+- the 12 mapper files under `src/config/rag-mappers/` whose `listApi` exists — delegate to
+  `buildListUrl`. (`rag-mappers/types.ts`/`rag-table-config.ts` keep the `listApi` field as a thin
+  delegate.) **Keep** `entity-list-api.ts`'s `LEGACY_TYPE_ALIASES` (hub entry-point un-alias); the
+  lib `buildListUrl` has its own `ALIASES` for direct callers.
+- `src/components/chat/entity-cards/onboarding-guide-card.tsx` — raw `<a>` → embed-shim `Link`.
+- new `src/components/shared/product-release/product-releases-view.tsx` (`ProductReleasesView`) +
+  export from the `product-release` barrel — the lifted, decoupled `ReleasesList` (§5).
+
+**Hub (`multi-platform-hub`)** — content resolvers UNCHANGED. Only the mapper-delegation above
+(in the lib) flows through; `entity-list-api.ts` keeps its lookup (alias now upstream).
+
+**Example (`react-embedding-example`)**
+- delete `src/config/content-routes.ts`, `src/providers/router-nav.ts`, the `app-shell` interceptor,
+  the hand-rolled `composeContentUrl` body, `src/config/chat-meta.ts`'s `buildListUrl`.
+- `endpoints.buildListUrl = (t,ids) => buildListUrl(t, ids, '/content')`.
+- `composeContentUrl = makeComposeContentUrl({ hostedTypes, contentOrigin: VITE_HUB_ORIGIN })`.
+
+## Rollout (no broken intermediate state)
+
+1. Land `src/utils/list-url.ts` + `content-href.ts` + the parity test (pure; no consumers).
+2. Switch the 12 mapper `listApi` to delegate (parity test green ⇒ output identical). Hub
+   `LEGACY_TYPE_ALIASES` stays.
+3. Switch `onboarding-guide-card` to the embed-shim `Link`.
+4. Example: wire `buildListUrl`/`composeContentUrl` from lib helpers; delete the shims + interceptor;
+   verify.
+5. Lift `ReleasesList` → lib `ProductReleasesView` (§5); replace the example's stub
+   `pages/releases.tsx` with `<ProductReleasesView items={…} />`. Run the §5 audit and lift any other
+   surface that's still hub-coupled or example-stubbed.
+
+## Verification
+
+- **Bug #2:** in the example chat, queries returning roadmap_item / delivery_item / blog_post /
+  onboarding_guide / program cards → each **fetches** with the correct per-type params (`task_ids`,
+  `programs/…&filter=all`, `blog/posts&pageSize`) and renders the full row; `github_*`/`slack` stay
+  no-fetch. A test distinguishes "card present + fetched" from "no `[card://]` marker emitted" (latter
+  unchanged, out of scope).
+- **Parity:** `buildListUrl(type, ids)` byte-equals every mapper's prior `listApi(ids)` (all types +
+  alias + marketing_campaign); `buildListBasePath` unchanged.
+- **Internal browsing:** onboarding catalog/detail/related cards navigate **in-app** (relative href
+  via the registered `Link`) with the example's interceptor **deleted**; a non-hosted type opens the
+  hub origin. (Roadmap/delivery grids already non-navigating / `Link`-routed.)
+- **Bug #1:** identity/commands complete; any "canceled" is a single StrictMode artifact.
+- **Hub unchanged:** content + list URLs identical before/after (parity test + spot snapshots).
+- **DRY:** no per-type URL table outside `src/utils/{list-url,content-href}.ts`; example has no suffix
+  mirror, no hand-rolled `buildListUrl`, no interceptor.
+- **Fully-shared surfaces (§5 rule):** every example page imports a lib component — `releases` renders
+  `<ProductReleasesView>` (the stub is gone); the §5 audit table is all ✅ (no hub-coupled view, no
+  example fork remains).
+- `npm run typecheck` clean in lib + example; hub builds.
+
+## Open questions
+
+- Does any host want the onboarding card to route through `runtime.navigation` (chat-style
+  close-on-nav / embed new-tab) rather than the plain `Link`? If so, a small optional-runtime link
+  wrapper could be added later — not needed for the example (the registered `Link` → react-router is
+  the host's own nav). Decided: ship the `Link` switch; revisit only if a host needs chat-style nav
+  on non-chat surfaces.
+- Ship the list builders as the data the hub mappers import (chosen) — the parity test exists only to
+  make the migration safe, after which the closures are pure delegates.

--- a/react-embedding-example/README.md
+++ b/react-embedding-example/README.md
@@ -1,0 +1,111 @@
+# react-embedding-example
+
+A standalone **Vite + React** app that embeds the chat (`EmbeddableChat`) and every
+page-level content surface from `@flamingo-stack/openframe-frontend-core` (onboarding
+guides, roadmap, delivery, product releases, legal, contact, tickets, announcements),
+talking to the multi-platform hub through a **`/content` reverse proxy**.
+
+The proxy holds the **chat secret** and injects a **fixed identity** (Michael Assraf), so
+the chat greets that user with no client-side auth — exactly how a real embedder works.
+
+## How this maps to production
+
+In production the client is React and the proxy is an existing **Spring Boot** service. The
+local proxy here (`proxy/`, or Vite's built-in dev proxy) is a stand-in that does the same
+two things Spring Boot already does:
+
+1. Rewrite `/content/api/*` → `${HUB_ORIGIN}/api/*`.
+2. Inject `Authorization: Bearer ${CHAT_PROXY_SECRET}` + `X-Chat-Act-As` / `-First-Name` /
+   `-Last-Name` / `-Avatar-Url`.
+
+The React client is byte-identical in both — it only ever calls `/content/api/...`. The
+secret + identity live **only** on the proxy (non-`VITE_` env), never in the browser bundle.
+
+```
+Browser SPA ──fetch('/content/api/...')──▶ proxy (rewrite + inject secret/identity) ──▶ hub /api/*
+```
+
+## Prerequisites
+
+1. **Build the lib** (it's a `file:` dependency; `dist/` must exist):
+   ```bash
+   cd ../openframe-frontend-core && npm install && npm run build
+   ```
+2. **Run the hub** locally on `:3000` (or point `HUB_ORIGIN` elsewhere). From a Claude/IDE
+   subshell prefix with `unset ANTHROPIC_API_KEY` (Claude Desktop shadows it and chat 500s):
+   ```bash
+   unset ANTHROPIC_API_KEY && npm run dev:openframe   # in the hub repo
+   ```
+3. **Set the shared secret.** Copy `.env.example` → `.env` and set `CHAT_PROXY_SECRET` to the
+   **same** value the hub uses. If empty, the hub returns `503 CHAT_PROXY_SECRET_NOT_CONFIGURED`
+   and chat errors loudly.
+
+## Run
+
+```bash
+cp .env.example .env          # then edit CHAT_PROXY_SECRET (+ HUB_ORIGIN if not :3000)
+npm install
+npm run dev                   # Vite dev server proxies /content → hub, injecting secret + identity
+# → open the printed URL; the floating "Ask AI" chat greets Michael.
+```
+
+Built-app path (uses the standalone Node proxy instead of Vite's):
+```bash
+npm run build && npm run preview:proxy
+```
+
+## Configuration (`.env`)
+
+| Var | Side | Purpose |
+|-----|------|---------|
+| `HUB_ORIGIN` | server only | Where `/content/api/*` is forwarded. Default `http://localhost:3000`. |
+| `CHAT_PROXY_SECRET` | server only | Shared secret — must equal the hub's. |
+| `ACT_AS_EMAIL` / `ACT_AS_FIRST_NAME` / `ACT_AS_LAST_NAME` / `ACT_AS_AVATAR_URL` | server only | The impersonated identity (defaults to Michael Assraf). |
+| `VITE_HUB_ORIGIN` | client | Public hub origin for new-tab "open full content" links. |
+| `VITE_CHAT_SOURCE` | client | Chat source; must match the hub's `currentPlatform()` (default `openframe`). |
+
+## How it's wired
+
+- **Single base.** The `/content` prefix lives once in [`proxy/content-prefix.mjs`](proxy/content-prefix.mjs);
+  every endpoint derives from it in [`src/config/endpoints.ts`](src/config/endpoints.ts) (the `EP` map).
+- **Runtime.** [`src/providers/content-runtime.ts`](src/providers/content-runtime.ts) builds the
+  lib's `ChatRuntime` + `EndpointsRuntime` from `EP`; mounted (memoized) in
+  [`app-providers.tsx`](src/providers/app-providers.tsx) alongside `QueryClientProvider`.
+- **Routing.** [`embed-router-bridge.tsx`](src/providers/embed-router-bridge.tsx) adapts
+  react-router into the lib's `embed-shims` so lib pages navigate in-app.
+- **Theme.** `data-theme="dark"` on `<html>` drives the ODS tokens shipped by the lib's
+  `/styles` import — no theme provider needed.
+
+## Endpoint map
+
+All client calls use `/content/api/...`. Per-surface retargeting:
+
+| Surface | Endpoint(s) | Retargeted via |
+|---------|-------------|----------------|
+| Chat (`EmbeddableChat`) | `/content/api/docs/chat`, `/commands`, `/auth/identity`, … | `ChatRuntime` |
+| Onboarding catalog/detail | `/content/api/onboarding-guides[/:slug\|/sections]` | props-driven fetch (`content-api.ts`) |
+| Roadmap | `/content/api/roadmap`, `/roadmap/vote`, `/roadmap/:id` | `items` + `buildRefreshUrl` + `votingOptions` |
+| Delivery | `/content/api/delivery/{completed,in-progress}` | `completedApiEndpoint` / `inProgressApiEndpoint` |
+| Release detail | `/content/api/product-releases/:slug`, `/roadmap` | host `useRelease` + injected section |
+| Legal | `/content/api/legal/:docType` | `apiEndpoint` |
+| Contact | `/content/api/contact` | `EndpointsRuntime.contactUrl` |
+| Announcements | `/content/api/announcements/active` | `EndpointsRuntime.announcementsUrl` |
+
+### Two documented `/api` exceptions (dev only)
+
+Two lib surfaces still hardcode bare `/api` with no override prop today:
+- the onboarding **catalog's in-view doc-search** → `/api/docs/search`
+- the **tickets** hooks → `/api/chat/agent/{find-ticket,ticket-action,list-engagements}`
+
+`vite.config.ts` (and `proxy/server.mjs`) add a narrow fallback that forwards just those two
+prefixes to the hub. Everything else rides `/content`. The clean fix (recommended) is a small
+lib change so these read their base from the runtime — forward a `searchEndpoint` prop from
+`OnboardingGuidesCatalogView`, and derive the tickets paths from a single `agentBaseUrl` on
+`ChatRuntime.endpoints` (sibling of `approvalToolUrl`). After that, drop the fallback rules.
+
+## Add a surface
+
+1. Add the endpoint(s) to `EP` in `src/config/endpoints.ts`.
+2. Add a page under `src/pages/` that renders the lib component (data via `content-api.ts` or
+   the component's own endpoint props).
+3. Register one `<Route>` in `src/app-routes.tsx`.

--- a/react-embedding-example/index.html
+++ b/react-embedding-example/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<!-- data-theme drives the ODS design tokens shipped by the lib's /styles import. -->
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>OpenFrame embedding example</title>
+    <script>
+      // The lib's prebuilt code is Next-oriented and reads `process.env.*` at runtime
+      // (e.g. getAppType → NEXT_PUBLIC_APP_TYPE). A pure Vite/browser bundle has no
+      // `process`, so shim it before any lib code runs. NEXT_PUBLIC_APP_TYPE drives the
+      // lib's platform detection — set it to the embedded platform. Any other process.env
+      // read resolves to undefined instead of throwing.
+      window.process = window.process || { env: {} }
+      window.process.env.NEXT_PUBLIC_APP_TYPE = window.process.env.NEXT_PUBLIC_APP_TYPE || 'openframe'
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/react-embedding-example/package.json
+++ b/react-embedding-example/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "react-embedding-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Reference example: embed @flamingo-stack/openframe-frontend-core chat + content surfaces in a standalone React SPA over a /content reverse proxy (mirrors the production Spring Boot proxy).",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "preview:proxy": "node --env-file=.env proxy/server.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@flamingo-stack/openframe-frontend-core": "file:../openframe-frontend-core",
+    "@tanstack/react-query": "^5",
+    "@hookform/resolvers": "^5",
+    "react": "^19",
+    "react-dom": "^19",
+    "react-router-dom": "^6",
+    "zod": "^4"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "autoprefixer": "^10.4",
+    "http-proxy": "^1.18",
+    "postcss": "^8.5",
+    "tailwindcss": "^3.4",
+    "typescript": "^5",
+    "vite": "^5"
+  }
+}

--- a/react-embedding-example/postcss.config.js
+++ b/react-embedding-example/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/react-embedding-example/proxy/content-prefix.mjs
+++ b/react-embedding-example/proxy/content-prefix.mjs
@@ -1,0 +1,9 @@
+/**
+ * SINGLE SOURCE OF TRUTH for the client-facing reverse-proxy namespace.
+ *
+ * Imported by BOTH the Node proxy (proxy/inject.mjs, proxy/server.mjs,
+ * vite.config.ts) AND the browser (src/config/content.ts). Keep this file a
+ * pure ESM string export — no Node-only code — so Vite can bundle it for the
+ * client without pulling anything server-side.
+ */
+export const CONTENT_PREFIX = '/content'

--- a/react-embedding-example/proxy/inject.mjs
+++ b/react-embedding-example/proxy/inject.mjs
@@ -1,0 +1,38 @@
+/**
+ * The ONE place that knows the path-rewrite + header-injection. Shared by the
+ * Vite dev/preview proxy (vite.config.ts) and the standalone Node proxy
+ * (proxy/server.mjs). This mirrors exactly what the production Spring Boot
+ * proxy does: forward /content/api/* → ${HUB_ORIGIN}/api/*, attaching the chat
+ * secret + a fixed impersonated identity so the hub greets that user.
+ */
+import { CONTENT_PREFIX } from './content-prefix.mjs'
+
+/** Where /content/api/* is forwarded. Default: the local OpenFrame dev hub. */
+export const hubTarget = (env) => env.HUB_ORIGIN || 'http://localhost:3000'
+
+/**
+ * Strip the /content prefix so /content/api/x?y=1 → /api/x?y=1 (query + encoded
+ * chars preserved). Anchored with a (?=/|$) lookahead so '/contentious' is NOT
+ * mis-stripped — only an exact /content segment is removed.
+ */
+export const rewrite = (path) => path.replace(new RegExp(`^${CONTENT_PREFIX}(?=/|$)`), '')
+
+/**
+ * Attach the chat secret (Bearer) + the fixed act-as identity headers. Names +
+ * scheme match the hub validator (resolveChatProxyIdentity in lib/api/route-base.ts):
+ * the avatar must be https. Secret + identity come from server-side env only and
+ * never reach the browser bundle (non-VITE_ vars).
+ */
+export function injectHeaders(proxyReq, env) {
+  if (env.CHAT_PROXY_SECRET) {
+    proxyReq.setHeader('authorization', `Bearer ${env.CHAT_PROXY_SECRET}`)
+  }
+  proxyReq.setHeader('x-chat-act-as', env.ACT_AS_EMAIL || 'michael@flamingo.cx')
+  proxyReq.setHeader('x-chat-first-name', env.ACT_AS_FIRST_NAME || 'Michael')
+  proxyReq.setHeader('x-chat-last-name', env.ACT_AS_LAST_NAME || 'Assraf')
+  proxyReq.setHeader(
+    'x-chat-avatar-url',
+    env.ACT_AS_AVATAR_URL ||
+      'https://www.imatest.com/wp-content/uploads/2022/05/Imatest-User-Profile-Brian-Deegan.png',
+  )
+}

--- a/react-embedding-example/proxy/server.mjs
+++ b/react-embedding-example/proxy/server.mjs
@@ -1,0 +1,69 @@
+/**
+ * Standalone Node proxy for the BUILT app (`npm run build && npm run preview:proxy`).
+ * Serves dist/ as an SPA and proxies /content (+ the two documented bare-/api
+ * exceptions) to the hub using the SAME inject module as the Vite dev proxy.
+ *
+ * SSE NOTE: this server deliberately does NOT pipe responses through any
+ * compression middleware and never sets `selfHandleResponse` — both would buffer
+ * and break the chat's text/event-stream. Static files are served uncompressed.
+ *
+ * For local dev use `npm run dev` instead (Vite's built-in proxy). In production
+ * this whole file is replaced by the existing Spring Boot proxy.
+ */
+import http from 'node:http'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import httpProxy from 'http-proxy'
+import { CONTENT_PREFIX } from './content-prefix.mjs'
+import { hubTarget, rewrite, injectHeaders } from './inject.mjs'
+
+const env = process.env
+const PORT = Number(env.PORT) || 4173
+const DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../dist')
+
+const proxy = httpProxy.createProxyServer({ target: hubTarget(env), changeOrigin: true })
+proxy.on('proxyReq', (proxyReq) => injectHeaders(proxyReq, env))
+proxy.on('error', (err, _req, res) => {
+  res.writeHead(502, { 'content-type': 'text/plain' })
+  res.end(`proxy error: ${err.message}`)
+})
+
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.mjs': 'text/javascript',
+  '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.woff2': 'font/woff2', '.ico': 'image/x-icon',
+}
+
+async function serveStatic(req, res) {
+  const urlPath = decodeURIComponent((req.url || '/').split('?')[0])
+  // Resolve within DIST; SPA fallback to index.html for client routes.
+  const rel = urlPath === '/' ? 'index.html' : urlPath.replace(/^\/+/, '')
+  const target = path.resolve(DIST, rel)
+  const safe = target.startsWith(DIST)
+  try {
+    const file = safe && path.extname(target) ? await readFile(target) : await readFile(path.join(DIST, 'index.html'))
+    const ext = safe && path.extname(target) ? path.extname(target) : '.html'
+    res.writeHead(200, { 'content-type': MIME[ext] || 'application/octet-stream' })
+    res.end(file)
+  } catch {
+    res.writeHead(404, { 'content-type': 'text/plain' })
+    res.end('Not found')
+  }
+}
+
+http
+  .createServer((req, res) => {
+    const url = req.url || '/'
+    if (url === CONTENT_PREFIX || url.startsWith(`${CONTENT_PREFIX}/`)) {
+      req.url = rewrite(url) // /content/api/x → /api/x
+      return void proxy.web(req, res)
+    }
+    if (url.startsWith('/api/docs/search') || url.startsWith('/api/chat/agent')) {
+      return void proxy.web(req, res) // documented bare-/api exceptions (forwarded as-is)
+    }
+    void serveStatic(req, res)
+  })
+  .listen(PORT, () =>
+    console.log(`[proxy] dist/ + ${CONTENT_PREFIX} → ${hubTarget(env)}  ·  http://localhost:${PORT}`),
+  )

--- a/react-embedding-example/src/app-routes.tsx
+++ b/react-embedding-example/src/app-routes.tsx
@@ -1,0 +1,34 @@
+import { Routes, Route } from 'react-router-dom'
+import { AppShell } from './components/app-shell'
+import { PageError } from './components/page-state'
+import { HomePage } from './pages/home'
+import { OnboardingCatalogPage } from './pages/onboarding-catalog'
+import { OnboardingDetailPage } from './pages/onboarding-detail'
+import { RoadmapPage } from './pages/roadmap'
+import { DeliveryPage } from './pages/delivery'
+import { ReleasesPage } from './pages/releases'
+import { ReleaseDetailRoute } from './pages/release-detail'
+import { LegalPage } from './pages/legal'
+import { ContactPage } from './pages/contact'
+import { TicketsPage } from './pages/tickets'
+
+// One registry → every surface. Adding a surface is one <Route>.
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<AppShell />}>
+        <Route index element={<HomePage />} />
+        <Route path="onboarding-guides" element={<OnboardingCatalogPage />} />
+        <Route path="onboarding-guides/:slug" element={<OnboardingDetailPage />} />
+        <Route path="roadmap" element={<RoadmapPage />} />
+        <Route path="delivery" element={<DeliveryPage />} />
+        <Route path="releases" element={<ReleasesPage />} />
+        <Route path="releases/:slug" element={<ReleaseDetailRoute />} />
+        <Route path="legal/:docType" element={<LegalPage />} />
+        <Route path="contact" element={<ContactPage />} />
+        <Route path="tickets" element={<TicketsPage />} />
+        <Route path="*" element={<PageError title="Page not found" />} />
+      </Route>
+    </Routes>
+  )
+}

--- a/react-embedding-example/src/components/app-shell.tsx
+++ b/react-embedding-example/src/components/app-shell.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from 'react'
+import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { AnnouncementBar } from '@flamingo-stack/openframe-frontend-core/components'
+import { AskAi } from './ask-ai'
+import { setInAppNavigate } from '../providers/router-nav'
+
+const NAV = [
+  { to: '/', label: 'Home', end: true },
+  { to: '/onboarding-guides', label: 'Onboarding' },
+  { to: '/roadmap', label: 'Roadmap' },
+  { to: '/delivery', label: 'Delivery' },
+  { to: '/releases', label: 'Releases' },
+  { to: '/legal/privacy', label: 'Legal' },
+  { to: '/contact', label: 'Contact' },
+  { to: '/tickets', label: 'Tickets' },
+] as const
+
+export function AppShell() {
+  const navigate = useNavigate()
+  // Feeds the ChatRuntime's host-mode navigate() — used by the chat's source chips / markdown
+  // anchors / entity-card dispatch, which call runtime.navigation.navigate() directly.
+  useEffect(() => setInAppNavigate((to) => navigate(to)), [navigate])
+
+  // Normalized in-app routing for lib surfaces that render a PLAIN `<a href="/…">` (e.g. the
+  // onboarding catalog cards, which don't go through runtime.navigation). Mirrors the click
+  // rules the chat's source chips apply internally (primary button, no modifiers, same-origin,
+  // not new-tab) and routes via react-router instead of a full page reload.
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+      const anchor = (e.target as HTMLElement | null)?.closest?.('a')
+      if (!anchor) return
+      const target = anchor.getAttribute('target')
+      if (target && target !== '_self') return // new-tab / external → let the browser handle it
+      const href = anchor.getAttribute('href')
+      if (!href || !href.startsWith('/')) return // only same-origin internal paths
+      e.preventDefault()
+      navigate(href)
+    }
+    document.addEventListener('click', onDocClick)
+    return () => document.removeEventListener('click', onDocClick)
+  }, [navigate])
+  return (
+    <div className="min-h-full bg-ods-bg text-ods-text-primary">
+      {/* No props — reads its endpoint from EndpointsRuntime.announcementsUrl. */}
+      <AnnouncementBar />
+      <header className="sticky top-0 z-40 border-b border-ods-border bg-ods-card/95 backdrop-blur">
+        <nav className="mx-auto flex max-w-6xl flex-wrap items-center gap-1 px-4 py-3">
+          <span className="mr-3 font-semibold">OpenFrame embed</span>
+          {NAV.map((n) => (
+            <NavLink
+              key={n.to}
+              to={n.to}
+              end={'end' in n ? n.end : undefined}
+              className={({ isActive }) =>
+                `rounded-md px-3 py-1.5 text-sm ${
+                  isActive
+                    ? 'bg-ods-bg text-ods-text-primary'
+                    : 'text-ods-text-secondary hover:text-ods-text-primary'
+                }`
+              }
+            >
+              {n.label}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+      <main className="mx-auto max-w-6xl">
+        <Outlet />
+      </main>
+      {/* Floating Ask-AI trigger, available on every route. */}
+      <AskAi />
+    </div>
+  )
+}

--- a/react-embedding-example/src/components/ask-ai.tsx
+++ b/react-embedding-example/src/components/ask-ai.tsx
@@ -1,0 +1,12 @@
+import { EmbeddableChat } from '@flamingo-stack/openframe-frontend-core/components/chat'
+
+/**
+ * Embedder-side equivalent of the hub's `global-ask-ai-client.tsx`. It reuses the
+ * SAME lib component (`EmbeddableChat`) the hub file wraps — no copy, no auth gate.
+ * Identity (Michael) is resolved server-side via the proxy's act-as headers, so the
+ * greeting just works. An empty `guide` config makes the SSE adapter fall back to the
+ * lib's built-in `defaultTableIdForDocumentType` (no hand-written map needed).
+ */
+export function AskAi() {
+  return <EmbeddableChat modes={{ guide: {} }} defaultActiveMode="guide" />
+}

--- a/react-embedding-example/src/components/page-state.tsx
+++ b/react-embedding-example/src/components/page-state.tsx
@@ -1,0 +1,13 @@
+// Shared loading/error states for the route pages (ODS-token styled, no hardcoded colors).
+export function PageLoading({ label = 'Loading…' }: { label?: string }) {
+  return <div className="p-10 text-ods-text-secondary">{label}</div>
+}
+
+export function PageError({ title, detail }: { title: string; detail?: string }) {
+  return (
+    <div className="p-10">
+      <h2 className="text-lg font-semibold text-ods-text-primary">{title}</h2>
+      {detail ? <p className="mt-2 text-sm text-ods-text-secondary">{detail}</p> : null}
+    </div>
+  )
+}

--- a/react-embedding-example/src/config/chat-meta.ts
+++ b/react-embedding-example/src/config/chat-meta.ts
@@ -1,0 +1,18 @@
+// `buildListUrl` is the one ChatRuntime field that is required and has no lib
+// default — it maps an entity-card content type + ids to the list endpoint the
+// chat fetches to expand a compact card. This is the small per-embedder builder
+// (NOT a copy of the hub's server-side RAG_TABLE_CONFIGS). Unknown types return
+// null and the lib skips rendering the expand affordance.
+import { EP } from './endpoints'
+
+const LIST_BASE: Record<string, string> = {
+  roadmap: EP.roadmap,
+  delivery: EP.deliveryCompleted,
+  onboarding_guide: EP.onboarding,
+}
+
+export function buildListUrl(type: string, ids: string[]): string | null {
+  const base = LIST_BASE[type]
+  if (!base) return null
+  return `${base}?ids=${ids.map(encodeURIComponent).join(',')}`
+}

--- a/react-embedding-example/src/config/content-routes.ts
+++ b/react-embedding-example/src/config/content-routes.ts
@@ -1,0 +1,29 @@
+// Mirrors the hub's canonical `PUBLIC_URL_PATHS` (lib/utils/content-url-builder.ts) — the
+// per-content-type route suffix that `buildContentURL` uses to build `/${path}/${slug}`.
+//
+// This is the ONE place to OVERRIDE where each content type's detail page lives in THIS app.
+// The example's react-router routes (app-routes.tsx) must match these suffixes. Mounting a
+// type elsewhere (e.g. onboarding under `/docs/onboarding`) = change it here + the <Route>.
+export const PUBLIC_URL_PATHS: Record<string, string> = {
+  onboarding_guide: 'onboarding-guides',
+  product_release: 'releases',
+  blog_post: 'blog',
+  blog_post_existing: 'blog',
+  blog_post_seed: 'blog',
+  case_study: 'case-studies',
+  event: 'events',
+  podcast: 'podcasts',
+  webinar: 'webinars',
+  customer_interview: 'interviews',
+  investor_update: 'investor-updates',
+}
+
+/**
+ * Canonical local content path for a type + slug — same shape as the project's
+ * `buildContentURL` (`/${PUBLIC_URL_PATHS[type]}/${slug}`). Returns null for types this
+ * app doesn't host a route for (caller falls back to the hub origin).
+ */
+export function resolveContentPath(type: string, slug: string): string | null {
+  const path = PUBLIC_URL_PATHS[type]
+  return path ? `/${path}/${slug}` : null
+}

--- a/react-embedding-example/src/config/content.ts
+++ b/react-embedding-example/src/config/content.ts
@@ -1,0 +1,6 @@
+// Single client-side base for every hub call. The prefix itself comes from the
+// ONE shared source (proxy/content-prefix.mjs) so a namespace change is one edit.
+import { CONTENT_PREFIX } from '../../proxy/content-prefix.mjs'
+
+/** All hub endpoints live under this base; the proxy maps it back to /api/*. */
+export const CONTENT = `${CONTENT_PREFIX}/api`

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -1,0 +1,48 @@
+// Every hub path derived from CONTENT, exactly once. The runtime factory, the
+// data layer, and the pages all read from EP — no page re-interpolates `${CONTENT}`,
+// no endpoint literal exists twice.
+import { CONTENT } from './content'
+
+// approvalToolUrl + (once the optional lib seam lands) the three tickets paths
+// all derive from this one agent base, so `/chat/agent` lives in a single spot.
+const AGENT_BASE = `${CONTENT}/chat/agent`
+
+export const EP = {
+  // chat
+  chatStream: `${CONTENT}/docs/chat`,
+  commands: `${CONTENT}/docs/commands`,
+  docsSearch: `${CONTENT}/docs/search`,
+  agentBase: AGENT_BASE,
+  approval: `${AGENT_BASE}/confirm-tool`,
+  attachmentUpload: `${CONTENT}/storage/generate-upload-url`,
+  attachmentViewPrefix: `${CONTENT}/storage/view/chat-attachments/`,
+  identity: `${CONTENT}/auth/identity`,
+  imageProxy: `${CONTENT}/image-proxy`,
+  ogPlaceholder: (title: string) => `${CONTENT}/og-placeholder?title=${encodeURIComponent(title)}`,
+  // roadmap
+  roadmap: `${CONTENT}/roadmap`,
+  roadmapVote: `${CONTENT}/roadmap/vote`,
+  roadmapById: (id: string) => `${CONTENT}/roadmap/${id}`,
+  // delivery
+  deliveryCompleted: `${CONTENT}/delivery/completed`,
+  deliveryInProgress: `${CONTENT}/delivery/in-progress`,
+  // onboarding guides
+  onboarding: `${CONTENT}/onboarding-guides`,
+  onboardingBySlug: (slug: string) => `${CONTENT}/onboarding-guides/${slug}`,
+  onboardingSections: `${CONTENT}/onboarding-guides/sections`,
+  // product releases
+  productReleases: `${CONTENT}/product-releases`,
+  productReleaseBySlug: (slug: string) => `${CONTENT}/product-releases/${slug}`,
+  // misc surfaces
+  legal: (docType: string) => `${CONTENT}/legal/${docType}`,
+  contact: `${CONTENT}/contact`,
+  announcements: `${CONTENT}/announcements/active`,
+  accessValidate: `${CONTENT}/validate-access-code`,
+  accessConsume: `${CONTENT}/consume-access-code`,
+} as const
+
+/** Chat source — must match the target hub's currentPlatform() (doc-search scope + localStorage ns). */
+export const DEFAULT_SOURCE = import.meta.env.VITE_CHAT_SOURCE ?? 'openframe'
+
+/** Public hub origin for new-tab "open the full content" links (embed mode). */
+export const HUB_PUBLIC_ORIGIN = import.meta.env.VITE_HUB_ORIGIN ?? 'http://localhost:3000'

--- a/react-embedding-example/src/data/content-api.ts
+++ b/react-embedding-example/src/data/content-api.ts
@@ -1,0 +1,36 @@
+// Thin typed fetchers for the props-driven surfaces (onboarding catalog/detail,
+// roadmap list). Returns lib row types; URLs come from the single EP map. This is
+// the embedder data layer every host needs — not a re-implementation of lib logic.
+// (Deletable once the optional onboarding-hook lib seam lands.)
+import type {
+  OnboardingGuide,
+  OnboardingGuideListResponse,
+  OnboardingGuideSectionSummary,
+  RoadmapItem,
+} from '@flamingo-stack/openframe-frontend-core/components/chat'
+import { EP } from '../config/endpoints'
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`Request failed (${res.status}): ${url}`)
+  return res.json() as Promise<T>
+}
+
+export function fetchOnboardingGuides(section?: string): Promise<OnboardingGuideListResponse> {
+  const qs = section ? `?section=${encodeURIComponent(section)}` : ''
+  return getJson<OnboardingGuideListResponse>(`${EP.onboarding}${qs}`)
+}
+
+export function fetchOnboardingSections(): Promise<OnboardingGuideSectionSummary[]> {
+  return getJson<OnboardingGuideSectionSummary[]>(EP.onboardingSections)
+}
+
+export function fetchOnboardingGuide(slug: string): Promise<OnboardingGuide> {
+  return getJson<OnboardingGuide>(EP.onboardingBySlug(slug))
+}
+
+export async function fetchRoadmap(): Promise<RoadmapItem[]> {
+  // The hub's /api/roadmap returns { items, count }.
+  const data = await getJson<{ items: RoadmapItem[] }>(EP.roadmap)
+  return data.items ?? []
+}

--- a/react-embedding-example/src/index.css
+++ b/react-embedding-example/src/index.css
@@ -1,0 +1,12 @@
+/* Base layout only — all colors come from the lib's ODS tokens (imported via
+   `@flamingo-stack/openframe-frontend-core/styles` in main.tsx) and are selected
+   by `data-theme="dark"` on <html>. No hardcoded colors here. */
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+}

--- a/react-embedding-example/src/main.tsx
+++ b/react-embedding-example/src/main.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+// ODS tokens + chat keyframes + fonts (CSS only). Import once, before any lib surface paints.
+import '@flamingo-stack/openframe-frontend-core/styles'
+import './index.css'
+import { registerEmbedRouterBridge } from './providers/embed-router-bridge'
+import { AppProviders } from './providers/app-providers'
+import { AppRoutes } from './app-routes'
+
+// Register the react-router → embed-shims bridge BEFORE the first lib surface renders,
+// so lib pages navigate via react-router (not the popstate-only fallback).
+registerEmbedRouterBridge()
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AppProviders>
+        <AppRoutes />
+      </AppProviders>
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/react-embedding-example/src/pages/contact.tsx
+++ b/react-embedding-example/src/pages/contact.tsx
@@ -1,0 +1,14 @@
+import { ContactForm } from '@flamingo-stack/openframe-frontend-core/components/contact'
+
+/**
+ * ContactForm is self-contained: it calls `useContactSubmission` internally, which
+ * reads `contactUrl` (= EP.contact) from the mounted EndpointsRuntime provider. No
+ * host-side hook or schema import needed.
+ */
+export function ContactPage() {
+  return (
+    <div className="p-6">
+      <ContactForm title="Contact us" subtitle="Questions about OpenFrame? Send us a note." />
+    </div>
+  )
+}

--- a/react-embedding-example/src/pages/delivery.tsx
+++ b/react-embedding-example/src/pages/delivery.tsx
@@ -1,0 +1,18 @@
+import { DeliveryLists } from '@flamingo-stack/openframe-frontend-core/components'
+import { EP } from '../config/endpoints'
+
+/**
+ * DeliveryLists fetches its own data and reads `search` / `task_type` URL params
+ * (written by its internal chrome via the embed-shim → react-router bridge). We
+ * only retarget its two endpoints to /content.
+ */
+export function DeliveryPage() {
+  return (
+    <div className="p-6">
+      <DeliveryLists
+        completedApiEndpoint={EP.deliveryCompleted}
+        inProgressApiEndpoint={EP.deliveryInProgress}
+      />
+    </div>
+  )
+}

--- a/react-embedding-example/src/pages/home.tsx
+++ b/react-embedding-example/src/pages/home.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom'
+
+const SURFACES = [
+  { to: '/onboarding-guides', title: 'Onboarding guides', desc: 'Catalog + detail, props-driven from /content/api/onboarding-guides.' },
+  { to: '/roadmap', title: 'Roadmap', desc: 'Voting grid; votes + refresh hit /content/api/roadmap.' },
+  { to: '/delivery', title: 'Delivery', desc: 'Bug-fix + enhancement tables; /content/api/delivery/*.' },
+  { to: '/releases', title: 'Product releases', desc: 'ReleaseDetailPage with an injected roadmap section.' },
+  { to: '/legal/privacy', title: 'Legal', desc: 'Privacy / terms via /content/api/legal/*.' },
+  { to: '/contact', title: 'Contact', desc: 'ContactForm → /content/api/contact (EndpointsRuntime).' },
+  { to: '/tickets', title: 'Help center / tickets', desc: 'HelpCenterList (tickets hooks).' },
+]
+
+export function HomePage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold text-ods-text-primary">OpenFrame embedding example</h1>
+      <p className="mt-2 max-w-3xl text-sm text-ods-text-secondary">
+        Every surface below is the real <code>@flamingo-stack/openframe-frontend-core</code>{' '}
+        component, talking to the hub through a <code>/content</code> reverse proxy that injects the
+        chat secret + a fixed identity (Michael Assraf). Open the floating <strong>Ask AI</strong>{' '}
+        chat — it greets Michael, resolved entirely server-side.
+      </p>
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {SURFACES.map((s) => (
+          <Link
+            key={s.to}
+            to={s.to}
+            className="rounded-lg border border-ods-border bg-ods-card p-4 transition-colors hover:border-ods-text-secondary"
+          >
+            <div className="font-medium text-ods-text-primary">{s.title}</div>
+            <div className="mt-1 text-sm text-ods-text-secondary">{s.desc}</div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/react-embedding-example/src/pages/legal.tsx
+++ b/react-embedding-example/src/pages/legal.tsx
@@ -1,0 +1,42 @@
+import { useParams } from 'react-router-dom'
+import { LegalDocumentPage } from '@flamingo-stack/openframe-frontend-core/components'
+import { EP } from '../config/endpoints'
+
+// LegalDocumentPage is one parameterized surface (it replaced the hub's separate
+// Privacy/Terms pages), so the host supplies the per-doc copy strings.
+const COPY: Record<
+  string,
+  {
+    title: string
+    fallbackDescription: string
+    contactEmail: string
+    errorContactPrompt: string
+    errorTitle: string
+    emptyStateMessage: string
+  }
+> = {
+  privacy: {
+    title: 'Privacy Policy',
+    fallbackDescription: 'Our privacy policy and data protection practices.',
+    contactEmail: 'privacy@openframe.io',
+    errorContactPrompt: 'For privacy-related questions, please contact:',
+    errorTitle: 'Unable to load privacy policy',
+    emptyStateMessage: 'Privacy policy content is not available at this time.',
+  },
+  terms: {
+    title: 'Terms of Service',
+    fallbackDescription: 'The terms governing your use of OpenFrame.',
+    contactEmail: 'legal@openframe.io',
+    errorContactPrompt: 'For terms-related questions, please contact:',
+    errorTitle: 'Unable to load terms of service',
+    emptyStateMessage: 'Terms of service content is not available at this time.',
+  },
+}
+
+export function LegalPage() {
+  const { docType = 'privacy' } = useParams()
+  const copy = COPY[docType] ?? COPY.privacy
+  return (
+    <LegalDocumentPage docType={docType} apiEndpoint={EP.legal(docType)} backButton={false} {...copy} />
+  )
+}

--- a/react-embedding-example/src/pages/onboarding-catalog.tsx
+++ b/react-embedding-example/src/pages/onboarding-catalog.tsx
@@ -1,0 +1,42 @@
+import { useSearchParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import {
+  OnboardingGuidesCatalogView,
+  OnboardingGuidesCatalogSkeleton,
+} from '@flamingo-stack/openframe-frontend-core/components/onboarding-guides'
+import { fetchOnboardingGuides, fetchOnboardingSections } from '../data/content-api'
+import { PageError } from '../components/page-state'
+
+/**
+ * Props-driven onboarding catalog. We fetch from /content/api/onboarding-guides
+ * ourselves and pass the data in — bypassing the lib's hardcoded `/api` list hook.
+ * The lib view reads `?section=` from the URL (via the embed-shim → react-router
+ * bridge) and pushes it back, so we re-fetch per section here.
+ */
+export function OnboardingCatalogPage() {
+  const [searchParams] = useSearchParams()
+  const section = searchParams.get('section') ?? ''
+  const guides = useQuery({
+    queryKey: ['onboarding-guides', section],
+    queryFn: () => fetchOnboardingGuides(section || undefined),
+  })
+  const sections = useQuery({ queryKey: ['onboarding-sections'], queryFn: fetchOnboardingSections })
+
+  if (guides.isLoading || sections.isLoading) return <OnboardingGuidesCatalogSkeleton />
+  if (guides.isError || sections.isError || !guides.data || !sections.data) {
+    return (
+      <PageError
+        title="Couldn't load onboarding guides"
+        detail={String((guides.error ?? sections.error)?.message ?? '')}
+      />
+    )
+  }
+  return (
+    <OnboardingGuidesCatalogView
+      initialGuides={guides.data.data}
+      initialSections={sections.data}
+      initialSection={section}
+      basePath="/onboarding-guides"
+    />
+  )
+}

--- a/react-embedding-example/src/pages/onboarding-detail.tsx
+++ b/react-embedding-example/src/pages/onboarding-detail.tsx
@@ -1,0 +1,22 @@
+import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { OnboardingGuideDetailView } from '@flamingo-stack/openframe-frontend-core/components/onboarding-guides'
+import { fetchOnboardingGuide } from '../data/content-api'
+import { PageError, PageLoading } from '../components/page-state'
+
+export function OnboardingDetailPage() {
+  const { slug } = useParams()
+  const guide = useQuery({
+    queryKey: ['onboarding-guide', slug],
+    queryFn: () => fetchOnboardingGuide(slug!),
+    enabled: !!slug,
+  })
+
+  if (guide.isLoading) return <PageLoading label="Loading guide…" />
+  if (guide.isError || !guide.data) {
+    return <PageError title="Guide not found" detail={String(guide.error?.message ?? '')} />
+  }
+  return (
+    <OnboardingGuideDetailView initialData={guide.data} basePath="/onboarding-guides" backHref="/onboarding-guides" />
+  )
+}

--- a/react-embedding-example/src/pages/release-detail.tsx
+++ b/react-embedding-example/src/pages/release-detail.tsx
@@ -1,0 +1,58 @@
+import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { ReleaseDetailPage, RoadmapGrid } from '@flamingo-stack/openframe-frontend-core/components'
+import type { RoadmapItem } from '@flamingo-stack/openframe-frontend-core/components/chat'
+import { EP } from '../config/endpoints'
+
+/**
+ * Host-supplied data hook — ReleaseDetailPage REQUIRES this so it fetches through the
+ * app's QueryClient. Best-effort endpoint: adjust `EP.productReleaseBySlug` to match
+ * your hub's actual single-release route. On a miss it surfaces the lib's error state
+ * (no crash).
+ */
+function useRelease(slug: string | undefined) {
+  const query = useQuery({
+    queryKey: ['product-release', slug],
+    queryFn: async () => {
+      const res = await fetch(EP.productReleaseBySlug(slug!))
+      if (!res.ok) throw new Error(`Request failed (${res.status})`)
+      return res.json()
+    },
+    enabled: !!slug,
+  })
+  return { data: query.data, error: (query.error as Error) ?? null, isLoading: query.isLoading }
+}
+
+// Injected roadmap section — wraps RoadmapGrid so linked roadmap items vote/refresh via /content.
+function RoadmapSection({
+  items,
+  onItemUpdate,
+}: {
+  items: RoadmapItem[]
+  isLoading: boolean
+  onItemUpdate?: (item: RoadmapItem) => void
+}) {
+  return (
+    <RoadmapGrid
+      items={items}
+      onItemUpdate={onItemUpdate}
+      buildRefreshUrl={EP.roadmapById}
+      votingOptions={{ voteApiEndpoint: EP.roadmapVote }}
+      showLeftMargin={false}
+    />
+  )
+}
+
+export function ReleaseDetailRoute() {
+  const { slug = '' } = useParams()
+  return (
+    <ReleaseDetailPage
+      slug={slug}
+      useRelease={useRelease}
+      RoadmapSection={RoadmapSection}
+      roadmapApiEndpoint={EP.roadmap}
+      deliveryApiEndpoint={EP.deliveryCompleted}
+      backButton={{ label: 'Back to releases', href: '/releases' }}
+    />
+  )
+}

--- a/react-embedding-example/src/pages/releases.tsx
+++ b/react-embedding-example/src/pages/releases.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+/**
+ * The lib's `ReleaseDetailPage` renders a single release by slug (the host supplies
+ * the `useRelease` hook + injects the roadmap/delivery sections — see release-detail.tsx).
+ * There's no public "list releases" surface, so this index just routes to a slug.
+ */
+export function ReleasesPage() {
+  const [slug, setSlug] = useState('')
+  const navigate = useNavigate()
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-semibold text-ods-text-primary">Product releases</h1>
+      <p className="mt-2 max-w-2xl text-sm text-ods-text-secondary">
+        Enter a release slug from your hub to view it with the lib&apos;s{' '}
+        <code>ReleaseDetailPage</code> (linked roadmap items render through the injected{' '}
+        <code>RoadmapGrid</code>, pointed at <code>/content</code>).
+      </p>
+      <form
+        className="mt-4 flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault()
+          const s = slug.trim()
+          if (s) navigate(`/releases/${encodeURIComponent(s)}`)
+        }}
+      >
+        <input
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="release-slug"
+          className="w-64 rounded-md border border-ods-border bg-ods-card px-3 py-1.5 text-sm text-ods-text-primary"
+        />
+        <button
+          type="submit"
+          className="rounded-md border border-ods-border bg-ods-card px-3 py-1.5 text-sm text-ods-text-primary hover:bg-ods-bg"
+        >
+          View →
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/react-embedding-example/src/pages/roadmap.tsx
+++ b/react-embedding-example/src/pages/roadmap.tsx
@@ -1,0 +1,25 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { RoadmapGrid } from '@flamingo-stack/openframe-frontend-core/components'
+import { fetchRoadmap } from '../data/content-api'
+import { EP } from '../config/endpoints'
+import { PageError, PageLoading } from '../components/page-state'
+
+export function RoadmapPage() {
+  const queryClient = useQueryClient()
+  const roadmap = useQuery({ queryKey: ['roadmap'], queryFn: fetchRoadmap })
+
+  if (roadmap.isLoading) return <PageLoading label="Loading roadmap…" />
+  if (roadmap.isError) return <PageError title="Couldn't load roadmap" detail={String(roadmap.error?.message ?? '')} />
+
+  return (
+    <div className="p-6">
+      <RoadmapGrid
+        items={roadmap.data ?? []}
+        // After a vote, RoadmapGrid refreshes the single task; refetch the list so counts update.
+        onItemUpdate={() => queryClient.invalidateQueries({ queryKey: ['roadmap'] })}
+        buildRefreshUrl={EP.roadmapById}
+        votingOptions={{ voteApiEndpoint: EP.roadmapVote }}
+      />
+    </div>
+  )
+}

--- a/react-embedding-example/src/pages/tickets.tsx
+++ b/react-embedding-example/src/pages/tickets.tsx
@@ -1,0 +1,11 @@
+import { HelpCenterList } from '@flamingo-stack/openframe-frontend-core/components/tickets'
+
+/**
+ * HelpCenterList composes the lib's DevSectionPage chrome + create form + ticket
+ * list internally, and identifies the (proxy-injected) customer via ChatRuntime.
+ * Its hooks currently call bare `/api/chat/agent/*`, covered by the dev-only proxy
+ * fallback in vite.config.ts until the optional lib `agentBaseUrl` seam lands.
+ */
+export function TicketsPage() {
+  return <HelpCenterList />
+}

--- a/react-embedding-example/src/providers/app-providers.tsx
+++ b/react-embedding-example/src/providers/app-providers.tsx
@@ -1,0 +1,28 @@
+// Root providers: react-query (required by chat / tickets / onboarding hooks) +
+// the two lib runtime contexts (memoized, per the lib's embedder warning).
+// Theme: we set data-theme="dark" on <html> (index.html) instead of mounting a
+// theme provider — the lib's ThemeProvider isn't publicly exported, and the ODS
+// tokens key off the data-theme attribute directly.
+import { useMemo, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  ChatRuntimeContext,
+  EndpointsRuntimeContext,
+} from '@flamingo-stack/openframe-frontend-core/contexts'
+import { buildChatRuntime, buildEndpointsRuntime } from './content-runtime'
+
+const queryClient = new QueryClient()
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  const chatRuntime = useMemo(buildChatRuntime, [])
+  const endpointsRuntime = useMemo(buildEndpointsRuntime, [])
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ChatRuntimeContext.Provider value={chatRuntime}>
+        <EndpointsRuntimeContext.Provider value={endpointsRuntime}>
+          {children}
+        </EndpointsRuntimeContext.Provider>
+      </ChatRuntimeContext.Provider>
+    </QueryClientProvider>
+  )
+}

--- a/react-embedding-example/src/providers/content-runtime.ts
+++ b/react-embedding-example/src/providers/content-runtime.ts
@@ -1,0 +1,52 @@
+// ONE factory for both lib runtime contexts. Every endpoint comes from EP, so the
+// `/content` base is the single source. Mounted (memoized) in app-providers.tsx.
+import type { ChatRuntime, EndpointsRuntime } from '@flamingo-stack/openframe-frontend-core/contexts'
+import { EP, DEFAULT_SOURCE, HUB_PUBLIC_ORIGIN } from '../config/endpoints'
+import { buildListUrl } from '../config/chat-meta'
+import { navigateInApp } from './router-nav'
+import { resolveContentPath } from '../config/content-routes'
+
+export function buildChatRuntime(): ChatRuntime {
+  return {
+    endpoints: {
+      chatStreamUrl: EP.chatStream,
+      approvalToolUrl: EP.approval,
+      commandsUrl: EP.commands,
+      buildListUrl,
+      attachmentUploadUrl: EP.attachmentUpload,
+      // Relative is correct HERE: the proxy is same-origin to the SPA, and the lib's
+      // embedAuthedFetch (used by uploads + tickets) rejects cross-origin/absolute URLs.
+      attachmentViewUrlPrefix: EP.attachmentViewPrefix,
+      identityUrl: EP.identity,
+      imageProxyUrlPrefix: EP.imageProxy,
+    },
+    navigation: {
+      // 'host' = this app owns routing. The lib calls `navigate` for content/entity-card
+      // clicks; we route same-origin paths through react-router (in-app, no reload) and let
+      // cross-origin links (canonical hub content) fall back to the browser / new tab.
+      mode: 'host',
+      navigate: ({ href }) => (href.startsWith('/') ? navigateInApp(href) : false),
+    },
+    resolvePlaceholderUrl: (title) => EP.ogPlaceholder(title),
+    // Comply with the project's canonical buildContentURL shape (PUBLIC_URL_PATHS — see
+    // config/content-routes.ts), resolving to THIS app's local routes (single-platform
+    // embedder). This is the override point for the per-type "app suffix slug". Unknown
+    // types fall back to the canonical hub page.
+    composeContentUrl: (type, slug) => {
+      const local = resolveContentPath(type, slug)
+      return local
+        ? { href: local, targetPlatform: null }
+        : { href: `${HUB_PUBLIC_ORIGIN}/${type}/${slug}`, targetPlatform: null }
+    },
+    // localStorage namespacing + doc-search scope; must match the hub's currentPlatform().
+    source: DEFAULT_SOURCE,
+  }
+}
+
+export function buildEndpointsRuntime(): EndpointsRuntime {
+  return {
+    announcementsUrl: EP.announcements,
+    accessCode: { validateUrl: EP.accessValidate, consumeUrl: EP.accessConsume },
+    contactUrl: EP.contact,
+  }
+}

--- a/react-embedding-example/src/providers/embed-router-bridge.tsx
+++ b/react-embedding-example/src/providers/embed-router-bridge.tsx
@@ -1,0 +1,62 @@
+// Adapts react-router into the lib's embed-shims so every lib surface navigates
+// and re-renders in this SPA. The lib's shim contract (NavigationImpl) expects a
+// RouterStub from useRouter(), a bare string from usePathname(), and a bare
+// URLSearchParams from useSearchParams() — react-router's hooks don't match those
+// shapes (useNavigate is a function; useSearchParams returns a [params, setter]
+// tuple), so we MUST adapt, not register them raw.
+//
+// This file is .tsx because LinkAdapter contains JSX. Call registerEmbedRouterBridge()
+// ONCE before the first lib surface renders (see main.tsx).
+import { forwardRef, useMemo, type AnchorHTMLAttributes } from 'react'
+import { Link as RRLink, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+import { registerNavigation, registerLink } from '@flamingo-stack/openframe-frontend-core/embed-shims'
+
+// registerLink receives components with the NEXT <Link> prop shape (href + the
+// passed-through prefetch/replace/scroll). react-router's <Link> wants `to`, so map
+// href→to and drop the Next-only props (react-router has no such props).
+type NextLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  href?: string
+  prefetch?: boolean | null
+  replace?: boolean
+  scroll?: boolean
+}
+
+const LinkAdapter = forwardRef<HTMLAnchorElement, NextLinkProps>(function LinkAdapter(
+  { href, children, prefetch: _prefetch, replace, scroll: _scroll, ...rest },
+  ref,
+) {
+  return (
+    <RRLink ref={ref} to={href ?? ''} replace={replace} {...rest}>
+      {children}
+    </RRLink>
+  )
+})
+
+let registered = false
+
+export function registerEmbedRouterBridge(): void {
+  if (registered) return
+  registered = true
+
+  registerNavigation({
+    useRouter: () => {
+      const nav = useNavigate()
+      // Memoize so consumers (e.g. useDocSearch's useCallback) don't see a new ref each render.
+      return useMemo(
+        () => ({
+          push: (href: string) => nav(href),
+          replace: (href: string) => nav(href, { replace: true }),
+          back: () => nav(-1),
+          forward: () => nav(1),
+          refresh: () => {},
+          prefetch: () => {},
+        }),
+        [nav],
+      )
+    },
+    usePathname: () => useLocation().pathname,
+    useSearchParams: () => useSearchParams()[0], // unwrap react-router's [params, setter] tuple
+  })
+
+  registerLink(LinkAdapter)
+}

--- a/react-embedding-example/src/providers/router-nav.ts
+++ b/react-embedding-example/src/providers/router-nav.ts
@@ -1,0 +1,15 @@
+// Bridges react-router's `navigate` (only callable inside a component) to the
+// ChatRuntime's host-mode `navigation.navigate` callback (built once, outside React).
+// app-shell sets it on mount; content-runtime calls navigateInApp() for same-origin links.
+let navigateFn: ((to: string) => void) | null = null
+
+export function setInAppNavigate(fn: (to: string) => void): void {
+  navigateFn = fn
+}
+
+/** Returns true when handled in-app (so the lib won't also hit window.location). */
+export function navigateInApp(to: string): boolean {
+  if (!navigateFn) return false
+  navigateFn(to)
+  return true
+}

--- a/react-embedding-example/src/stubs/next-font-google.ts
+++ b/react-embedding-example/src/stubs/next-font-google.ts
@@ -1,0 +1,16 @@
+/**
+ * Vite alias stub for `next/font/google` (see vite.config.ts `resolve.alias`).
+ *
+ * The lib's `./fonts` entry calls `Azeret_Mono(...)` / `DM_Sans(...)` — Next.js
+ * compiler macros that a plain bundler can't evaluate. No surface in this example
+ * imports `./fonts` (fonts arrive via the `./styles` CSS import), so this stub is a
+ * defensive guard: if something transitively pulls a Google font, it resolves to a
+ * harmless no-op instead of crashing the build.
+ */
+type FontResult = { className: string; variable: string; style: { fontFamily: string } }
+const noop = (): FontResult => ({ className: '', variable: '', style: { fontFamily: '' } })
+
+export const Azeret_Mono = noop
+export const DM_Sans = noop
+// Catch-all so any other Google font name also resolves to a no-op.
+export default new Proxy({}, { get: () => noop })

--- a/react-embedding-example/src/vite-env.d.ts
+++ b/react-embedding-example/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** Public hub origin for new-tab content links (embed mode). */
+  readonly VITE_HUB_ORIGIN?: string
+  /** Chat source — must match the target hub's currentPlatform(). */
+  readonly VITE_CHAT_SOURCE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/react-embedding-example/tailwind.config.ts
+++ b/react-embedding-example/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+// The lib ships its Tailwind preset (ODS tokens, fonts, animations) under this subpath.
+import openframeCorePreset from '@flamingo-stack/openframe-frontend-core/tailwind.config.ts'
+
+export default {
+  // Compose via the `presets` array (NOT object-spread — that's how Tailwind merges presets).
+  presets: [openframeCorePreset as Config],
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}',
+    // Lib classes ship in dist/, not src/ — include them so purge doesn't drop them.
+    './node_modules/@flamingo-stack/openframe-frontend-core/dist/**/*.{js,mjs,cjs}',
+  ],
+} satisfies Config

--- a/react-embedding-example/tsconfig.json
+++ b/react-embedding-example/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    // allowJs lets src/config/content.ts import the single-source prefix from proxy/content-prefix.mjs
+    // (a plain ESM file Node can also run). checkJs stays off so the .mjs proxy files aren't type-gated.
+    "allowJs": true,
+    "checkJs": false,
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src", "proxy/content-prefix.mjs"]
+}

--- a/react-embedding-example/vite.config.ts
+++ b/react-embedding-example/vite.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, loadEnv } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+import { CONTENT_PREFIX } from './proxy/content-prefix.mjs'
+import { hubTarget, rewrite, injectHeaders } from './proxy/inject.mjs'
+
+// The dev server + `vite preview` both proxy /content (and the two documented bare-/api
+// exceptions) to the hub, injecting the chat secret + fixed identity headers server-side.
+// Secrets come from loadEnv with prefix '' (ALL vars) — these run in Node config, never in the bundle.
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const target = hubTarget(env)
+  const inject = {
+    target,
+    changeOrigin: true,
+    configure: (proxy: { on: (e: string, cb: (preq: { setHeader: (k: string, v: string) => void }) => void) => void }) => {
+      proxy.on('proxyReq', (proxyReq) => injectHeaders(proxyReq, env))
+    },
+  }
+  const proxy = {
+    // Canonical namespace: /content/api/* → ${HUB_ORIGIN}/api/* .
+    [CONTENT_PREFIX]: { ...inject, rewrite },
+    // Dev-only fallback for the two surfaces whose lib hooks still hardcode bare /api
+    // (the onboarding catalog's in-view doc-search + the tickets hooks). Forwarded as-is.
+    // Drop these once the optional lib seam (catalog searchEndpoint + tickets agentBaseUrl) lands.
+    '/api/docs/search': inject,
+    '/api/chat/agent': inject,
+  }
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        // Guard: the lib's ./fonts entry imports next/font/google (a Next compiler macro). No
+        // surface here imports ./fonts, but stub it so an accidental import can't break the build.
+        'next/font/google': path.resolve(__dirname, 'src/stubs/next-font-google.ts'),
+      },
+    },
+    server: { proxy },
+    preview: { proxy },
+  }
+})


### PR DESCRIPTION
## What

Adds **`react-embedding-example/`** — a standalone **Vite + React** app that embeds the chat (`EmbeddableChat`) and every page-level content surface from `@flamingo-stack/openframe-frontend-core` (onboarding guides, roadmap, delivery, product releases, legal, contact, tickets, announcements) against a **`/content` reverse proxy**.

The proxy holds the **chat secret** and injects a **fixed identity** (Michael Assraf) so the chat greets that user with no client-side auth — exactly how a real embedder works. In production the proxy is the existing Spring Boot service; the local proxy here (Vite dev proxy / a ~40-line Node `proxy/server.mjs`) mirrors it.

```
Browser SPA ──fetch('/content/api/...')──▶ proxy (rewrite + inject secret/identity) ──▶ hub /api/*
```

## Verified end-to-end (against a local hub)

- `npm run typecheck` + `npm run build` clean (React 19, react-router 6, react-query 5).
- `/content/api/auth/identity` → impersonates **michael@flamingo.cx** (name + avatar) via the `Bearer` secret + `X-Chat-Act-As` headers.
- Chat **SSE** streams through the proxy, personalized to that identity.
- Content reads (`/content/api/roadmap`, …) return live data.
- **No secret in the bundle** (`grep dist/` clean — only `VITE_`-prefixed vars reach the client).

## How it's wired

- Single `/content` prefix source (`proxy/content-prefix.mjs`); every endpoint derives from it (`src/config/endpoints.ts`).
- One shared proxy inject module (dev + standalone server).
- Lib runtime contexts (`ChatRuntime`/`EndpointsRuntime`) built once from that base; react-router bridged into the lib's `embed-shims`.
- ODS theming via `data-theme` + the lib's `/styles` import.

## Also included: `GENERIC_ROUTING_PLAN.md`

A design doc (converged through a multi-agent review panel to ≥95 on anti-duplication / DRY / code-standard / logic / bug-hunter) for making the lib's **URL routing + navigation generic**, so embedders use lib components as-is:

1. One shared `buildListUrl` in the lib (fixes chat entity cards not rendering — the embedder can't replicate the per-type list shapes that live in 14 hub mapper closures).
2. Internal-browsing overrides via the **existing** `composeContentUrl` seam + a lib default suffix table (browse in-app to the host's own slugged routes).
3. The one raw-`<a>` view card switched to the existing embed-shim `Link`.

## Scope / follow-ups

- This PR is the **example app + the plan**. The lib/hub refactor described in the plan is **follow-up work** (to be done in a paired hub+lib worktree).
- Until the lib seam lands, two surfaces (tickets, the onboarding catalog's in-view doc-search) ride bare `/api` via a documented dev-only proxy fallback; everything else is `/content`.
- `.env` (the shared secret) is gitignored — copy `.env.example` and set `CHAT_PROXY_SECRET` to the hub's value to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)