### PR TITLE
Changed kafka rmm topic name

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/CommandResultService.java
@@ -24,7 +24,7 @@ public class CommandResultService {
 
     private final OssTenantRetryingKafkaProducer kafkaProducer;
 
-    @Value("${openframe.oss-tenant.kafka.topics.outbound.command-results-topic}")
+    @Value("${openframe.oss-tenant.kafka.topics.outbound.rmm-topic}")
     private String commandResultsTopic;
 
     public void processCommandResult(String machineId, CommandResultMessage message) {

--- a/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/integration/CommandResultListenerIT.java
@@ -63,7 +63,7 @@ class CommandResultListenerIT {
         }
         registry.add("nats.spring.server",
                 () -> "nats://" + NATS.getHost() + ":" + NATS.getMappedPort(4222));
-        registry.add("openframe.oss-tenant.kafka.topics.outbound.command-results-topic", () -> TOPIC);
+        registry.add("openframe.oss-tenant.kafka.topics.outbound.rmm-topic", () -> TOPIC);
     }
 
     @Autowired


### PR DESCRIPTION
Relates to https://app.clickup.com/t/9013925967/86aht5nky

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Kafka outbound topic configuration used by the command-result forwarding path to point to the new outbound topic key.

* **Tests**
  * Adjusted integration test configuration so the test expects command-result messages on the updated outbound topic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->