### PR TITLE
Upd/debezium service

### DIFF
--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/listener/DebeziumConnectorInitializer.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/listener/DebeziumConnectorInitializer.java
@@ -4,14 +4,19 @@ import com.openframe.data.document.tool.IntegratedTool;
 import com.openframe.data.service.IntegratedToolService;
 import com.openframe.data.service.TenantIdProvider;
 import com.openframe.debezium.service.DebeziumService;
+import com.openframe.debezium.util.ConnectorSpecs;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @Slf4j
@@ -21,6 +26,9 @@ public class DebeziumConnectorInitializer {
     private final DebeziumService debeziumService;
     private final IntegratedToolService integratedToolService;
     private final TenantIdProvider tenantIdProvider;
+
+    @Value("${openframe.debezium.reconcile.delete-orphans:false}")
+    private boolean deleteOrphans;
 
     @Autowired
     public DebeziumConnectorInitializer(DebeziumService debeziumService,
@@ -34,7 +42,47 @@ public class DebeziumConnectorInitializer {
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
         log.info("Application ready, checking Debezium connectors...");
+        reconcileOrphanedConnectors();
         initializeConnectorsIfEmpty();
+    }
+
+    /**
+     * Prune connectors in Kafka Connect down to one canonical version per known
+     * base — deletes orphans (base maps to no tool spec, e.g. an old tenant-prefixed
+     * naming scheme) and stale older {@code _vN} versions left by an interrupted
+     * recreate. Runs once on startup; disabled by default, opt in with
+     * {@code openframe.debezium.reconcile.delete-orphans=true}. Known base names
+     * are taken from ALL tools (enabled and disabled) so a temporarily-disabled
+     * tool's connector is not treated as an orphan.
+     *
+     * <p>Runs before {@link #initializeConnectorsIfEmpty()}: clearing orphans
+     * first lets an otherwise orphan-only cluster fall through to a clean
+     * initialization from MongoDB.
+     */
+    public void reconcileOrphanedConnectors() {
+        if (!deleteOrphans || integratedToolService == null) {
+            return;
+        }
+        if (!tenantIdProvider.isTenantRegistered()) {
+            return;
+        }
+        Set<String> knownBaseNames = integratedToolService.getAllTools().stream()
+                .flatMap(ConnectorSpecs::specStreamOf)
+                .map(ConnectorSpecs::nameOf)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        // No known specs → cannot distinguish orphans from everything; skip rather
+        // than delete the whole cluster.
+        if (knownBaseNames.isEmpty()) {
+            return;
+        }
+        List<String> existingConnectors = debeziumService.listConnectors();
+        // listConnectors() returns empty on transient API failure — never treat
+        // that as "every connector is an orphan".
+        if (existingConnectors.isEmpty()) {
+            return;
+        }
+        debeziumService.deleteOrphanedConnectors(knownBaseNames, existingConnectors);
     }
 
     /**

--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/naming/VersionedConnectorNameStrategy.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/naming/VersionedConnectorNameStrategy.java
@@ -1,0 +1,97 @@
+package com.openframe.debezium.naming;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Versioned connector-naming strategy. Each connector is created under
+ * {@code <baseName>_vN}. The version counter is only advanced when the recovery
+ * manager has to recreate an unrecoverable connector
+ * ({@link com.openframe.debezium.service.ConnectorRecoveryManager}), or when
+ * {@code DebeziumService} detects config drift on re-registration. After
+ * successful creation of {@code _v(N+1)} the older versions are removed, leaving
+ * exactly one active version per base name.
+ *
+ * <p>Activated by {@code openframe.debezium.recovery.recreation.enabled=true} —
+ * the same flag that enables the {@code MongoRecreationTracker}, since versioned
+ * naming exists precisely to make recreate-based recovery safe: versioned names
+ * give a clean Kafka Connect offset namespace, so a stuck connector can be
+ * recreated without colliding with the old name's retained offsets. Used by the
+ * shared SaaS cluster and by any per-tenant cluster that opts in.
+ */
+@Component
+@Primary
+@ConditionalOnProperty(name = "openframe.debezium.recovery.recreation.enabled", havingValue = "true")
+public class VersionedConnectorNameStrategy implements ConnectorNameStrategy {
+
+    private static final String VERSION_SEPARATOR = "_v";
+    private static final Pattern VERSION_SUFFIX =
+            Pattern.compile("^(?<base>.+?)" + Pattern.quote(VERSION_SEPARATOR) + "(?<ver>\\d+)$");
+    private static final int LEGACY_VERSION = 0;
+    private static final int INITIAL_VERSION = 1;
+
+    @Override
+    public boolean supportsRecreation() {
+        return true;
+    }
+
+    @Override
+    public boolean matchesBase(String baseName, String connectorName) {
+        return parse(baseName, connectorName).isPresent();
+    }
+
+    @Override
+    public Optional<String> currentVersion(String baseName, List<String> existing) {
+        return existing.stream()
+                .filter(c -> matchesBase(baseName, c))
+                .max(Comparator.comparingInt(this::versionOf));
+    }
+
+    @Override
+    public String extractBaseName(String connectorName) {
+        if (connectorName == null) return null;
+        Matcher m = VERSION_SUFFIX.matcher(connectorName);
+        return m.matches() ? m.group("base") : connectorName;
+    }
+
+    @Override
+    public String resolveNextName(String baseName, List<String> existing) {
+        int next = existing.stream()
+                .filter(c -> matchesBase(baseName, c))
+                .mapToInt(this::versionOf)
+                .max()
+                .orElse(0) + 1;
+        return baseName + VERSION_SEPARATOR + Math.max(next, INITIAL_VERSION);
+    }
+
+    /**
+     * @return matcher when {@code connectorName} is either {@code baseName} or
+     *         {@code baseName_v<digits>}; {@code Optional.empty()} otherwise.
+     */
+    private Optional<Matcher> parse(String baseName, String connectorName) {
+        if (baseName == null || connectorName == null) return Optional.empty();
+        if (connectorName.equals(baseName)) {
+            // Legacy match — return any matcher just as a non-empty marker.
+            return Optional.of(VERSION_SUFFIX.matcher(connectorName));
+        }
+        Matcher m = VERSION_SUFFIX.matcher(connectorName);
+        return m.matches() && baseName.equals(m.group("base")) ? Optional.of(m) : Optional.empty();
+    }
+
+    private int versionOf(String connectorName) {
+        Matcher m = VERSION_SUFFIX.matcher(connectorName);
+        if (!m.matches()) return LEGACY_VERSION;
+        try {
+            return Integer.parseInt(m.group("ver"));
+        } catch (NumberFormatException ignored) {
+            return LEGACY_VERSION;
+        }
+    }
+}

--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/recovery/InMemoryRecreationTracker.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/recovery/InMemoryRecreationTracker.java
@@ -1,0 +1,76 @@
+package com.openframe.debezium.recovery;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory rolling-window limiter for connector recreations — a Mongo-free
+ * alternative to {@link MongoRecreationTracker} for the per-tenant cluster, where
+ * each tenant runs its own management pod, so a JVM-local counter is inherently
+ * tenant-scoped (no shared collection, no cross-tenant interference, no tenant
+ * discriminator needed).
+ *
+ * <p>Activated by {@code openframe.debezium.recovery.recreation.in-memory=true};
+ * takes precedence over the Mongo tracker (which backs off via
+ * {@code @ConditionalOnMissingBean}).
+ *
+ * <p>Trade-off vs. the Mongo tracker: state is per-pod and resets on restart, and
+ * is not shared across replicas. With the health-check {@code @SchedulerLock}
+ * (one replica at a time) this is a soft cap that may be slightly exceeded under
+ * multi-replica drift-recreates — acceptable for a runaway-protection limiter.
+ */
+@Slf4j
+@Component
+@Primary
+@ConditionalOnProperty(name = "openframe.debezium.recovery.recreation.in-memory", havingValue = "true")
+public class InMemoryRecreationTracker implements RecreationTracker {
+
+    private static final Duration WINDOW = Duration.ofHours(1);
+
+    private final int maxPerHour;
+    private final Map<String, Deque<Instant>> eventsByBase = new ConcurrentHashMap<>();
+
+    public InMemoryRecreationTracker(
+            @Value("${openframe.debezium.recovery.max-recreations-per-hour:1}") int maxPerHour) {
+        this.maxPerHour = maxPerHour;
+    }
+
+    @Override
+    public synchronized boolean canRecreate(String baseName) {
+        long recent = prunedQueue(baseName).size();
+        boolean allowed = recent < maxPerHour;
+        if (!allowed) {
+            log.warn("Recreation limit reached for '{}': {}/{} in last hour", baseName, recent, maxPerHour);
+        }
+        return allowed;
+    }
+
+    @Override
+    public synchronized void record(String baseName) {
+        eventsByBase.computeIfAbsent(baseName, k -> new ArrayDeque<>()).addLast(Instant.now());
+        log.info("Recorded recreation for '{}'", baseName);
+    }
+
+    /**
+     * Return the base's event queue with entries older than the window dropped.
+     * Pruning on read keeps the map bounded without a background sweep.
+     */
+    private Deque<Instant> prunedQueue(String baseName) {
+        Instant cutoff = Instant.now().minus(WINDOW);
+        Deque<Instant> queue = eventsByBase.computeIfAbsent(baseName, k -> new ArrayDeque<>());
+        while (!queue.isEmpty() && queue.peekFirst().isBefore(cutoff)) {
+            queue.pollFirst();
+        }
+        return queue;
+    }
+}

--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/recovery/MongoRecreationTracker.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/recovery/MongoRecreationTracker.java
@@ -4,6 +4,7 @@ import com.openframe.data.document.connector.ConnectorRecreationEvent;
 import com.openframe.data.repository.connector.ConnectorRecreationEventRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -16,11 +17,14 @@ import java.time.Instant;
  * limit check counts documents in the last hour for the given base name. Stale
  * events are purged on each write — no TTL index needed.
  *
- * Activated by {@code openframe.debezium.recovery.recreation.enabled=true}.
+ * Activated by {@code openframe.debezium.recovery.recreation.enabled=true}. Used
+ * on the shared cluster; backs off when an {@link InMemoryRecreationTracker} is
+ * present (per-tenant cluster, {@code recreation.in-memory=true}).
  */
 @Slf4j
 @Component
 @ConditionalOnProperty(name = "openframe.debezium.recovery.recreation.enabled", havingValue = "true")
+@ConditionalOnMissingBean(value = RecreationTracker.class, ignored = MongoRecreationTracker.class)
 public class MongoRecreationTracker implements RecreationTracker {
 
     private static final Duration WINDOW = Duration.ofHours(1);

--- a/openframe-debezium-initializer/src/main/java/com/openframe/debezium/service/DebeziumService.java
+++ b/openframe-debezium-initializer/src/main/java/com/openframe/debezium/service/DebeziumService.java
@@ -322,6 +322,48 @@ public class DebeziumService {
                         }));
     }
 
+    /**
+     * Prune connectors in Kafka Connect down to one canonical version per known
+     * base, deleting:
+     * <ul>
+     *   <li><b>orphans</b> — connectors whose base name maps to no known tool spec
+     *       (e.g. an old tenant-prefixed naming scheme the active strategy no
+     *       longer recognises): reconcile never recreates them, recovery keeps
+     *       restarting them, and they may hold replication slots that block the
+     *       canonical connector;</li>
+     *   <li><b>stale versions</b> — older {@code <base>_vN} of a known base left
+     *       behind by an interrupted recreate; only the current (highest) version
+     *       is kept.</li>
+     * </ul>
+     * Base-name and version resolution honour the active {@link ConnectorNameStrategy}
+     * (a no-op for stale-version pruning under the identity strategy).
+     *
+     * <p>{@code knownBaseNames} must be derived from ALL tools (enabled and
+     * disabled) — a temporarily-disabled tool's connector is not an orphan. The
+     * caller must guarantee {@code knownBaseNames} and {@code actualConnectors}
+     * are non-empty to avoid mass-deletion on a transient outage.
+     */
+    public void deleteOrphanedConnectors(Set<String> knownBaseNames, List<String> actualConnectors) {
+        actualConnectors.stream()
+                .filter(name -> !knownBaseNames.contains(nameStrategy.extractBaseName(name)))
+                .forEach(name -> {
+                    log.warn("{} Deleting orphaned connector '{}' (base='{}') — no matching tool spec",
+                            DebeziumLog.PREFIX, name, nameStrategy.extractBaseName(name));
+                    deleteConnector(name);
+                });
+
+        // Collapse each known base to its current version, removing stale older
+        // versions a prior recreate failed to clean up. Resolved against the
+        // pre-deletion snapshot — orphans removed above share no base here.
+        knownBaseNames.forEach(base -> nameStrategy.currentVersion(base, actualConnectors)
+                .ifPresent(current -> nameStrategy.staleVersions(base, current, actualConnectors)
+                        .forEach(stale -> {
+                            log.warn("{} Deleting stale connector version '{}' (base='{}', keeping '{}')",
+                                    DebeziumLog.PREFIX, stale, base, current);
+                            deleteConnector(stale);
+                        })));
+    }
+
     private String connectorUrl(String name) {
         return UriComponentsBuilder.fromHttpUrl(connectorsBaseUrl)
                 .pathSegment(name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional automatic cleanup of orphaned Debezium connectors at startup, controlled by `openframe.debezium.reconcile.delete-orphans` configuration flag (default: `false`).
  * Introduced versioned connector naming scheme for improved connector lifecycle management and recreation support.
  * Added in-memory rate limiting for connector recreations, configurable via `openframe.debezium.recovery.max-recreations-per-hour` (default: `1` per hour).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->