### PR TITLE
Add PrivilegeLevel{USER, ADMIN} to CommandInput

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/command/RunCommandInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/command/RunCommandInput.java
@@ -1,5 +1,6 @@
 package com.openframe.api.dto.command;
 
+import com.openframe.data.document.rmm.CommandInitiator;
 import com.openframe.data.document.rmm.ScriptShell;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -20,6 +21,9 @@ public class RunCommandInput {
 
     @NotNull
     private ScriptShell shell;
+
+    @NotNull
+    private CommandInitiator initiator;
 
     @Positive
     private Integer timeoutSeconds;

--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/command/RunCommandInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/command/RunCommandInput.java
@@ -1,6 +1,6 @@
 package com.openframe.api.dto.command;
 
-import com.openframe.data.document.rmm.CommandInitiator;
+import com.openframe.data.document.rmm.PrivilegeLevel;
 import com.openframe.data.document.rmm.ScriptShell;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -23,7 +23,7 @@ public class RunCommandInput {
     private ScriptShell shell;
 
     @NotNull
-    private CommandInitiator initiator;
+    private PrivilegeLevel privilegeLevel;
 
     @Positive
     private Integer timeoutSeconds;

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/rmm/CommandDispatchService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/rmm/CommandDispatchService.java
@@ -36,14 +36,14 @@ public class CommandDispatchService {
                 .executionId(executionId)
                 .code(input.getCommand())
                 .shell(input.getShell())
-                .initiator(input.getInitiator())
+                .privilegeLevel(input.getPrivilegeLevel())
                 .timeout(input.getTimeoutSeconds())
                 .build();
 
         commandNatsPublisher.publishCommand(input.getMachineId(), message);
 
-        log.info("Dispatched command executionId={} machineId={} shell={} initiator={}",
-                executionId, input.getMachineId(), input.getShell(), input.getInitiator());
+        log.info("Dispatched command executionId={} machineId={} shell={} privilegeLevel={}",
+                executionId, input.getMachineId(), input.getShell(), input.getPrivilegeLevel());
         return CommandDispatchResponse.builder()
                 .executionId(executionId)
                 .build();

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/rmm/CommandDispatchService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/rmm/CommandDispatchService.java
@@ -36,13 +36,14 @@ public class CommandDispatchService {
                 .executionId(executionId)
                 .code(input.getCommand())
                 .shell(input.getShell())
+                .initiator(input.getInitiator())
                 .timeout(input.getTimeoutSeconds())
                 .build();
 
         commandNatsPublisher.publishCommand(input.getMachineId(), message);
 
-        log.info("Dispatched command executionId={} machineId={} shell={}",
-                executionId, input.getMachineId(), input.getShell());
+        log.info("Dispatched command executionId={} machineId={} shell={} initiator={}",
+                executionId, input.getMachineId(), input.getShell(), input.getInitiator());
         return CommandDispatchResponse.builder()
                 .executionId(executionId)
                 .build();

--- a/openframe-api-service-core/src/main/resources/schema/command.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/command.graphqls
@@ -14,11 +14,11 @@ input RunCommandInput {
     machineId: String!
     shell: ScriptShell!
     command: String!
-    initiator: CommandInitiator!
+    privilegeLevel: PrivilegeLevel!
     timeoutSeconds: Int
 }
 
-enum CommandInitiator {
+enum PrivilegeLevel {
     USER
     ADMIN
 }

--- a/openframe-api-service-core/src/main/resources/schema/command.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/command.graphqls
@@ -14,7 +14,13 @@ input RunCommandInput {
     machineId: String!
     shell: ScriptShell!
     command: String!
+    initiator: CommandInitiator!
     timeoutSeconds: Int
+}
+
+enum CommandInitiator {
+    USER
+    ADMIN
 }
 
 type CommandDispatchResponse {

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/CommandDispatchServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/CommandDispatchServiceTest.java
@@ -4,7 +4,7 @@ import com.openframe.api.dto.command.CancelDispatchResponse;
 import com.openframe.api.dto.command.CancelExecutionInput;
 import com.openframe.api.dto.command.CommandDispatchResponse;
 import com.openframe.api.dto.command.RunCommandInput;
-import com.openframe.data.document.rmm.CommandInitiator;
+import com.openframe.data.document.rmm.PrivilegeLevel;
 import com.openframe.data.document.rmm.ScriptShell;
 import com.openframe.data.nats.rmm.model.CancelMessage;
 import com.openframe.data.nats.rmm.model.CommandMessage;
@@ -45,7 +45,7 @@ class CommandDispatchServiceTest {
         input.setMachineId(MACHINE_ID);
         input.setShell(ScriptShell.BASH);
         input.setCommand("df -h");
-        input.setInitiator(CommandInitiator.ADMIN);
+        input.setPrivilegeLevel(PrivilegeLevel.ADMIN);
     }
 
     @Test
@@ -61,14 +61,14 @@ class CommandDispatchServiceTest {
         assertThat(sent.getExecutionId()).isEqualTo(response.getExecutionId());
         assertThat(sent.getCode()).isEqualTo("df -h");
         assertThat(sent.getShell()).isEqualTo(ScriptShell.BASH);
-        assertThat(sent.getInitiator()).isEqualTo(CommandInitiator.ADMIN);
+        assertThat(sent.getPrivilegeLevel()).isEqualTo(PrivilegeLevel.ADMIN);
         assertThat(sent.getTimeout()).isNull();   // not provided → agent default
     }
 
     @Test
-    @DisplayName("runCommand: forwards the initiator (USER vs ADMIN) verbatim — the wire payload reflects exactly what the dashboard declared, not a backend default")
-    void runCommand_forwardsInitiatorVerbatim() {
-        input.setInitiator(CommandInitiator.USER);
+    @DisplayName("runCommand: forwards the privilegeLevel (USER vs ADMIN) verbatim — the wire payload reflects exactly what the dashboard declared, not a backend default")
+    void runCommand_forwardsPrivilegeLevelVerbatim() {
+        input.setPrivilegeLevel(PrivilegeLevel.USER);
 
         commandDispatchService.runCommand(input);
 
@@ -76,7 +76,7 @@ class CommandDispatchServiceTest {
         verify(commandNatsPublisher).publishCommand(eq(MACHINE_ID), captor.capture());
         // Re-asserts both sides of the enum so the dispatch path can't silently
         // collapse to a single value (e.g. always ADMIN) without breaking this test.
-        assertThat(captor.getValue().getInitiator()).isEqualTo(CommandInitiator.USER);
+        assertThat(captor.getValue().getPrivilegeLevel()).isEqualTo(PrivilegeLevel.USER);
     }
 
     @Test

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/CommandDispatchServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/CommandDispatchServiceTest.java
@@ -4,6 +4,7 @@ import com.openframe.api.dto.command.CancelDispatchResponse;
 import com.openframe.api.dto.command.CancelExecutionInput;
 import com.openframe.api.dto.command.CommandDispatchResponse;
 import com.openframe.api.dto.command.RunCommandInput;
+import com.openframe.data.document.rmm.CommandInitiator;
 import com.openframe.data.document.rmm.ScriptShell;
 import com.openframe.data.nats.rmm.model.CancelMessage;
 import com.openframe.data.nats.rmm.model.CommandMessage;
@@ -44,6 +45,7 @@ class CommandDispatchServiceTest {
         input.setMachineId(MACHINE_ID);
         input.setShell(ScriptShell.BASH);
         input.setCommand("df -h");
+        input.setInitiator(CommandInitiator.ADMIN);
     }
 
     @Test
@@ -59,7 +61,22 @@ class CommandDispatchServiceTest {
         assertThat(sent.getExecutionId()).isEqualTo(response.getExecutionId());
         assertThat(sent.getCode()).isEqualTo("df -h");
         assertThat(sent.getShell()).isEqualTo(ScriptShell.BASH);
+        assertThat(sent.getInitiator()).isEqualTo(CommandInitiator.ADMIN);
         assertThat(sent.getTimeout()).isNull();   // not provided → agent default
+    }
+
+    @Test
+    @DisplayName("runCommand: forwards the initiator (USER vs ADMIN) verbatim — the wire payload reflects exactly what the dashboard declared, not a backend default")
+    void runCommand_forwardsInitiatorVerbatim() {
+        input.setInitiator(CommandInitiator.USER);
+
+        commandDispatchService.runCommand(input);
+
+        ArgumentCaptor<CommandMessage> captor = ArgumentCaptor.forClass(CommandMessage.class);
+        verify(commandNatsPublisher).publishCommand(eq(MACHINE_ID), captor.capture());
+        // Re-asserts both sides of the enum so the dispatch path can't silently
+        // collapse to a single value (e.g. always ADMIN) without breaking this test.
+        assertThat(captor.getValue().getInitiator()).isEqualTo(CommandInitiator.USER);
     }
 
     @Test

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/CommandInitiator.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/CommandInitiator.java
@@ -1,0 +1,6 @@
+package com.openframe.data.document.rmm;
+
+public enum CommandInitiator {
+    USER,
+    ADMIN
+}

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/PrivilegeLevel.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/PrivilegeLevel.java
@@ -1,6 +1,6 @@
 package com.openframe.data.document.rmm;
 
-public enum CommandInitiator {
+public enum PrivilegeLevel {
     USER,
     ADMIN
 }

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandMessage.java
@@ -1,7 +1,7 @@
 package com.openframe.data.nats.rmm.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.openframe.data.document.rmm.CommandInitiator;
+import com.openframe.data.document.rmm.PrivilegeLevel;
 import com.openframe.data.document.rmm.ScriptShell;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
  *   "executionId": "01HXYZ...",
  *   "code": "echo hello",
  *   "shell": "BASH",
- *   "initiator": "ADMIN",
+ *   "privilegeLevel": "ADMIN",
  *   "timeout": 30
  * }
  * }</pre>
@@ -41,7 +41,7 @@ public class CommandMessage {
 
     private ScriptShell shell;
 
-    private CommandInitiator initiator;
+    private PrivilegeLevel privilegeLevel;
 
     private Integer timeout;
 }

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandMessage.java
@@ -1,6 +1,7 @@
 package com.openframe.data.nats.rmm.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.openframe.data.document.rmm.CommandInitiator;
 import com.openframe.data.document.rmm.ScriptShell;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -8,11 +9,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Wire payload sent to the OpenFrame agent over NATS JetStream for a single
- * script / ad-hoc-command execution.
+ * Wire payload sent to the OpenFrame agent over core NATS for a single
+ * ad-hoc-command execution.
  *
  * <pre>
- *   Stream:  COMMAND_EXECUTION
  *   Subject: machine.{machineId}.command-execution
  * </pre>
  *
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
  *   "executionId": "01HXYZ...",
  *   "code": "echo hello",
  *   "shell": "BASH",
+ *   "initiator": "ADMIN",
  *   "timeout": 30
  * }
  * }</pre>
@@ -39,6 +40,8 @@ public class CommandMessage {
     private String code;
 
     private ScriptShell shell;
+
+    private CommandInitiator initiator;
 
     private Integer timeout;
 }


### PR DESCRIPTION
Related to https://app.clickup.com/t/9013925967/86ahuahqz

New contract:

```
 {
    "executionId": "test-run-001",
    "code": "whoami",
    "shell": "/bin/bash",
    "privilegeLevel": "USER",
    "timeout": 30
  }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command dispatch API now requires specifying a privilege level (USER or ADMIN) when dispatching shell commands.
  * Privilege level information is properly tracked and included throughout the command execution pipeline for improved control and auditing.

* **Tests**
  * Added test coverage to verify privilege level handling and forwarding behavior in command dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->