### PR TITLE
Update NotificationContextDispatchIT to reflect Spring default TypeMa…

### DIFF
--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/document/notification/NotificationContextDispatchIT.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/document/notification/NotificationContextDispatchIT.java
@@ -83,8 +83,8 @@ class NotificationContextDispatchIT extends BaseMongoIntegrationTest {
     }
 
     @Test
-    @DisplayName("Given a saved Notification, when inspecting the raw Mongo document, then the embedded context has no internal _class field — type is the sole discriminator")
-    void given_saved_notification_when_inspecting_raw_doc_then_context_has_no_class_field() {
+    @DisplayName("Given a saved Notification, when inspecting the raw Mongo document, then the embedded context carries the `type` discriminator used by Jackson for polymorphic dispatch")
+    void given_saved_notification_when_inspecting_raw_doc_then_context_has_type_discriminator() {
         Notification original = Notification.builder()
                 .title("Extended event")
                 .createdAt(Instant.now())
@@ -104,8 +104,5 @@ class NotificationContextDispatchIT extends BaseMongoIntegrationTest {
         Document context = raw.get("context", Document.class);
         assertThat(context).isNotNull();
         assertThat(context.getString("type")).isEqualTo(TestExtendedContext.TYPE);
-        assertThat(context.containsKey("_class"))
-                .as("context document should not carry _class — type is the canonical discriminator")
-                .isFalse();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test assertions for notification context validation to verify polymorphic type discriminators are properly embedded in stored documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->