### PR TITLE
feat(platform-domains): env-overridable SSOT for platform→domain + reverse resolver

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -66,6 +66,12 @@
       "require": "./dist/schemas/contact-schema.cjs",
       "default": "./dist/schemas/contact-schema.js"
     },
+    "./platform-domains": {
+      "types": "./dist/platform-domains.d.ts",
+      "import": "./dist/platform-domains.js",
+      "require": "./dist/platform-domains.cjs",
+      "default": "./dist/platform-domains.js"
+    },
     "./components/ui/file-manager": {
       "types": "./dist/components/ui/file-manager/index.d.ts",
       "import": "./dist/components/ui/file-manager/index.js",

--- a/openframe-frontend-core/src/__tests__/platform-domains.test.ts
+++ b/openframe-frontend-core/src/__tests__/platform-domains.test.ts
@@ -101,19 +101,28 @@ describe('host primitives', () => {
 })
 
 describe('env override path', () => {
-  it('an override wins over the default (per-distinct-var, no cross-contamination)', () => {
-    vi.stubEnv('NEXT_PUBLIC_TMCG_URL', 'https://sentinel-tmcg.example')
-    expect(getPlatformProductionUrl('tmcg')).toBe('https://sentinel-tmcg.example')
-    // a non-sharing key is unaffected
-    expect(getPlatformProductionUrl('openmsp')).toBe('https://www.openmsp.ai')
+  // ENV_OVERRIDES captures `process.env.NEXT_PUBLIC_*` at MODULE LOAD — required so the
+  // values are build-inlined (literal keys) in the browser bundle. So an override must be
+  // set BEFORE the module evaluates: stub env → resetModules → dynamic import.
+  afterEach(() => {
     vi.unstubAllEnvs()
+    vi.resetModules()
   })
-  it('the shared NEXT_PUBLIC_FLAMINGO_URL drives all three of its keys', () => {
+  it('an override wins over the default (per-distinct-var, no cross-contamination)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_TMCG_URL', 'https://sentinel-tmcg.example')
+    vi.resetModules()
+    const mod = await import('../platform-domains')
+    expect(mod.getPlatformProductionUrl('tmcg')).toBe('https://sentinel-tmcg.example')
+    // a non-sharing key is unaffected
+    expect(mod.getPlatformProductionUrl('openmsp')).toBe('https://www.openmsp.ai')
+  })
+  it('the shared NEXT_PUBLIC_FLAMINGO_URL drives all three of its keys', async () => {
     vi.stubEnv('NEXT_PUBLIC_FLAMINGO_URL', 'https://sentinel-flamingo.example')
+    vi.resetModules()
+    const mod = await import('../platform-domains')
     for (const k of ['flamingo', 'flamingo-teaser', 'universal']) {
-      expect(getPlatformProductionUrl(k)).toBe('https://sentinel-flamingo.example')
+      expect(mod.getPlatformProductionUrl(k)).toBe('https://sentinel-flamingo.example')
     }
-    vi.unstubAllEnvs()
   })
 })
 

--- a/openframe-frontend-core/src/__tests__/platform-domains.test.ts
+++ b/openframe-frontend-core/src/__tests__/platform-domains.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  PLATFORM_DOMAINS,
+  byKey,
+  getPlatformProductionUrl,
+  getPlatformByHostname,
+  getAllPlatformBaseDomains,
+  hostOf,
+  expandWwwApex,
+  toRegistrableBaseDomain,
+  aliasHostsOf,
+} from '../platform-domains'
+
+/**
+ * Helper: run a fn with a stubbed `window.location.hostname` (prod, non-localhost,
+ * non-vercel) so getAllPlatformBaseDomains exercises its production branch.
+ */
+function withProdWindow<T>(hostname: string, fn: () => T): T {
+  vi.stubGlobal('window', { location: { hostname } })
+  try {
+    return fn()
+  } finally {
+    vi.unstubAllGlobals()
+  }
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('platform-domains — forward resolution (defaults = byte-identical to the old cn.ts switch)', () => {
+  it('returns each defaultUrl when no env override is set', () => {
+    for (const entry of PLATFORM_DOMAINS) {
+      expect(getPlatformProductionUrl(entry.key)).toBe(entry.defaultUrl)
+    }
+  })
+  it('falls back to flamingo.run for an unknown key (old default case)', () => {
+    expect(getPlatformProductionUrl('not-a-platform')).toBe('https://www.flamingo.run')
+  })
+})
+
+describe('🔒 cross-subdomain cookie sharing (the SSO invariant — must never regress)', () => {
+  // With NO NEXT_PUBLIC_*_URL overrides set (today's production reality), the defaults
+  // alone MUST still produce the registrable base domains that scope the auth cookie
+  // across every hub subdomain. This is exactly what pure-env-only would have broken.
+  it('emits .flamingo.so / .flamingo.run / .openmsp.ai / .tmcg.miami / .openframe.ai from defaults', () => {
+    const bases = withProdWindow('company-hub.flamingo.so', getAllPlatformBaseDomains)
+    for (const must of ['.flamingo.so', '.flamingo.run', '.openmsp.ai', '.tmcg.miami', '.openframe.ai']) {
+      expect(bases).toContain(must)
+    }
+  })
+  it('shares one base domain across all *.flamingo.so hubs (cross-hub SSO)', () => {
+    for (const hub of ['marketing-hub', 'company-hub', 'product-hub', 'revenue-hub', 'people-hub']) {
+      expect(toRegistrableBaseDomain(hostOf(getPlatformProductionUrl(hub))!)).toBe('flamingo.so')
+    }
+  })
+  it('keeps flamingo.cx OUT of the cookie set (alias excluded) but IN the reverse map', () => {
+    const bases = withProdWindow('www.flamingo.run', getAllPlatformBaseDomains)
+    expect(bases).not.toContain('.flamingo.cx')
+    expect(getPlatformByHostname('flamingo.cx')).toBe('flamingo-teaser')
+  })
+  it('returns [] for localhost and .vercel.app (host-only cookies)', () => {
+    expect(withProdWindow('localhost', getAllPlatformBaseDomains)).toEqual([])
+    expect(withProdWindow('foo.vercel.app', getAllPlatformBaseDomains)).toEqual(['.vercel.app', 'vercel.app'])
+  })
+})
+
+describe('reverse resolver (first-wins ordering + aliases)', () => {
+  it.each([
+    ['www.flamingo.run', 'flamingo'],
+    ['flamingo.run', 'flamingo'],
+    ['flamingo.cx', 'flamingo-teaser'],
+    ['www.flamingo.cx', 'flamingo-teaser'],
+    ['openframe.ai', 'openframe'],
+    ['www.openframe.ai', 'openframe'],
+    ['hub.openframe.ai', 'openframe'], // additive fix — was null in the old PLATFORM_DOMAIN_MAP
+    ['marketing-hub.flamingo.so', 'marketing-hub'],
+    ['WWW.OPENMSP.AI', 'openmsp'], // case-insensitive
+    ['evil.com', null],
+  ])('%s → %s', (host, expected) => {
+    expect(getPlatformByHostname(host)).toBe(expected)
+  })
+})
+
+describe('host primitives', () => {
+  it('hostOf strips scheme + port, lowercases, null on garbage', () => {
+    expect(hostOf('https://WWW.Openmsp.ai:8443/x')).toBe('www.openmsp.ai')
+    expect(hostOf('not a url')).toBeNull()
+    expect(hostOf(null)).toBeNull()
+  })
+  it('expandWwwApex handles www / apex / 3-label / 1-label', () => {
+    expect(expandWwwApex('www.openmsp.ai')).toEqual(['www.openmsp.ai', 'openmsp.ai'])
+    expect(expandWwwApex('openmsp.ai')).toEqual(['openmsp.ai', 'www.openmsp.ai'])
+    expect(expandWwwApex('hub.openframe.ai')).toEqual(['hub.openframe.ai'])
+    expect(expandWwwApex('localhost')).toEqual(['localhost'])
+  })
+  it('toRegistrableBaseDomain + aliasHostsOf', () => {
+    expect(toRegistrableBaseDomain('marketing-hub.flamingo.so')).toBe('flamingo.so')
+    expect(toRegistrableBaseDomain('localhost')).toBeUndefined()
+    expect(aliasHostsOf('flamingo-teaser')).toEqual(['flamingo.cx', 'www.flamingo.cx'])
+    expect(aliasHostsOf('openmsp')).toEqual([])
+  })
+})
+
+describe('env override path', () => {
+  it('an override wins over the default (per-distinct-var, no cross-contamination)', () => {
+    vi.stubEnv('NEXT_PUBLIC_TMCG_URL', 'https://sentinel-tmcg.example')
+    expect(getPlatformProductionUrl('tmcg')).toBe('https://sentinel-tmcg.example')
+    // a non-sharing key is unaffected
+    expect(getPlatformProductionUrl('openmsp')).toBe('https://www.openmsp.ai')
+    vi.unstubAllEnvs()
+  })
+  it('the shared NEXT_PUBLIC_FLAMINGO_URL drives all three of its keys', () => {
+    vi.stubEnv('NEXT_PUBLIC_FLAMINGO_URL', 'https://sentinel-flamingo.example')
+    for (const k of ['flamingo', 'flamingo-teaser', 'universal']) {
+      expect(getPlatformProductionUrl(k)).toBe('https://sentinel-flamingo.example')
+    }
+    vi.unstubAllEnvs()
+  })
+})
+
+describe('registry integrity', () => {
+  it('byKey resolves every key and openframe-dashboard is pseudo', () => {
+    expect(byKey('openframe-dashboard')?.pseudo).toBe(true)
+    expect(byKey('not-a-platform')).toBeUndefined()
+  })
+})

--- a/openframe-frontend-core/src/__tests__/platform-domains.test.ts
+++ b/openframe-frontend-core/src/__tests__/platform-domains.test.ts
@@ -9,7 +9,7 @@ import {
   expandWwwApex,
   toRegistrableBaseDomain,
   aliasHostsOf,
-} from '../platform-domains'
+} from '@/platform-domains'
 
 /**
  * Helper: run a fn with a stubbed `window.location.hostname` (prod, non-localhost,
@@ -24,7 +24,10 @@ function withProdWindow<T>(hostname: string, fn: () => T): T {
   }
 }
 
-afterEach(() => vi.unstubAllGlobals())
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
 
 describe('platform-domains — forward resolution (defaults = byte-identical to the old cn.ts switch)', () => {
   it('returns each defaultUrl when no env override is set', () => {
@@ -111,7 +114,7 @@ describe('env override path', () => {
   it('an override wins over the default (per-distinct-var, no cross-contamination)', async () => {
     vi.stubEnv('NEXT_PUBLIC_TMCG_URL', 'https://sentinel-tmcg.example')
     vi.resetModules()
-    const mod = await import('../platform-domains')
+    const mod = await import('@/platform-domains')
     expect(mod.getPlatformProductionUrl('tmcg')).toBe('https://sentinel-tmcg.example')
     // a non-sharing key is unaffected
     expect(mod.getPlatformProductionUrl('openmsp')).toBe('https://www.openmsp.ai')
@@ -119,7 +122,7 @@ describe('env override path', () => {
   it('the shared NEXT_PUBLIC_FLAMINGO_URL drives all three of its keys', async () => {
     vi.stubEnv('NEXT_PUBLIC_FLAMINGO_URL', 'https://sentinel-flamingo.example')
     vi.resetModules()
-    const mod = await import('../platform-domains')
+    const mod = await import('@/platform-domains')
     for (const k of ['flamingo', 'flamingo-teaser', 'universal']) {
       expect(mod.getPlatformProductionUrl(k)).toBe('https://sentinel-flamingo.example')
     }

--- a/openframe-frontend-core/src/platform-domains.ts
+++ b/openframe-frontend-core/src/platform-domains.ts
@@ -165,9 +165,10 @@ export function isPreviewEnv(): boolean {
   return process.env.VERCEL_ENV === 'preview'
 }
 
-/** Host-form preview predicate (a `*.vercel.app` host). */
+/** Host-form preview predicate (a `*.vercel.app` host). Dot-bounded suffix so a
+ *  malicious `foo.vercel.app.evil.com` is NOT treated as preview. */
 export function isPreviewHost(hostname: string): boolean {
-  return hostname.includes('.vercel.app')
+  return hostname.endsWith('.vercel.app')
 }
 
 /**

--- a/openframe-frontend-core/src/platform-domains.ts
+++ b/openframe-frontend-core/src/platform-domains.ts
@@ -1,0 +1,237 @@
+/**
+ * Platform-Domain SSOT (single source of truth) + derivations.
+ *
+ * ONE registry maps each platform → its canonical production URL (`defaultUrl`,
+ * the load-bearing source) with an optional per-deploy `NEXT_PUBLIC_*_URL`
+ * OVERRIDE. Everything else — the reverse host→platform resolver, the cookie
+ * base-domain set (the cross-subdomain SSO mechanism), www/apex expansion, the
+ * URL→host parse, preview detection — derives from this one table.
+ *
+ * EDGE-SAFE + PURE: no React/clsx/tailwind, no `server-only`, no `node:`
+ * builtins, no `'use client'`. So it is legal in the Edge middleware
+ * (`proxy.ts`), in `'use client'` providers, AND in `server-only` modules
+ * (e.g. cookie-domain-server.ts) simultaneously. The ONLY non-pure export is
+ * `getAllPlatformBaseDomains`, which reads `typeof window`/`process.env` to
+ * preserve byte-identical cookie behavior.
+ */
+
+import type { PlatformName } from './types/platform'
+
+export type PlatformDomainKey = PlatformName | 'openframe-dashboard'
+
+export interface PlatformDomainEntry {
+  /** Platform key (matches `PlatformName`, plus the forward-only `openframe-dashboard`). */
+  key: PlatformDomainKey
+  /** Canonical production URL — the LOAD-BEARING source of truth (today's hardcoded fallbacks). */
+  defaultUrl: string
+  /** `NEXT_PUBLIC_*_URL` per-deploy OVERRIDE. The `defaultUrl` covers it when unset. */
+  envVar: string
+  /** Legacy/secondary hosts that REVERSE-map to this key (no env var exists — NOT canonical). */
+  aliasHostnames?: string[]
+  /** Forward-only: no DB row, excluded from the reverse index + cookie set (e.g. the product-CTA dashboard). */
+  pseudo?: boolean
+}
+
+export const PLATFORM_DOMAINS: readonly PlatformDomainEntry[] = [
+  { key: 'marketing-hub', defaultUrl: 'https://marketing-hub.flamingo.so', envVar: 'NEXT_PUBLIC_MARKETING_HUB_URL' },
+  { key: 'company-hub',   defaultUrl: 'https://company-hub.flamingo.so',   envVar: 'NEXT_PUBLIC_COMPANY_HUB_URL' },
+  { key: 'product-hub',   defaultUrl: 'https://product-hub.flamingo.so',   envVar: 'NEXT_PUBLIC_PRODUCT_HUB_URL' },
+  { key: 'revenue-hub',   defaultUrl: 'https://revenue-hub.flamingo.so',   envVar: 'NEXT_PUBLIC_REVENUE_HUB_URL' },
+  { key: 'people-hub',    defaultUrl: 'https://people-hub.flamingo.so',    envVar: 'NEXT_PUBLIC_PEOPLE_HUB_URL' },
+  { key: 'openmsp',       defaultUrl: 'https://www.openmsp.ai',            envVar: 'NEXT_PUBLIC_OPENMSP_URL' },
+  // ORDERING INVARIANT (first-wins, load-bearing): `flamingo` MUST precede `flamingo-teaser` + `universal`.
+  // All three resolve to www.flamingo.run; the reverse index is first-wins → flamingo claims the shared host,
+  // teaser keeps only its unique flamingo.cx aliases, universal contributes no unique host.
+  // ⚠️ DO NOT REORDER — enforced by the module-load self-check at the bottom of this file.
+  { key: 'flamingo',         defaultUrl: 'https://www.flamingo.run',  envVar: 'NEXT_PUBLIC_FLAMINGO_URL' },
+  { key: 'tmcg',             defaultUrl: 'https://www.tmcg.miami',    envVar: 'NEXT_PUBLIC_TMCG_URL' },
+  { key: 'flamingo-teaser',  defaultUrl: 'https://www.flamingo.run',  envVar: 'NEXT_PUBLIC_FLAMINGO_URL', aliasHostnames: ['flamingo.cx', 'www.flamingo.cx'] },
+  { key: 'openframe',        defaultUrl: 'https://openframe.ai',      envVar: 'NEXT_PUBLIC_OPENFRAME_URL', aliasHostnames: ['openframe.ai', 'www.openframe.ai', 'hub.openframe.ai'] },
+  { key: 'openframe-dashboard', defaultUrl: 'https://openframe.ai',   envVar: 'NEXT_PUBLIC_OPENFRAME_DASHBOARD_URL', pseudo: true },
+  { key: 'universal',        defaultUrl: 'https://www.flamingo.run',  envVar: 'NEXT_PUBLIC_FLAMINGO_URL' },
+]
+
+// ── Compile-time key guards (anchor the table on PlatformName, both directions) ──
+// (1) Removal/typo guard: every table key must be a valid PlatformDomainKey.
+const _tableSatisfies = PLATFORM_DOMAINS satisfies readonly PlatformDomainEntry[]
+void _tableSatisfies
+// (2) Addition guard: a NEW PlatformName member that lacks a table row fails the build.
+type _MissingKey = Exclude<PlatformName, (typeof PLATFORM_DOMAINS)[number]['key']>
+const _exhaustive: [_MissingKey] extends [never] ? true : false = true
+void _exhaustive
+
+// ── Env overrides (the ONLY place env URLs enter — literal-key inlined + compile-time-guarded) ──
+// `process.env.NEXT_PUBLIC_X` is build-inlined ONLY with a LITERAL key, so the env-var name is the
+// irreducible two-copy (the registry `envVar` column + the literal access below). The `satisfies` makes
+// `tsc`/`next build` FAIL if this map is missing a registry env var OR carries a stale one (bidirectional).
+type EnvVarKey = (typeof PLATFORM_DOMAINS)[number]['envVar']
+const ENV_OVERRIDES = {
+  NEXT_PUBLIC_MARKETING_HUB_URL: process.env.NEXT_PUBLIC_MARKETING_HUB_URL,
+  NEXT_PUBLIC_COMPANY_HUB_URL: process.env.NEXT_PUBLIC_COMPANY_HUB_URL,
+  NEXT_PUBLIC_PRODUCT_HUB_URL: process.env.NEXT_PUBLIC_PRODUCT_HUB_URL,
+  NEXT_PUBLIC_REVENUE_HUB_URL: process.env.NEXT_PUBLIC_REVENUE_HUB_URL,
+  NEXT_PUBLIC_PEOPLE_HUB_URL: process.env.NEXT_PUBLIC_PEOPLE_HUB_URL,
+  NEXT_PUBLIC_OPENMSP_URL: process.env.NEXT_PUBLIC_OPENMSP_URL,
+  NEXT_PUBLIC_FLAMINGO_URL: process.env.NEXT_PUBLIC_FLAMINGO_URL,
+  NEXT_PUBLIC_TMCG_URL: process.env.NEXT_PUBLIC_TMCG_URL,
+  NEXT_PUBLIC_OPENFRAME_URL: process.env.NEXT_PUBLIC_OPENFRAME_URL,
+  NEXT_PUBLIC_OPENFRAME_DASHBOARD_URL: process.env.NEXT_PUBLIC_OPENFRAME_DASHBOARD_URL,
+} satisfies Record<EnvVarKey, string | undefined>
+
+/** The registry entry for a key (undefined for an unknown key). */
+export function byKey(key: string): PlatformDomainEntry | undefined {
+  return PLATFORM_DOMAINS.find((e) => e.key === key)
+}
+
+/** Read a platform's `NEXT_PUBLIC_*_URL` override (or null). */
+function envOverrideFor(key: string): string | null {
+  const envVar = byKey(key)?.envVar
+  if (!envVar) return null
+  return (ENV_OVERRIDES as Record<string, string | undefined>)[envVar] || null
+}
+
+/**
+ * Canonical production URL for a platform: env override wins, else the `defaultUrl`.
+ * NEVER throws / undefined — the default guarantees a host (this is what keeps the
+ * cookie base-domains, the reverse map, and CSP intact even with every override unset).
+ * Byte-identical to the old cn.ts switch (incl. the unknown-key flamingo.run fallback).
+ */
+export function getPlatformProductionUrl(platform: string): string {
+  return (
+    envOverrideFor(platform) ??
+    byKey(platform)?.defaultUrl ??
+    envOverrideFor('flamingo') ??
+    'https://www.flamingo.run'
+  )
+}
+
+// ── Single-owner host primitives ──
+
+/** Canonical URL→host parser: `.hostname` (PORT-STRIPPED, lowercased), null on parse failure. */
+export function hostOf(value: string | null | undefined): string | null {
+  if (!value) return null
+  try {
+    return new URL(value).hostname.toLowerCase()
+  } catch {
+    return null
+  }
+}
+
+/** Expand a host into its `www.`/apex pair. 3+-label and single-label hosts return `[host]`. */
+export function expandWwwApex(host: string): string[] {
+  if (host.startsWith('www.')) return [host, host.slice(4)]
+  if (host.split('.').length === 2) return [host, `www.${host}`]
+  return [host]
+}
+
+/** Registrable base domain (`parts.slice(-2).join('.')`), dotless; undefined for <2-label. */
+export function toRegistrableBaseDomain(host: string): string | undefined {
+  const parts = host.split('.')
+  if (parts.length >= 2) return parts.slice(-2).join('.')
+  return undefined
+}
+
+/** An entry's alias hosts (single-owner reader). */
+export function aliasHostsOf(key: string): string[] {
+  return byKey(key)?.aliasHostnames ?? []
+}
+
+/** All hosts an entry contributes to the reverse index (resolved host + optional aliases). */
+function hostsForEntry(entry: PlatformDomainEntry, opts: { includeAliases: boolean }): string[] {
+  const resolved = hostOf(getPlatformProductionUrl(entry.key))
+  const hosts = resolved ? expandWwwApex(resolved) : []
+  if (opts.includeAliases) hosts.push(...aliasHostsOf(entry.key))
+  return hosts
+}
+
+/**
+ * Reverse resolver: hostname → platform key (first-wins over registry order, non-pseudo only).
+ * Guarantees openframe.ai / www.openframe.ai / hub.openframe.ai → openframe in every env.
+ * Replaces the hub `PLATFORM_DOMAIN_MAP`.
+ */
+export function getPlatformByHostname(hostname: string): PlatformDomainKey | null {
+  const host = hostname.toLowerCase()
+  for (const entry of PLATFORM_DOMAINS) {
+    if (entry.pseudo) continue
+    if (hostsForEntry(entry, { includeAliases: true }).includes(host)) return entry.key
+  }
+  return null
+}
+
+// ── Preview detection (two distinct predicates — env-form vs host-form) ──
+
+/** Env-form preview predicate (Vercel `VERCEL_ENV`). */
+export function isPreviewEnv(): boolean {
+  return process.env.VERCEL_ENV === 'preview'
+}
+
+/** Host-form preview predicate (a `*.vercel.app` host). */
+export function isPreviewHost(hostname: string): boolean {
+  return hostname.includes('.vercel.app')
+}
+
+/**
+ * ALL unique cookie base domains (the cross-subdomain SSO mechanism).
+ *
+ * NON-PURE (the sole such export): reads `typeof window` + `process.env` to
+ * preserve byte-identical cookie behavior. Keeps the original three branches:
+ *   1. localhost / private IP → [] (host-only cookies)
+ *   2. Vercel preview (env OR host) → ['.vercel.app','vercel.app']
+ *   3. production → for each non-pseudo platform, registrable base of its resolved
+ *      host, emitted as both `.base` and bare `base`.
+ *
+ * Because `getPlatformProductionUrl` always yields a host (override OR default),
+ * `.flamingo.so` / `.flamingo.run` / `.openmsp.ai` / `.tmcg.miami` / `.openframe.ai`
+ * are ALWAYS present → cross-hub SSO is byte-identical to today.
+ */
+export function getAllPlatformBaseDomains(): string[] {
+  if (typeof window === 'undefined') return []
+
+  const hostname = window.location.hostname
+
+  // Case 1: localhost / private IP — no domains
+  if (hostname === 'localhost' || hostname === '127.0.0.1' || hostname.startsWith('127.')) {
+    return []
+  }
+
+  // Case 2: Vercel preview — vercel.app domain
+  const previewEnv =
+    process.env.VERCEL_ENV === 'preview' ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
+    isPreviewHost(hostname)
+  if (previewEnv) {
+    return ['.vercel.app', 'vercel.app']
+  }
+
+  // Case 3: production — registrable base of every non-pseudo platform's resolved host
+  const baseDomains = new Set<string>()
+  for (const entry of PLATFORM_DOMAINS) {
+    if (entry.pseudo) continue
+    const host = hostOf(getPlatformProductionUrl(entry.key))
+    if (!host) continue
+    const base = toRegistrableBaseDomain(host)
+    if (base) {
+      baseDomains.add(`.${base}`)
+      baseDomains.add(base)
+    }
+  }
+  return Array.from(baseDomains)
+}
+
+// ── Module-load ordering self-check (NON-fatal — this module is imported by cn.ts → ~everything,
+// so a hard throw would be a total outage if the assertion were ever over-strict). A reorder that
+// moves flamingo-teaser/universal before flamingo (e.g. an IDE alphabetize) surfaces loudly in the
+// build + prod logs instead of silently cross-tabbing flamingo links to the wrong owner. The
+// authoritative guard is the reverse-map vitest (src/__tests__/platform-domains.test.ts). ⚠️ keep
+// `flamingo` before `flamingo-teaser`/`universal` in PLATFORM_DOMAINS.
+if (
+  getPlatformByHostname('www.flamingo.run') !== 'flamingo' ||
+  getPlatformByHostname('flamingo.cx') !== 'flamingo-teaser' ||
+  getPlatformByHostname('hub.openframe.ai') !== 'openframe'
+) {
+  // eslint-disable-next-line no-console
+  console.error(
+    '[platform-domains] ⚠️ PLATFORM_DOMAINS ordering invariant violated — `flamingo` must precede ' +
+      '`flamingo-teaser`/`universal`, and the openframe aliases must be intact. Do not reorder the table.',
+  )
+}

--- a/openframe-frontend-core/src/utils/cn.ts
+++ b/openframe-frontend-core/src/utils/cn.ts
@@ -1,5 +1,10 @@
 import { clsx, type ClassValue } from "clsx"
 import { extendTailwindMerge } from "tailwind-merge"
+// Platform→domain resolution moved to the SSOT module `src/platform-domains.ts`.
+// `getPlatformProductionUrl` / `getAllPlatformBaseDomains` now live there (re-exported
+// via the utils barrel for existing callers); `getBaseUrl` stays here because it owns the
+// dev-localhost + Vercel-self-origin branches, and delegates its platform branch.
+import { getPlatformProductionUrl } from "../platform-domains"
 
 const twMerge = extendTailwindMerge<'ods-typography'>({
   extend: {
@@ -17,145 +22,24 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 /**
- * Platform URL mappings for production (with environment variable overrides)
- */
-export function getPlatformProductionUrl(platform: string): string {
-  switch (platform) {
-    // *-hub platforms — env var convention: NEXT_PUBLIC_<NAME>_HUB_URL
-    case 'marketing-hub':
-      return process.env.NEXT_PUBLIC_MARKETING_HUB_URL || 'https://marketing-hub.flamingo.so';
-    case 'company-hub':
-      return process.env.NEXT_PUBLIC_COMPANY_HUB_URL || 'https://company-hub.flamingo.so';
-    case 'product-hub':
-      return process.env.NEXT_PUBLIC_PRODUCT_HUB_URL || 'https://product-hub.flamingo.so';
-    case 'revenue-hub':
-      return process.env.NEXT_PUBLIC_REVENUE_HUB_URL || 'https://revenue-hub.flamingo.so';
-    case 'people-hub':
-      return process.env.NEXT_PUBLIC_PEOPLE_HUB_URL || 'https://people-hub.flamingo.so';
-    // Standalone platforms — env var convention: NEXT_PUBLIC_<NAME>_URL
-    case 'openmsp':
-      return process.env.NEXT_PUBLIC_OPENMSP_URL || 'https://www.openmsp.ai';
-    case 'flamingo':
-      return process.env.NEXT_PUBLIC_FLAMINGO_URL || 'https://www.flamingo.run';
-    case 'tmcg':
-      return process.env.NEXT_PUBLIC_TMCG_URL || 'https://www.tmcg.miami';
-    case 'flamingo-teaser':
-      return process.env.NEXT_PUBLIC_FLAMINGO_URL || 'https://www.flamingo.run';
-    case 'openframe':
-      return process.env.NEXT_PUBLIC_OPENFRAME_URL || 'https://openframe.ai';
-    // OpenFrame product / dashboard — the "Start Free Trial" CTA target. DISTINCT from
-    // the `openframe` content hub above: production overrides that one to
-    // hub.openframe.ai via NEXT_PUBLIC_OPENFRAME_URL (the knowledge/docs deployment),
-    // so a product CTA must NOT reuse it. Defaults to the product apex so the CTA is
-    // correct even when the (optional) dashboard override is unset.
-    case 'openframe-dashboard':
-      return process.env.NEXT_PUBLIC_OPENFRAME_DASHBOARD_URL || 'https://openframe.ai';
-    case 'universal':
-      return process.env.NEXT_PUBLIC_FLAMINGO_URL || 'https://www.flamingo.run';
-    default:
-      return process.env.NEXT_PUBLIC_FLAMINGO_URL || 'https://www.flamingo.run';
-  }
-}
-
-/**
- * Get ALL unique base domains from getPlatformProductionUrl
- *
- * Extracts domains by calling getPlatformProductionUrl for each platform identifier.
- * Platform identifiers match the switch cases in getPlatformProductionUrl.
- *
- * Handles 3 cases:
- * 1. LOCALHOST DEBUG - No domain (hostname-specific cookies)
- * 2. VERCEL PREVIEW (*.vercel.app) - Use vercel.app domain
- * 3. PRODUCTION - Extract from ALL platform URLs via getPlatformProductionUrl
- *
- * @returns Array of all unique base domains (with and without wildcard)
- */
-export function getAllPlatformBaseDomains(): string[] {
-  if (typeof window === 'undefined') return []
-
-  const hostname = window.location.hostname
-
-  // Case 1: LOCALHOST DEBUG - no domains needed
-  if (hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname.startsWith('127.')) {
-    return []
-  }
-
-  // Case 2: VERCEL PREVIEW - use vercel.app domain
-  const isVercelPreview = process.env.VERCEL_ENV === 'preview' ||
-                         process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview' ||
-                         hostname.includes('.vercel.app')
-
-  if (isVercelPreview) {
-    return ['.vercel.app', 'vercel.app']
-  }
-
-  // Case 3: PRODUCTION - extract from ALL platforms using getPlatformProductionUrl
-  // Platform identifiers MUST match switch cases in getPlatformProductionUrl —
-  // otherwise the corresponding domain is omitted from cookie scope.
-  const platformIdentifiers = [
-    'marketing-hub', 'company-hub', 'product-hub', 'revenue-hub', 'people-hub',
-    'openmsp', 'flamingo', 'tmcg', 'flamingo-teaser', 'openframe', 'universal'
-  ]
-
-  const baseDomains = new Set<string>()
-
-  platformIdentifiers.forEach(platform => {
-    try {
-      const url = getPlatformProductionUrl(platform)
-      const urlHostname = new URL(url).hostname
-      const parts = urlHostname.split('.')
-
-      if (parts.length >= 2) {
-        const baseDomain = parts.slice(-2).join('.')
-        baseDomains.add(`.${baseDomain}`) // Wildcard
-        baseDomains.add(baseDomain) // Non-wildcard
-      }
-    } catch (error) {
-      console.warn('[Platform Domains] Failed to parse URL for platform:', platform, error)
-    }
-  })
-
-  return Array.from(baseDomains)
-}
-
-/**
  * Get the application base URL for the current environment
  *
  * @param platform - Optional platform name (openmsp, flamingo, tmcg, openframe, etc.)
  * @returns The base URL with protocol (https:// or http://)
  *
  * Priority order:
- * 1. Environment variable override (NEXT_PUBLIC_*_URL)
- * 2. Platform-specific URL (if platform parameter provided)
+ * 1. Development (http://localhost:3000)
+ * 2. Platform-specific URL via the SSOT (if `platform` provided) — env override ?? default
  * 3. VERCEL_PROJECT_PRODUCTION_URL (Vercel production domain)
- * 4. Production fallback (current app or openmsp)
- * 5. Development (http://localhost:3000)
+ * 4. Production fallback: the DEPLOYING platform's canonical URL (NEXT_PUBLIC_APP_TYPE),
+ *    openmsp if unset — sourced from the SSOT, no hardcoded literal.
  *
- * Environment Variables (optional overrides — only set when production domain
- * differs from the hardcoded default):
- *
- * Hub deployments (NEXT_PUBLIC_<NAME>_HUB_URL):
- * - NEXT_PUBLIC_MARKETING_HUB_URL  -> marketing-hub.flamingo.so
- * - NEXT_PUBLIC_COMPANY_HUB_URL    -> company-hub.flamingo.so
- * - NEXT_PUBLIC_PRODUCT_HUB_URL    -> product-hub.flamingo.so
- * - NEXT_PUBLIC_REVENUE_HUB_URL    -> revenue-hub.flamingo.so
- * - NEXT_PUBLIC_PEOPLE_HUB_URL     -> people-hub.flamingo.so
- *
- * Standalone platforms (NEXT_PUBLIC_<NAME>_URL):
- * - NEXT_PUBLIC_OPENMSP_URL          -> www.openmsp.ai
- * - NEXT_PUBLIC_FLAMINGO_URL         -> www.flamingo.run
- * - NEXT_PUBLIC_TMCG_URL             -> www.tmcg.miami
- * - NEXT_PUBLIC_FLAMINGO_TEASER_URL  -> www.flamingo.cx
- * - NEXT_PUBLIC_OPENFRAME_URL        -> openframe.ai
- * - NEXT_PUBLIC_OPENFRAME_DASHBOARD_URL -> openframe.ai (product/dashboard CTA target;
- *     distinct from the openframe content hub, which prod points at hub.openframe.ai)
+ * The per-platform canonical URLs + their `NEXT_PUBLIC_*_URL` overrides are the single
+ * source of truth in `src/platform-domains.ts` (`PLATFORM_DOMAINS`).
  *
  * @example
- * getBaseUrl() // Current app URL
- * getBaseUrl('flamingo') // https://www.flamingo.run (production) or http://localhost:3000 (dev)
- * getBaseUrl('openmsp') // https://www.openmsp.ai (or NEXT_PUBLIC_OPENMSP_URL if set)
+ * getBaseUrl() // Current deployment's URL
+ * getBaseUrl('flamingo') // https://www.flamingo.run (prod) or http://localhost:3000 (dev)
  */
 export function getBaseUrl(platform?: string): string {
   // In development, always use localhost (regardless of platform)
@@ -163,7 +47,7 @@ export function getBaseUrl(platform?: string): string {
     return process.env.NEXT_PUBLIC_DEV_URL || 'http://localhost:3000'
   }
 
-  // If platform is specified, return its production URL with env variable override support
+  // If platform is specified, return its production URL (env override ?? default)
   if (platform) {
     return getPlatformProductionUrl(platform)
   }
@@ -173,8 +57,8 @@ export function getBaseUrl(platform?: string): string {
     return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   }
 
-  // Production fallback: Use canonical www domain to avoid Google "Page with redirect" issue.
-  // openmsp.ai redirects to www.openmsp.ai, so we set the base URL to the
-  // final destination to ensure canonical URLs do not require a redirect.
-  return 'https://www.openmsp.ai'
+  // Production fallback: the deploying platform's canonical www domain (avoids Google
+  // "Page with redirect"). Derived from the SSOT for the current app type (openmsp when
+  // unset → 'https://www.openmsp.ai', byte-identical to the old hardcoded fallback).
+  return getPlatformProductionUrl(process.env.NEXT_PUBLIC_APP_TYPE || 'openmsp')
 }

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -1,5 +1,10 @@
 // Utils exports - client-side only
-export { cn, getAllPlatformBaseDomains } from './cn'
+export { cn } from './cn'
+// Platform→domain SSOT lives in `../platform-domains` (single definition). Re-exported
+// here so existing `/utils` callers keep working; the new resolver/helpers
+// (getPlatformByHostname/hostOf/expandWwwApex/…) are exposed via the `/platform-domains`
+// subpath ONLY (one import surface for the new API).
+export { getPlatformProductionUrl, getAllPlatformBaseDomains } from '../platform-domains'
 // Number / currency / byte / date formatters live in `./format` (single
 // source of truth). Re-exported here so existing callers that pull from
 // the barrel keep working without changing imports.
@@ -8,7 +13,7 @@ export { formatDate, formatNumber, formatPrice, formatBytes } from './format'
 export { PLAY_ICON_PATH } from '../components/icons-v2-generated/media-playback/play-icon'
 export { getPlatformAccentColor, getCurrentPlatform, type ColorCategory, HEX_PATTERN } from './ods-color-utils'
 export { delay, generateRandomString, truncateString, deepClone, getSlackCommunityJoinUrl } from './common'
-export { getBaseUrl, getPlatformProductionUrl } from '../utils/cn'
+export { getBaseUrl } from '../utils/cn'
 
 export * from './platform-config'
 export * from './os-platforms'

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -48,6 +48,11 @@ export default defineConfig([
       // callers; new server-side callers should import from this
       // subpath directly.
       'components/features/mux-origins': 'src/components/features/mux-origins.ts',
+      // Platform-domain SSOT — pure, zero-dep, edge-safe (no React, no browser
+      // APIs, no server-only). Its own entry so the hub's Edge middleware
+      // (proxy.ts) + cors.ts can import `hostOf`/`expandWwwApex`/`isPreviewEnv`
+      // without pulling the full utils barrel into the Edge bundle.
+      'platform-domains': 'src/platform-domains.ts',
     },
     format: ['esm', 'cjs'],
     dts: false,


### PR DESCRIPTION
## What

New `src/platform-domains.ts` — **one registry** that is the single source of truth for the platform→domain fact, replacing the non-enumerable `getPlatformProductionUrl` switch + the scattered reverse map / cookie list / www-apex / URL-strip duplicates.

```
{ key, defaultUrl, envVar, aliasHostnames?, pseudo? }
getPlatformProductionUrl(key) = NEXT_PUBLIC_*_URL override ?? defaultUrl   // never throws
```

Derivations (single owner each), all from the one table:
- `getPlatformByHostname` — reverse resolver (**adds `hub.openframe.ai → openframe`**, was missing)
- `getAllPlatformBaseDomains` — cookie base-domains (**the cross-subdomain SSO mechanism**)
- `hostOf` (`.hostname`, port-stripped) / `expandWwwApex` / `toRegistrableBaseDomain` / `aliasHostsOf` / `isPreviewEnv` / `isPreviewHost`
- `./platform-domains` subpath export — pure, zero-dep, **edge-safe** (so the hub's Edge middleware + `cors.ts` can import without the `/utils` barrel)

## Why it keeps `defaultUrl` (NOT env-only)

The auth-cookie `Domain` (`*.flamingo.so` cross-hub SSO) is derived from each platform's URL. **Verified: 6 of 12 `NEXT_PUBLIC_*_URL` are unset today** (incl. openmsp + 4 of 5 `*.flamingo.so` hubs) — those hosts come from the **hardcoded fallback**, not env. So the defaults are load-bearing; pure env-only would have dropped `.flamingo.so` and broken SSO. The registry keeps `defaultUrl` as the canonical source + the env var as an override → byte-identical resolution.

## Guards + tests
- Two compile-time key guards anchor the table on `PlatformName` (`satisfies` + `Exclude` exhaustiveness); `ENV_OVERRIDES satisfies Record<EnvVarKey>` locks the irreducible env-var two-copy.
- `src/__tests__/platform-domains.test.ts` — the 🔒 cross-subdomain cookie invariant (with overrides unset **and** set), reverse map, https/port primitives, env-override no-cross-contamination.
- `cn.ts` deletes the switch; `getBaseUrl` delegates + no-arg fallback derives from the deploying platform.

## Pairs with
multi-platform-hub PR (CORS hardening + consumes this SSOT). **Published as a snapshot for the hub preview before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized platform-domain module providing canonical URL resolution, preview detection, reverse hostname lookup, alias handling, and cross-subdomain base-domain computation.
  * Environment-based URL overrides with deterministic production fallbacks.

* **Tests**
  * Comprehensive test coverage for forward/reverse resolution, aliasing, env overrides, preview detection, and registry integrity.

* **Refactor**
  * Utilities reorganized to re-export platform-domain APIs from the new central module; base URL resolution now consults the central source in production.

* **Chores**
  * Build/package entry added to support edge-safe imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->