### PR TITLE
refactor: Improve logging

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseTempAttachmentService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseTempAttachmentService.java
@@ -93,7 +93,7 @@ public class KnowledgeBaseTempAttachmentService {
         if (tempIds == null || tempIds.isEmpty()) {
             return List.of();
         }
-        log.info("Linking {} temp attachments to article: {}", tempIds.size(), articleId);
+        log.debug("Linking {} temp attachments to article: {} by: {}", tempIds.size(), articleId, uploadedBy);
 
         List<TempAttachment> temps = tempAttachmentRepository.findByIdIn(tempIds);
         if (temps.size() != tempIds.size()) {

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included debug="true" scan="false">
+
+    <!--
+      DEV-ONLY variant of shared-logback-includes-logfmt.xml that shortens stack traces with
+      net.logstash.logback.stacktrace.ShortenedThrowableConverter (depth 30, maxLength 2048,
+      rootCauseFirst, inlineHash, framework-frame exclusions).
+
+      TEXT appenders use the `exShort` conversion word (registered in the parent
+      shared-logback-spring-logfmt-shortened.xml). Option order:
+      maxDepthPerThrowable, shortenedClassNameLength(full=no shortening), maxLength,
+      then keyword options (rootFirst, inlineHash), then frame-exclusion regexes.
+      %replace(...) flattens newlines so the whole trace stays on one logfmt line.
+
+      IMPORTANT: the conversion-word options are processed by logback's ${} variable-substitution
+      parser, which mis-handles a literal '$'. So the text exclusion regexes are written WITHOUT
+      '$' (CGLIB frames matched as substrings; no trailing-anchor on Thread.run). The JSON
+      <exclude> elements below are plain element text and keep the canonical '$' anchors.
+      Both lists target the same frames. Verified against logback 1.5.6 + logstash-encoder 8.0.
+    -->
+
+    <!-- Console Appender in logfmt -->
+    <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>ts=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} level=%-5level service=${SPRING_APP_NAME} logger=%logger{36} thread=%thread msg="%replace(%msg){'\r?\n',' '}" stack="%replace(%exShort{30,full,2048,rootFirst,inlineHash,FastClassByCGLIB,EnhancerBySpringCGLIB,^sun\.reflect\..*\.invoke,^com\.sun\.,^sun\.net\.,^net\.sf\.cglib\.proxy\.MethodProxy\.invoke,^org\.springframework\.cglib\.,^org\.springframework\.transaction\.,^org\.springframework\.validation\.,^org\.springframework\.app\.,^org\.springframework\.aop\.,^java\.lang\.reflect\.Method\.invoke,^org\.springframework\.ws\..*\.invoke,^org\.springframework\.ws\.transport\.,^org\.springframework\.ws\.soap\.saaj\.SaajSoapMessage\.,^org\.springframework\.ws\.client\.core\.WebServiceTemplate\.,^org\.springframework\.web\.filter\.,^org\.apache\.tomcat\.,^org\.apache\.catalina\.,^org\.apache\.coyote\.,^java\.util\.concurrent\.ThreadPoolExecutor\.runWorker,^java\.lang\.Thread\.run}){'\r?\n',' | '}"%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Rolling File Appender (Text Format - logfmt) -->
+    <appender name="RollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${SPRING_APP_NAME}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>50MB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>ts=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} level=%-5level service=${SPRING_APP_NAME} logger=%logger{36} thread=%thread msg="%replace(%msg){'\r?\n',' '}" stack="%replace(%exShort{30,full,2048,rootFirst,inlineHash,FastClassByCGLIB,EnhancerBySpringCGLIB,^sun\.reflect\..*\.invoke,^com\.sun\.,^sun\.net\.,^net\.sf\.cglib\.proxy\.MethodProxy\.invoke,^org\.springframework\.cglib\.,^org\.springframework\.transaction\.,^org\.springframework\.validation\.,^org\.springframework\.app\.,^org\.springframework\.aop\.,^java\.lang\.reflect\.Method\.invoke,^org\.springframework\.ws\..*\.invoke,^org\.springframework\.ws\.transport\.,^org\.springframework\.ws\.soap\.saaj\.SaajSoapMessage\.,^org\.springframework\.ws\.client\.core\.WebServiceTemplate\.,^org\.springframework\.web\.filter\.,^org\.apache\.tomcat\.,^org\.apache\.catalina\.,^org\.apache\.coyote\.,^java\.util\.concurrent\.ThreadPoolExecutor\.runWorker,^java\.lang\.Thread\.run}){'\r?\n',' | '}"%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- JSON rolling appender with shortened stack trace -->
+    <appender name="JsonRollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${SPRING_APP_NAME}.json</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.json</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>50MB</totalSizeCap>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp />
+                <logLevel />
+                <threadName />
+                <loggerName />
+                <message />
+                <stackTrace>
+                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                        <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                        <maxLength>2048</maxLength>
+                        <rootCauseFirst>true</rootCauseFirst>
+                        <inlineHash>true</inlineHash>
+
+                        <!-- https://github.com/logfellow/logstash-logback-encoder/blob/main/stack-hash.md#recommended-exclusion-patterns -->
+                        <!-- generated class names -->
+                        <exclude>\$\$FastClassByCGLIB\$\$</exclude>
+                        <exclude>\$\$EnhancerBySpringCGLIB\$\$</exclude>
+                        <exclude>^sun\.reflect\..*\.invoke</exclude>
+                        <!-- JDK internals -->
+                        <exclude>^com\.sun\.</exclude>
+                        <exclude>^sun\.net\.</exclude>
+                        <!-- dynamic invocation -->
+                        <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
+                        <exclude>^org\.springframework\.cglib\.</exclude>
+                        <exclude>^org\.springframework\.transaction\.</exclude>
+                        <exclude>^org\.springframework\.validation\.</exclude>
+                        <exclude>^org\.springframework\.app\.</exclude>
+                        <exclude>^org\.springframework\.aop\.</exclude>
+                        <exclude>^java\.lang\.reflect\.Method\.invoke</exclude>
+                        <!-- Spring plumbing -->
+                        <exclude>^org\.springframework\.ws\..*\.invoke</exclude>
+                        <exclude>^org\.springframework\.ws\.transport\.</exclude>
+                        <exclude>^org\.springframework\.ws\.soap\.saaj\.SaajSoapMessage\.</exclude>
+                        <exclude>^org\.springframework\.ws\.client\.core\.WebServiceTemplate\.</exclude>
+                        <exclude>^org\.springframework\.web\.filter\.</exclude>
+                        <!-- Tomcat internals -->
+                        <exclude>^org\.apache\.tomcat\.</exclude>
+                        <exclude>^org\.apache\.catalina\.</exclude>
+                        <exclude>^org\.apache\.coyote\.</exclude>
+                        <exclude>^java\.util\.concurrent\.ThreadPoolExecutor\.runWorker</exclude>
+                        <exclude>^java\.lang\.Thread\.run$</exclude>
+                    </throwableConverter>
+                </stackTrace>
+            </providers>
+        </encoder>
+    </appender>
+
+    <!-- Add all appenders to root -->
+    <root level="info">
+        <appender-ref ref="ConsoleAppender" />
+        <appender-ref ref="RollingFileAppender" />
+        <appender-ref ref="JsonRollingFileAppender" />
+    </root>
+</included>

--- a/openframe-config-core/src/main/resources/logging/shared-logback-spring-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-spring-logfmt-shortened.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  DEV-ONLY variant of shared-logback-spring-logfmt.xml.
+  Identical to the canonical file except it registers the `exShort` conversion word and
+  includes shared-logback-includes-logfmt-shortened.xml, which shortens stack traces
+  (ShortenedThrowableConverter: depth 30, maxLength 2048, rootCauseFirst, inlineHash,
+  framework-frame exclusions) on both the logfmt text appenders and the JSON appender.
+
+  Only configs/dev points its logging.config at this file. Once validated, fold the
+  shortened config into the canonical files for all envs and delete this fork.
+-->
+<configuration debug="true" scan="false">
+    <springProperty scope="context" name="SPRING_APP_NAME" source="spring.application.name"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>
+    <springProperty scope="context" name="CONFIG_SERVER_URL" source="spring.config.url"/>
+
+    <property name="SPRING_CONTAINER_IP" value="${CONTAINER_IP:-localhost}" />
+
+    <!-- Register the shortened-stacktrace converter so the logfmt text patterns can use %exShort{...}. -->
+    <conversionRule conversionWord="exShort"
+                    converterClass="net.logstash.logback.stacktrace.ShortenedThrowableConverter"/>
+
+    <!-- Route JUL (java.util.logging) to SLF4J/Logback and reset existing handlers -->
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <!-- Include logfmt-based logging configuration with shortened stack traces -->
+    <include resource="logging/shared-logback-includes-logfmt-shortened.xml"/>
+</configuration>

--- a/openframe-data-device-aspect/src/main/java/com/openframe/data/service/impl/MachineTagEventServiceImpl.java
+++ b/openframe-data-device-aspect/src/main/java/com/openframe/data/service/impl/MachineTagEventServiceImpl.java
@@ -42,9 +42,9 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processMachineSave(Machine machine) {
         try {
-            log.info("Processing machine save event: {}", machine);
+            log.debug("Processing machine save event: {}", machine);
             sendMachineEventToKafka(machine);
-            log.info("Machine event processed successfully");
+            log.debug("Machine event processed successfully: machineId={}", machine.getMachineId());
         } catch (Exception e) {
             log.error("Error processing machine save event: {}", e.getMessage(), e);
         }
@@ -53,7 +53,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processMachineSaveAll(Iterable<Machine> machines) {
         try {
-            log.info("Processing machine saveAll event: {} machines", machines);
+            log.debug("Processing machine saveAll event: {} machines", machines);
             for (Machine machine : machines) {
                 sendMachineEventToKafka(machine);
             }
@@ -65,7 +65,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagAssignmentSave(TagAssignment assignment) {
         try {
-            log.info("Processing tag assignment save event: {}", assignment);
+            log.debug("Processing tag assignment save event: {}", assignment);
             if (assignment.getEntityType() != TagEntityType.DEVICE) {
                 log.debug("Skipping non-DEVICE tag assignment: {}", assignment.getEntityType());
                 return;
@@ -80,7 +80,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagAssignmentSaveAll(Iterable<TagAssignment> assignments) {
         try {
-            log.info("Processing tag assignment saveAll event: {} assignments", assignments);
+            log.debug("Processing tag assignment saveAll event: {} assignments", assignments);
 
             // Group by entityId to avoid duplicate processing
             Set<String> processedEntityIds = new HashSet<>();
@@ -102,9 +102,9 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagSave(Tag tag) {
         try {
-            log.info("Processing tag save event: {}", tag);
+            log.debug("Processing tag save event: {}", tag);
             sendTagEventToKafka(tag);
-            log.info("Tag event processed successfully");
+            log.debug("Tag event processed successfully: tagId={}", tag.getId());
         } catch (Exception e) {
             log.error("Error processing tag save event: {}", e.getMessage(), e);
         }
@@ -113,7 +113,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagSaveAll(Iterable<Tag> tags) {
         try {
-            log.info("Processing tag saveAll event: {} tags", tags);
+            log.debug("Processing tag saveAll event: {} tags", tags);
 
             // Process each tag
             for (Tag tag : tags) {
@@ -216,7 +216,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
             // Build MachinePinotMessage with complete data
             MachinePinotMessage message = buildMachinePinotMessage(machineEntity, machineTags);
 
-            ossTenantKafkaProducer.publish(machineEventsTopic,  machineEntity.getMachineId(), message);
+            ossTenantKafkaProducer.publish(machineEventsTopic, machineEntity.getMachineId(), message);
         } catch (Exception e) {
             log.error("Error sending machine event to Kafka for machine {}: {}",
                     machineEntity.getMachineId(), e.getMessage(), e);
@@ -324,7 +324,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
      * Used by delete handlers where the TagAssignment list must exclude the tag being removed.
      */
     private MachinePinotMessage buildMachinePinotMessageFromParts(Machine machine, List<Tag> tags,
-                                                                   List<TagAssignment> assignments) {
+                                                                  List<TagAssignment> assignments) {
         Map<String, TagAssignment> assignmentByTagId = assignments.stream()
                 .collect(Collectors.toMap(TagAssignment::getTagId, a -> a, (a, b) -> a));
 

--- a/openframe-data-kafka/src/main/java/com/openframe/kafka/producer/GenericKafkaProducer.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/kafka/producer/GenericKafkaProducer.java
@@ -44,7 +44,7 @@ public abstract class GenericKafkaProducer {
                 var md = res.getRecordMetadata();
                 logSendSuccess(md.topic(), key, md.partition(), md.offset());
             } else {
-                log.info("Kafka PRODUCE success: topic={}, key={} (no record metadata)", topic, redact(key));
+                log.debug("Kafka PRODUCE success: topic={}, key={} (no record metadata)", topic, redact(key));
             }
         });
 
@@ -121,7 +121,7 @@ public abstract class GenericKafkaProducer {
     }
 
     private void logSendSuccess(String topic, String key, int partition, long offset) {
-        log.info("Kafka PRODUCE success: topic={}, key={}, partition={}, offset={}",
+        log.debug("Kafka PRODUCE success: topic={}, key={}, partition={}, offset={}",
                 topic, redact(key), partition, offset);
     }
 

--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/service/DebeziumService.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/service/DebeziumService.java
@@ -123,7 +123,7 @@ public class DebeziumService {
             restTemplate.put(connectorConfigUrl(baseName), requestEntity);
             log.info("Connector '{}' config updated", baseName);
         } catch (Exception e) {
-            log.error("Failed to update connector '{}' config", baseName, e);log.error("Failed to update connector '{}' config", baseName, e);
+            log.error("Failed to update connector '{}' config", baseName, e);
         }
     }
 

--- a/openframe-management-service-core/src/main/java/com/openframe/management/initializer/TacticalRmmScriptsInitializer.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/initializer/TacticalRmmScriptsInitializer.java
@@ -165,7 +165,7 @@ public class TacticalRmmScriptsInitializer implements ApplicationRunner {
 
             tacticalRmmClient.updateScript(tacticalServerUrl, apiKey, scriptId, request);
             
-            log.info("Successfully updated script: {})", config.getName());
+            log.info("Successfully updated script: {}", config.getName());
         } catch (Exception e) {
             log.error("Failed to update script: {}", config.getName(), e);
             throw new IllegalStateException("Failed to update script: " + config.getName(), e);


### PR DESCRIPTION
## Description
Reduces log volume / storage cost in openframe-oss-lib via two refactors:

## Improvements
**1. Demote logs from INFO → DEBUG**
- `GenericKafkaProducer` — both "Kafka PRODUCE success" lines (fire on **every** published Kafka message) → DEBUG.
- `MachineTagEventServiceImpl` — the per-event "Processing … save/saveAll event" and "… processed successfully" lines (fire via an AOP aspect on **every** Machine/Tag/TagAssignment repository save) → DEBUG; success lines enriched with `machineId`/`tagId`.
- `KnowledgeBaseTempAttachmentService` — "Linking N temp attachments…" → DEBUG, and the actor (`by: uploadedBy`) added to the message.

**2. Add a dev-only logback config that shortens stack traces**
- New `logging/shared-logback-spring-logfmt-shortened.xml` + `shared-logback-includes-logfmt-shortened.xml`: registers an `exShort` conversion word and applies `ShortenedThrowableConverter` (depth 30, maxLength 2048, `rootCauseFirst`, `inlineHash`, framework-frame exclusions) to **both** the logfmt text appenders (console/file) and the JSON appender.
- Opt-in only: the canonical `shared-logback-*-logfmt.xml` files are **untouched**, so an environment gets the shortening only if it points `logging.config` at the new `-shortened` file (wired for **dev only**, in the saas-tenant configs repo). Prod/stage are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed malformed script update message.
  * Removed duplicate error logging during connector updates.

* **Chores**
  * Added structured logging configuration with logfmt and JSON outputs.
  * Reduced several informational logs to debug to declutter runtime output.
  * Included uploader and more context in attachment linking logs.
* **Stability**
  * Shortened/filtered stack traces for clearer, more concise logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->