### PR TITLE
fix(tickets): eliminate body→skeleton→data double-flash in conversation drawer

### DIFF
--- a/openframe-frontend-core/src/components/tickets/hooks/use-ticket-engagements.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-ticket-engagements.ts
@@ -88,12 +88,17 @@ export function useTicketEngagements(
   const identity = useChatIdentity()
   const identityKey = identity.user?.email ?? 'anon'
 
-  const queryEnabled =
+  // "Will this ticket fetch its timeline once identity is ready?" — i.e. it's a
+  // real, non-optimistic ticket the caller enabled. INDEPENDENT of whether
+  // identity has resolved yet, so the loading state is correct from the very
+  // first render (before `useChatIdentity` settles).
+  const fetchable =
     enabled &&
-    identity.authTier !== 'anon' &&
-    !!identity.user?.email &&
     !!externalTicketId &&
     !externalTicketId.startsWith('temp-') // optimistic placeholders have no real id yet
+
+  const queryEnabled =
+    fetchable && identity.authTier !== 'anon' && !!identity.user?.email
 
   const query = useQuery({
     queryKey: ['ticket-engagements', externalTicketId, identityKey],
@@ -126,7 +131,22 @@ export function useTicketEngagements(
 
   return {
     engagements: query.data ?? [],
-    isLoading: queryEnabled && query.isLoading,
+    // Loading-state truth that prevents the "body → blink → skeleton → data"
+    // double-flash. The bug: `useChatIdentity` starts at anon defaults and
+    // resolves async, so on the first render `queryEnabled` is false and the
+    // OLD `queryEnabled && query.isLoading` returned FALSE — the panel rendered
+    // the ticket body, THEN identity resolved, the query enabled, isLoading
+    // flipped true → skeleton appeared (the blink), then data landed.
+    //
+    // Fix: for a fetchable ticket we are "loading" whenever we don't yet have
+    // the timeline to show — that includes the window while identity is still
+    // resolving (so we skeleton from the FIRST render, never the body) AND the
+    // cold query fetch (`data === undefined`). A background poll keeps
+    // `query.data` defined, so it never re-flashes the skeleton. Non-fetchable
+    // (optimistic/disabled) or a resolved-anon viewer → not loading.
+    isLoading:
+      fetchable &&
+      (identity.isLoading || (queryEnabled && query.data === undefined)),
     isFetching: query.isFetching,
     error: (query.error as Error | null) ?? null,
     refetch: () => {


### PR DESCRIPTION
## Symptom
Opening a ticket conversation flashed the message **body**, then **blinked to the skeleton**, then showed the real data.

## Root cause
Identity-resolution race in `useTicketEngagements`. `useChatIdentity()` starts at anon defaults and resolves async, so on the first render `queryEnabled` was false and the old `isLoading = queryEnabled && query.isLoading` returned **false** → the panel fell through and rendered the ticket body. Identity then resolved → query enabled → `isLoading` flipped **true** → skeleton appeared (the blink) → fetch settled → data.

## Fix
Split "is this ticket fetchable" (real, non-optimistic, enabled — identity-independent) from "is the query enabled right now". `isLoading` is now true for a fetchable ticket whenever the timeline isn't ready to show:
- while identity is still resolving (so it skeletons from the **first** render, never the body), OR
- during the cold query fetch (`data === undefined`).

A background poll keeps `query.data` defined, so it never re-flashes the skeleton; a resolved-anon viewer or a non-fetchable (optimistic/disabled) ticket is not loading.

## Scope
One file: `openframe-frontend-core/src/components/tickets/hooks/use-ticket-engagements.ts` (+24/−4). `tsc --noEmit`: 0 errors.

## Note on commits
This branch also carries the ticket Help Center redesign + the anchoring-proof smooth-scroll fix (also in PR #1079), since none are on `main` yet — so the diff vs `main` is 3 commits. The skeleton fix itself is the single top commit. Merge #1079 first and this collapses to the one-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)