### PR TITLE
Change mesh multi-tenant node-id property

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/transformer/MeshCentralAgentIdTransformer.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/transformer/MeshCentralAgentIdTransformer.java
@@ -13,9 +13,8 @@ public class MeshCentralAgentIdTransformer implements ToolAgentIdTransformer {
 
     private static final String LEGACY_NODE_PREFIX = "node//";
 
-    @Value("${openframe.cluster-id:}")
-    private String tenantId;
-
+    @Value("${openframe.client.meshcentral.node-id:}")
+    private String nodeId;
     @Value("${openframe.client.meshcentral.tenant-scoped-node-id:false}")
     private boolean tenantScopedNodeId;
 
@@ -33,7 +32,7 @@ public class MeshCentralAgentIdTransformer implements ToolAgentIdTransformer {
 
         String transformedId;
         if (tenantScopedNodeId) {
-            transformedId = "node/" + tenantId + "/" + agentToolId;
+            transformedId = "node/" + nodeId + "/" + agentToolId;
         } else {
             //TODO Legacy empty-domain form (kept as the default). delete after mesh release
             transformedId = LEGACY_NODE_PREFIX + agentToolId;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MeshCentral agent identification configuration to use a dedicated node identifier instead of cluster identifier. Configuration property `openframe.client.meshcentral.node-id` is now available (defaults to empty).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->