### PR TITLE
AppLayoutDrawer + Mingo AI header button + in-layout chat

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -191,7 +191,7 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "yalc:watch": "NODE_OPTIONS='--max-old-space-size=4096' nodemon --watch src --watch tsconfig.json --watch tsup.config.ts --watch tailwind.config.ts --watch package.json -e ts,tsx,json,css --ignore dist --ignore node_modules --ignore '*.lock' --ignore .yalc --ignore yalc.lock --exec 'rm -rf dist && tsup && yalc push --changed'",
+    "yalc:watch": "NODE_OPTIONS='--max-old-space-size=4096' nodemon --watch src --watch tsconfig.json --watch tsup.config.ts --watch tailwind.config.ts --watch package.json -e ts,tsx,json,css --ignore dist --ignore node_modules --ignore '*.lock' --ignore .yalc --ignore yalc.lock --exec 'rm -rf dist && tsup && tsc -p tsconfig.declarations.json && yalc push --changed'",
     "yalc:push": "yalc push",
     "yalc:publish": "yalc publish",
     "generate:icons": "node scripts/generate-icons.mjs",

--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -47,6 +47,7 @@ import { XmarkIcon } from '../icons-v2-generated/signs-and-symbols/xmark-icon'
 
 import { ChatFooter } from './chat-container'
 import { ChatInput } from './chat-input'
+import { ChatSidebar } from './chat-sidebar'
 import { MingoOnboardingCard } from './mingo-onboarding-card'
 import { MingoOnboardingCardSkeleton } from './mingo-onboarding-card-skeleton'
 import { ChatMessageList } from './chat-message-list'
@@ -167,6 +168,20 @@ export interface EmbeddableChatProps {
    * else `'mingo'`.
    */
   defaultActiveMode?: ChatMode
+
+  /**
+   * Wrapper shell around the chat body.
+   *   - `'drawer'` (default): wraps in a body-level Radix Drawer (slide-in
+   *     overlay from the right) — the original MPH / standalone behaviour.
+   *   - `'none'`: no shell. Renders only the chat body so the consumer can
+   *     host it inside their own container (e.g. `AppLayoutDrawerContent`).
+   *     The internal "Ask AI" trigger and iOS body scroll-lock are also
+   *     suppressed — those are Drawer-shell concerns. The consumer is
+   *     responsible for mount/unmount and for opening/closing via the
+   *     `open` / `onOpenChange` props (which the in-body close button still
+   *     drives).
+   */
+  shell?: 'drawer' | 'none'
 }
 
 // =============================================================================
@@ -562,7 +577,13 @@ function EmbeddableChatInner({
   activeMode: controlledActiveMode,
   onActiveModeChange,
   defaultActiveMode,
+  shell = 'drawer',
 }: EmbeddableChatProps) {
+  // `shell === 'none'` means the consumer hosts us inside their own panel
+  // (e.g. AppLayoutDrawer in openframe-frontend). Several drawer-shell
+  // concerns are unconditional in this codebase — gate them off here so
+  // we don't double-up with the host's behaviour.
+  const shellLess = shell === 'none'
   const runtime = useRequiredChatRuntime()
   const source = runtime.source as DocSource
   const commandsUrl = runtime.endpoints.commandsUrl
@@ -603,12 +624,15 @@ function EmbeddableChatInner({
 
   // iOS scroll-lock — react-aria's two-layer approach plus body fixed-pos.
   // See hub original for the long mechanism comment; logic copied verbatim.
-  usePreventScroll({ isDisabled: !isOpen })
+  // Skipped in shell-less mode: the host (AppLayoutDrawer) is in-layout, so
+  // there's no body-level overlay that should block page scrolling.
+  usePreventScroll({ isDisabled: !isOpen || shellLess })
 
   const navigatingAwayRef = useRef(false)
 
   useEffect(() => {
     if (!isOpen) return
+    if (shellLess) return
     if (typeof window === 'undefined') return
     if (!isIOS()) return
 
@@ -634,7 +658,7 @@ function EmbeddableChatInner({
       if (window.location.pathname !== openPathname) return
       window.scrollTo(0, scrollY)
     }
-  }, [isOpen])
+  }, [isOpen, shellLess])
 
   // Imperative handle to the chat input.
   const chatInputRef = useRef<ChatInputRef | null>(null)
@@ -755,7 +779,45 @@ function EmbeddableChatInner({
     currentCacheHitRatePct,
     currentUsageBreakdown,
     displayRef,
+    // ─── Dialog management (Mingo-mode sidebar) ───
+    dialogs,
+    activeDialogId,
+    selectDialog,
+    startNewDialog,
+    isDialogsLoading,
+    hasMoreDialogs,
+    loadMoreDialogs,
   } = useUnifiedChat({ modes: effectiveModes, activeMode })
+
+  // Whether the in-panel dialog sidebar should render. Gated on:
+  //   1. Mingo mode is active (Guide has localStorage-only history that
+  //      isn't yet structured as a sidebar list — see
+  //      [[chat-architecture-and-migration]] for the asymmetry).
+  //   2. The host wired `fetchDialogs` — managed-dialog mode, not the
+  //      bare-transport Tauri flow.
+  const showSidebar =
+    activeMode === 'mingo' && effectiveModes.mingo?.fetchDialogs !== undefined
+
+  // Pending startNewDialog promise — used to gate the "Start new chat"
+  // button while creation is in flight so a double-click doesn't spawn
+  // two backend dialogs.
+  const [isStartingNewDialog, setIsStartingNewDialog] = useState<boolean>(false)
+  const handleStartNewDialog = useCallback(async () => {
+    if (isStartingNewDialog) return
+    setIsStartingNewDialog(true)
+    try {
+      await startNewDialog()
+    } finally {
+      setIsStartingNewDialog(false)
+    }
+  }, [isStartingNewDialog, startNewDialog])
+
+  const handleSelectDialog = useCallback(
+    (id: string) => {
+      selectDialog(id)
+    },
+    [selectDialog],
+  )
 
   // Chat-attachment hooks (v2 attachment feature).
   const {
@@ -930,8 +992,9 @@ function EmbeddableChatInner({
   return (
     <>
       {/* Floating "Ask AI" button — sticky-dock pattern. See hub original
-          for the full mechanism explanation. */}
-      {showInternalTrigger && (
+          for the full mechanism explanation. Suppressed in shell-less mode:
+          the host controls open/close, so an internal trigger would race. */}
+      {showInternalTrigger && !shellLess && (
         <div
           aria-hidden={isOpen}
           className={`sticky bottom-0 h-0 z-[9990] pointer-events-none ${
@@ -953,36 +1016,17 @@ function EmbeddableChatInner({
         </div>
       )}
 
-      <Drawer open={isOpen} onOpenChange={(o: boolean) => !o && handleClose()}>
-        <ChatPanelContext.Provider value={chatPanelHandle}>
-          {/*
-            Panel-level handle for descendants (inline cards via
-            `ChatCardNavWrap`, markdown-body links via
-            `NavLinkAnchorViaRuntime`) to close the panel after same-tab
-            navigation. Same-tab clicks fire `closeChat`; new-tab clicks
-            leave the panel open while the new tab loads.
-          */}
-          <DrawerContent
-            side="right"
-            flush
-            resizable
-            minSize={480}
-            maxSize={1280}
-            defaultSize={640}
-            storageKey="mingo-chat-width"
-            resizeAriaLabel="Resize chat panel"
-            overlayClassName="mingo-chat-overlay md:bg-black/20"
-            aria-describedby={undefined}
-            className="
-              mingo-chat-content !bg-ods-bg shadow-2xl
-              focus:outline-none focus-visible:outline-none
-              w-screen md:w-auto
-            "
-          >
-            <VisuallyHidden>
-              <DialogPrimitive.Title>{sourceLabel} AI Assistant</DialogPrimitive.Title>
-            </VisuallyHidden>
-
+      {/*
+        Conditional shell — overlay (Drawer, MPH default) vs inline
+        (positioned `<aside>` anchored to the nearest positioned
+        ancestor, openframe-frontend's nav-embedded chat). Both share
+        the same `body` JSX so the chat content is defined exactly
+        once; the IIFE keeps both branches type-balanced inside JSX
+        (no opening tag in one ternary branch + closing in another).
+      */}
+      {(() => {
+        const body = (
+          <>
             <div className="flex h-full flex-col overflow-hidden">
               {/* Figma node 7363:205930 — top-navigation. Title intentionally
                   omitted; a chevron-left + "New Chat" back-style affordance
@@ -1020,6 +1064,27 @@ function EmbeddableChatInner({
                   <XmarkIcon className="text-ods-text-secondary" size={24} />
                 </button>
               </div>
+
+              {/* Sidebar + chat-panel row. When Mingo is the active mode and
+                  `fetchDialogs` is wired, the in-panel `<ChatSidebar>` lists
+                  the user's backend-driven dialog history. Guide mode keeps
+                  history in localStorage and currently renders no sidebar. */}
+              <div className="flex flex-1 min-h-0 overflow-hidden">
+                {showSidebar && (
+                  <ChatSidebar
+                    className="w-72 shrink-0"
+                    dialogs={dialogs}
+                    activeDialogId={activeDialogId ?? undefined}
+                    onDialogSelect={handleSelectDialog}
+                    onNewChat={() => { void handleStartNewDialog() }}
+                    isLoading={isDialogsLoading && dialogs.length === 0}
+                    isCreatingDialog={isStartingNewDialog}
+                    hasNextPage={hasMoreDialogs}
+                    isFetchingNextPage={isDialogsLoading && dialogs.length > 0}
+                    onLoadMore={() => { void loadMoreDialogs() }}
+                  />
+                )}
+                <div className="flex flex-1 flex-col min-h-0 min-w-0">
 
               {showModeToggle ? (
                 <div
@@ -1222,11 +1287,63 @@ function EmbeddableChatInner({
                   </div>
                 </div>
               </div>
+                </div>
+              </div>
             </div>
             {galleryModal}
-          </DrawerContent>
-        </ChatPanelContext.Provider>
-      </Drawer>
+          </>
+        )
+
+        // Shell-less branch — host (e.g. AppLayoutDrawer) provides the panel
+        // chrome, focus trap, animation, and size. We render only the chat
+        // body plus ChatPanelContext so descendants can still close after
+        // same-tab navigation via the host's `onOpenChange`.
+        if (shellLess) {
+          return (
+            <ChatPanelContext.Provider value={chatPanelHandle}>
+              {body}
+            </ChatPanelContext.Provider>
+          )
+        }
+
+        // Body-level Radix Drawer — backdrop, iOS scroll-lock, focus
+        // trap, drag-to-resize handle. Slides in from the right edge.
+        return (
+          <Drawer open={isOpen} onOpenChange={(o: boolean) => !o && handleClose()}>
+            <ChatPanelContext.Provider value={chatPanelHandle}>
+              {/*
+                Panel-level handle for descendants (inline cards via
+                `ChatCardNavWrap`, markdown-body links via
+                `NavLinkAnchorViaRuntime`) to close the panel after same-tab
+                navigation. Same-tab clicks fire `closeChat`; new-tab clicks
+                leave the panel open while the new tab loads.
+              */}
+              <DrawerContent
+                side="right"
+                flush
+                resizable
+                minSize={showSidebar ? 720 : 480}
+                maxSize={1600}
+                defaultSize={showSidebar ? 960 : 640}
+                storageKey={showSidebar ? 'mingo-chat-width-with-sidebar' : 'mingo-chat-width'}
+                resizeAriaLabel="Resize chat panel"
+                overlayClassName="mingo-chat-overlay md:bg-black/20"
+                aria-describedby={undefined}
+                className="
+                  mingo-chat-content !bg-ods-bg shadow-2xl
+                  focus:outline-none focus-visible:outline-none
+                  w-screen md:w-auto
+                "
+              >
+                <VisuallyHidden>
+                  <DialogPrimitive.Title>{sourceLabel} AI Assistant</DialogPrimitive.Title>
+                </VisuallyHidden>
+                {body}
+              </DrawerContent>
+            </ChatPanelContext.Provider>
+          </Drawer>
+        )
+      })()}
     </>
   )
 }

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -570,7 +570,8 @@ export function useNatsChatAdapter(
   const loadDialogHistory = useCallback(
     async (id: string, cursor?: string): Promise<void> => {
       if (!fetchDialogMessages) return
-      const seq = ++historyLoadSeqRef.current
+      historyLoadSeqRef.current += 1
+      const seq = historyLoadSeqRef.current
       setIsMessagesLoading(true)
       try {
         const result = await fetchDialogMessages({
@@ -632,12 +633,21 @@ export function useNatsChatAdapter(
     if (prevDialogIdRef.current === dialogId) return
     prevDialogIdRef.current = dialogId
 
+    // Invalidate any in-flight history load for the previous dialog. Bumping
+    // here (not only inside loadDialogHistory) covers the clear/delete path
+    // — switching to a null/empty dialog never starts a new load, so without
+    // this an in-flight response could repopulate the just-cleared state.
+    historyLoadSeqRef.current += 1
+
     // Drop accumulator + message state for the previous dialog.
     resetAccumulator()
     setMessages([])
     setMessagesNextCursor(null)
     setDialogTokenUsage(null)
     setStreamingPhase('idle')
+    // No load runs when there's no active dialog, so clear the flag here;
+    // otherwise the superseded load's guarded `finally` leaves it stuck on.
+    setIsMessagesLoading(false)
 
     if (!active || !dialogId) return
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -561,9 +561,16 @@ export function useNatsChatAdapter(
   // accumulator, and seed `messages`. Streaming chunks for the same
   // dialog then append on top.
 
+  // Monotonic guard: each history load captures a sequence number; when a
+  // response resolves, it only applies if it's still the latest request. This
+  // prevents a slow response for a previously-selected dialog from clobbering
+  // the state of the dialog the user just switched to.
+  const historyLoadSeqRef = useRef(0)
+
   const loadDialogHistory = useCallback(
     async (id: string, cursor?: string): Promise<void> => {
       if (!fetchDialogMessages) return
+      const seq = ++historyLoadSeqRef.current
       setIsMessagesLoading(true)
       try {
         const result = await fetchDialogMessages({
@@ -571,6 +578,8 @@ export function useNatsChatAdapter(
           cursor,
           limit: messagesPageSize,
         })
+        // Ignore stale responses superseded by a newer dialog selection.
+        if (seq !== historyLoadSeqRef.current) return
         const { messages: rawProcessed } = processHistoricalMessagesWithErrors(
           result.messages,
           {
@@ -598,7 +607,11 @@ export function useNatsChatAdapter(
       } catch (err) {
         console.error('[useNatsChatAdapter] fetchDialogMessages failed:', err)
       } finally {
-        setIsMessagesLoading(false)
+        // Only the latest request owns the loading flag — a superseded one
+        // must not clear it while the newer load is still in flight.
+        if (seq === historyLoadSeqRef.current) {
+          setIsMessagesLoading(false)
+        }
       }
     },
     [

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -7,7 +7,7 @@
  * `useChat({ mode })` can dispatch between them with zero shell-side
  * branching.
  *
- * Composition (no new logic — all the pieces already exist in the lib):
+ * Composition layers (in order from low to high):
  *
  *   ┌──────────────────────────────────────────────────────────────┐
  *   │ useNatsDialogSubscription   live tail of agent events        │
@@ -23,6 +23,29 @@
  *   │                                                              │
  *   │ config.publishUserMessage   consumer-owned send (HTTP/NATS)  │
  *   └──────────────────────────────────────────────────────────────┘
+ *
+ * Two operating modes, distinguished by the presence of `fetchDialogs`:
+ *
+ *   1. **Bare-transport mode** (current Tauri Fae Chat usage):
+ *      consumer supplies `config.dialogId` explicitly and owns dialog
+ *      management above the adapter. The adapter does no list/select
+ *      bookkeeping — every dialog field on the return value falls back
+ *      to an empty default. This is the original v0 API; preserved
+ *      byte-compatible so existing pinned consumers keep working.
+ *
+ *   2. **Managed-dialog mode** (openframe-frontend, EmbeddableChat
+ *      sidebar): consumer supplies `fetchDialogs`,
+ *      `fetchDialogMessages`, `createDialog`, etc. and the adapter
+ *      owns the dialog state machine. The active dialog id, the list,
+ *      pagination cursors, token usage hydration, and history merge
+ *      all live inside this hook. The host renders the sidebar via
+ *      `EmbeddableChat`'s built-in `<ChatSidebar>` slot and calls
+ *      `selectDialog` / `startNewDialog` from there.
+ *
+ * The two modes are NOT mutually exclusive — passing `config.dialogId`
+ * alongside `fetchDialogs` forces the adapter into controlled mode (the
+ * external id wins) while still using the host's list fetchers for the
+ * sidebar.
  *
  * Why publish is consumer-owned: the NATS module exposes a low-level
  * `publishBytes/String/Json` but the actual user-message endpoint varies
@@ -46,39 +69,83 @@ import {
 import { useNatsDialogSubscription } from './use-nats-dialog-subscription'
 import { useRealtimeChunkProcessor } from './use-realtime-chunk-processor'
 import { useChunkCatchup } from './use-chunk-catchup'
+import { processHistoricalMessagesWithErrors } from '../utils/process-historical-messages'
 import type {
   ChunkData,
   FetchChunksFunction,
+  HistoricalMessage,
   MessageSegment,
   NatsMessageType,
   StreamingPhase,
+  ChatApprovalStatus,
 } from '../types'
 import type {
+  ChatConnectionState,
+  DialogTokenUsage,
   UnifiedChatState,
   UnifiedChatMessage,
   UnifiedSendMessageOptions,
 } from '../types/unified-chat-state.types'
+import type { DialogItem } from '../types/component.types'
 import type { ChatRef } from '../chat-ref.types'
 
 // =============================================================================
 // Config + options
 // =============================================================================
 
+/** Page-fetch parameters passed to `fetchDialogs`. The adapter owns the
+ *  cursor — the host only resolves it against the backend. */
+export interface FetchDialogsParams {
+  cursor?: string
+  limit?: number
+  search?: string
+}
+
+/** Successful `fetchDialogs` response. `nextCursor: null` means "no more
+ *  pages" — used to terminate the infinite-scroll observer in the
+ *  sidebar. */
+export interface FetchDialogsResult {
+  dialogs: DialogItem[]
+  nextCursor: string | null
+}
+
+/** Page-fetch parameters passed to `fetchDialogMessages`. */
+export interface FetchDialogMessagesParams {
+  dialogId: string
+  cursor?: string
+  limit?: number
+}
+
+/** Successful `fetchDialogMessages` response. `tokenUsage` is optional —
+ *  some backends only attach it to the dialog header query, in which case
+ *  hosts can either include it on the first page only (will populate the
+ *  ModelDisplay readout) or fold it in via a separate update path. */
+export interface FetchDialogMessagesResult {
+  messages: HistoricalMessage[]
+  nextCursor: string | null
+  tokenUsage?: DialogTokenUsage | null
+}
+
 /**
  * Consumer-supplied configuration for the NATS chat adapter.
  *
- * Every field is consumer-owned — the lib does not assume a particular
- * backend protocol or auth scheme. Hosts wire these up against their
- * own OpenFrame deployment.
+ * Every field except `getNatsWsUrl` + `publishUserMessage` is optional —
+ * the lib does not assume a particular backend protocol or auth scheme.
+ * Hosts wire these up against their own OpenFrame deployment.
  */
 export interface UseNatsChatAdapterConfig {
   /**
-   * Active conversation/dialog id. When `null` the adapter stays
-   * subscription-idle (no NATS connection, no catchup fetch). Set this
-   * once the consumer's "open new conversation" flow has allocated an
-   * id from the backend.
+   * Active conversation/dialog id. When omitted (`undefined`) the
+   * adapter manages its own active dialog id internally — the host
+   * drives selection through `selectDialog` / `startNewDialog`. When
+   * explicitly set (including `null`) the adapter treats this as
+   * controlled mode and uses the value verbatim. v0 consumers (the
+   * Tauri Fae Chat client) pass an explicit id here and own the
+   * lifecycle externally; v1+ consumers (the openframe-frontend
+   * EmbeddableChat) leave it undefined and rely on `fetchDialogs`
+   * for sidebar-driven selection.
    */
-  dialogId: string | null
+  dialogId?: string | null
 
   /**
    * Build the NATS WebSocket URL. Returning `null` short-circuits the
@@ -136,6 +203,78 @@ export interface UseNatsChatAdapterConfig {
    * `toolCalls[]`. Set `false` to fall back to legacy per-tool cards.
    */
   batchApprovalsEnabled?: boolean
+
+  // ─── Managed-dialog mode (sidebar + history) ─────────────────────────────
+
+  /**
+   * Fetch a paginated page of dialogs for the sidebar. When provided,
+   * the adapter switches to managed-dialog mode: it owns the active
+   * dialog id, the dialog list, and pagination state. When omitted,
+   * the adapter operates in bare-transport mode (current Tauri Fae
+   * Chat usage) and the sidebar fields on the return value stay empty.
+   */
+  fetchDialogs?: (params: FetchDialogsParams) => Promise<FetchDialogsResult>
+
+  /**
+   * Fetch a page of historical messages for a dialog. Required for
+   * sidebar-driven dialog switching — when omitted, selecting a
+   * dialog brings up an empty thread until streaming starts.
+   *
+   * Messages must arrive in the same wire shape the openframe backend
+   * emits (HistoricalMessage with messageData[]); the adapter feeds
+   * them through `processHistoricalMessagesWithErrors` to produce
+   * accumulator-compatible segments.
+   */
+  fetchDialogMessages?: (
+    params: FetchDialogMessagesParams,
+  ) => Promise<FetchDialogMessagesResult>
+
+  /**
+   * Allocate a fresh dialog on the backend. Returns the new dialog id
+   * which the adapter sets as the active dialog. When omitted, the
+   * "Start new chat" affordance on the sidebar is hidden (or the host
+   * can implement its own).
+   */
+  createDialog?: () => Promise<{ dialogId: string }>
+
+  /** Delete a dialog from history. When omitted, the sidebar item's
+   *  delete affordance is hidden. */
+  deleteDialog?: (dialogId: string) => Promise<void>
+
+  /**
+   * Approve a pending tool-call request. Wired into the segment
+   * accumulator's `onApprove` so approval-card buttons fire this
+   * directly. When omitted, approval cards render disabled buttons.
+   */
+  approveRequest?: (requestId: string) => Promise<void>
+
+  /** Reject counterpart of `approveRequest`. */
+  rejectRequest?: (requestId: string, reason?: string) => Promise<void>
+
+  /**
+   * Cancel in-flight assistant generation. Without this, `stopMessage`
+   * only flips the UI status — the backend continues until the agent
+   * finishes naturally. With this, the backend stops emitting chunks.
+   */
+  stopGeneration?: (dialogId: string) => Promise<void>
+
+  /** Display name for the assistant in historical messages — defaults
+   *  to `'Mingo'`. */
+  assistantName?: string
+
+  /**
+   * GraphQL `chatType` discriminator to filter historical messages by.
+   * When set, `processHistoricalMessagesWithErrors` skips messages
+   * whose `chatType` doesn't match. Openframe-frontend uses
+   * `'ADMIN_AI_CHAT'` here.
+   */
+  chatTypeFilter?: string
+
+  /** Default page size for dialog list pagination. Defaults to 20. */
+  dialogsPageSize?: number
+
+  /** Default page size for message history pagination. Defaults to 50. */
+  messagesPageSize?: number
 }
 
 /**
@@ -192,6 +331,43 @@ function updateTrailingAssistant(
   ]
 }
 
+/**
+ * Map `ProcessedMessage` (lib's historical-message format) into
+ * `UnifiedChatMessage` (the unified-chat-state contract). Only `user`
+ * and `assistant` roles round-trip; `error` is dropped on the floor
+ * here because the unified contract surfaces errors as banners, not
+ * inline messages. (Hosts that need inline error bubbles can extend
+ * the contract later.)
+ */
+function mapProcessedToUnified(
+  processed: Array<{
+    id: string
+    role: 'user' | 'assistant' | 'error'
+    content: string | MessageSegment[]
+    name?: string
+  }>,
+): UnifiedChatMessage[] {
+  const out: UnifiedChatMessage[] = []
+  for (const m of processed) {
+    if (m.role === 'error') continue
+    if (Array.isArray(m.content)) {
+      out.push({
+        id: m.id,
+        role: m.role,
+        content: '',
+        segments: m.content,
+      })
+    } else {
+      out.push({
+        id: m.id,
+        role: m.role,
+        content: m.content,
+      })
+    }
+  }
+  return out
+}
+
 // =============================================================================
 // Hook
 // =============================================================================
@@ -202,17 +378,140 @@ export function useNatsChatAdapter(
 ): UnifiedChatState {
   const { active = true } = options
   const {
-    dialogId,
+    dialogId: controlledDialogId,
     getNatsWsUrl,
     clientConfig,
     publishUserMessage,
     fetchChunks,
     enableThinking,
     batchApprovalsEnabled,
+    fetchDialogs,
+    fetchDialogMessages,
+    createDialog: createDialogCallback,
+    deleteDialog: deleteDialogCallback,
+    approveRequest: approveRequestCallback,
+    rejectRequest: rejectRequestCallback,
+    stopGeneration: stopGenerationCallback,
+    assistantName = 'Mingo',
+    chatTypeFilter,
+    dialogsPageSize = 20,
+    messagesPageSize = 50,
   } = config
+
+  // ─── Active dialog id resolution ──────────────────────────────────────────
+  // The discriminator is *capability*, not *value*: when the host wires
+  // `fetchDialogs` we know they want the adapter to own the dialog list,
+  // active id, and sidebar wiring. Any `controlledDialogId` they pass in
+  // that mode is ignored (host shouldn't be fighting the adapter for
+  // selection). When `fetchDialogs` is absent (Tauri Fae Chat) the adapter
+  // is in bare-transport mode and the host's `dialogId` is the source of
+  // truth — including `null`, which means "no dialog selected, idle WS".
+
+  const isManagedMode = fetchDialogs !== undefined
+  const [internalDialogId, setInternalDialogId] = useState<string | null>(null)
+  const dialogId = isManagedMode
+    ? internalDialogId
+    : controlledDialogId !== undefined
+    ? controlledDialogId
+    : null
+
+  // ─── Message thread + streaming phase ─────────────────────────────────────
 
   const [messages, setMessages] = useState<UnifiedChatMessage[]>([])
   const [streamingPhase, setStreamingPhase] = useState<StreamingPhase>('idle')
+
+  // Approval status map. Used both to dedupe pending segments at render
+  // time and to feed `processHistoricalMessagesWithErrors` so previously
+  // resolved approvals don't re-render as actionable on dialog switch.
+  const [approvalStatuses, setApprovalStatuses] = useState<
+    Record<string, ChatApprovalStatus>
+  >({})
+
+  // ─── Dialog list state (managed-dialog mode only) ─────────────────────────
+
+  const [dialogs, setDialogs] = useState<DialogItem[]>([])
+  const [dialogsNextCursor, setDialogsNextCursor] = useState<string | null>(null)
+  const [isDialogsLoading, setIsDialogsLoading] = useState<boolean>(false)
+  const [isCreatingDialog, setIsCreatingDialog] = useState<boolean>(false)
+
+  // ─── Message-history pagination ───────────────────────────────────────────
+
+  const [messagesNextCursor, setMessagesNextCursor] = useState<string | null>(null)
+  const [isMessagesLoading, setIsMessagesLoading] = useState<boolean>(false)
+
+  // ─── Token usage (Mingo per-dialog cumulative) ────────────────────────────
+
+  const [dialogTokenUsage, setDialogTokenUsage] = useState<DialogTokenUsage | null>(
+    null,
+  )
+
+  // ─── Connection state ─────────────────────────────────────────────────────
+
+  const [connectionState, setConnectionState] =
+    useState<ChatConnectionState>('connecting')
+
+  // ─── Approval handlers ────────────────────────────────────────────────────
+  // Optimistically flip status before the network round-trip so the
+  // accumulator's render reflects the user's choice immediately.
+
+  const handleApprove = useCallback(
+    async (requestId: string) => {
+      if (!approveRequestCallback) return
+      setApprovalStatuses((prev) => ({ ...prev, [requestId]: 'approved' }))
+      try {
+        await approveRequestCallback(requestId)
+      } catch (err) {
+        // Revert the optimistic flip on failure so the user can retry.
+        setApprovalStatuses((prev) => {
+          const next = { ...prev }
+          delete next[requestId]
+          return next
+        })
+        console.error('[useNatsChatAdapter] approveRequest failed:', err)
+      }
+    },
+    [approveRequestCallback],
+  )
+
+  const handleReject = useCallback(
+    async (requestId: string, reason?: string) => {
+      if (!rejectRequestCallback) return
+      setApprovalStatuses((prev) => ({ ...prev, [requestId]: 'rejected' }))
+      try {
+        await rejectRequestCallback(requestId, reason)
+      } catch (err) {
+        setApprovalStatuses((prev) => {
+          const next = { ...prev }
+          delete next[requestId]
+          return next
+        })
+        console.error('[useNatsChatAdapter] rejectRequest failed:', err)
+      }
+    },
+    [rejectRequestCallback],
+  )
+
+  // Stable refs so the accumulator's callbacks don't churn on re-render.
+  const handleApproveRef = useRef(handleApprove)
+  handleApproveRef.current = handleApprove
+  const handleRejectRef = useRef(handleReject)
+  handleRejectRef.current = handleReject
+
+  // Accumulator-compatible adapters. The lib's accumulator contract is
+  // `(requestId?: string) => void | Promise<void>` — single optional arg,
+  // no rejection reason. Our public API surface widens that to require a
+  // string + accept a reason, so we narrow here at the boundary. Reason
+  // is unavailable from button-click callers (the accumulator doesn't
+  // pass it) so we only forward the requestId; consumers that need
+  // structured reject reasons can call `rejectRequest` directly.
+  const accumApprove = useCallback((requestId?: string): void | Promise<void> => {
+    if (!requestId) return
+    return handleApproveRef.current(requestId)
+  }, [])
+  const accumReject = useCallback((requestId?: string): void | Promise<void> => {
+    if (!requestId) return
+    return handleRejectRef.current(requestId)
+  }, [])
 
   // Stable callback ref so `useRealtimeChunkProcessor`'s options object
   // doesn't churn every render and tear down the accumulator state.
@@ -228,12 +527,16 @@ export function useNatsChatAdapter(
     onStreamEnd: () => setStreamingPhase('idle'),
   })
 
-  // Real-time chunk → segment processor.
+  // Real-time chunk → segment processor. Approval handlers route through
+  // the refs so a config change (e.g. callback identity churn from the
+  // host) doesn't tear down the accumulator.
   const { processChunk, reset: resetAccumulator } = useRealtimeChunkProcessor({
     callbacks: {
       onSegmentsUpdate: (segments) => callbacksRef.current.onSegmentsUpdate(segments),
       onStreamStart: () => callbacksRef.current.onStreamStart(),
       onStreamEnd: () => callbacksRef.current.onStreamEnd(),
+      onApprove: accumApprove,
+      onReject: accumReject,
     },
     enableThinking,
     batchApprovalsEnabled,
@@ -252,9 +555,88 @@ export function useNatsChatAdapter(
     fetchChunks,
   })
 
-  // Trigger initial backfill whenever a fresh dialog activates. Mirrors the
-  // pattern in `.use-chunk-catchup.md`: enable buffering first so realtime
-  // chunks queue behind the historical fetch, then flush in order.
+  // ─── Historical message hydration ─────────────────────────────────────────
+  // When the active dialog changes AND a `fetchDialogMessages` callback
+  // is wired, load the first page of history, process it through the
+  // accumulator, and seed `messages`. Streaming chunks for the same
+  // dialog then append on top.
+
+  const loadDialogHistory = useCallback(
+    async (id: string, cursor?: string): Promise<void> => {
+      if (!fetchDialogMessages) return
+      setIsMessagesLoading(true)
+      try {
+        const result = await fetchDialogMessages({
+          dialogId: id,
+          cursor,
+          limit: messagesPageSize,
+        })
+        const { messages: rawProcessed } = processHistoricalMessagesWithErrors(
+          result.messages,
+          {
+            assistantName,
+            assistantType: 'mingo',
+            chatTypeFilter,
+            onApprove: accumApprove,
+            onReject: accumReject,
+            approvalStatuses,
+            batchApprovalsEnabled,
+          },
+        )
+        const unified = mapProcessedToUnified(rawProcessed)
+        if (cursor === undefined) {
+          // First page — replace.
+          setMessages(unified)
+        } else {
+          // Older page — prepend.
+          setMessages((prev) => [...unified, ...prev])
+        }
+        setMessagesNextCursor(result.nextCursor)
+        if (result.tokenUsage !== undefined) {
+          setDialogTokenUsage(result.tokenUsage)
+        }
+      } catch (err) {
+        console.error('[useNatsChatAdapter] fetchDialogMessages failed:', err)
+      } finally {
+        setIsMessagesLoading(false)
+      }
+    },
+    [
+      fetchDialogMessages,
+      messagesPageSize,
+      assistantName,
+      chatTypeFilter,
+      approvalStatuses,
+      batchApprovalsEnabled,
+      accumApprove,
+      accumReject,
+    ],
+  )
+
+  // Reset + reload when the active dialog changes.
+  const prevDialogIdRef = useRef<string | null | undefined>(undefined)
+  useEffect(() => {
+    if (prevDialogIdRef.current === dialogId) return
+    prevDialogIdRef.current = dialogId
+
+    // Drop accumulator + message state for the previous dialog.
+    resetAccumulator()
+    setMessages([])
+    setMessagesNextCursor(null)
+    setDialogTokenUsage(null)
+    setStreamingPhase('idle')
+
+    if (!active || !dialogId) return
+
+    // Hydrate history first; then catchup will fold in any chunks that
+    // landed between the history snapshot and the live tail.
+    void loadDialogHistory(dialogId)
+  }, [active, dialogId, loadDialogHistory, resetAccumulator])
+
+  // Trigger initial chunk backfill whenever a fresh dialog activates.
+  // Runs alongside history hydration — history seeds processed messages,
+  // catchup buffers raw chunks in case the WS came online after history
+  // was already snapshotted.
   useEffect(() => {
     if (!active || !dialogId) return
     resetChunkTracking()
@@ -264,9 +646,10 @@ export function useNatsChatAdapter(
     })
   }, [active, dialogId, resetChunkTracking, startInitialBuffering, catchUpChunks])
 
-  // Live tail subscription. `enabled` is gated on both `active` and a
-  // non-null dialogId so the consumer doesn't pay socket cost before
-  // a conversation exists.
+  // ─── Live NATS subscription ───────────────────────────────────────────────
+  // Gated on `active` and a non-null dialogId so the consumer doesn't pay
+  // socket cost before a conversation exists.
+
   useNatsDialogSubscription({
     enabled: active && dialogId != null,
     dialogId,
@@ -277,10 +660,59 @@ export function useNatsChatAdapter(
       // with historical playback. `useChunkCatchup` itself forwards to
       // `processChunk` once dedupe checks pass.
       catchupProcessChunk(payload as ChunkData, messageType)
+      // First successful event marks the connection as up.
+      setConnectionState('connected')
     },
   })
 
-  // ─── Public API ───────────────────────────────────────────────────────────
+  // Without a finer hook signal we treat "active + dialog selected" as
+  // connecting until the first event lands, and "no dialog" as idle-
+  // connected (nothing to subscribe to anyway).
+  useEffect(() => {
+    if (!active || !dialogId) {
+      setConnectionState('connected')
+      return
+    }
+    setConnectionState('connecting')
+  }, [active, dialogId])
+
+  // ─── Dialog list management (managed-dialog mode) ─────────────────────────
+
+  const loadDialogsPage = useCallback(
+    async (cursor?: string): Promise<void> => {
+      if (!fetchDialogs) return
+      setIsDialogsLoading(true)
+      try {
+        const result = await fetchDialogs({
+          cursor,
+          limit: dialogsPageSize,
+        })
+        setDialogsNextCursor(result.nextCursor)
+        if (cursor === undefined) {
+          setDialogs(result.dialogs)
+        } else {
+          setDialogs((prev) => [...prev, ...result.dialogs])
+        }
+      } catch (err) {
+        console.error('[useNatsChatAdapter] fetchDialogs failed:', err)
+      } finally {
+        setIsDialogsLoading(false)
+      }
+    },
+    [fetchDialogs, dialogsPageSize],
+  )
+
+  // Initial dialog list load.
+  const initialDialogsLoadedRef = useRef(false)
+  useEffect(() => {
+    if (!fetchDialogs) return
+    if (!active) return
+    if (initialDialogsLoadedRef.current) return
+    initialDialogsLoadedRef.current = true
+    void loadDialogsPage()
+  }, [active, fetchDialogs, loadDialogsPage])
+
+  // ─── Public action handlers ───────────────────────────────────────────────
 
   const sendMessage = useCallback(
     async (
@@ -314,18 +746,104 @@ export function useNatsChatAdapter(
   )
 
   const stopMessage = useCallback(() => {
-    // NATS streams are driven server-side; the client can't really
-    // "cancel" an in-flight agent task without backend cooperation.
-    // For now we just drop the UI status — incoming chunks will still
-    // be accepted and rendered if the agent completes anyway.
+    // Best-effort UI flip. The actual backend cancellation is gated on
+    // the host-supplied callback.
     setStreamingPhase('idle')
-  }, [])
+    if (stopGenerationCallback && dialogId) {
+      void stopGenerationCallback(dialogId).catch((err) => {
+        console.error('[useNatsChatAdapter] stopGeneration failed:', err)
+      })
+    }
+  }, [stopGenerationCallback, dialogId])
 
   const clearMessages = useCallback(() => {
     setMessages([])
     resetAccumulator()
     setStreamingPhase('idle')
   }, [resetAccumulator])
+
+  const selectDialog = useCallback(
+    (id: string | null) => {
+      if (!isManagedMode) {
+        // Bare-transport mode: the host owns dialog id externally. No-op
+        // here so we don't compete with the host's own state machine.
+        // Hosts wanting EmbeddableChat-driven selection should wire
+        // `fetchDialogs` to flip the adapter into managed-dialog mode.
+        return
+      }
+      setInternalDialogId(id)
+    },
+    [isManagedMode],
+  )
+
+  const startNewDialog = useCallback(async (): Promise<string | null> => {
+    if (!createDialogCallback) return null
+    if (isCreatingDialog) return null
+    try {
+      setIsCreatingDialog(true)
+      const result = await createDialogCallback()
+      // Optimistically prepend a placeholder dialog so the sidebar shows
+      // the new conversation immediately. The next list refresh will
+      // replace it with the canonical entry.
+      setDialogs((prev) => [
+        {
+          id: result.dialogId,
+          title: 'New Chat',
+          timestamp: new Date(),
+        },
+        ...prev.filter((d) => d.id !== result.dialogId),
+      ])
+      if (isManagedMode) {
+        setInternalDialogId(result.dialogId)
+      }
+      return result.dialogId
+    } catch (err) {
+      console.error('[useNatsChatAdapter] createDialog failed:', err)
+      return null
+    } finally {
+      setIsCreatingDialog(false)
+    }
+  }, [createDialogCallback, isCreatingDialog, isManagedMode])
+
+  const deleteDialog = useCallback(
+    async (id: string): Promise<void> => {
+      if (!deleteDialogCallback) return
+      try {
+        await deleteDialogCallback(id)
+        setDialogs((prev) => prev.filter((d) => d.id !== id))
+        if (isManagedMode && internalDialogId === id) {
+          setInternalDialogId(null)
+        }
+      } catch (err) {
+        console.error('[useNatsChatAdapter] deleteDialog failed:', err)
+      }
+    },
+    [deleteDialogCallback, internalDialogId, isManagedMode],
+  )
+
+  const loadMoreDialogs = useCallback(async (): Promise<void> => {
+    if (!dialogsNextCursor) return
+    await loadDialogsPage(dialogsNextCursor)
+  }, [dialogsNextCursor, loadDialogsPage])
+
+  const loadMoreMessages = useCallback(async (): Promise<void> => {
+    if (!dialogId || !messagesNextCursor) return
+    await loadDialogHistory(dialogId, messagesNextCursor)
+  }, [dialogId, messagesNextCursor, loadDialogHistory])
+
+  const approveRequest = useCallback(
+    async (requestId: string) => {
+      await handleApproveRef.current(requestId)
+    },
+    [],
+  )
+
+  const rejectRequest = useCallback(
+    async (requestId: string, reason?: string) => {
+      await handleRejectRef.current(requestId, reason)
+    },
+    [],
+  )
 
   // No-op refs — Mingo agent has no RAG entity-card affordances.
   const discussRef = useCallback((_ref: ChatRef) => {
@@ -338,6 +856,8 @@ export function useNatsChatAdapter(
   // ─── Return shape ─────────────────────────────────────────────────────────
 
   const isLoading = streamingPhase !== 'idle'
+  const hasMoreDialogs = dialogsNextCursor != null
+  const hasMoreMessages = messagesNextCursor != null
 
   return useMemo<UnifiedChatState>(
     () => ({
@@ -357,6 +877,25 @@ export function useNatsChatAdapter(
       currentOutputTokens: null,
       currentCacheHitRatePct: null,
       currentUsageBreakdown: null,
+      // Dialog management
+      dialogs,
+      activeDialogId: dialogId,
+      selectDialog,
+      startNewDialog,
+      deleteDialog,
+      isDialogsLoading: isDialogsLoading || isCreatingDialog,
+      isMessagesLoading,
+      hasMoreDialogs,
+      loadMoreDialogs,
+      hasMoreMessages,
+      loadMoreMessages,
+      // Approval mutations
+      approveRequest,
+      rejectRequest,
+      // Token usage
+      dialogTokenUsage,
+      // Connection state
+      connectionState,
     }),
     [
       messages,
@@ -367,6 +906,22 @@ export function useNatsChatAdapter(
       clearMessages,
       discussRef,
       displayRef,
+      dialogs,
+      dialogId,
+      selectDialog,
+      startNewDialog,
+      deleteDialog,
+      isDialogsLoading,
+      isCreatingDialog,
+      isMessagesLoading,
+      hasMoreDialogs,
+      loadMoreDialogs,
+      hasMoreMessages,
+      loadMoreMessages,
+      approveRequest,
+      rejectRequest,
+      dialogTokenUsage,
+      connectionState,
     ],
   )
 }

--- a/openframe-frontend-core/src/components/chat/hooks/use-slash-commands.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-slash-commands.ts
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useState } from "react";
+import { embedAuthedFetch } from "../../../utils/embed-authed-fetch";
 import type {
   SlashCommandActionId,
   SlashCommandSummaryAction,
@@ -44,6 +45,12 @@ export type {
  * (e.g. `https://hub.openframe.ai/api/commands` → the base arg is
  * ignored).
  *
+ * Auth: rides on `embedAuthedFetch` (same bearer-act-as + 401 self-heal
+ * as the chat stream / identity / attachment calls) so a host that runs
+ * proxy-impersonation or a refresh-capable auth adapter gets its creds
+ * attached here too — no host-side `window.fetch` patch required. Hosts
+ * with no adapter fall through to cookie auth unchanged.
+ *
  * Returns the parsed `commands` array; on any non-2xx (auth,
  * rate-limit, chat-disabled) returns an empty array — the autocomplete
  * UI silently shows no suggestions rather than surfacing 401/403/429
@@ -56,7 +63,9 @@ export async function fetchSlashCommands(
 ): Promise<SlashCommandSummary[]> {
   const url = new URL(commandsUrl, window.location.origin);
   if (prefix) url.searchParams.set("q", prefix);
-  const res = await fetch(url.toString(), { signal });
+  // `headers: {}` opts out of the default `Content-Type: application/json`
+  // — this is a bare GET with no body, so no content-type is needed.
+  const res = await embedAuthedFetch(url.toString(), { signal, headers: {} });
   if (!res.ok) return [];
   const data = (await res.json()) as { commands?: SlashCommandSummary[] };
   return data.commands ?? [];

--- a/openframe-frontend-core/src/components/chat/hooks/use-sse-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-sse-chat-adapter.ts
@@ -57,6 +57,7 @@ import type {
   UnifiedSendMessageOptions,
   StreamingPhase,
 } from '../types/unified-chat-state.types'
+import type { DialogItem } from '../types/component.types'
 
 // =============================================================================
 // Public types
@@ -1054,5 +1055,49 @@ export function useSseChatAdapter(
     /** Cross-call usage breakdown (Haiku rewriter/classifier/summarizer
      *  token counts). null until the trailing usage frame lands. */
     currentUsageBreakdown: latestMeta?.breakdown ?? null,
+    // ─── Dialog management — stubs for v1 ────────────────────────────────
+    // Guide mode currently keeps its history in `localStorage` opaquely
+    // under the hood (`runtime.source` namespaced key). Surfacing that
+    // history as a structured dialog list is a follow-up; for now the
+    // shape is satisfied with empty defaults so the unified contract
+    // type-checks and EmbeddableChat hides sidebar affordances when
+    // `dialogs.length === 0`.
+    dialogs: SSE_EMPTY_DIALOGS,
+    activeDialogId: null,
+    selectDialog: noopSelectDialog,
+    startNewDialog: noopStartNewDialog,
+    deleteDialog: noopDeleteDialog,
+    isDialogsLoading: false,
+    isMessagesLoading: false,
+    hasMoreDialogs: false,
+    loadMoreDialogs: noopAsync,
+    hasMoreMessages: false,
+    loadMoreMessages: noopAsync,
+    approveRequest: noopApproveRequest,
+    rejectRequest: noopRejectRequest,
+    dialogTokenUsage: null,
+    connectionState: 'connected' as const,
   }
+}
+
+// ─── Stable no-op references for the Guide-mode dialog-management stubs ──
+// Plain module-scope constants so the adapter's return identity stays
+// stable across renders — consumers that memo on these fields don't get
+// spurious re-runs.
+const SSE_EMPTY_DIALOGS: DialogItem[] = []
+const noopSelectDialog = (_id: string | null): void => {
+  /* Guide mode has no managed dialog list yet */
+}
+const noopStartNewDialog = async (): Promise<string | null> => null
+const noopDeleteDialog = async (_id: string): Promise<void> => {
+  /* no-op until Guide localStorage history is exposed */
+}
+const noopAsync = async (): Promise<void> => {
+  /* no-op pagination stub */
+}
+const noopApproveRequest = async (_id: string): Promise<void> => {
+  /* Guide mode has no tool-call approval workflow */
+}
+const noopRejectRequest = async (_id: string, _reason?: string): Promise<void> => {
+  /* Guide mode has no tool-call approval workflow */
 }

--- a/openframe-frontend-core/src/components/chat/hooks/use-unified-chat.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-unified-chat.ts
@@ -141,6 +141,40 @@ export function useUnifiedChat(
     [activeState],
   )
 
+  // Dialog-management forwards — one thin wrapper per action so the
+  // returned identity stays stable as long as the active adapter's
+  // identity does. We don't recreate per-call to avoid spurious child
+  // re-renders downstream.
+  const selectDialog = useCallback(
+    (id: string | null) => activeState.selectDialog(id),
+    [activeState],
+  )
+  const startNewDialog = useCallback(
+    () => activeState.startNewDialog(),
+    [activeState],
+  )
+  const deleteDialog = useCallback(
+    (id: string) => activeState.deleteDialog(id),
+    [activeState],
+  )
+  const loadMoreDialogs = useCallback(
+    () => activeState.loadMoreDialogs(),
+    [activeState],
+  )
+  const loadMoreMessages = useCallback(
+    () => activeState.loadMoreMessages(),
+    [activeState],
+  )
+  const approveRequest = useCallback(
+    (requestId: string) => activeState.approveRequest(requestId),
+    [activeState],
+  )
+  const rejectRequest = useCallback(
+    (requestId: string, reason?: string) =>
+      activeState.rejectRequest(requestId, reason),
+    [activeState],
+  )
+
   return useMemo<UnifiedChatState>(
     () => ({
       messages: activeState.messages,
@@ -158,6 +192,24 @@ export function useUnifiedChat(
       currentOutputTokens: activeState.currentOutputTokens,
       currentCacheHitRatePct: activeState.currentCacheHitRatePct,
       currentUsageBreakdown: activeState.currentUsageBreakdown,
+      // Dialog management (forwarded from active adapter)
+      dialogs: activeState.dialogs,
+      activeDialogId: activeState.activeDialogId,
+      selectDialog,
+      startNewDialog,
+      deleteDialog,
+      isDialogsLoading: activeState.isDialogsLoading,
+      isMessagesLoading: activeState.isMessagesLoading,
+      hasMoreDialogs: activeState.hasMoreDialogs,
+      loadMoreDialogs,
+      hasMoreMessages: activeState.hasMoreMessages,
+      loadMoreMessages,
+      // Approvals
+      approveRequest,
+      rejectRequest,
+      // Token usage + connection
+      dialogTokenUsage: activeState.dialogTokenUsage,
+      connectionState: activeState.connectionState,
     }),
     [
       activeState,
@@ -166,6 +218,13 @@ export function useUnifiedChat(
       clearMessages,
       discussRef,
       displayRef,
+      selectDialog,
+      startNewDialog,
+      deleteDialog,
+      loadMoreDialogs,
+      loadMoreMessages,
+      approveRequest,
+      rejectRequest,
     ],
   )
 }

--- a/openframe-frontend-core/src/components/chat/types/unified-chat-state.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/unified-chat-state.types.ts
@@ -21,6 +21,44 @@ import type { ScrollAnchor } from './message.types'
 import type { ChatRef } from '../chat-ref.types'
 import type { ChatSource } from '../hooks/use-sse-chat-adapter'
 import type { ChatAttachment } from '../utils/chat-attachment-markdown'
+import type { DialogItem } from './component.types'
+
+// ─── Per-dialog token usage (Mingo backend telemetry) ────────────────────────
+
+/**
+ * Token usage snapshot for the active Mingo dialog, hydrated from the
+ * backend's `dialog.tokenUsage` GraphQL field. Mirrors the shape returned
+ * by the openframe `dialogs` GraphQL endpoint so hosts can pass it through
+ * `fetchDialogMessages` without re-mapping.
+ *
+ * Null when no Mingo dialog is active, when the backend hasn't reported
+ * usage yet, or when the active mode is Guide (SSE telemetry surfaces via
+ * `currentInputTokens`/`currentOutputTokens` instead).
+ */
+export interface DialogTokenUsage {
+  /** Backend chat-type discriminator, e.g. `ADMIN_AI_CHAT`. Free-form. */
+  chatType?: string
+  /** Total input tokens consumed so far in this dialog. */
+  inputTokensSize: number
+  /** Total output tokens emitted so far in this dialog. */
+  outputTokensSize: number
+  /** Sum of input + output. May be > input + output when the backend
+   *  counts cache reads in a separate bucket — trust the backend value. */
+  totalTokensSize: number
+  /** Current LLM context-window occupancy in tokens — what the model
+   *  has loaded right now, not the cumulative dialog sum. */
+  contextSize?: number
+}
+
+// ─── Connection state (transport-level) ──────────────────────────────────────
+
+/**
+ * High-level transport connection status. Drives any UI affordance that
+ * needs to communicate "live tail is/isn't healthy" to the user. SSE/Guide
+ * adapter currently reports `'connected'` whenever a turn isn't streaming
+ * — the SSE side is request-response and has no long-lived socket.
+ */
+export type ChatConnectionState = 'connected' | 'connecting' | 'disconnected'
 
 // ─── Streaming phase (unified across transports) ─────────────────────────────
 
@@ -212,4 +250,82 @@ export interface UnifiedChatState {
    * arrives. Always null in Mingo mode.
    */
   currentUsageBreakdown: UnifiedUsageBreakdown | null
+
+  // ─── Dialog management (Mingo: backend; Guide: localStorage) ──────────────
+  //
+  // All fields below are optional in practice: a transport adapter that
+  // doesn't manage multi-dialog history (older `useNatsChatAdapter`
+  // configs, the Guide adapter with localStorage disabled) returns the
+  // empty/null defaults so existing consumers keep working unchanged.
+  // Callers gate UI on `dialogs.length > 0` or `activeDialogId != null`.
+
+  /**
+   * History of dialogs available for the active mode. Mingo: paginated
+   * from the openframe backend. Guide: list of recent threads from
+   * localStorage. Empty when the active adapter doesn't expose dialog
+   * management.
+   */
+  dialogs: DialogItem[]
+
+  /** Currently-selected dialog id, or `null` when no dialog is active
+   *  (draft state — "start a new conversation"). */
+  activeDialogId: string | null
+
+  /** Switch the panel to an existing dialog. Idempotent — selecting the
+   *  active id is a no-op. Pass `null` to drop back to draft state. */
+  selectDialog: (id: string | null) => void
+
+  /** Allocate a fresh dialog on the backend (Mingo) or in localStorage
+   *  (Guide) and switch to it. Returns the new dialog id. When the
+   *  adapter doesn't support creation, resolves to `null`. */
+  startNewDialog: () => Promise<string | null>
+
+  /** Delete a dialog from history. No-op when the adapter doesn't
+   *  expose `deleteDialog` (Guide localStorage always supports it;
+   *  Mingo gates on the host-provided callback). */
+  deleteDialog: (id: string) => Promise<void>
+
+  /** True while the dialog list is being fetched for the first time. */
+  isDialogsLoading: boolean
+
+  /** True while message history for the active dialog is being fetched. */
+  isMessagesLoading: boolean
+
+  /** Whether more dialogs remain on the server (Mingo cursor pagination). */
+  hasMoreDialogs: boolean
+
+  /** Fetch the next page of dialogs. No-op when `hasMoreDialogs` is false. */
+  loadMoreDialogs: () => Promise<void>
+
+  /** Whether more historical messages remain in the active dialog. */
+  hasMoreMessages: boolean
+
+  /** Fetch the next page of historical messages for the active dialog. */
+  loadMoreMessages: () => Promise<void>
+
+  // ─── Approval mutations (Mingo agent tool-call workflow) ──────────────────
+
+  /** Approve an in-flight tool-call request. Errors surface via the
+   *  host-supplied toast in the callback config (lib does not own UI). */
+  approveRequest: (requestId: string) => Promise<void>
+
+  /** Reject an in-flight tool-call request. Optional `reason` is
+   *  forwarded to the backend when supported. */
+  rejectRequest: (requestId: string, reason?: string) => Promise<void>
+
+  // ─── Per-dialog token usage (Mingo only) ──────────────────────────────────
+
+  /** Cumulative token usage for the active Mingo dialog. Null in Guide
+   *  mode or when the backend hasn't reported usage yet. Per-turn
+   *  metadata (`currentInputTokens` etc.) is orthogonal — that fires on
+   *  every SSE `message_start`, while this hydrates from the dialog
+   *  fetch + live `TOKEN_USAGE` events. */
+  dialogTokenUsage: DialogTokenUsage | null
+
+  // ─── Connection state ─────────────────────────────────────────────────────
+
+  /** High-level transport connection state. Drives reconnect UI in
+   *  Mingo mode; always `'connected'` in Guide mode (SSE is request-
+   *  response and has no persistent socket to monitor). */
+  connectionState: ChatConnectionState
 }

--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -10,6 +10,7 @@ import { Menu01Icon, SearchIcon, XmarkIcon } from '../icons-v2-generated'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, SquareAvatar } from '../ui'
 import { HeaderButton } from './header-button'
 import { HeaderGlobalSearch } from './header-global-search'
+import { HeaderMingoButton } from './header-mingo-button'
 import { HeaderOrganizationFilter } from './header-organization-filter'
 
 export interface AppHeaderProps {
@@ -21,6 +22,13 @@ export interface AppHeaderProps {
   onOrgChange?: (id: string) => void
   showNotifications?: boolean
   unreadCount?: number
+  /** Render the "Mingo AI" launcher button (drawer-style trigger for an
+   *  in-layout `AppLayoutDrawer` hosting the chat panel). Defaults to off. */
+  showMingoAI?: boolean
+  /** Click handler for the Mingo AI button — typically toggles the drawer. */
+  onMingoAI?: () => void
+  /** Whether the Mingo drawer is currently open (visually pressed state). */
+  isMingoAIActive?: boolean
   // User block
   showUser?: boolean
   userName?: string
@@ -49,6 +57,9 @@ export const AppHeader = React.memo(function AppHeader({
   onOrgChange,
   showNotifications,
   unreadCount = 0,
+  showMingoAI = false,
+  onMingoAI,
+  isMingoAIActive = false,
   showUser,
   userName,
   userEmail,
@@ -115,6 +126,18 @@ export const AppHeader = React.memo(function AppHeader({
           selectedOrgId={selectedOrgId}
           onOrgChange={onOrgChange}
           className={cn("hidden lg:flex", dimmedClass)}
+        />
+      )}
+
+      {/* Mingo AI launcher — placed to the LEFT of notifications so the user
+          menu cluster (notifications → avatar) stays anchored to the right. */}
+      {showMingoAI && (
+        <HeaderMingoButton
+          onClick={onMingoAI}
+          isActive={isMingoAIActive}
+          iconOnly={!isMdUp}
+          disabled={disabled || !onMingoAI}
+          className={dimmedClass}
         />
       )}
 

--- a/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
@@ -1,0 +1,620 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "../../utils/cn"
+import {
+  DrawerBody,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  type DrawerSide,
+} from "../ui/drawer"
+import { useAppLayoutDrawerContainer } from "./app-layout"
+
+/**
+ * AppLayoutDrawer is a Drawer variant that renders **inside** AppLayout's main
+ * content area instead of as a viewport-level overlay. Header and sidebar stay
+ * visible and interactive while it is open.
+ *
+ * Implementation differs from the standard Drawer in three ways:
+ *   1. `DialogPrimitive.Portal` targets the AppLayout container (provided via
+ *      React Context) rather than `document.body`.
+ *   2. Positioning is `absolute` (clipped to the container) instead of `fixed`.
+ *   3. The Dialog is non-modal (`modal={false}`) — outside content is not
+ *      inert, so header/sidebar interactions still work while the drawer is open.
+ *
+ * Caveat of non-modal mode: Radix's built-in `DialogPrimitive.Overlay` returns
+ * null (see @radix-ui/react-dialog source). We render our own overlay div as a
+ * sibling of `DialogPrimitive.Content` in the portal so it (a) provides the
+ * standard dim backdrop and (b) catches pointer events over the main area —
+ * otherwise clicks pass through to underlying buttons, causing a close-and-
+ * reopen flicker when the click target is also a trigger.
+ *
+ * Everything else (visual chrome, slide animation, resize handle, sub-components)
+ * matches the standard Drawer. Sub-components (header/title/body/footer) are
+ * re-exported aliases of the originals so styling stays in lockstep.
+ */
+
+const DrawerOpenContext = React.createContext<boolean>(false)
+
+interface AppLayoutDrawerRootProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Root> {}
+
+const AppLayoutDrawerRoot = ({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  modal = false,
+  children,
+  ...rest
+}: AppLayoutDrawerRootProps) => {
+  // Shadow Dialog.Root's open state so descendants (specifically the overlay
+  // rendered inside Content) can drive their own `data-state` for animations.
+  // Radix doesn't expose its internal open state via a public context.
+  const [internalOpen, setInternalOpen] = React.useState(defaultOpen ?? false)
+  const isControlled = openProp !== undefined
+  const open = isControlled ? (openProp as boolean) : internalOpen
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!isControlled) setInternalOpen(next)
+      onOpenChange?.(next)
+    },
+    [isControlled, onOpenChange],
+  )
+
+  return (
+    <DrawerOpenContext.Provider value={open}>
+      <DialogPrimitive.Root
+        {...rest}
+        open={open}
+        onOpenChange={handleOpenChange}
+        modal={modal}
+      >
+        {children}
+      </DialogPrimitive.Root>
+    </DrawerOpenContext.Provider>
+  )
+}
+AppLayoutDrawerRoot.displayName = "AppLayoutDrawer"
+
+const AppLayoutDrawerTrigger = DialogPrimitive.Trigger
+const AppLayoutDrawerClose = DialogPrimitive.Close
+
+const appLayoutDrawerVariants = cva(
+  "absolute z-[45] flex outline-none focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-300",
+  {
+    variants: {
+      side: {
+        right:
+          "inset-y-0 right-0 items-center data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+        left:
+          "inset-y-0 left-0 items-center data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+        top:
+          "inset-x-0 top-0 justify-center data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 justify-center data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+      },
+      flush: {
+        false: "",
+        true: "",
+      },
+    },
+    compoundVariants: [
+      { side: "right", flush: false, class: "pr-4 py-4" },
+      { side: "left", flush: false, class: "pl-4 py-4" },
+      { side: "top", flush: false, class: "pt-4 px-4" },
+      { side: "bottom", flush: false, class: "pb-4 px-4" },
+      // flush=true: keep wrapper padding on desktop (uniform 16px gap so the
+      // panel floats), drop on mobile for full-bleed — matches base Drawer.
+      { side: "right", flush: true, class: "md:pr-4 md:py-4" },
+      { side: "left", flush: true, class: "md:pl-4 md:py-4" },
+      { side: "top", flush: true, class: "md:pt-4 md:px-4" },
+      { side: "bottom", flush: true, class: "md:pb-4 md:px-4" },
+    ],
+    defaultVariants: {
+      side: "right",
+      flush: false,
+    },
+  },
+)
+
+const appLayoutDrawerPanelVariants = cva(
+  "relative flex flex-col overflow-hidden bg-ods-card outline-none focus:outline-none focus-visible:outline-none",
+  {
+    variants: {
+      side: {
+        right: "h-full",
+        left: "h-full",
+        top: "w-full",
+        bottom: "w-full",
+      },
+      flush: {
+        false: "gap-4 rounded-md border border-ods-border p-4",
+        true: "",
+      },
+    },
+    compoundVariants: [
+      { side: "right", flush: true, class: "md:rounded-md md:border md:border-ods-border" },
+      { side: "left", flush: true, class: "md:rounded-md md:border md:border-ods-border" },
+      { side: "top", flush: true, class: "md:rounded-md md:border md:border-ods-border" },
+      { side: "bottom", flush: true, class: "md:rounded-md md:border md:border-ods-border" },
+    ],
+    defaultVariants: {
+      side: "right",
+      flush: false,
+    },
+  },
+)
+
+const HORIZONTAL_SIDES: ReadonlySet<DrawerSide> = new Set(["left", "right"])
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min
+  return Math.min(max, Math.max(min, value))
+}
+
+interface UseContainedResizableSizeArgs {
+  enabled: boolean
+  isHorizontal: boolean
+  minSize: number
+  maxSize: number
+  defaultSize: number
+  storageKey?: string
+  container: HTMLElement | null
+}
+
+function useContainedResizableSize({
+  enabled,
+  isHorizontal,
+  minSize,
+  maxSize,
+  defaultSize,
+  storageKey,
+  container,
+}: UseContainedResizableSizeArgs) {
+  const [available, setAvailable] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!enabled || !container) return
+    const update = () => {
+      setAvailable(isHorizontal ? container.clientWidth : container.clientHeight)
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(container)
+    return () => ro.disconnect()
+  }, [enabled, container, isHorizontal])
+
+  const clampToContainer = React.useCallback(
+    (value: number) => {
+      // Reserve 32px (16px outside-edge padding from the wrapper + 16px
+      // matching gap on the inside edge) so the panel sits symmetrically
+      // inside the container. This also keeps the resize grip on-screen at
+      // maximum extent.
+      const effectiveMax = available > 0 ? Math.min(maxSize, available - 32) : maxSize
+      return clamp(value, minSize, Math.max(minSize, effectiveMax))
+    },
+    [available, minSize, maxSize],
+  )
+
+  const readInitial = React.useCallback(() => {
+    if (!enabled) return defaultSize
+    if (typeof window === "undefined") return defaultSize
+    if (!storageKey) return defaultSize
+    try {
+      const raw = window.localStorage.getItem(storageKey)
+      if (!raw) return defaultSize
+      const parsed = parseFloat(raw)
+      if (!Number.isFinite(parsed)) return defaultSize
+      return parsed
+    } catch {
+      return defaultSize
+    }
+  }, [enabled, storageKey, defaultSize])
+
+  const [size, setSizeRaw] = React.useState<number>(readInitial)
+
+  const setSize = React.useCallback(
+    (next: number) => setSizeRaw(clampToContainer(next)),
+    [clampToContainer],
+  )
+
+  React.useEffect(() => {
+    if (!enabled || !storageKey || typeof window === "undefined") return
+    try {
+      window.localStorage.setItem(storageKey, String(Math.round(size)))
+    } catch {
+      // ignore quota / disabled-storage
+    }
+  }, [enabled, size, storageKey])
+
+  // Re-clamp the stored size whenever the container resizes so a previously
+  // saved size never overflows after the user shrinks the viewport.
+  React.useEffect(() => {
+    if (!enabled) return
+    setSizeRaw((prev) => clampToContainer(prev))
+  }, [enabled, clampToContainer])
+
+  return { size, setSize }
+}
+
+interface AppLayoutDrawerResizeHandleProps {
+  side: DrawerSide
+  size: number
+  minSize: number
+  maxSize: number
+  onSize: (next: number) => void
+  ariaLabel?: string
+}
+
+function AppLayoutDrawerResizeHandle({
+  side,
+  size,
+  minSize,
+  maxSize,
+  onSize,
+  ariaLabel,
+}: AppLayoutDrawerResizeHandleProps) {
+  const isHorizontal = HORIZONTAL_SIDES.has(side)
+  const startRef = React.useRef<{ x: number; y: number; size: number } | null>(null)
+
+  const direction = side === "right" || side === "bottom" ? -1 : 1
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0 && e.pointerType === "mouse") return
+    e.preventDefault()
+    startRef.current = { x: e.clientX, y: e.clientY, size }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    document.body.style.cursor = isHorizontal ? "col-resize" : "row-resize"
+    document.body.style.userSelect = "none"
+  }
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const start = startRef.current
+    if (!start) return
+    const delta = isHorizontal ? e.clientX - start.x : e.clientY - start.y
+    onSize(start.size + delta * direction)
+  }
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!startRef.current) return
+    startRef.current = null
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    } catch {
+      // ignore — pointer may already be released
+    }
+    document.body.style.cursor = ""
+    document.body.style.userSelect = ""
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const step = e.shiftKey ? 40 : 16
+    if (isHorizontal) {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault()
+        onSize(size + step * (side === "right" ? 1 : -1))
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault()
+        onSize(size + step * (side === "right" ? -1 : 1))
+      }
+    } else {
+      if (e.key === "ArrowUp") {
+        e.preventDefault()
+        onSize(size + step * (side === "bottom" ? 1 : -1))
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault()
+        onSize(size + step * (side === "bottom" ? -1 : 1))
+      }
+    }
+    if (e.key === "Home") {
+      e.preventDefault()
+      onSize(minSize)
+    } else if (e.key === "End") {
+      e.preventDefault()
+      onSize(maxSize)
+    }
+  }
+
+  const trackPosition =
+    side === "right"
+      ? "right-full top-4 bottom-4 w-3 items-center justify-end pr-1"
+      : side === "left"
+        ? "left-full top-4 bottom-4 w-3 items-center justify-start pl-1"
+        : side === "bottom"
+          ? "bottom-full left-4 right-4 h-3 justify-center items-end pb-1"
+          : "top-full left-4 right-4 h-3 justify-center items-start pt-1"
+
+  const cursorClass = isHorizontal ? "cursor-col-resize" : "cursor-row-resize"
+  const gripClass = isHorizontal ? "h-10 w-1" : "w-10 h-1"
+
+  return (
+    <div
+      role="separator"
+      tabIndex={0}
+      aria-orientation={isHorizontal ? "vertical" : "horizontal"}
+      aria-valuenow={Math.round(size)}
+      aria-valuemin={minSize}
+      aria-valuemax={maxSize}
+      aria-label={
+        ariaLabel ?? (isHorizontal ? "Resize panel width" : "Resize panel height")
+      }
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "group absolute z-20 flex select-none touch-none",
+        "outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0",
+        trackPosition,
+        cursorClass,
+      )}
+    >
+      <div
+        aria-hidden
+        className={cn(
+          "rounded-full bg-[var(--system-greys-soft-grey,#3A3A3A)]",
+          gripClass,
+        )}
+      />
+    </div>
+  )
+}
+
+export interface AppLayoutDrawerContentProps
+  extends Omit<
+      React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>,
+      "style"
+    >,
+    VariantProps<typeof appLayoutDrawerVariants> {
+  flush?: boolean
+  resizable?: boolean
+  minSize?: number
+  maxSize?: number
+  defaultSize?: number
+  storageKey?: string
+  /** Pixel breakpoint below which `resizable` is disabled and inline size is
+   *  not applied (so the panel can render full-area on mobile). */
+  mobileBreakpoint?: number
+  overlayClassName?: string
+  resizeAriaLabel?: string
+  style?: React.CSSProperties
+  panelStyle?: React.CSSProperties
+  panelClassName?: string
+  /** Override the portal container. Defaults to AppLayout's main-area container
+   *  (from context). Pass `null` to opt out of portaling. */
+  container?: HTMLElement | null
+  /** When `true` (default), clicks on the dim overlay over the main content
+   *  area close the drawer. Clicks on AppLayout chrome (header, sidebar) NEVER
+   *  close the drawer regardless of this flag — chrome interactions shouldn't
+   *  accidentally dismiss a persistent panel. Pass `false` to make the drawer
+   *  fully persistent (X button or Escape only). Consumer-provided
+   *  `onInteractOutside` still runs first and can preventDefault to override. */
+  dismissOnInteractOutside?: boolean
+  /** Debug helper — when `true`, on each open the component snapshots the
+   *  scroll metrics (scrollLeft / scrollWidth / clientWidth / overflow-x) of
+   *  every ancestor of the portal container, at mount, after RAF, +150ms,
+   *  +350ms, and on close. Use to diagnose layout-shift on open: look for an
+   *  ancestor that gains `scrollLeft > 0` or has `overflow-x: visible` while
+   *  `scrollWidth > clientWidth`. Remove the prop once diagnosed. */
+  debugLayoutShift?: boolean
+}
+
+const AppLayoutDrawerContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  AppLayoutDrawerContentProps
+>(
+  (
+    {
+      side = "right",
+      flush = false,
+      resizable = false,
+      minSize = 320,
+      // No upper cap by default — the AppLayout container width is the natural
+      // limit. Consumers can still pass an explicit `maxSize` to clamp tighter.
+      maxSize = Number.POSITIVE_INFINITY,
+      defaultSize,
+      storageKey,
+      mobileBreakpoint = 768,
+      overlayClassName,
+      resizeAriaLabel,
+      className,
+      style,
+      panelStyle,
+      panelClassName,
+      container,
+      dismissOnInteractOutside = true,
+      onInteractOutside,
+      debugLayoutShift = false,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const contextContainer = useAppLayoutDrawerContainer()
+    const portalContainer = container !== undefined ? container : contextContainer
+    const open = React.useContext(DrawerOpenContext)
+
+    // Diagnostic: walk ancestors and snapshot horizontal-scroll metrics
+    // around the open transition. See `debugLayoutShift` prop doc.
+    React.useEffect(() => {
+      if (!debugLayoutShift) return
+      if (!open) return
+      if (typeof window === "undefined") return
+      if (!portalContainer) return
+
+      const collect = () => {
+        const list: Element[] = []
+        let el: Element | null = portalContainer
+        while (el) {
+          list.push(el)
+          el = el.parentElement
+        }
+        // Add documentElement explicitly in case ancestor chain stopped early.
+        if (!list.includes(document.documentElement)) {
+          list.push(document.documentElement)
+        }
+        return list
+      }
+
+      const snapshot = (label: string) => {
+        const data = collect().map((el, i) => {
+          const cs = window.getComputedStyle(el)
+          const overflows = el.scrollWidth > el.clientWidth
+          const cls = String((el as HTMLElement).className ?? "")
+            .replace(/\s+/g, " ")
+            .slice(0, 60)
+          return {
+            depth: i,
+            tag:
+              el.tagName.toLowerCase() +
+              ((el as HTMLElement).id ? "#" + (el as HTMLElement).id : ""),
+            class: cls,
+            "overflow-x": cs.overflowX,
+            scrollLeft: el.scrollLeft,
+            scrollWidth: el.scrollWidth,
+            clientWidth: el.clientWidth,
+            hOverflow: overflows ? "⚠️" : "",
+          }
+        })
+        // eslint-disable-next-line no-console
+        console.groupCollapsed(`[AppLayoutDrawer] ${label}`)
+        // eslint-disable-next-line no-console
+        console.table(data)
+        // eslint-disable-next-line no-console
+        console.groupEnd()
+      }
+
+      snapshot("open: t0 (mount)")
+      const raf = requestAnimationFrame(() => snapshot("open: t≈16ms (RAF 1)"))
+      const t150 = window.setTimeout(() => snapshot("open: t≈150ms (mid-anim)"), 150)
+      const t350 = window.setTimeout(() => snapshot("open: t≈350ms (post-anim)"), 350)
+
+      return () => {
+        cancelAnimationFrame(raf)
+        clearTimeout(t150)
+        clearTimeout(t350)
+        snapshot("close")
+      }
+    }, [open, portalContainer, debugLayoutShift])
+
+    const resolvedSide: DrawerSide = side ?? "right"
+    const isHorizontal = HORIZONTAL_SIDES.has(resolvedSide)
+    const initialSize = defaultSize ?? (isHorizontal ? 560 : 480)
+
+    const [isMobile, setIsMobile] = React.useState(false)
+    React.useEffect(() => {
+      if (typeof window === "undefined") return
+      const mq = window.matchMedia(`(max-width: ${mobileBreakpoint - 1}px)`)
+      const update = () => setIsMobile(mq.matches)
+      update()
+      mq.addEventListener("change", update)
+      return () => mq.removeEventListener("change", update)
+    }, [mobileBreakpoint])
+
+    const { size, setSize } = useContainedResizableSize({
+      enabled: resizable,
+      isHorizontal,
+      minSize,
+      maxSize,
+      defaultSize: initialSize,
+      storageKey,
+      container: portalContainer,
+    })
+
+    const applyInlineSize = resizable && !isMobile
+    const sizeStyle: React.CSSProperties = applyInlineSize
+      ? isHorizontal
+        ? { width: size }
+        : { height: size }
+      : {}
+
+    return (
+      <DialogPrimitive.Portal container={portalContainer}>
+        {/* Overlay rendered manually: Radix's DialogPrimitive.Overlay returns
+            null in non-modal mode, so we render a plain div here. Setting
+            `pointer-events-auto` ensures it catches clicks on the main area
+            so they don't fall through to buttons underneath — that would
+            otherwise fire both Radix's outside-close AND the button's
+            own onClick, producing a close-then-reopen flicker. */}
+        <div
+          aria-hidden
+          data-state={open ? "open" : "closed"}
+          className={cn(
+            "absolute inset-0 z-[40] bg-black/50 pointer-events-auto outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            overlayClassName,
+          )}
+        />
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(appLayoutDrawerVariants({ side, flush }))}
+          style={style}
+          onInteractOutside={(event) => {
+            onInteractOutside?.(event)
+            if (event.defaultPrevented) return
+            // Chrome (header, sidebar) sits OUTSIDE the portal container.
+            // Those clicks never dismiss — they navigate, etc. Only clicks
+            // INSIDE the portal container (the overlay over main) can dismiss.
+            const target = event.target as Node | null
+            const isInsideContainer =
+              !!target && !!portalContainer?.contains(target)
+            if (!isInsideContainer) {
+              event.preventDefault()
+              return
+            }
+            if (!dismissOnInteractOutside) event.preventDefault()
+          }}
+          {...props}
+        >
+          {applyInlineSize ? (
+            <AppLayoutDrawerResizeHandle
+              side={resolvedSide}
+              size={size}
+              minSize={minSize}
+              maxSize={maxSize}
+              onSize={setSize}
+              ariaLabel={resizeAriaLabel}
+            />
+          ) : null}
+          <div
+            className={cn(
+              appLayoutDrawerPanelVariants({ side, flush }),
+              className,
+              panelClassName,
+            )}
+            style={{ ...sizeStyle, ...panelStyle }}
+          >
+            {children}
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    )
+  },
+)
+AppLayoutDrawerContent.displayName = "AppLayoutDrawerContent"
+
+// Sub-components are visually identical to the base Drawer's — re-export as
+// aliases so the namespace stays consistent for consumers.
+const AppLayoutDrawerHeader = DrawerHeader
+const AppLayoutDrawerTitle = DrawerTitle
+const AppLayoutDrawerDescription = DrawerDescription
+const AppLayoutDrawerBody = DrawerBody
+const AppLayoutDrawerFooter = DrawerFooter
+
+export {
+  AppLayoutDrawerRoot as AppLayoutDrawer,
+  AppLayoutDrawerTrigger,
+  AppLayoutDrawerClose,
+  AppLayoutDrawerContent,
+  AppLayoutDrawerHeader,
+  AppLayoutDrawerTitle,
+  AppLayoutDrawerDescription,
+  AppLayoutDrawerBody,
+  AppLayoutDrawerFooter,
+}

--- a/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
@@ -359,7 +359,7 @@ function AppLayoutDrawerResizeHandle({
       <div
         aria-hidden
         className={cn(
-          "rounded-full bg-[var(--system-greys-soft-grey,#3A3A3A)]",
+          "rounded-full bg-ods-border",
           gripClass,
         )}
       />
@@ -547,7 +547,7 @@ const AppLayoutDrawerContent = React.forwardRef<
           aria-hidden
           data-state={open ? "open" : "closed"}
           className={cn(
-            "absolute inset-0 z-[40] bg-black/50 pointer-events-auto outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "absolute inset-0 z-[40] bg-black/50 outline-none data-[state=open]:pointer-events-auto data-[state=closed]:pointer-events-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
             overlayClassName,
           )}
         />

--- a/openframe-frontend-core/src/components/navigation/app-layout.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout.tsx
@@ -1,12 +1,24 @@
 'use client'
 
-import { Suspense, useCallback, useState } from 'react'
+import { createContext, Suspense, useCallback, useContext, useState } from 'react'
 import { NavigationSidebarConfig } from '../../types/navigation'
 import { cn } from '../../utils'
 import { NotificationDrawer } from '../features/notifications/notification-drawer'
 import { AppHeader, AppHeaderProps } from './app-header'
 import { MobileBurgerMenu, MobileBurgerMenuProps } from './mobile-burger-menu'
 import { NavigationSidebar } from './navigation-sidebar'
+
+/**
+ * Container element that wraps `<main>` and serves as the portal target for
+ * `AppLayoutDrawer`. Drawers rendered into this container sit on top of the
+ * main content area only — the sidebar and header remain visible and
+ * interactive. Null when AppLayout hasn't mounted (or when used outside of it).
+ */
+const AppLayoutDrawerContainerContext = createContext<HTMLElement | null>(null)
+
+export function useAppLayoutDrawerContainer(): HTMLElement | null {
+  return useContext(AppLayoutDrawerContainerContext)
+}
 
 export interface AppLayoutProps {
   children: React.ReactNode
@@ -22,6 +34,13 @@ export interface AppLayoutProps {
    * (`children`) is not affected and stays fully interactive.
    */
   disabled?: boolean
+  /**
+   * Slot for an in-layout drawer (typically an `AppLayoutDrawer` tree). Rendered
+   * inside the layout's drawer-container context so the drawer can portal into
+   * the main-area container. Keeping it separate from `children` clarifies that
+   * the drawer is part of the layout chrome, not page content.
+   */
+  drawer?: React.ReactNode
 }
 
 export function AppLayout({
@@ -33,8 +52,10 @@ export function AppLayout({
   className,
   mobileBurgerMenuProps,
   disabled = false,
+  drawer,
 }: AppLayoutProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [drawerContainer, setDrawerContainer] = useState<HTMLDivElement | null>(null)
 
   const handleToggleMobileMenu = useCallback(() => {
     setMobileMenuOpen(prev => !prev)
@@ -45,34 +66,52 @@ export function AppLayout({
   }, [])
 
   return (
-    <div className={cn("flex h-screen bg-ods-bg", className)}>
-      <NavigationSidebar config={sidebarConfig} disabled={disabled} />
-      {/* Mobile Burger Menu - opens below header */}
-      <MobileBurgerMenu
-        {...mobileBurgerMenuProps}
-        isOpen={mobileMenuOpen}
-        onClose={handleCloseMobileMenu}
-        config={sidebarConfig}
-        disabled={disabled}
-      />
-
-      {/* Main Content Area */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <AppHeader
-          {...headerProps}
-          isMobileMenuOpen={mobileMenuOpen}
-          onToggleMobileMenu={handleToggleMobileMenu}
+    <AppLayoutDrawerContainerContext.Provider value={drawerContainer}>
+      <div className={cn("flex h-screen bg-ods-bg", className)}>
+        <NavigationSidebar config={sidebarConfig} disabled={disabled} />
+        {/* Mobile Burger Menu - opens below header */}
+        <MobileBurgerMenu
+          {...mobileBurgerMenuProps}
+          isOpen={mobileMenuOpen}
+          onClose={handleCloseMobileMenu}
+          config={sidebarConfig}
           disabled={disabled}
         />
-        <NotificationDrawer />
 
-        {/* Main Content */}
-        <main className={cn("flex-1 overflow-y-auto", mainClassName)}>
-          <Suspense fallback={loadingFallback ?? null}>
-            {children}
-          </Suspense>
-        </main>
+        {/* Main Content Area */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <AppHeader
+            {...headerProps}
+            isMobileMenuOpen={mobileMenuOpen}
+            onToggleMobileMenu={handleToggleMobileMenu}
+            disabled={disabled}
+          />
+          <NotificationDrawer />
+
+          {/* Main + AppLayoutDrawer portal target. `relative` so the drawer
+              can absolutely position within just this area (not over
+              header/sidebar); `overflow-hidden` clips the drawer's slide-in
+              animation visually AND contains layout overflow so it doesn't
+              propagate up to <html>. (Scroll-snap-back below handles the
+              browser's programmatic scroll-on-focus side effect.) */}
+          <div
+            ref={setDrawerContainer}
+            className="flex-1 flex flex-col relative overflow-hidden"
+          >
+            <main className={cn("flex-1 overflow-y-auto", mainClassName)}>
+              <Suspense fallback={loadingFallback ?? null}>
+                {children}
+              </Suspense>
+            </main>
+            {/* `drawer` slot — rendered here so it sits inside the
+                AppLayoutDrawerContainerContext and can portal into this exact
+                container. Mount location is irrelevant for visual placement
+                (Radix Portal handles that), but keeping it close to the target
+                makes the React tree match the visual nesting. */}
+            {drawer}
+          </div>
+        </div>
       </div>
-    </div>
+    </AppLayoutDrawerContainerContext.Provider>
   )
 }

--- a/openframe-frontend-core/src/components/navigation/header-mingo-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/header-mingo-button.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import React from 'react'
+import { cn } from '../../utils/cn'
+import { MingoIcon } from '../icons'
+
+export interface HeaderMingoButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Active/pressed state — set to `true` while the Mingo drawer is open. */
+  isActive?: boolean
+  /** When true, hides the "Mingo AI" label and renders only the icon (so the
+   *  control collapses to a square `HeaderButton`-sized affordance on narrow
+   *  viewports). Defaults to `false`. */
+  iconOnly?: boolean
+  className?: string
+}
+
+/**
+ * "Mingo AI" launcher button for `AppHeader`. Mirrors the `HeaderButton`
+ * visual contract (sticky header height, `ods-card` rest / `ods-bg-hover`
+ * hover / `ods-bg-active` active, divider via `AppHeader`'s `divide-x`), but
+ * carries both the Mingo logo and the bold "Mingo AI" wordmark.
+ *
+ * Figma: 7532:222103 — `button-full`.
+ */
+export function HeaderMingoButton({
+  isActive = false,
+  iconOnly = false,
+  className,
+  ...props
+}: HeaderMingoButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label="Mingo AI"
+      aria-pressed={isActive}
+      className={cn(
+        'flex items-center shrink-0 h-full gap-2 px-4',
+        'transition-colors duration-200',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-ods-accent',
+        isActive
+          ? 'text-ods-text-primary bg-ods-bg-active'
+          : 'text-ods-text-primary bg-ods-card hover:bg-ods-bg-hover',
+        className,
+      )}
+      {...props}
+    >
+      <MingoIcon className="w-6 h-6 shrink-0" />
+      {!iconOnly && (
+        <span className="text-h3 font-bold tracking-[-0.36px] whitespace-nowrap">
+          Mingo AI
+        </span>
+      )}
+    </button>
+  )
+}
+
+export default HeaderMingoButton

--- a/openframe-frontend-core/src/components/navigation/index.ts
+++ b/openframe-frontend-core/src/components/navigation/index.ts
@@ -25,14 +25,30 @@ export type { NavigationSidebarProps } from './navigation-sidebar'
 export { AppHeader } from './app-header'
 export type { AppHeaderProps } from './app-header'
 
-export { AppLayout } from './app-layout'
+export { AppLayout, useAppLayoutDrawerContainer } from './app-layout'
 export type { AppLayoutProps } from './app-layout'
+
+export {
+  AppLayoutDrawer,
+  AppLayoutDrawerTrigger,
+  AppLayoutDrawerClose,
+  AppLayoutDrawerContent,
+  AppLayoutDrawerHeader,
+  AppLayoutDrawerTitle,
+  AppLayoutDrawerDescription,
+  AppLayoutDrawerBody,
+  AppLayoutDrawerFooter,
+} from './app-layout-drawer'
+export type { AppLayoutDrawerContentProps } from './app-layout-drawer'
 
 export { MobileBurgerMenu } from './mobile-burger-menu'
 export type { MobileBurgerMenuProps } from './mobile-burger-menu'
 
 export { HeaderButton } from './header-button'
 export type { HeaderButtonProps } from './header-button'
+
+export { HeaderMingoButton } from './header-mingo-button'
+export type { HeaderMingoButtonProps } from './header-mingo-button'
 
 export { HeaderGlobalSearch } from './header-global-search'
 export type { HeaderGlobalSearchProps } from './header-global-search'

--- a/openframe-frontend-core/src/stories/AppLayoutDrawer.stories.tsx
+++ b/openframe-frontend-core/src/stories/AppLayoutDrawer.stories.tsx
@@ -1,0 +1,228 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useState } from 'react'
+import { fn } from 'storybook/test'
+
+import {
+  BracketCurlyIcon,
+  ChartDonutIcon,
+  IdCardIcon,
+  MonitorIcon,
+  Settings02Icon,
+} from '../components/icons-v2-generated'
+import {
+  AppLayout,
+  AppLayoutDrawer,
+  AppLayoutDrawerBody,
+  AppLayoutDrawerContent,
+  AppLayoutDrawerDescription,
+  AppLayoutDrawerHeader,
+  AppLayoutDrawerTitle,
+} from '../components/navigation'
+import { Button } from '../components/ui/button'
+import { NavigationSidebarConfig } from '../types/navigation'
+
+const navigationItems: NavigationSidebarConfig['items'] = [
+  { id: 'dashboard', label: 'Dashboard', icon: <ChartDonutIcon size={24} />, path: '/dashboard', isActive: true },
+  { id: 'customers', label: 'Customers', icon: <IdCardIcon size={24} />, path: '/customers' },
+  { id: 'devices', label: 'Devices', icon: <MonitorIcon size={24} />, path: '/devices' },
+  { id: 'scripts', label: 'Scripts', icon: <BracketCurlyIcon size={24} />, path: '/scripts' },
+  { id: 'settings', label: 'Settings', icon: <Settings02Icon size={24} />, path: '/settings', section: 'secondary' },
+]
+
+const meta = {
+  title: 'Navigation/AppLayoutDrawer',
+  component: AppLayoutDrawer,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+A Drawer variant that renders **inside** AppLayout's main content area
+instead of as a viewport-level overlay. The sidebar and header remain
+visible and interactive while it is open.
+
+## When to use
+- Side panels (chat, details, filters) that should not cover the global
+  chrome (header, sidebar).
+- Anything that conceptually belongs to the current page rather than the
+  whole app.
+
+For an overlay that covers the entire viewport (e.g. notifications,
+auth modals), use the standard \`Drawer\` from \`components/ui\` instead.
+        `,
+      },
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof AppLayoutDrawer>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function DashboardChildren({ onOpenDrawer }: { onOpenDrawer: () => void }) {
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-ods-text-primary">Devices Overview</h1>
+        <p className="text-ods-text-secondary mt-1">8,250 Devices in Total</p>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {[
+          { label: 'Active Devices', value: '6,930' },
+          { label: 'Active Tickets', value: '136' },
+          { label: 'Resolved Tickets', value: '825' },
+        ].map((stat) => (
+          <div key={stat.label} className="p-4 bg-ods-card rounded-lg border border-ods-border">
+            <p className="text-sm text-ods-text-secondary">{stat.label}</p>
+            <p className="text-2xl font-semibold text-ods-text-primary mt-1">{stat.value}</p>
+          </div>
+        ))}
+      </div>
+      <Button onClick={onOpenDrawer}>Open in-layout drawer</Button>
+    </div>
+  )
+}
+
+/**
+ * Right-side in-layout drawer, passed via the `drawer` slot prop.
+ * The drawer is persistent — clicks on the overlay/header/sidebar
+ * do NOT close it; use the X button or Escape.
+ */
+export const Right: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(false)
+    return (
+      <AppLayout
+        sidebarConfig={{ items: navigationItems, onNavigate: fn(), onToggleMinimized: fn() }}
+        headerProps={{
+          showNotifications: true,
+          showUser: true,
+          userName: 'Mingo AI',
+          userEmail: 'mingo@openframe.dev',
+          onProfile: fn(),
+          onLogout: fn(),
+        }}
+        mobileBurgerMenuProps={{
+          user: {
+            userName: 'Mingo AI',
+            userEmail: 'mingo@openframe.dev',
+            userRole: 'Admin',
+          },
+        }}
+        drawer={
+          <AppLayoutDrawer open={open} onOpenChange={setOpen}>
+            <AppLayoutDrawerContent side="right">
+              <AppLayoutDrawerHeader>
+                <AppLayoutDrawerTitle>Current Chats</AppLayoutDrawerTitle>
+                <AppLayoutDrawerDescription>
+                  Persistent: clicks on AppLayout chrome don&apos;t close this.
+                </AppLayoutDrawerDescription>
+              </AppLayoutDrawerHeader>
+              <AppLayoutDrawerBody>
+                <p className="text-sm text-ods-text-secondary">Chat content goes here.</p>
+              </AppLayoutDrawerBody>
+            </AppLayoutDrawerContent>
+          </AppLayoutDrawer>
+        }
+      >
+        <DashboardChildren onOpenDrawer={() => setOpen(true)} />
+      </AppLayout>
+    )
+  },
+}
+
+/**
+ * Resizable variant — drag the inside edge to resize. Clamped to the
+ * AppLayout main-area dimensions (not the viewport).
+ */
+export const ResizableRight: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(true)
+    return (
+      <AppLayout
+        sidebarConfig={{ items: navigationItems, onNavigate: fn(), onToggleMinimized: fn() }}
+        headerProps={{
+          showNotifications: true,
+          showUser: true,
+          userName: 'Mingo AI',
+          userEmail: 'mingo@openframe.dev',
+          onProfile: fn(),
+          onLogout: fn(),
+        }}
+        mobileBurgerMenuProps={{
+          user: {
+            userName: 'Mingo AI',
+            userEmail: 'mingo@openframe.dev',
+            userRole: 'Admin',
+          },
+        }}
+        drawer={
+          <AppLayoutDrawer open={open} onOpenChange={setOpen}>
+            <AppLayoutDrawerContent
+              side="right"
+              resizable
+              minSize={360}
+              defaultSize={560}
+              storageKey="storybook:app-layout-drawer:right"
+            >
+              <AppLayoutDrawerHeader>
+                <AppLayoutDrawerTitle>Resizable Drawer</AppLayoutDrawerTitle>
+              </AppLayoutDrawerHeader>
+              <AppLayoutDrawerBody>
+                <p className="text-sm text-ods-text-secondary">
+                  Drag the grip on the left edge to resize. The panel can extend all
+                  the way to the container edge (minus a 16px symmetric gap).
+                </p>
+              </AppLayoutDrawerBody>
+            </AppLayoutDrawerContent>
+          </AppLayoutDrawer>
+        }
+      >
+        <DashboardChildren onOpenDrawer={() => setOpen(true)} />
+      </AppLayout>
+    )
+  },
+}
+
+/**
+ * Left-side variant.
+ */
+export const Left: Story = {
+  render: function Render() {
+    const [open, setOpen] = useState(false)
+    return (
+      <AppLayout
+        sidebarConfig={{ items: navigationItems, onNavigate: fn(), onToggleMinimized: fn() }}
+        headerProps={{
+          showNotifications: true,
+          showUser: true,
+          userName: 'Mingo AI',
+          userEmail: 'mingo@openframe.dev',
+          onProfile: fn(),
+          onLogout: fn(),
+        }}
+        mobileBurgerMenuProps={{
+          user: {
+            userName: 'Mingo AI',
+            userEmail: 'mingo@openframe.dev',
+            userRole: 'Admin',
+          },
+        }}
+        drawer={
+          <AppLayoutDrawer open={open} onOpenChange={setOpen}>
+            <AppLayoutDrawerContent side="left">
+              <AppLayoutDrawerHeader>
+                <AppLayoutDrawerTitle>Filters</AppLayoutDrawerTitle>
+              </AppLayoutDrawerHeader>
+              <AppLayoutDrawerBody>
+                <p className="text-sm text-ods-text-secondary">Left-side drawer content.</p>
+              </AppLayoutDrawerBody>
+            </AppLayoutDrawerContent>
+          </AppLayoutDrawer>
+        }
+      >
+        <DashboardChildren onOpenDrawer={() => setOpen(true)} />
+      </AppLayout>
+    )
+  },
+}

--- a/openframe-frontend-core/src/utils/.embed-authed-fetch.md
+++ b/openframe-frontend-core/src/utils/.embed-authed-fetch.md
@@ -9,6 +9,13 @@ Drop-in replacement for `fetch()` that:
 - Delegates to `applyProxyAuth` to merge `Authorization` and `X-Chat-Act-As` headers — **proxy credentials always win** over caller-supplied headers
 - Defaults `Content-Type: application/json` when no headers are provided
 - Forces `credentials: 'same-origin'` to ensure Supabase auth cookies are included alongside bearer tokens
+- **Self-heals on `401`** when a host registered an `EmbedAuthAdapter` with a `refresh` callback: calls `refresh()` once, and on success retries the same request a single time with freshly-recomputed headers (so a rotated bearer is picked up). Concurrent 401s share ONE refresh. With no adapter / no `refresh`, the 401 passes through unchanged.
+
+### `setEmbedAuthAdapter(adapter | null)` + `EmbedAuthAdapter`
+Optional host-owned auth override registered at module level (one chat panel per app). The adapter can supply:
+- `getHeaders()` — headers merged onto every call AFTER proxy-auth (adapter wins), re-read per request so token rotation is seen
+- `credentials` — overrides the default `'same-origin'` (e.g. `'include'` for cross-origin cookie auth)
+- `refresh()` — `Promise<boolean>` 401 self-heal hook (see above). This lifts the openframe `apiClient`'s refresh-then-retry behaviour into the lib so embedded surfaces no longer need a host-side `window.fetch` monkey-patch to survive an expired token mid-session.
 
 ### `assertSameOrigin(url)` *(internal)*
 Defense-in-depth guard that:

--- a/openframe-frontend-core/src/utils/__tests__/embed-authed-fetch.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/embed-authed-fetch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { embedAuthedFetch } from '../embed-authed-fetch'
+import { embedAuthedFetch, setEmbedAuthAdapter } from '../embed-authed-fetch'
 
 /**
  * Tests focus on the same-origin guard rather than the proxy-auth
@@ -11,9 +11,15 @@ describe('embedAuthedFetch.assertSameOrigin guard', () => {
 
   beforeEach(() => {
     globalThis.fetch = vi.fn(async () => new Response('ok')) as typeof fetch
+    // The cross-origin guard has a dev-mode escape hatch (warn + allow
+    // instead of throw) when `NODE_ENV !== 'production'` — see
+    // `embed-authed-fetch.ts`. Pin the env to production so these tests
+    // exercise the bearer-leak defense, not the dev convenience path.
+    vi.stubEnv('NODE_ENV', 'production')
   })
   afterEach(() => {
     globalThis.fetch = originalFetch
+    vi.unstubAllEnvs()
     vi.restoreAllMocks()
   })
 
@@ -62,5 +68,101 @@ describe('embedAuthedFetch.assertSameOrigin guard', () => {
       headers: { Authorization: 'Bearer leaked-secret' },
     })).toThrow()
     expect(spy).not.toHaveBeenCalled()
+  })
+})
+
+describe('embedAuthedFetch 401 self-heal (adapter.refresh)', () => {
+  const originalFetch = globalThis.fetch
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    setEmbedAuthAdapter(null)
+    vi.restoreAllMocks()
+  })
+
+  it('refreshes once then retries the request on a 401', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('nope', { status: 401 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    const refresh = vi.fn(async () => true)
+    setEmbedAuthAdapter({ getHeaders: () => ({ Authorization: 'Bearer t' }), refresh })
+
+    const res = await embedAuthedFetch('/api/chat/x')
+    expect(res.status).toBe(200)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('surfaces the 401 (no retry) when refresh resolves false', async () => {
+    const fetchSpy = vi.fn(async () => new Response('nope', { status: 401 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    const refresh = vi.fn(async () => false)
+    setEmbedAuthAdapter({ refresh })
+
+    const res = await embedAuthedFetch('/api/chat/x')
+    expect(res.status).toBe(401)
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not retry a second time when the refreshed token is also 401', async () => {
+    const fetchSpy = vi.fn(async () => new Response('nope', { status: 401 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    const refresh = vi.fn(async () => true)
+    setEmbedAuthAdapter({ refresh })
+
+    const res = await embedAuthedFetch('/api/chat/x')
+    expect(res.status).toBe(401)
+    // refresh fired once; the retry's 401 is surfaced rather than looping.
+    expect(refresh).toHaveBeenCalledTimes(1)
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('de-dupes concurrent 401s into a single refresh', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('nope', { status: 401 }))
+      .mockResolvedValueOnce(new Response('nope', { status: 401 }))
+      .mockResolvedValue(new Response('ok', { status: 200 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    // A refresh that stays pending until we release it — so BOTH 401s are
+    // parked on the single shared slot before it settles. (If it resolved
+    // eagerly, the slot could clear between the two 401s and the test would
+    // race.)
+    let releaseRefresh: (v: boolean) => void = () => {}
+    const refreshGate = new Promise<boolean>((resolve) => {
+      releaseRefresh = resolve
+    })
+    const refresh = vi.fn(() => refreshGate)
+    setEmbedAuthAdapter({ refresh })
+
+    const p1 = embedAuthedFetch('/api/chat/a')
+    const p2 = embedAuthedFetch('/api/chat/b')
+
+    // Wait until both initial fetches have 401'd and reached the (still
+    // pending) refresh slot, then release it so both retries fire.
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+    releaseRefresh(true)
+
+    const [r1, r2] = await Promise.all([p1, p2])
+    expect(r1.status).toBe(200)
+    expect(r2.status).toBe(200)
+    // Both 401s shared ONE refresh call.
+    expect(refresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes a 401 through untouched when no adapter is registered', async () => {
+    const fetchSpy = vi.fn(async () => new Response('nope', { status: 401 }))
+    globalThis.fetch = fetchSpy as typeof fetch
+
+    const res = await embedAuthedFetch('/api/chat/x')
+    expect(res.status).toBe(401)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/openframe-frontend-core/src/utils/embed-authed-fetch.ts
+++ b/openframe-frontend-core/src/utils/embed-authed-fetch.ts
@@ -204,11 +204,32 @@ export function embedAuthedFetch(url: string, init: RequestInit = {}): Promise<R
  * server. Resets to `null` once settled so the next genuine expiry can
  * refresh again.
  */
-let inFlightRefresh: Promise<boolean> | null = null
+// Stored on `globalThis` rather than a module-local so the "single refresh"
+// guarantee survives module duplication. Bundlers can ship more than one copy
+// of this module (e.g. across chunks or a host + embedded build); a per-module
+// variable would let each copy run its own refresh cycle, re-creating the
+// thundering-herd this dedupe exists to prevent.
+const IN_FLIGHT_REFRESH_GLOBAL_KEY = '__embedAuthedFetchInFlightRefresh__'
+
+function getInFlightRefresh(): Promise<boolean> | null {
+  if (typeof globalThis === 'undefined') return null
+  return (
+    ((globalThis as Record<string, unknown>)[IN_FLIGHT_REFRESH_GLOBAL_KEY] as
+      | Promise<boolean>
+      | null
+      | undefined) ?? null
+  )
+}
+
+function setInFlightRefresh(refresh: Promise<boolean> | null): void {
+  if (typeof globalThis === 'undefined') return
+  ;(globalThis as Record<string, unknown>)[IN_FLIGHT_REFRESH_GLOBAL_KEY] = refresh
+}
 
 function dedupedRefresh(): Promise<boolean> {
   const adapter = getRegisteredAuthAdapter()
   if (!adapter?.refresh) return Promise.resolve(false)
+  let inFlightRefresh = getInFlightRefresh()
   if (!inFlightRefresh) {
     // Wrap in `Promise.resolve` so an adapter that throws synchronously
     // (rather than rejecting) still funnels through the shared slot and
@@ -217,8 +238,9 @@ function dedupedRefresh(): Promise<boolean> {
       .then(() => adapter.refresh!())
       .catch(() => false)
       .finally(() => {
-        inFlightRefresh = null
+        setInFlightRefresh(null)
       })
+    setInFlightRefresh(inFlightRefresh)
   }
   return inFlightRefresh
 }

--- a/openframe-frontend-core/src/utils/embed-authed-fetch.ts
+++ b/openframe-frontend-core/src/utils/embed-authed-fetch.ts
@@ -22,6 +22,117 @@
 
 import { applyProxyAuth } from './embed-proxy-auth-storage'
 
+// =============================================================================
+// Host-supplied auth adapter (opt-in)
+// =============================================================================
+
+/**
+ * Hosts that have their own auth model (cookie sessions, app-specific
+ * JWT in localStorage, OAuth access tokens, …) can register an adapter
+ * to override the lib's default `embedProxyAuth` flow. When set, the
+ * adapter's `getHeaders()` result is merged onto every `embedAuthedFetch`
+ * call AFTER the default proxy-auth header step (so adapter headers
+ * win over both caller and proxy values), and `credentials` overrides
+ * the default `'same-origin'` behaviour.
+ *
+ * Default (no adapter): MPH-style proxy-impersonation — bearer + act-as
+ * read from localStorage, `credentials: 'same-origin'`. No consumer
+ * needs to touch this unless they want a different auth model.
+ *
+ * Use cases:
+ *   - openframe-frontend has its own JWT in `localStorage.of_access_token`
+ *     and cookie-based session; register an adapter to attach the JWT
+ *     and request `credentials: 'include'` so cookies travel cross-origin
+ *     to the openframe gateway.
+ *   - Future embed hosts with OAuth access tokens, signed URLs, etc.
+ *
+ * Lifetime: setter is module-level (intentionally — `embedAuthedFetch`
+ * is a plain utility, not a hook, so it can't read React context). Host
+ * runtime providers should call `setEmbedAuthAdapter(...)` on mount and
+ * `setEmbedAuthAdapter(null)` on unmount. Multiple hosts registering at
+ * once is a programming error (one chat panel per app).
+ */
+export interface EmbedAuthAdapter {
+  /** Headers merged onto every embedded-fetch call. Return `{}` to add
+   *  nothing. Called per-request so reactive token refresh sees the latest
+   *  value from your auth store / storage. Values typed as
+   *  `string | undefined` so the common narrowed shape
+   *  `{ Authorization: token ? 'Bearer …' : undefined }` (or a conditional
+   *  `token ? { Authorization: … } : {}`) assigns cleanly — `undefined`
+   *  values are filtered before being merged into the request headers. */
+  getHeaders?: () => Record<string, string | undefined>
+  /** `RequestInit.credentials` mode. Default when no adapter: callers'
+   *  `init.credentials` or `'same-origin'`. Use `'include'` for cookie
+   *  auth against a different origin (CORS + `SameSite=None` required). */
+  credentials?: RequestCredentials
+  /**
+   * Optional 401 self-heal. When a request comes back `401`,
+   * `embedAuthedFetch` calls this once, and — if it resolves `true` —
+   * retries the SAME request exactly once with freshly-recomputed
+   * headers (so a rotated bearer from `getHeaders()` is picked up).
+   * Resolve `false` to surface the 401 to the caller unchanged.
+   *
+   * This is the capability the openframe `apiClient` has had all along
+   * (refresh-the-access-token-then-retry); registering it here gives the
+   * embedded chat/ticket surfaces the same self-healing auth instead of
+   * dying on an expired token. Concurrent 401s are de-duplicated by the
+   * wrapper, so this fires at most once per refresh cycle even when a
+   * stampede of chat requests all expire together — your implementation
+   * does NOT need its own in-flight guard (though a token-refresh manager
+   * that already dedups is harmless).
+   *
+   * Keep it idempotent and side-effect-light: on failure the wrapper just
+   * returns the original 401 — logout/redirect decisions belong to the
+   * host's own auth layer, not to this fetch wrapper.
+   */
+  refresh?: () => Promise<boolean>
+}
+
+/**
+ * The registered adapter is parked on `globalThis`, NOT in a module-private
+ * `let`. Reason: this lib ships multiple entry points (`/utils`,
+ * `/components/chat`, …) and a consumer's bundler can inline this file into
+ * more than one chunk — giving each chunk its OWN module scope. If the host
+ * calls `setEmbedAuthAdapter` from the `/utils` copy while the chat's
+ * `embedAuthedFetch` runs from the `/components/chat` copy, a module-local
+ * `let` would be set on one copy and read as `null` on the other (the exact
+ * "credentials: same-origin, no Bearer, no refresh" symptom). A single
+ * `globalThis` slot is shared across every copy, so registration always
+ * reaches the fetch path.
+ */
+const ADAPTER_GLOBAL_KEY = '__embedAuthedFetchAdapter__'
+
+function getRegisteredAuthAdapter(): EmbedAuthAdapter | null {
+  if (typeof globalThis === 'undefined') return null
+  return (globalThis as Record<string, unknown>)[ADAPTER_GLOBAL_KEY] as EmbedAuthAdapter | null ?? null
+}
+
+function storeRegisteredAuthAdapter(adapter: EmbedAuthAdapter | null): void {
+  if (typeof globalThis === 'undefined') return
+  ;(globalThis as Record<string, unknown>)[ADAPTER_GLOBAL_KEY] = adapter
+}
+
+/**
+ * Register a host-owned auth adapter for `embedAuthedFetch`. Pass `null`
+ * to clear (typically on provider unmount).
+ *
+ * Module-level state — there is one chat panel per app, so a single
+ * registration is sufficient. Calling this twice with different non-null
+ * adapters replaces the previous one (the most recent registration wins);
+ * a `console.warn` flags the overwrite so duplicate-provider mounts get
+ * caught in dev.
+ */
+export function setEmbedAuthAdapter(adapter: EmbedAuthAdapter | null): void {
+  if (adapter && getRegisteredAuthAdapter() && process.env.NODE_ENV !== 'production') {
+    console.warn(
+      '[setEmbedAuthAdapter] overwriting a previously-registered auth ' +
+        'adapter. Two chat-runtime providers should not coexist — verify ' +
+        'mount order and pass `null` from the unmounting provider.',
+    )
+  }
+  storeRegisteredAuthAdapter(adapter)
+}
+
 /**
  * `fetch` wrapper that attaches embed-proxy bearer headers (when
  * present in sessionStorage) and forces `credentials: 'same-origin'`
@@ -40,13 +151,26 @@ import { applyProxyAuth } from './embed-proxy-auth-storage'
  * the current window's origin; cross-origin URLs throw before the bearer
  * leaves the page. This is a defense-in-depth guard for future call sites
  * — there is no legitimate cross-origin use of this fetch wrapper.
+ *
+ * **401 self-heal:** when a registered adapter supplies `refresh`, a `401`
+ * response triggers a single token refresh + retry of the same request
+ * (see `EmbedAuthAdapter.refresh`). This is the openframe `apiClient`'s
+ * refresh-then-retry behaviour, lifted into the lib so embedded surfaces
+ * no longer need a host-side `window.fetch` monkey-patch to survive an
+ * expired access token mid-chat. With no adapter (or no `refresh`), the
+ * 401 passes straight through unchanged.
  */
 export function embedAuthedFetch(url: string, init: RequestInit = {}): Promise<Response> {
+  // Same-origin guard runs SYNCHRONOUSLY (not awaited inside the async
+  // helper below) so a bearer-leaking cross-origin URL throws before any
+  // promise is created — callers and tests rely on the synchronous throw.
   assertSameOrigin(url)
 
   // `applyProxyAuth` accepts `Record<string, string>`; normalize the
-  // caller's headers to that shape. RequestInit accepts `HeadersInit`
-  // which is broader (Headers instance OR array of tuples).
+  // caller's headers to that shape ONCE, up front. RequestInit accepts
+  // `HeadersInit` which is broader (Headers instance OR array of tuples).
+  // We re-derive the per-request headers from this base on every attempt
+  // (initial + post-refresh retry) so a rotated bearer is picked up.
   //
   // When the caller passes no headers, fall back to the same default
   // `applyProxyAuth` uses internally — `Content-Type: application/json` —
@@ -69,14 +193,92 @@ export function embedAuthedFetch(url: string, init: RequestInit = {}): Promise<R
     }
   }
 
-  const { url: authedUrl, headers } = applyProxyAuth(url, baseHeaders)
-  return fetch(authedUrl, {
+  return fetchWithRefresh(url, init, baseHeaders, false)
+}
+
+/**
+ * Single in-flight refresh shared across all concurrent `embedAuthedFetch`
+ * callers. A stampede of chat requests that all 401 at the same moment must
+ * trigger the adapter's `refresh()` ONCE, not N times — otherwise an
+ * expiring session fires a thundering herd of refresh calls at the auth
+ * server. Resets to `null` once settled so the next genuine expiry can
+ * refresh again.
+ */
+let inFlightRefresh: Promise<boolean> | null = null
+
+function dedupedRefresh(): Promise<boolean> {
+  const adapter = getRegisteredAuthAdapter()
+  if (!adapter?.refresh) return Promise.resolve(false)
+  if (!inFlightRefresh) {
+    // Wrap in `Promise.resolve` so an adapter that throws synchronously
+    // (rather than rejecting) still funnels through the shared slot and
+    // clears it. A rejected refresh is treated as "could not refresh".
+    inFlightRefresh = Promise.resolve()
+      .then(() => adapter.refresh!())
+      .catch(() => false)
+      .finally(() => {
+        inFlightRefresh = null
+      })
+  }
+  return inFlightRefresh
+}
+
+/**
+ * Core fetch path: merge proxy-auth + adapter headers, issue the request,
+ * and — on a `401` with a refresh-capable adapter — refresh once and retry
+ * the identical request a single time. Mirrors the openframe `apiClient`'s
+ * refresh-then-retry contract (`isRetry` guards against infinite loops).
+ */
+async function fetchWithRefresh(
+  url: string,
+  init: RequestInit,
+  baseHeaders: Record<string, string>,
+  isRetry: boolean,
+): Promise<Response> {
+  // Re-run the merge each attempt: `applyProxyAuth` reads the latest stored
+  // proxy creds and `getHeaders()` reads the latest bearer, so a retry after
+  // refresh carries the rotated token rather than the stale one. `{...baseHeaders}`
+  // keeps the caller's normalized headers immutable across attempts.
+  const { url: authedUrl, headers } = applyProxyAuth(url, { ...baseHeaders })
+
+  // Host-supplied auth adapter layer. Runs AFTER the proxy-auth merge so
+  // adapter headers override both caller and proxy values — the adapter
+  // is the host's explicit "this is my auth model" override, intentionally
+  // last-writer-wins. When no adapter is registered, this is a zero-cost
+  // no-op (object spread of `{}`).
+  const adapter = getRegisteredAuthAdapter()
+  if (adapter?.getHeaders) {
+    // Filter `undefined` values — the adapter type allows them so consumers
+    // don't have to narrow `{ Authorization: token ? '…' : undefined }`-shaped
+    // returns, but `fetch` headers must be strings.
+    for (const [k, v] of Object.entries(adapter.getHeaders())) {
+      if (v !== undefined) headers[k] = v
+    }
+  }
+  const credentials = adapter?.credentials ?? init.credentials ?? 'same-origin'
+
+  const response = await fetch(authedUrl, {
     ...init,
     headers,
-    // Always include Supabase auth cookies. `applyProxyAuth` handles
-    // the bearer header layer; cookies are the session-tier carrier.
-    credentials: init.credentials ?? 'same-origin',
+    // Default `same-origin` carries Supabase cookies for the MPH proxy-
+    // auth model. Hosts on different origins (openframe-frontend ↔
+    // openframe gateway) register `credentials: 'include'` via the
+    // adapter to make their own cookies travel cross-origin (CORS +
+    // `SameSite=None` must be configured server-side for that to work).
+    credentials,
   })
+
+  // 401 self-heal: refresh the token once and retry. Only when an adapter
+  // opted into `refresh`, and only on the first attempt — a 401 on the
+  // retry means the fresh token is also unauthorized, so surface it.
+  if (response.status === 401 && !isRetry && adapter?.refresh) {
+    const refreshed = await dedupedRefresh()
+    if (refreshed) {
+      return fetchWithRefresh(url, init, baseHeaders, true)
+    }
+  }
+
+  return response
 }
 
 /**
@@ -118,6 +320,22 @@ function assertSameOrigin(url: string): void {
     )
   }
   if (target.origin !== pageOrigin) {
+    // Dev-mode escape hatch — embedded apps (e.g. openframe-frontend)
+    // run on a different origin from their gateway during local dev,
+    // and forcing a Next.js `rewrites()` workaround is more error-prone
+    // than relaxing the guard for the dev build. In production
+    // (`NODE_ENV === 'production'`) the guard stays absolute — same
+    // defense-in-depth bearer-leak protection as before. The check is
+    // baked at build time by Next/webpack/Turbopack so prod bundles
+    // contain only the throwing branch (no dev string in the artifact).
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[embedAuthedFetch] cross-origin fetch to ${target.origin} ` +
+          `allowed in dev (NODE_ENV !== 'production'). Production builds ` +
+          `will reject this — wire a same-origin proxy before shipping.`,
+      )
+      return
+    }
     throw new Error(
       `embedAuthedFetch: refusing cross-origin fetch to ${target.origin} — pass a relative /api/* path instead`,
     )

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -120,7 +120,11 @@ export {
 // surfaces from importing a chat-prefixed symbol. Old chat-prefixed
 // aliases are kept as @deprecated re-exports at
 // `components/chat/utils/chat-authed-fetch.ts` + `chat-proxy-auth-storage.ts`.
-export { embedAuthedFetch } from './embed-authed-fetch'
+export {
+  embedAuthedFetch,
+  setEmbedAuthAdapter,
+  type EmbedAuthAdapter,
+} from './embed-authed-fetch'
 export {
   type EmbedProxyAuth,
   getEmbedProxyAuth,


### PR DESCRIPTION
## Summary

- New **`AppLayoutDrawer`** family — a `Drawer` variant that renders **inside** `AppLayout`'s main-area instead of as a body-level overlay. Sidebar and header stay visible and interactive; non-modal Radix Dialog portals into AppLayout's drawer-container context; dim-overlay click closes, chrome clicks don't.
- New **`drawer` slot prop** on `AppLayout` for hosting the drawer cleanly (no mixing with page `children`).
- New **`HeaderMingoButton`** (Mingo logo + "Mingo AI" wordmark, Figma `7532:222103`) + `showMingoAI` / `onMingoAI` / `isMingoAIActive` slots on `AppHeader`.
- **`EmbeddableChat` gains `shell="none"`** so it can render only the chat body and live inside `AppLayoutDrawerContent` (instead of bringing its own body-level Drawer). Internal "Ask AI" trigger and iOS body scroll-lock are suppressed in this mode.
- **`ChatInput` programmatic focus uses `preventScroll: true`** — fixes a ~500px content jump that happened when auto-focus targeted an off-screen-animating drawer panel.
- **Relax `EmbedAuthAdapter.getHeaders` type** to `Record<string, string | undefined>` and filter `undefined` values before merging — common conditional-header shapes (e.g. `{ Authorization: token ? 'Bearer …' : undefined }`) now type-check.
- **`yalc:watch` now rebuilds `.d.ts`** (`tsc -p tsconfig.declarations.json` after `tsup`) so consumers via `yalc push` always get fresh type declarations instead of inheriting a dts-less dist.
- **Pin `NODE_ENV='production'`** in the `assertSameOrigin` guard tests so the dev-escape-hatch in `embed-authed-fetch.ts` doesn't mask the cross-origin throw behavior the tests are validating.

## Files

**New:**
- `src/components/navigation/app-layout-drawer.tsx` — `AppLayoutDrawer`, `AppLayoutDrawerContent`, header/body/footer/title aliases, resize handle, container-aware clamp
- `src/components/navigation/header-mingo-button.tsx`
- `src/stories/AppLayoutDrawer.stories.tsx` (Right / ResizableRight / Left stories)

**Modified:**
- `src/components/navigation/app-layout.tsx` — drawer-container context, `drawer` slot prop, `useAppLayoutDrawerContainer` hook
- `src/components/navigation/app-header.tsx` — `HeaderMingoButton` slot
- `src/components/navigation/index.ts` — exports
- `src/components/chat/chat-input.tsx` — `focus({ preventScroll: true })` in three call sites
- `src/components/chat/embeddable-chat.tsx` — `shell` prop, gate `usePreventScroll` and iOS hack on `shellLess`, shell-less branch in render
- `src/components/chat/hooks/*`, `src/components/chat/types/unified-chat-state.types.ts` — already-staged adapter / 401 self-heal work that ships alongside
- `src/utils/embed-authed-fetch.ts` — `EmbedAuthAdapter`, `setEmbedAuthAdapter`, 401 self-heal, same-origin guard; relaxed `getHeaders` return type + undefined filter
- `src/utils/__tests__/embed-authed-fetch.test.ts` — pin `NODE_ENV='production'` for guard tests
- `src/utils/.embed-authed-fetch.md`, `src/utils/index.ts` — docs + barrel
- `package.json` — `yalc:watch` now runs `tsc -p tsconfig.declarations.json`

## Usage (openframe-frontend)

```tsx
const [chatOpen, setChatOpen] = useState(false)

<AppLayout
  headerProps={{
    showMingoAI: true,
    onMingoAI: () => setChatOpen(o => !o),
    isMingoAIActive: chatOpen,
    ...,
  }}
  drawer={
    <AppLayoutDrawer open={chatOpen} onOpenChange={setChatOpen}>
      <AppLayoutDrawerContent flush resizable defaultSize={640} storageKey="mingo-chat-width">
        <EmbeddableChat shell="none" open={chatOpen} onOpenChange={setChatOpen} ... />
      </AppLayoutDrawerContent>
    </AppLayoutDrawer>
  }
>
  <YourPage />
</AppLayout>
```

## Test plan

- [x] `npm run test:run` — 90/90 passing
- [x] `npm run build` — success, 2539 `.d.ts` generated
- [x] `npm run type-check` — clean
- [x] Storybook stories load (`Right`, `ResizableRight`, `Left`)
- [ ] Smoke in openframe-frontend: open Mingo AI from header, verify no content shift, sidebar/header remain interactive, overlay-click closes, sidebar/header click does not close, Esc closes, X in chat header closes, resize from inside edge persists across reload via `storageKey`
- [ ] Verify ChatInput focus doesn't scroll the page when opening the drawer (the original bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell-less chat embedding, multi-conversation sidebar with dialog management, in-layout resizable drawer, and a Mingo AI header launcher

* **Improvements**
  * Unified chat dialog lifecycle, connection & per-dialog token usage tracking, slash-commands routed via embedder auth adapter, and auth-aware fetch with single-refresh retry on 401

* **Tests**
  * Added tests for 401 refresh, retry and de-duplication behavior

* **Documentation**
  * Documented embed-auth adapter contract and 401 self-heal behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->