### PR TITLE
refactor(logging): demote high-frequency device & WebSocket logs to D…

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/listener/MachineHeartbeatListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/MachineHeartbeatListener.java
@@ -56,12 +56,12 @@ public class MachineHeartbeatListener {
             // Generate timestamp at service side
             Instant eventTimestamp = Instant.now();
 
-            log.info("Processing machine heartbeat: machineId={} timestamp={}", machineId, eventTimestamp);
+            log.debug("Processing machine heartbeat: machineId={} timestamp={}", machineId, eventTimestamp);
 
             // Process the heartbeat
             machineStatusService.processHeartbeat(machineId, eventTimestamp);
 
-            log.info("Machine heartbeat processed successfully");
+            log.debug("Machine heartbeat processed successfully");
         } catch (Exception e) {
             log.error("Unexpected error processing heartbeat for machine {}", machineId, e);
         }

--- a/openframe-client-core/src/main/java/com/openframe/client/listener/ToolConnectionListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/ToolConnectionListener.java
@@ -80,7 +80,7 @@ public class ToolConnectionListener {
         try {
             ConsumerInfo existingConsumer = jsm.getConsumerInfo(STREAM_NAME, CONSUMER_NAME);
 
-            log.info("Existing consumer config: {}", existingConsumer.getConsumerConfiguration());
+            log.debug("Existing consumer config: {}", existingConsumer.getConsumerConfiguration());
 
             ConsumerConfiguration consumerConfig = ConsumerConfiguration.builder()
                     .durable(CONSUMER_NAME)
@@ -93,14 +93,14 @@ public class ToolConnectionListener {
                     .deliverGroup(DELIVERY_GROUP)
                     .build();
 
-            log.info("New consumer config: " + consumerConfig);
+            log.debug("New consumer config: {}", consumerConfig);
 
             jsm.addOrUpdateConsumer(STREAM_NAME, consumerConfig);
 
             return consumerConfig;
         } catch (JetStreamApiException e) {
             if (e.getErrorCode() == 404) {
-                log.info("Consumer {} {} doesn't exist", STREAM_NAME, CONSUMER_NAME);
+                log.debug("Consumer {} {} doesn't exist", STREAM_NAME, CONSUMER_NAME);
                 ConsumerConfiguration consumerConfig = ConsumerConfiguration.builder()
                         .durable(CONSUMER_NAME)
                         .ackPolicy(AckPolicy.Explicit)
@@ -133,18 +133,18 @@ public class ToolConnectionListener {
             long deliveredCount = message.metaData().deliveredCount();
             boolean lastAttempt = isLastAttempt(deliveredCount);
 
-            log.info("Processing tool connection: machineId={} toolType={} agentToolId={} (delivery={})", machineId, toolType, agentToolId, deliveredCount);
+            log.debug("Processing tool connection: machineId={} toolType={} agentToolId={} (delivery={})", machineId, toolType, agentToolId, deliveredCount);
 
             // Process the tool connection
             toolConnectionService.addToolConnection(machineId, toolType, agentToolId, lastAttempt);
 
             // Acknowledge successful processing
             message.ack();
-            log.info("Tool connection processed successfully and acked");
+            log.debug("Tool connection processed successfully and acked");
         } catch (Exception e) {
             log.error("Unexpected error processing tool connection: {}", messagePayload, e);
             // Don't ack the message and let it be redelivered
-            log.info("Leaving message unacked for potential redelivery: tool connection");
+            log.debug("Leaving message unacked for potential redelivery: tool connection");
         }
     }
 

--- a/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
@@ -33,7 +33,7 @@ public class MachineStatusService {
     }
 
     private void update(String machineId, DeviceStatus newStatus, Instant eventTimestamp) {
-        log.info("Received status update event to {} for machineId={} eventTimestamp={}", newStatus, machineId, eventTimestamp);
+        log.debug("Received status update event to {} for machineId={} eventTimestamp={}", newStatus, machineId, eventTimestamp);
 
         Machine machine = machineRepository.findByMachineId(machineId)
                 .orElseThrow(() -> new MachineNotFoundException(machineId));
@@ -54,7 +54,7 @@ public class MachineStatusService {
         machine.setStatus(newStatus);
         machine.setLastSeen(eventTimestamp);
         machineRepository.save(machine);
-        log.info("Updated machineId={} to status={} at {}", machine.getMachineId(), newStatus, eventTimestamp);
+        log.debug("Updated machineId={} to status={} at {}", machine.getMachineId(), newStatus, eventTimestamp);
 
         if (previousStatus == DeviceStatus.PENDING && (newStatus == DeviceStatus.ONLINE || newStatus == DeviceStatus.OFFLINE)) {
             log.info("Device first connected: machineId={}, transition {} -> {}", machine.getMachineId(), previousStatus, newStatus);

--- a/openframe-data-device-aspect/src/main/java/com/openframe/data/service/impl/MachineTagEventServiceImpl.java
+++ b/openframe-data-device-aspect/src/main/java/com/openframe/data/service/impl/MachineTagEventServiceImpl.java
@@ -71,7 +71,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
                 return;
             }
             sendTagAssignmentEventToKafka(assignment);
-            log.info("Tag assignment event processed successfully for machine: {}", assignment.getEntityId());
+            log.debug("Tag assignment event processed successfully for machine: {}", assignment.getEntityId());
         } catch (Exception e) {
             log.error("Error processing tag assignment save event: {}", e.getMessage(), e);
         }
@@ -127,7 +127,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagAssignmentDelete(String machineId, String tagId) {
         try {
-            log.info("Processing tag assignment delete event: machineId={}, tagId={}", machineId, tagId);
+            log.debug("Processing tag assignment delete event: machineId={}, tagId={}", machineId, tagId);
 
             Machine machine = fetchMachine(machineId);
             if (machine == null) {
@@ -155,7 +155,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
             MachinePinotMessage message = buildMachinePinotMessageFromParts(machine, remainingTags, remainingAssignments);
             ossTenantKafkaProducer.publish(machineEventsTopic, machineId, message);
 
-            log.info("Tag assignment delete event processed for machine: {}", machineId);
+            log.debug("Tag assignment delete event processed for machine: {}", machineId);
         } catch (Exception e) {
             log.error("Error processing tag assignment delete event: {}", e.getMessage(), e);
         }
@@ -164,11 +164,11 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
     @Override
     public void processTagAssignmentDeleteByTagId(String tagId) {
         try {
-            log.info("Processing bulk tag assignment delete by tagId: {}", tagId);
+            log.debug("Processing bulk tag assignment delete by tagId: {}", tagId);
 
             List<String> affectedMachineIds = fetchMachineIdsForTag(tagId);
             if (affectedMachineIds.isEmpty()) {
-                log.info("No machines affected by tag deletion: {}", tagId);
+                log.debug("No machines affected by tag deletion: {}", tagId);
                 return;
             }
 
@@ -202,7 +202,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
                 }
             }
 
-            log.info("Bulk tag assignment delete processed for {} machines", affectedMachineIds.size());
+            log.debug("Bulk tag assignment delete processed for {} machines", affectedMachineIds.size());
         } catch (Exception e) {
             log.error("Error processing bulk tag assignment delete: {}", e.getMessage(), e);
         }
@@ -264,7 +264,7 @@ public class MachineTagEventServiceImpl implements MachineTagEventService {
                 }
             }
 
-            log.info("Processed tag key change for {} machines", machineIds.size());
+            log.debug("Processed tag key change for {} machines", machineIds.size());
         }
     }
 

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -47,7 +47,7 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
             public Mono<Void> handle(WebSocketSession proxySession) {
                 String sessionId = proxySession.getId();
                 if (debugPath) {
-                    log.info(LOG_PREFIX + "downstream proxy session opened", sessionId, target);
+                    log.debug(LOG_PREFIX + "downstream proxy session opened", sessionId, target);
                 }
                 return handler.handle(proxySession)
                         .doFinally(signal -> {
@@ -58,7 +58,7 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                                         .timeout(CLOSE_TIMEOUT)
                                         .doOnSuccess(__ -> {
                                             if (debugPath) {
-                                                log.info(LOG_PREFIX + "downstream proxy session closed", sessionId, target);
+                                                log.debug(LOG_PREFIX + "downstream proxy session closed", sessionId, target);
                                             }
                                         })
                                         .onErrorResume(ex -> Mono.empty())
@@ -66,7 +66,7 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                                                 ex -> log.error(LOG_PREFIX + "failed to close: {}",
                                                         sessionId, target, ex.getMessage()));
                             } else if (debugPath) {
-                                log.info(LOG_PREFIX + "relay completed, already closed (signal={})",
+                                log.debug(LOG_PREFIX + "relay completed, already closed (signal={})",
                                         sessionId, target, signal);
                             }
                         });

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
@@ -51,7 +51,7 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
 
                     gatewayTrafficMetrics.webSocketOpened(sessionId, path, sub);
                     if (debugPath) {
-                        log.info(LOG_PREFIX + "session opened, scheduling JWT expiry close", sessionId, path, sub);
+                        log.debug(LOG_PREFIX + "session opened, scheduling JWT expiry close", sessionId, path, sub);
                     }
 
                     long secondsUntilExpiration = Duration.between(Instant.now(), expiresAt).getSeconds();
@@ -84,17 +84,17 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
     private Disposable scheduleSessionRemoveJob(WebSocketSession session, String path, String sub, boolean debugPath, long secondsUntilExpiration) {
         String sessionId = session.getId();
         if (debugPath) {
-            log.info(LOG_PREFIX + "scheduling session remove job in {}s", sessionId, path, sub, secondsUntilExpiration);
+            log.debug(LOG_PREFIX + "scheduling session remove job in {}s", sessionId, path, sub, secondsUntilExpiration);
         }
         return Mono.delay(Duration.ofSeconds(secondsUntilExpiration))
                 .flatMap(__ -> {
                     if (debugPath) {
-                        log.info(LOG_PREFIX + "executing session remove job (JWT expiry)", sessionId, path, sub);
+                        log.debug(LOG_PREFIX + "executing session remove job (JWT expiry)", sessionId, path, sub);
                     }
                     return session.close()
                             .doOnSuccess(___ -> {
                                 if (debugPath) {
-                                    log.info(LOG_PREFIX + "closed by session remove job", sessionId, path, sub);
+                                    log.debug(LOG_PREFIX + "closed by session remove job", sessionId, path, sub);
                                 }
                             })
                             .doOnError(ex -> log.error(LOG_PREFIX + "session remove job close failed: {}", sessionId, path, sub, ex.getMessage(), ex));
@@ -118,14 +118,14 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
                             String logSub = info != null ? info.sub() : sub;
                             gatewayTrafficMetrics.webSocketClosed(sessionId, path, logSub);
                             if (loggingProperties.isDebugPath(path)) {
-                                log.info(LOG_PREFIX + "session closed code={} reason={} lifetime={}",
+                                log.debug(LOG_PREFIX + "session closed code={} reason={} lifetime={}",
                                         sessionId, path, logSub, status.getCode(), status.getReason(), formatLifetime(lifetimeSec));
                             } else {
-                                log.info(LOG_PREFIX + "session closed code={} reason={}",
+                                log.debug(LOG_PREFIX + "session closed code={} reason={}",
                                         sessionId, path, logSub, status.getCode(), status.getReason());
                             }
                             if (loggingProperties.isDebugPath(path)) {
-                                log.info(LOG_PREFIX + "disposed session remove job (client closed first)", sessionId, path, logSub);
+                                log.debug(LOG_PREFIX + "disposed session remove job (client closed first)", sessionId, path, logSub);
                             }
                             disposable.dispose();
                         },


### PR DESCRIPTION
…EBUG

## Description
Lowers a set of high-frequency / low-signal log statements from INFO to DEBUG
across the gateway and device pipeline. Level-only — no behavior, API, or
business-logic changes.

## Improvements
- **Gateway WebSocket lifecycle** — the `"Debug ws …"` session logs (opened/closed,
  JWT-expiry scheduling, proxy relay) in `WebSocketServiceSecurityDecorator` and
  `ProxySessionCleanupWebSocketClient`. They literally say "Debug" but were emitted at INFO.
- **Device status / heartbeat hot paths** (`openframe-client-core`) —
  `MachineStatusService` per-status-update lines and `MachineHeartbeatListener`
  per-heartbeat lines, which fire on every device heartbeat.
- **Tool-connection consumer** (`ToolConnectionListener`) — per-message processing/ack
  lines and verbose startup consumer-config dumps (one string-concat log also switched
  to parameterized).
- **Device-tag Pinot-sync propagation** (`MachineTagEventServiceImpl`) — tag-assignment
  delete / bulk-delete / tag-key-change events, aligning them with the save paths that
  were already at DEBUG.

## Why?

Profiling the dev cluster showed these are the dominant INFO sources and the bulk of
production log volume / storage cost:

These are routine per-event / per-heartbeat traces with no operator value at the INFO
baseline; the detail stays available on demand by enabling DEBUG for the relevant
package. Demoting them sharply reduces log noise and ingestion cost while preserving
every business event, lifecycle milestone, and error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging levels across heartbeat processing, connection management, status updates, and WebSocket session lifecycle events from INFO to DEBUG, improving control over logging verbosity and reducing standard output noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->