### PR TITLE
refactor(types): drop single platform_id from announcement + program types (array-only)

### DIFF
--- a/openframe-frontend-core/src/components/chat/types/entities/program-types.ts
+++ b/openframe-frontend-core/src/components/chat/types/entities/program-types.ts
@@ -137,7 +137,10 @@ export interface BaseProgramItem {
   date: string; // ISO date string - maps to: start_at, published_at
   external_url?: string | null; // Registration/play link
   hosts?: ProgramHost[] | null; // Speakers/hosts
-  platform_id: string;
+  // Platform tagging lives in the host app's `entity_platforms` array (exposed
+  // under the per-entity arrayKey, e.g. `podcast_platforms`), NOT a derived
+  // singular `platform_id` on the item. ProgramCard routes via the `href` /
+  // `targetPlatform` props the caller computes, so it needs no platform field here.
 }
 
 // ============================================================================
@@ -356,7 +359,6 @@ export function transformEventToProgram(event: LumaEventRow): EventItem {
     date: event.start_at,
     external_url: event.event_url ?? null,
     hosts: event.hosts ?? null,
-    platform_id: event.platform_id,
     luma_api_id: event.luma_api_id,
     end_at: event.end_at,
     timezone: event.timezone ?? null,
@@ -385,7 +387,6 @@ export function transformPodcastToProgram(episode: PodcastEpisodeRow): PodcastIt
     date: episode.published_at ?? episode.created_at,
     external_url: episode.external_url ?? null,
     hosts: episode.hosts ?? null,
-    platform_id: episode.platform_id,
     podbean_episode_id: episode.podbean_episode_id,
     podbean_podcast_id: episode.podbean_podcast_id,
     audio_url: episode.audio_url ?? null,
@@ -417,7 +418,6 @@ export function transformWebinarToProgram(webinar: WebinarRow): WebinarItem {
     date: webinar.display_date_override ?? webinar.start_at,
     external_url: webinar.registration_url ?? null,
     hosts: webinar.hosts ?? null,
-    platform_id: webinar.platform_id,
     livestorm_event_id: webinar.livestorm_event_id,
     start_at: webinar.start_at,
     end_at: webinar.end_at ?? null,

--- a/openframe-frontend-core/src/stories/__fixtures__/chat-cards.ts
+++ b/openframe-frontend-core/src/stories/__fixtures__/chat-cards.ts
@@ -402,7 +402,6 @@ export const podcastItem: BaseProgramItem = {
   date: isoDaysAgo(3),
   external_url: 'https://flamingo.cx/podcasts/ep-042',
   hosts: sampleHosts,
-  platform_id: 'platform-openmsp',
 }
 
 export const webinarItem: BaseProgramItem = {
@@ -415,7 +414,6 @@ export const webinarItem: BaseProgramItem = {
   date: isoDaysAgo(-5),
   external_url: 'https://flamingo.cx/webinars/msp-pricing-teardown',
   hosts: [sampleHosts[0]!],
-  platform_id: 'platform-openmsp',
 }
 
 export const eventItem: BaseProgramItem = {
@@ -428,7 +426,6 @@ export const eventItem: BaseProgramItem = {
   date: isoDaysAgo(-21),
   external_url: 'https://lu.ma/msp-austin-2026',
   hosts: sampleHosts,
-  platform_id: 'platform-openmsp',
 }
 
 // =============================================================================

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -62,7 +62,7 @@ export interface CreateAnnouncementData {
   icon_png_url?: string;
   /** Extra props for the main bar/icon */
   icon_svg_props?: Record<string, any>;
-  platform_id: string;  // Foreign key to platforms table
+  platforms?: string[];  // entity_platforms set (multi-select)
   is_active?: boolean;
   // CTA (Call-To-Action) fields
   cta_enabled?: boolean;
@@ -86,7 +86,7 @@ export interface UpdateAnnouncementData {
   icon_png_url?: string;
   /** Extra props for the main bar/icon */
   icon_svg_props?: Record<string, any>;
-  platform_id?: string;  // Foreign key to platforms table
+  platforms?: string[];  // entity_platforms set (multi-select)
   is_active?: boolean;
   // CTA (Call-To-Action) fields
   cta_enabled?: boolean;
@@ -126,7 +126,7 @@ export interface AnnouncementFormData {
   icon_type: IconType;
   icon_svg_name: string;
   icon_png_file?: File;
-  platform_id: string;  // Foreign key to platforms table
+  platforms: string[];  // entity_platforms set (multi-select; no single platform_id)
   is_active: boolean;
   // CTA (Call-To-Action) fields
   cta_enabled: boolean;


### PR DESCRIPTION
Paired with the host-app entity_platforms unification (**flamingo-stack/multi-platform-hub**, PR linked there). Platform tagging moved to a unified many-to-many `entity_platforms` relation, so the shared types must stop modeling a single platform.

## Changes
- **`AnnouncementFormData` / `CreateAnnouncementData` / `UpdateAnnouncementData`**: `platform_id: string` → `platforms: string[]` (multi-select; the host writes the relation to `entity_platforms`).
- **`BaseProgramItem`**: drop the single `platform_id` field — program cards read the `<entity>_platforms[]` array via props.

## Notes
- Type/contract changes only; no lib runtime behavior changes. `<ProgramCard>` / `<PlatformBadgeList>` already take the platform set via props.
- **Merge + publish before the hub** — the host app pins an exact `openframe-frontend-core` version and Vercel installs it from npm (yalc is dev-only), so the hub's prod build needs these exports published first.
- 3 files, +7/-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Program item platform identification is now managed by the host application's configuration rather than stored per-item, improving platform consistency across the system.

* **New Features**
  * Announcements now support assignment to multiple platforms simultaneously, enabling broader content distribution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->