### PR TITLE
feat(chat): caller-provided guide quick actions; gate guide banner to guide+default

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -1140,9 +1140,11 @@ function EmbeddableChatInner({
               />
 
               {/* Guide-mode indicator banner (Figma node 7532:328222) —
-                  full-bleed accent strip below the header whenever Guide mode
-                  is active. Fades in to match the panel's view transitions. */}
-              {activeMode === 'guide' && (
+                  full-bleed accent strip below the header. Shown only when
+                  Guide mode is active AND the default (Mingo) mode also exists:
+                  the banner contrasts the temporary Guide session against the
+                  default chat, so it's meaningless in a guide-only setup. */}
+              {activeMode === 'guide' && !!effectiveModes.mingo && (
                 <GuideModeBanner className="animate-in fade-in-0 duration-200" />
               )}
 

--- a/openframe-frontend-core/src/components/chat/guide-welcome.tsx
+++ b/openframe-frontend-core/src/components/chat/guide-welcome.tsx
@@ -26,8 +26,10 @@ export interface GuideWelcomeProps {
   title?: React.ReactNode
   /** Greeting sub-line. Defaults to the OpenFrame temporary-session copy. */
   subtitle?: React.ReactNode
-  /** Quick-action chips. The first `maxVisibleQuickActions` render inline; the
-   *  rest collapse under a trailing "⋯" overflow menu. */
+  /** Quick-action chips — caller-provided; there are no built-in defaults, so
+   *  the chip row is omitted entirely unless the host supplies actions. The
+   *  first `maxVisibleQuickActions` render inline; the rest collapse under a
+   *  trailing "⋯" overflow menu. */
   quickActions?: ReadonlyArray<GuideQuickAction>
   /** How many chips to show inline before overflowing to the menu (default 3). */
   maxVisibleQuickActions?: number
@@ -49,16 +51,6 @@ const DEFAULT_SUBTITLE =
   'This chat is temporary and will not be saved. Ask about OpenFrame docs, ' +
   'known issues, or manage your support tickets right here.'
 
-const DEFAULT_QUICK_ACTIONS: ReadonlyArray<GuideQuickAction> = [
-  { id: 'how-to-start', label: 'How to start' },
-  { id: 'connect-device', label: 'Connect device' },
-  { id: 'find-device', label: 'Find device' },
-  { id: 'remote-connection', label: 'Remote connection' },
-  { id: 'run-scripts', label: 'Run scripts' },
-  { id: 'device-software', label: 'Device software' },
-  { id: 'bulk-update', label: 'Bulk update' },
-]
-
 // =============================================================================
 // Component
 // =============================================================================
@@ -77,7 +69,7 @@ const DEFAULT_QUICK_ACTIONS: ReadonlyArray<GuideQuickAction> = [
 export function GuideWelcome({
   title = DEFAULT_TITLE,
   subtitle = DEFAULT_SUBTITLE,
-  quickActions = DEFAULT_QUICK_ACTIONS,
+  quickActions = [],
   maxVisibleQuickActions = 3,
   onQuickAction,
   children,

--- a/openframe-frontend-core/src/stories/GuideWelcome.stories.tsx
+++ b/openframe-frontend-core/src/stories/GuideWelcome.stories.tsx
@@ -14,6 +14,18 @@ const ACTIONS = [
   { id: 'find', label: 'Find', onClick: () => console.log('find') },
 ]
 
+// Quick actions are caller-provided (GuideWelcome ships no defaults); these
+// demonstrate the inline chips + the "⋯" overflow menu.
+const SAMPLE_QUICK_ACTIONS = [
+  { id: 'how-to-start', label: 'How to start' },
+  { id: 'connect-device', label: 'Connect device' },
+  { id: 'find-device', label: 'Find device' },
+  { id: 'remote-connection', label: 'Remote connection' },
+  { id: 'run-scripts', label: 'Run scripts' },
+  { id: 'device-software', label: 'Device software' },
+  { id: 'bulk-update', label: 'Bulk update' },
+]
+
 const SAMPLE_LIST = (
   <div className="shrink-0 overflow-hidden rounded-md border border-ods-border">
     <MingoOnboardingCard
@@ -79,6 +91,7 @@ type Story = StoryObj<typeof GuideWelcome>
 /** Full guide-mode empty state with the slash-command list and quick actions. */
 export const Default: Story = {
   args: {
+    quickActions: SAMPLE_QUICK_ACTIONS,
     onQuickAction: (a) => console.log('quick action', a.id),
     children: SAMPLE_LIST,
   },
@@ -87,7 +100,15 @@ export const Default: Story = {
 /** No slash commands available yet — greeting + quick actions only. */
 export const NoCommands: Story = {
   args: {
+    quickActions: SAMPLE_QUICK_ACTIONS,
     onQuickAction: (a) => console.log('quick action', a.id),
+  },
+}
+
+/** No quick actions supplied (the default) — the chip row is omitted entirely. */
+export const NoQuickActions: Story = {
+  args: {
+    children: SAMPLE_LIST,
   },
 }
 
@@ -96,6 +117,7 @@ export const CustomCopy: Story = {
   args: {
     title: 'Ask the Guide',
     subtitle: 'A temporary session for exploring docs and tickets.',
+    quickActions: SAMPLE_QUICK_ACTIONS,
     onQuickAction: (a) => console.log('quick action', a.id),
     children: SAMPLE_LIST,
   },


### PR DESCRIPTION
## Summary
Follow-up to #1092 (merged).

- **Guide quick-action chips are now caller-provided** — `GuideWelcome` ships **no** built-in defaults. The chip row (and its `⋯` overflow menu) renders only when the host passes `quickActions` (via `EmbeddableChat`'s `guideWelcome.quickActions`). Removed the hardcoded How-to-start / Connect-device / Find-device / Remote-connection / Run-scripts / Device-software / Bulk-update list.
- **Guide-mode banner is gated to "guide + default"** — the yellow `GUIDE MODE CHAT` strip shows only when Guide mode is active **and** the default (Mingo) mode also exists. The banner contrasts the temporary Guide session against the default chat, so it's hidden in a guide-only setup.
- **Stories**: pass explicit sample quick actions where the chip row is demonstrated; added a `NoQuickActions` story showing the row is omitted by default.

## Verification
- `npm run type-check` — clean for changed files. (A pre-existing `react-colorful` missing-dependency error inherited from `main`'s `color-preset-select.tsx` is unrelated; resolved by `npm install`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined conditions for displaying the Guide mode banner to ensure accurate display based on context and availability of required options.

* **Refactor**
  * Removed built-in default quick-action chips from the Guide welcome component. Applications can now explicitly provide custom quick actions to control the display of the quick-action chip row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->