### PR TITLE
Add CommandListener and Publish to Kafka

### DIFF
--- a/openframe-client-core/pom.xml
+++ b/openframe-client-core/pom.xml
@@ -37,6 +37,10 @@
         </dependency>
         <dependency>
             <groupId>com.openframe.oss</groupId>
+            <artifactId>openframe-data-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.openframe.oss</groupId>
             <artifactId>openframe-tool-agent-nats-installation</artifactId>
         </dependency>
         <dependency>

--- a/openframe-client-core/pom.xml
+++ b/openframe-client-core/pom.xml
@@ -93,6 +93,21 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
 

--- a/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
@@ -14,7 +14,6 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
 /**
@@ -51,17 +50,19 @@ public class CommandResultListener {
 
     private void handleMessage(Message message) {
         String subject = message.getSubject();
-        String payload = new String(message.getData(), StandardCharsets.UTF_8);
+        byte[] data = message.getData();
         try {
             String machineId = machineIdExtractor.extract(subject);
-            CommandResultMessage resultMessage = objectMapper.readValue(payload, CommandResultMessage.class);
+            CommandResultMessage resultMessage = objectMapper.readValue(data, CommandResultMessage.class);
 
             log.info("Processing command result: machineId={} executionId={} status={}",
                     machineId, resultMessage.getExecutionId(), resultMessage.getStatus());
 
             commandResultService.processCommandResult(machineId, resultMessage);
         } catch (Exception e) {
-            log.error("Unexpected error processing command result from subject {}: {}", subject, payload, e);
+            // Log metadata only — the raw payload may contain sensitive command output.
+            log.error("Unexpected error processing command result from subject {} (payloadSize={} bytes)",
+                    subject, data.length, e);
         }
     }
 

--- a/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
@@ -31,7 +31,7 @@ public class CommandResultListener {
     private final CommandResultService commandResultService;
     private final NatsTopicMachineIdExtractor machineIdExtractor;
 
-    private static final String SUBJECT = "machine.*.command-result";
+    private static final String SUBJECT = "machine.*.command-execution.result";
 
     private Dispatcher dispatcher;
 
@@ -55,8 +55,8 @@ public class CommandResultListener {
             String machineId = machineIdExtractor.extract(subject);
             CommandResultMessage resultMessage = objectMapper.readValue(data, CommandResultMessage.class);
 
-            log.info("Processing command result: machineId={} executionId={} status={}",
-                    machineId, resultMessage.getExecutionId(), resultMessage.getStatus());
+            log.info("Processing command result: machineId={} executionId={} exitCode={} timedOut={}",
+                    machineId, resultMessage.getExecutionId(), resultMessage.getExitCode(), resultMessage.getTimedOut());
 
             commandResultService.processCommandResult(machineId, resultMessage);
         } catch (Exception e) {

--- a/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/CommandResultListener.java
@@ -1,0 +1,79 @@
+package com.openframe.client.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openframe.client.service.CommandResultService;
+import com.openframe.client.service.NatsTopicMachineIdExtractor;
+import com.openframe.data.nats.rmm.model.CommandResultMessage;
+import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
+import io.nats.client.Message;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/**
+ * Subscribes to command-result messages published by the agent over
+ * <b>core NATS</b> (fire-and-forget, non-durable — mirrors the dispatch path)
+ * and hands them to {@link CommandResultService} to be relayed to Kafka.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CommandResultListener {
+
+    private final Connection natsConnection;
+    private final ObjectMapper objectMapper;
+    private final CommandResultService commandResultService;
+    private final NatsTopicMachineIdExtractor machineIdExtractor;
+
+    private static final String SUBJECT = "machine.*.command-result";
+
+    private Dispatcher dispatcher;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void subscribeToCommandResults() {
+        try {
+            // NATS Dispatcher manages threads internally
+            dispatcher = natsConnection.createDispatcher();
+            dispatcher.subscribe(SUBJECT, this::handleMessage);
+            log.info("Subscribed to command results: subject={}", SUBJECT);
+        } catch (Exception e) {
+            log.error("Failed to subscribe to command results", e);
+            throw new RuntimeException("Failed to subscribe to command results", e);
+        }
+    }
+
+    private void handleMessage(Message message) {
+        String subject = message.getSubject();
+        String payload = new String(message.getData(), StandardCharsets.UTF_8);
+        try {
+            String machineId = machineIdExtractor.extract(subject);
+            CommandResultMessage resultMessage = objectMapper.readValue(payload, CommandResultMessage.class);
+
+            log.info("Processing command result: machineId={} executionId={} status={}",
+                    machineId, resultMessage.getExecutionId(), resultMessage.getStatus());
+
+            commandResultService.processCommandResult(machineId, resultMessage);
+        } catch (Exception e) {
+            log.error("Unexpected error processing command result from subject {}: {}", subject, payload, e);
+        }
+    }
+
+    @PreDestroy
+    public void cleanup() {
+        if (dispatcher != null) {
+            try {
+                dispatcher.drain(Duration.ofSeconds(5));
+                log.info("Command result dispatcher drained successfully");
+            } catch (Exception e) {
+                log.error("Error draining command result dispatcher", e);
+            }
+        }
+    }
+}

--- a/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
@@ -33,8 +33,12 @@ public class CommandResultService {
         CommandResultEvent data = new CommandResultEvent();
         data.setMachineId(machineId);
         data.setExecutionId(message.getExecutionId());
-        data.setStatus(message.getStatus());
-        data.setResult(message.getResult());
+        data.setStdout(message.getStdout());
+        data.setStderr(message.getStderr());
+        data.setExitCode(message.getExitCode());
+        data.setExecutionTimeMs(message.getExecutionTimeMs());
+        data.setTimedOut(message.getTimedOut());
+        data.setError(message.getError());
         data.setEventTimestamp(now);
 
         DebeziumMessage.Payload<CommandResultEvent> payload = new DebeziumMessage.Payload<>();
@@ -47,7 +51,7 @@ public class CommandResultService {
 
         kafkaProducer.publish(commandResultsTopic, machineId, event);
 
-        log.info("Published command result to Kafka: topic={} machineId={} executionId={} status={}",
-                commandResultsTopic, machineId, data.getExecutionId(), data.getStatus());
+        log.info("Published command result to Kafka: topic={} machineId={} executionId={} exitCode={} timedOut={}",
+                commandResultsTopic, machineId, data.getExecutionId(), data.getExitCode(), data.getTimedOut());
     }
 }

--- a/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
@@ -1,0 +1,42 @@
+package com.openframe.client.service;
+
+import com.openframe.data.nats.rmm.model.CommandResultMessage;
+import com.openframe.kafka.model.CommandResultEvent;
+import com.openframe.kafka.producer.retry.OssTenantRetryingKafkaProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+/**
+ * Transforms a command-result message received from the agent over core NATS
+ * into a {@link CommandResultEvent} and publishes it to Kafka. Downstream
+ * processing (enrichment / persistence) is the stream-service's responsibility
+ * and is intentionally out of scope here.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommandResultService {
+
+    private final OssTenantRetryingKafkaProducer kafkaProducer;
+
+    @Value("${openframe.oss-tenant.kafka.topics.outbound.command-results-topic}")
+    private String commandResultsTopic;
+
+    public void processCommandResult(String machineId, CommandResultMessage message) {
+        CommandResultEvent event = new CommandResultEvent();
+        event.setMachineId(machineId);
+        event.setExecutionId(message.getExecutionId());
+        event.setStatus(message.getStatus());
+        event.setResult(message.getResult());
+        event.setEventTimestamp(Instant.now().toEpochMilli());
+
+        kafkaProducer.publish(commandResultsTopic, machineId, event);
+
+        log.info("Published command result to Kafka: topic={} machineId={} executionId={} status={}",
+                commandResultsTopic, machineId, event.getExecutionId(), event.getStatus());
+    }
+}

--- a/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
@@ -2,6 +2,7 @@ package com.openframe.client.service;
 
 import com.openframe.data.nats.rmm.model.CommandResultMessage;
 import com.openframe.kafka.model.CommandResultEvent;
+import com.openframe.kafka.model.debezium.DebeziumMessage;
 import com.openframe.kafka.producer.retry.OssTenantRetryingKafkaProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,16 +28,26 @@ public class CommandResultService {
     private String commandResultsTopic;
 
     public void processCommandResult(String machineId, CommandResultMessage message) {
+        long now = Instant.now().toEpochMilli();
+
+        CommandResultEvent data = new CommandResultEvent();
+        data.setMachineId(machineId);
+        data.setExecutionId(message.getExecutionId());
+        data.setStatus(message.getStatus());
+        data.setResult(message.getResult());
+        data.setEventTimestamp(now);
+
+        DebeziumMessage.Payload<CommandResultEvent> payload = new DebeziumMessage.Payload<>();
+        payload.setAfter(data);
+        payload.setOperation("c");
+        payload.setTimestamp(now);
+
         CommandResultEvent event = new CommandResultEvent();
-        event.setMachineId(machineId);
-        event.setExecutionId(message.getExecutionId());
-        event.setStatus(message.getStatus());
-        event.setResult(message.getResult());
-        event.setEventTimestamp(Instant.now().toEpochMilli());
+        event.setPayload(payload);
 
         kafkaProducer.publish(commandResultsTopic, machineId, event);
 
         log.info("Published command result to Kafka: topic={} machineId={} executionId={} status={}",
-                commandResultsTopic, machineId, event.getExecutionId(), event.getStatus());
+                commandResultsTopic, machineId, data.getExecutionId(), data.getStatus());
     }
 }

--- a/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
@@ -102,12 +102,16 @@ class CommandResultListenerIT {
                 org.mockito.ArgumentCaptor.forClass(CommandResultEvent.class);
         verify(kafkaProducer).publish(eq(TOPIC), eq("machine-42"), captor.capture());
 
-        CommandResultEvent event = captor.getValue();
-        assertThat(event.getMachineId()).isEqualTo("machine-42");
-        assertThat(event.getExecutionId()).isEqualTo("exec-1");
-        assertThat(event.getStatus()).isEqualTo("COMPLETED");
-        assertThat(event.getResult()).isEqualTo("hey\n");
-        assertThat(event.getEventTimestamp()).isNotNull();
+        CommandResultEvent envelope = captor.getValue();
+        assertThat(envelope.getPayload()).isNotNull();
+        assertThat(envelope.getPayload().getOperation()).isEqualTo("c");
+
+        CommandResultEvent data = envelope.getPayload().getAfter();
+        assertThat(data.getMachineId()).isEqualTo("machine-42");
+        assertThat(data.getExecutionId()).isEqualTo("exec-1");
+        assertThat(data.getStatus()).isEqualTo("COMPLETED");
+        assertThat(data.getResult()).isEqualTo("hey\n");
+        assertThat(data.getEventTimestamp()).isNotNull();
     }
 
     @Test

--- a/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
@@ -86,11 +86,15 @@ class CommandResultListenerIT {
     void commandResult_consumedTransformedAndForwardedToKafka() throws Exception {
         CommandResultMessage payload = CommandResultMessage.builder()
                 .executionId("exec-1")
-                .status("COMPLETED")
-                .result("hey\n")
+                .machineId("machine-42")
+                .stdout("hey\n")
+                .stderr("")
+                .exitCode(0)
+                .executionTimeMs(12L)
+                .timedOut(false)
                 .build();
 
-        natsConnection.publish("machine.machine-42.command-result",
+        natsConnection.publish("machine.machine-42.command-execution.result",
                 objectMapper.writeValueAsBytes(payload));
         natsConnection.flush(Duration.ofSeconds(2));
 
@@ -109,8 +113,10 @@ class CommandResultListenerIT {
         CommandResultEvent data = envelope.getPayload().getAfter();
         assertThat(data.getMachineId()).isEqualTo("machine-42");
         assertThat(data.getExecutionId()).isEqualTo("exec-1");
-        assertThat(data.getStatus()).isEqualTo("COMPLETED");
-        assertThat(data.getResult()).isEqualTo("hey\n");
+        assertThat(data.getStdout()).isEqualTo("hey\n");
+        assertThat(data.getExitCode()).isZero();
+        assertThat(data.getExecutionTimeMs()).isEqualTo(12L);
+        assertThat(data.getTimedOut()).isFalse();
         assertThat(data.getEventTimestamp()).isNotNull();
     }
 
@@ -119,11 +125,12 @@ class CommandResultListenerIT {
     void commandResult_perMachineKey() throws Exception {
         CommandResultMessage payload = CommandResultMessage.builder()
                 .executionId("exec-2")
-                .status("FAILED")
-                .result("boom")
+                .exitCode(1)
+                .stderr("boom")
+                .timedOut(false)
                 .build();
 
-        natsConnection.publish("machine.node-7.command-result",
+        natsConnection.publish("machine.node-7.command-execution.result",
                 objectMapper.writeValueAsBytes(payload));
         natsConnection.flush(Duration.ofSeconds(2));
 
@@ -137,16 +144,16 @@ class CommandResultListenerIT {
     void nonCommandResultSubject_isIgnored() throws Exception {
         CommandResultMessage payload = CommandResultMessage.builder()
                 .executionId("exec-ghost")
-                .status("COMPLETED")
-                .result("should-not-be-forwarded")
+                .exitCode(0)
+                .stdout("should-not-be-forwarded")
                 .build();
         byte[] body = objectMapper.writeValueAsBytes(payload);
 
-        // Wrong subject — must NOT match the listener's "machine.*.command-result" filter.
+        // Wrong subject — must NOT match the listener's "machine.*.command-execution.result" filter.
         natsConnection.publish("machine.ghost.heartbeat", body);
         // Sentinel on the correct subject, published right after on the same connection (FIFO):
         // once the sentinel is processed, the earlier message has already been routed (or filtered).
-        natsConnection.publish("machine.sentinel.command-result", body);
+        natsConnection.publish("machine.sentinel.command-execution.result", body);
         natsConnection.flush(Duration.ofSeconds(2));
 
         // Wait until the sentinel has flowed through the whole pipeline.

--- a/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
@@ -1,0 +1,156 @@
+package com.openframe.client.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openframe.client.integration.support.CommandResultIntegrationTestApplication;
+import com.openframe.data.nats.rmm.model.CommandResultMessage;
+import com.openframe.kafka.model.CommandResultEvent;
+import com.openframe.kafka.producer.retry.OssTenantRetryingKafkaProducer;
+import io.nats.client.Connection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * End-to-end (NATS) integration test for the command-result path: a message
+ * published by the agent over core NATS on {@code machine.<id>.command-result}
+ * must be consumed by {@link com.openframe.client.listener.CommandResultListener},
+ * transformed, and forwarded to Kafka via {@link OssTenantRetryingKafkaProducer}.
+ *
+ * <p>Uses a real NATS broker (Testcontainers); the Kafka producer is mocked so
+ * the assertion is on the transformed {@link CommandResultEvent} reaching the
+ * producer boundary — Kafka brokering itself is out of scope here.
+ */
+@SpringBootTest(
+        classes = CommandResultIntegrationTestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+@Tag("integration")
+@EnabledIfSystemProperty(named = "integration.tests", matches = "true")
+class CommandResultListenerIT {
+
+    private static final String TOPIC = "command-results";
+
+    static final GenericContainer<?> NATS =
+            new GenericContainer<>(DockerImageName.parse("nats:2.10-alpine"))
+                    .withExposedPorts(4222)
+                    .withCommand("-js")
+                    .waitingFor(Wait.forLogMessage(".*Server is ready.*", 1));
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        if (!NATS.isRunning()) {
+            NATS.start();
+        }
+        registry.add("nats.spring.server",
+                () -> "nats://" + NATS.getHost() + ":" + NATS.getMappedPort(4222));
+        registry.add("openframe.oss-tenant.kafka.topics.outbound.command-results-topic", () -> TOPIC);
+    }
+
+    @Autowired
+    private Connection natsConnection;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OssTenantRetryingKafkaProducer kafkaProducer;
+
+    @BeforeEach
+    void resetProducer() {
+        // Context (and its mock producer bean) is reused across test methods.
+        org.mockito.Mockito.reset(kafkaProducer);
+    }
+
+    @Test
+    @DisplayName("A command-result published over core NATS is consumed, transformed, and forwarded to Kafka keyed by machineId")
+    void commandResult_consumedTransformedAndForwardedToKafka() throws Exception {
+        CommandResultMessage payload = CommandResultMessage.builder()
+                .executionId("exec-1")
+                .status("COMPLETED")
+                .result("hey\n")
+                .build();
+
+        natsConnection.publish("machine.machine-42.command-result",
+                objectMapper.writeValueAsBytes(payload));
+        natsConnection.flush(Duration.ofSeconds(2));
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                verify(kafkaProducer).publish(eq(TOPIC), eq("machine-42"),
+                        org.mockito.ArgumentMatchers.any(CommandResultEvent.class)));
+
+        org.mockito.ArgumentCaptor<CommandResultEvent> captor =
+                org.mockito.ArgumentCaptor.forClass(CommandResultEvent.class);
+        verify(kafkaProducer).publish(eq(TOPIC), eq("machine-42"), captor.capture());
+
+        CommandResultEvent event = captor.getValue();
+        assertThat(event.getMachineId()).isEqualTo("machine-42");
+        assertThat(event.getExecutionId()).isEqualTo("exec-1");
+        assertThat(event.getStatus()).isEqualTo("COMPLETED");
+        assertThat(event.getResult()).isEqualTo("hey\n");
+        assertThat(event.getEventTimestamp()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("A command-result on a different machine subject is keyed by that machineId — per-machine routing is preserved")
+    void commandResult_perMachineKey() throws Exception {
+        CommandResultMessage payload = CommandResultMessage.builder()
+                .executionId("exec-2")
+                .status("FAILED")
+                .result("boom")
+                .build();
+
+        natsConnection.publish("machine.node-7.command-result",
+                objectMapper.writeValueAsBytes(payload));
+        natsConnection.flush(Duration.ofSeconds(2));
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                verify(kafkaProducer).publish(eq(TOPIC), eq("node-7"),
+                        any(CommandResultEvent.class)));
+    }
+
+    @Test
+    @DisplayName("A message on a non-command-result subject (machine.<id>.heartbeat) is filtered out by the subscription and never produces a Kafka event")
+    void nonCommandResultSubject_isIgnored() throws Exception {
+        CommandResultMessage payload = CommandResultMessage.builder()
+                .executionId("exec-ghost")
+                .status("COMPLETED")
+                .result("should-not-be-forwarded")
+                .build();
+        byte[] body = objectMapper.writeValueAsBytes(payload);
+
+        // Wrong subject — must NOT match the listener's "machine.*.command-result" filter.
+        natsConnection.publish("machine.ghost.heartbeat", body);
+        // Sentinel on the correct subject, published right after on the same connection (FIFO):
+        // once the sentinel is processed, the earlier message has already been routed (or filtered).
+        natsConnection.publish("machine.sentinel.command-result", body);
+        natsConnection.flush(Duration.ofSeconds(2));
+
+        // Wait until the sentinel has flowed through the whole pipeline.
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+                verify(kafkaProducer).publish(eq(TOPIC), eq("sentinel"), any(CommandResultEvent.class)));
+
+        // Exactly one publish total — only the sentinel — proving the heartbeat was filtered out.
+        verify(kafkaProducer, times(1)).publish(any(), any(), any(CommandResultEvent.class));
+        verify(kafkaProducer, never()).publish(eq(TOPIC), eq("ghost"), any(CommandResultEvent.class));
+    }
+}

--- a/openframe-client-core/src/test/java/com/openframe/client/integration/support/CommandResultIntegrationTestApplication.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/integration/support/CommandResultIntegrationTestApplication.java
@@ -1,0 +1,53 @@
+package com.openframe.client.integration.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openframe.client.listener.CommandResultListener;
+import com.openframe.client.service.CommandResultService;
+import com.openframe.client.service.NatsTopicMachineIdExtractor;
+import com.openframe.kafka.producer.retry.OssTenantRetryingKafkaProducer;
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * Minimal Spring context for the {@link CommandResultListener} integration test.
+ *
+ * <p>Deliberately avoids {@code @EnableAutoConfiguration} so that the Mongo /
+ * Cassandra / Redis machinery pulled in transitively by {@code client-core}
+ * does not try to connect. Only the beans on the command-result NATS→Kafka path
+ * are wired; the Kafka producer boundary is a Mockito mock so the test needs a
+ * NATS broker but not a Kafka broker.
+ */
+@SpringBootConfiguration
+@Import({
+        CommandResultListener.class,
+        CommandResultService.class,
+        NatsTopicMachineIdExtractor.class
+})
+public class CommandResultIntegrationTestApplication {
+
+    @Bean(destroyMethod = "close")
+    public Connection natsConnection(@Value("${nats.spring.server}") String server) throws Exception {
+        return Nats.connect(server);
+    }
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public OssTenantRetryingKafkaProducer ossTenantRetryingKafkaProducer() {
+        return Mockito.mock(OssTenantRetryingKafkaProducer.class);
+    }
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+}

--- a/openframe-client-core/src/test/java/com/openframe/client/listener/CommandResultListenerTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/listener/CommandResultListenerTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class CommandResultListenerTest {
 
-    private static final String SUBJECT = "machine.*.command-result";
+    private static final String SUBJECT = "machine.*.command-execution.result";
 
     @Mock
     private Connection natsConnection;
@@ -54,8 +54,11 @@ class CommandResultListenerTest {
     void handleMessage_extractsMachineIdDeserializesAndDelegates() throws Exception {
         MessageHandler handler = captureSubscribedHandler();
 
-        String json = "{\"executionId\":\"exec-1\",\"status\":\"COMPLETED\",\"result\":\"hey\\n\"}";
-        Message message = message("machine.machine-42.command-result", json);
+        // Agent serializes snake_case keys — must map onto the camelCase fields.
+        String json = "{\"execution_id\":\"exec-1\",\"machine_id\":\"machine-42\","
+                + "\"stdout\":\"hey\\n\",\"stderr\":\"\",\"exit_code\":0,"
+                + "\"execution_time_ms\":12,\"timed_out\":false}";
+        Message message = message("machine.machine-42.command-execution.result", json);
 
         handler.onMessage(message);
 
@@ -64,8 +67,10 @@ class CommandResultListenerTest {
 
         CommandResultMessage delivered = captor.getValue();
         assertThat(delivered.getExecutionId()).isEqualTo("exec-1");
-        assertThat(delivered.getStatus()).isEqualTo("COMPLETED");
-        assertThat(delivered.getResult()).isEqualTo("hey\n");
+        assertThat(delivered.getStdout()).isEqualTo("hey\n");
+        assertThat(delivered.getExitCode()).isZero();
+        assertThat(delivered.getExecutionTimeMs()).isEqualTo(12L);
+        assertThat(delivered.getTimedOut()).isFalse();
     }
 
     @Test
@@ -73,8 +78,8 @@ class CommandResultListenerTest {
     void handleMessage_ignoresUnknownFields() throws Exception {
         MessageHandler handler = captureSubscribedHandler();
 
-        String json = "{\"executionId\":\"exec-9\",\"status\":\"COMPLETED\",\"result\":\"ok\",\"exitCode\":0,\"future\":\"x\"}";
-        handler.onMessage(message("machine.m1.command-result", json));
+        String json = "{\"execution_id\":\"exec-9\",\"exit_code\":0,\"future\":\"x\",\"another_new\":42}";
+        handler.onMessage(message("machine.m1.command-execution.result", json));
 
         ArgumentCaptor<CommandResultMessage> captor = ArgumentCaptor.forClass(CommandResultMessage.class);
         verify(commandResultService).processCommandResult(eq("m1"), captor.capture());
@@ -86,7 +91,7 @@ class CommandResultListenerTest {
     void handleMessage_swallowsMalformedPayload() throws Exception {
         MessageHandler handler = captureSubscribedHandler();
 
-        Message message = message("machine.machine-42.command-result", "not-json");
+        Message message = message("machine.machine-42.command-execution.result", "not-json");
 
         assertThatCode(() -> handler.onMessage(message)).doesNotThrowAnyException();
         verifyNoInteractions(commandResultService);

--- a/openframe-client-core/src/test/java/com/openframe/client/listener/CommandResultListenerTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/listener/CommandResultListenerTest.java
@@ -1,0 +1,121 @@
+package com.openframe.client.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openframe.client.service.CommandResultService;
+import com.openframe.client.service.NatsTopicMachineIdExtractor;
+import com.openframe.data.nats.rmm.model.CommandResultMessage;
+import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
+import io.nats.client.Message;
+import io.nats.client.MessageHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommandResultListenerTest {
+
+    private static final String SUBJECT = "machine.*.command-result";
+
+    @Mock
+    private Connection natsConnection;
+    @Mock
+    private Dispatcher dispatcher;
+    @Mock
+    private CommandResultService commandResultService;
+
+    private CommandResultListener listener;
+
+    @BeforeEach
+    void setUp() {
+        // Real ObjectMapper + extractor — only the NATS transport and the downstream service are mocked.
+        listener = new CommandResultListener(
+                natsConnection,
+                new ObjectMapper(),
+                commandResultService,
+                new NatsTopicMachineIdExtractor());
+    }
+
+    @Test
+    @DisplayName("handleMessage: extracts machineId from the subject, deserializes the payload, and delegates to CommandResultService")
+    void handleMessage_extractsMachineIdDeserializesAndDelegates() throws Exception {
+        MessageHandler handler = captureSubscribedHandler();
+
+        String json = "{\"executionId\":\"exec-1\",\"status\":\"COMPLETED\",\"result\":\"hey\\n\"}";
+        Message message = message("machine.machine-42.command-result", json);
+
+        handler.onMessage(message);
+
+        ArgumentCaptor<CommandResultMessage> captor = ArgumentCaptor.forClass(CommandResultMessage.class);
+        verify(commandResultService).processCommandResult(eq("machine-42"), captor.capture());
+
+        CommandResultMessage delivered = captor.getValue();
+        assertThat(delivered.getExecutionId()).isEqualTo("exec-1");
+        assertThat(delivered.getStatus()).isEqualTo("COMPLETED");
+        assertThat(delivered.getResult()).isEqualTo("hey\n");
+    }
+
+    @Test
+    @DisplayName("handleMessage: ignores unknown JSON fields (forward-compatible wire contract with the agent)")
+    void handleMessage_ignoresUnknownFields() throws Exception {
+        MessageHandler handler = captureSubscribedHandler();
+
+        String json = "{\"executionId\":\"exec-9\",\"status\":\"COMPLETED\",\"result\":\"ok\",\"exitCode\":0,\"future\":\"x\"}";
+        handler.onMessage(message("machine.m1.command-result", json));
+
+        ArgumentCaptor<CommandResultMessage> captor = ArgumentCaptor.forClass(CommandResultMessage.class);
+        verify(commandResultService).processCommandResult(eq("m1"), captor.capture());
+        assertThat(captor.getValue().getExecutionId()).isEqualTo("exec-9");
+    }
+
+    @Test
+    @DisplayName("handleMessage: a malformed payload is swallowed and never reaches the service — a bad message must not kill the core-NATS dispatcher thread")
+    void handleMessage_swallowsMalformedPayload() throws Exception {
+        MessageHandler handler = captureSubscribedHandler();
+
+        Message message = message("machine.machine-42.command-result", "not-json");
+
+        assertThatCode(() -> handler.onMessage(message)).doesNotThrowAnyException();
+        verifyNoInteractions(commandResultService);
+    }
+
+    @Test
+    @DisplayName("handleMessage: an invalid subject (no machineId segment) is swallowed and never reaches the service")
+    void handleMessage_swallowsInvalidSubject() throws Exception {
+        MessageHandler handler = captureSubscribedHandler();
+
+        Message message = message("bogus-subject", "{\"executionId\":\"exec-1\"}");
+
+        assertThatCode(() -> handler.onMessage(message)).doesNotThrowAnyException();
+        verifyNoInteractions(commandResultService);
+    }
+
+    private MessageHandler captureSubscribedHandler() {
+        when(natsConnection.createDispatcher()).thenReturn(dispatcher);
+        listener.subscribeToCommandResults();
+
+        ArgumentCaptor<MessageHandler> handlerCaptor = ArgumentCaptor.forClass(MessageHandler.class);
+        verify(dispatcher).subscribe(eq(SUBJECT), handlerCaptor.capture());
+        return handlerCaptor.getValue();
+    }
+
+    private static Message message(String subject, String payload) {
+        Message message = org.mockito.Mockito.mock(Message.class);
+        when(message.getSubject()).thenReturn(subject);
+        when(message.getData()).thenReturn(payload.getBytes(StandardCharsets.UTF_8));
+        return message;
+    }
+}

--- a/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
@@ -1,0 +1,79 @@
+package com.openframe.client.service;
+
+import com.openframe.data.nats.rmm.model.CommandResultMessage;
+import com.openframe.kafka.model.CommandResultEvent;
+import com.openframe.kafka.producer.retry.OssTenantRetryingKafkaProducer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CommandResultServiceTest {
+
+    private static final String TOPIC = "command-results";
+    private static final String MACHINE_ID = "machine-42";
+
+    @Mock
+    private OssTenantRetryingKafkaProducer kafkaProducer;
+
+    @InjectMocks
+    private CommandResultService commandResultService;
+
+    @BeforeEach
+    void setUp() {
+        // @Value field is not injected by Mockito — set it explicitly.
+        ReflectionTestUtils.setField(commandResultService, "commandResultsTopic", TOPIC);
+    }
+
+    @Test
+    @DisplayName("processCommandResult: maps the agent message into a CommandResultEvent and publishes to the configured topic, keyed by machineId")
+    void processCommandResult_mapsAndPublishes() {
+        CommandResultMessage message = CommandResultMessage.builder()
+                .executionId("exec-1")
+                .status("COMPLETED")
+                .result("hey\n")
+                .build();
+
+        commandResultService.processCommandResult(MACHINE_ID, message);
+
+        ArgumentCaptor<CommandResultEvent> captor = ArgumentCaptor.forClass(CommandResultEvent.class);
+        verify(kafkaProducer).publish(eq(TOPIC), eq(MACHINE_ID), captor.capture());
+
+        CommandResultEvent event = captor.getValue();
+        assertThat(event.getMachineId()).isEqualTo(MACHINE_ID);
+        assertThat(event.getExecutionId()).isEqualTo("exec-1");
+        assertThat(event.getStatus()).isEqualTo("COMPLETED");
+        assertThat(event.getResult()).isEqualTo("hey\n");
+        // Timestamp is stamped server-side, not taken from the agent payload.
+        assertThat(event.getEventTimestamp()).isNotNull().isPositive();
+    }
+
+    @Test
+    @DisplayName("processCommandResult: still stamps a server-side eventTimestamp when the agent payload carries only an executionId")
+    void processCommandResult_stampsTimestampForSparsePayload() {
+        CommandResultMessage message = CommandResultMessage.builder()
+                .executionId("exec-2")
+                .build();
+
+        commandResultService.processCommandResult(MACHINE_ID, message);
+
+        ArgumentCaptor<CommandResultEvent> captor = ArgumentCaptor.forClass(CommandResultEvent.class);
+        verify(kafkaProducer).publish(eq(TOPIC), eq(MACHINE_ID), captor.capture());
+
+        CommandResultEvent event = captor.getValue();
+        assertThat(event.getExecutionId()).isEqualTo("exec-2");
+        assertThat(event.getStatus()).isNull();
+        assertThat(event.getResult()).isNull();
+        assertThat(event.getEventTimestamp()).isNotNull();
+    }
+}

--- a/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
@@ -40,8 +40,12 @@ class CommandResultServiceTest {
     void processCommandResult_mapsAndPublishes() {
         CommandResultMessage message = CommandResultMessage.builder()
                 .executionId("exec-1")
-                .status("COMPLETED")
-                .result("hey\n")
+                .machineId(MACHINE_ID)
+                .stdout("hey\n")
+                .stderr("")
+                .exitCode(0)
+                .executionTimeMs(12L)
+                .timedOut(false)
                 .build();
 
         commandResultService.processCommandResult(MACHINE_ID, message);
@@ -58,8 +62,11 @@ class CommandResultServiceTest {
         assertThat(data).isNotNull();
         assertThat(data.getMachineId()).isEqualTo(MACHINE_ID);
         assertThat(data.getExecutionId()).isEqualTo("exec-1");
-        assertThat(data.getStatus()).isEqualTo("COMPLETED");
-        assertThat(data.getResult()).isEqualTo("hey\n");
+        assertThat(data.getStdout()).isEqualTo("hey\n");
+        assertThat(data.getStderr()).isEmpty();
+        assertThat(data.getExitCode()).isZero();
+        assertThat(data.getExecutionTimeMs()).isEqualTo(12L);
+        assertThat(data.getTimedOut()).isFalse();
         // Timestamp is stamped server-side, not taken from the agent payload.
         assertThat(data.getEventTimestamp()).isNotNull().isPositive();
     }
@@ -78,8 +85,9 @@ class CommandResultServiceTest {
 
         CommandResultEvent data = captor.getValue().getPayload().getAfter();
         assertThat(data.getExecutionId()).isEqualTo("exec-2");
-        assertThat(data.getStatus()).isNull();
-        assertThat(data.getResult()).isNull();
+        assertThat(data.getStdout()).isNull();
+        assertThat(data.getExitCode()).isNull();
+        assertThat(data.getTimedOut()).isNull();
         assertThat(data.getEventTimestamp()).isNotNull();
     }
 }

--- a/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/service/CommandResultServiceTest.java
@@ -49,13 +49,19 @@ class CommandResultServiceTest {
         ArgumentCaptor<CommandResultEvent> captor = ArgumentCaptor.forClass(CommandResultEvent.class);
         verify(kafkaProducer).publish(eq(TOPIC), eq(MACHINE_ID), captor.capture());
 
-        CommandResultEvent event = captor.getValue();
-        assertThat(event.getMachineId()).isEqualTo(MACHINE_ID);
-        assertThat(event.getExecutionId()).isEqualTo("exec-1");
-        assertThat(event.getStatus()).isEqualTo("COMPLETED");
-        assertThat(event.getResult()).isEqualTo("hey\n");
+        CommandResultEvent envelope = captor.getValue();
+        assertThat(envelope.getPayload()).isNotNull();
+        assertThat(envelope.getPayload().getOperation()).isEqualTo("c");
+        assertThat(envelope.getPayload().getTimestamp()).isNotNull().isPositive();
+
+        CommandResultEvent data = envelope.getPayload().getAfter();
+        assertThat(data).isNotNull();
+        assertThat(data.getMachineId()).isEqualTo(MACHINE_ID);
+        assertThat(data.getExecutionId()).isEqualTo("exec-1");
+        assertThat(data.getStatus()).isEqualTo("COMPLETED");
+        assertThat(data.getResult()).isEqualTo("hey\n");
         // Timestamp is stamped server-side, not taken from the agent payload.
-        assertThat(event.getEventTimestamp()).isNotNull().isPositive();
+        assertThat(data.getEventTimestamp()).isNotNull().isPositive();
     }
 
     @Test
@@ -70,10 +76,10 @@ class CommandResultServiceTest {
         ArgumentCaptor<CommandResultEvent> captor = ArgumentCaptor.forClass(CommandResultEvent.class);
         verify(kafkaProducer).publish(eq(TOPIC), eq(MACHINE_ID), captor.capture());
 
-        CommandResultEvent event = captor.getValue();
-        assertThat(event.getExecutionId()).isEqualTo("exec-2");
-        assertThat(event.getStatus()).isNull();
-        assertThat(event.getResult()).isNull();
-        assertThat(event.getEventTimestamp()).isNotNull();
+        CommandResultEvent data = captor.getValue().getPayload().getAfter();
+        assertThat(data.getExecutionId()).isEqualTo("exec-2");
+        assertThat(data.getStatus()).isNull();
+        assertThat(data.getResult()).isNull();
+        assertThat(data.getEventTimestamp()).isNotNull();
     }
 }

--- a/openframe-data-kafka/src/main/java/com/openframe/data/model/enums/IntegratedToolType.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/data/model/enums/IntegratedToolType.java
@@ -2,6 +2,7 @@ package com.openframe.data.model.enums;
 
 public enum IntegratedToolType {
 
+    RMM("rmm"),
     MESHCENTRAL ("meshcentral"),
     TACTICAL ("tacticalrmm"),
     FLEET ("fleet-mdm");

--- a/openframe-data-kafka/src/main/java/com/openframe/data/model/enums/MessageType.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/data/model/enums/MessageType.java
@@ -9,6 +9,8 @@ public enum MessageType {
 
     MESHCENTRAL_EVENT(IntegratedToolType.MESHCENTRAL, DataEnrichmentServiceType.INTEGRATED_TOOLS_EVENTS,
             List.of(Destination.CASSANDRA, Destination.KAFKA), EventHandlerType.COMMON_TYPE),
+    RMM(IntegratedToolType.RMM, DataEnrichmentServiceType.INTEGRATED_TOOLS_EVENTS,
+            List.of(Destination.CASSANDRA, Destination.KAFKA), EventHandlerType.COMMON_TYPE),
     TACTICAL_RMM_AUDIT_EVENT(IntegratedToolType.TACTICAL, DataEnrichmentServiceType.INTEGRATED_TOOLS_EVENTS,
             List.of(Destination.CASSANDRA, Destination.KAFKA), EventHandlerType.COMMON_TYPE),
     TACTICAL_RMM_AGENT_HISTORY_EVENT(IntegratedToolType.TACTICAL, DataEnrichmentServiceType.INTEGRATED_TOOLS_EVENTS,

--- a/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
@@ -1,5 +1,7 @@
 package com.openframe.kafka.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.openframe.kafka.model.debezium.DebeziumMessage;
 import lombok.Data;
 
 /**
@@ -11,7 +13,8 @@ import lombok.Data;
  * {@code spring.json.trusted.packages} allow-list used by consumers.
  */
 @Data
-public class CommandResultEvent implements KafkaMessage {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommandResultEvent extends DebeziumMessage<CommandResultEvent> implements KafkaMessage {
 
     private String machineId;
     private String executionId;

--- a/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
@@ -1,0 +1,21 @@
+package com.openframe.kafka.model;
+
+import lombok.Data;
+
+/**
+ * Kafka event carrying the result of a dispatched RMM command, produced by the
+ * client-service after consuming the agent's {@code command-result} NATS
+ * message. Downstream the stream-service enriches/persists it (separate task).
+ *
+ * <p>Lives in {@code com.openframe.kafka.model} so it falls under the
+ * {@code spring.json.trusted.packages} allow-list used by consumers.
+ */
+@Data
+public class CommandResultEvent implements KafkaMessage {
+
+    private String machineId;
+    private String executionId;
+    private String status;
+    private String result;
+    private Long eventTimestamp;
+}

--- a/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
+++ b/openframe-data-kafka/src/main/java/com/openframe/kafka/model/CommandResultEvent.java
@@ -18,7 +18,11 @@ public class CommandResultEvent extends DebeziumMessage<CommandResultEvent> impl
 
     private String machineId;
     private String executionId;
-    private String status;
-    private String result;
+    private String stdout;
+    private String stderr;
+    private Integer exitCode;
+    private Long executionTimeMs;
+    private Boolean timedOut;
+    private String error;
     private Long eventTimestamp;
 }

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandResultMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandResultMessage.java
@@ -1,0 +1,23 @@
+package com.openframe.data.nats.rmm.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CommandResultMessage {
+
+    private String executionId;
+
+    private String status;
+
+    private String result;
+}

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandResultMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/rmm/model/CommandResultMessage.java
@@ -2,22 +2,43 @@ package com.openframe.data.nats.rmm.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Wire payload published by the OpenFrame agent over core NATS on
+ * {@code machine.{machineId}.command-execution.result}.
+ *
+ * <p>Mirrors the agent's {@code CommandExecutionResult} struct. The agent
+ * serializes with snake_case keys, so {@link JsonNaming} maps them onto these
+ * camelCase fields ({@code execution_id} → {@code executionId}, etc.).
+ */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CommandResultMessage {
 
     private String executionId;
 
-    private String status;
+    private String machineId;
 
-    private String result;
+    private String stdout;
+
+    private String stderr;
+
+    private Integer exitCode;
+
+    private Long executionTimeMs;
+
+    private Boolean timedOut;
+
+    private String error;
 }


### PR DESCRIPTION
Closes https://app.clickup.com/t/9013925967/86aht5p7m

<img width="2326" height="938" alt="image" src="https://github.com/user-attachments/assets/b83c9d56-d3fc-4e91-9ee1-a836f28735e4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming of richer machine command results to Kafka as structured events (machineId, executionId, stdout/stderr, exitCode, executionTimeMs, timedOut, error, eventTimestamp).
  * New RMM message type/tool integration for downstream processing.

* **Tests**
  * Added unit and integration tests validating NATS→Kafka end-to-end routing, per-machine keying, payload mapping, timestamp stamping, and resilience to malformed or non-matching messages; includes async/container-based test support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->