### PR TITLE
Forbid tenant owner to switch the tenant

### DIFF
--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/exception/OwnerCannotSwitchTenantException.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/exception/OwnerCannotSwitchTenantException.java
@@ -1,0 +1,10 @@
+package com.openframe.authz.exception;
+
+import com.openframe.core.exception.ConflictException;
+import com.openframe.core.exception.ErrorCode;
+
+public class OwnerCannotSwitchTenantException extends ConflictException {
+    public OwnerCannotSwitchTenantException(String email) {
+        super(ErrorCode.OWNER_CANNOT_SWITCH_TENANT, "Tenant owner cannot switch tenant: " + email);
+    }
+}

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/user/InvitationRegistrationService.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/user/InvitationRegistrationService.java
@@ -1,7 +1,9 @@
 package com.openframe.authz.service.user;
 
 import com.openframe.authz.dto.InvitationRegistrationRequest;
+import com.openframe.authz.exception.OwnerCannotSwitchTenantException;
 import com.openframe.authz.exception.UserActiveInAnotherTenantException;
+import com.openframe.data.document.user.UserRole;
 import com.openframe.authz.service.processor.RegistrationProcessor;
 import com.openframe.authz.service.processor.UserDeactivationProcessor;
 import com.openframe.authz.service.validation.InvitationValidator;
@@ -64,16 +66,19 @@ public class InvitationRegistrationService {
      *   - when switchTenant=true: deactivate and continue (return null to proceed with creation)
      *   - otherwise: throw
      */
-    private AuthUser handleExistingActiveUser(AuthUser current,
+    private AuthUser handleExistingActiveUser(AuthUser user,
                                               String targetTenantId,
                                               AuthInvitation invitation,
                                               InvitationRegistrationRequest request) {
-        if (targetTenantId.equals(current.getTenantId())) {
-            return current;
+        if (targetTenantId.equals(user.getTenantId())) {
+            return user;
         }
         if (TRUE.equals(request.getSwitchTenant())) {
-            userService.deactivateUser(current);
-            userDeactivationProcessor.postProcessDeactivation(current);
+            if (user.getRoles().contains(UserRole.OWNER)) {
+                throw new OwnerCannotSwitchTenantException(invitation.getEmail());
+            }
+            userService.deactivateUser(user);
+            userDeactivationProcessor.postProcessDeactivation(user);
             return null;
         }
         throw new UserActiveInAnotherTenantException(invitation.getEmail());

--- a/openframe-exception/src/main/java/com/openframe/core/exception/ErrorCode.java
+++ b/openframe-exception/src/main/java/com/openframe/core/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 
     // Authorization specific
     USER_ACTIVE_IN_ANOTHER_TENANT("USER_IS_ACTIVE_IN_ANOTHER_TENANT", 409),
+    OWNER_CANNOT_SWITCH_TENANT("OWNER_CANNOT_SWITCH_TENANT", 409),
 
     // Infrastructure error codes
     TYPE_MISMATCH("TYPE_MISMATCH", 400),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant owners can no longer switch tenants during the invitation registration process. The system now returns a conflict error when this action is attempted, ensuring proper access control and tenant ownership integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->