### PR TITLE
fix(chat): wire load-more pagination into chat thread

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -875,6 +875,8 @@ function EmbeddableChatInner({
     isMessagesLoading,
     hasMoreDialogs,
     loadMoreDialogs,
+    hasMoreMessages,
+    loadMoreMessages,
   } = useUnifiedChat({ modes: effectiveModes, activeMode, mingoStateOverride: mingoState })
 
   // Chat-attachment hooks (v2 attachment feature).
@@ -1307,6 +1309,9 @@ function EmbeddableChatInner({
                       // double-inset the thread; `pb-0` overrides via twMerge.
                       contentClassName="max-w-none pb-0"
                       fullWidth
+                      hasNextPage={hasMoreMessages}
+                      isFetchingNextPage={isMessagesLoading}
+                      onLoadMore={loadMoreMessages}
                     />
                     )}
                     {lastSources &&


### PR DESCRIPTION
## Summary
Wires message pagination into the embeddable chat thread. `hasMoreMessages` and `loadMoreMessages` from `useUnifiedChat` are now passed into the thread component so older messages page in on scroll.

## Changes
- Destructure `hasMoreMessages` / `loadMoreMessages` from `useUnifiedChat`
- Pass `hasNextPage`, `isFetchingNextPage`, and `onLoadMore` to the chat thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled message pagination in the embeddable chat component, allowing users to load additional messages within a chat thread after initial render.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->