### PR TITLE
fix(platform-domains): scheme-less env normalization + cookie guard/match shell

### DIFF
--- a/openframe-frontend-core/src/__tests__/platform-domains.test.ts
+++ b/openframe-frontend-core/src/__tests__/platform-domains.test.ts
@@ -9,6 +9,9 @@ import {
   expandWwwApex,
   toRegistrableBaseDomain,
   aliasHostsOf,
+  ensureScheme,
+  isNonCookieableHost,
+  matchCookieDomain,
 } from '@/platform-domains'
 
 /**
@@ -149,5 +152,38 @@ describe('registry integrity', () => {
   it('byKey resolves every key and openframe-dashboard is pseudo', () => {
     expect(byKey('openframe-dashboard')?.pseudo).toBe(true)
     expect(byKey('not-a-platform')).toBeUndefined()
+  })
+})
+
+describe('ensureScheme', () => {
+  it('adds https:// to a bare host, leaves a scheme\'d URL untouched', () => {
+    expect(ensureScheme('www.openmsp.ai')).toBe('https://www.openmsp.ai')
+    expect(ensureScheme('https://www.openmsp.ai')).toBe('https://www.openmsp.ai')
+    expect(ensureScheme('http://localhost:3000')).toBe('http://localhost:3000')
+  })
+  it('normalizes a protocol-relative //host (NOT https:////host → empty-host drop)', () => {
+    expect(ensureScheme('//hub.openframe.ai')).toBe('https://hub.openframe.ai')
+    expect(hostOf(ensureScheme('//hub.openframe.ai'))).toBe('hub.openframe.ai')
+  })
+})
+
+describe('cookie-domain guard + match (shared SSOT primitives)', () => {
+  it('isNonCookieableHost flags localhost / private IPs / *.vercel.app, not real hosts', () => {
+    for (const h of ['localhost', '127.0.0.1', '127.5.5.5', '192.168.1.2', '10.0.0.1', 'x.vercel.app']) {
+      expect(isNonCookieableHost(h)).toBe(true)
+    }
+    for (const h of ['www.openmsp.ai', 'marketing-hub.flamingo.so', 'hub.openframe.ai']) {
+      expect(isNonCookieableHost(h)).toBe(false)
+    }
+  })
+  it('matchCookieDomain returns the dotted base for a contained host (incl. apex), else undefined', () => {
+    const bases = ['.flamingo.so', '.openmsp.ai']
+    expect(matchCookieDomain('marketing-hub.flamingo.so', bases)).toBe('.flamingo.so')
+    expect(matchCookieDomain('flamingo.so', bases)).toBe('.flamingo.so')
+    expect(matchCookieDomain('app.openmsp.ai', bases)).toBe('.openmsp.ai')
+    expect(matchCookieDomain('evil.com', bases)).toBeUndefined()
+  })
+  it('matchCookieDomain accepts dotless bases and still returns the dotted form', () => {
+    expect(matchCookieDomain('foo.tmcg.miami', ['tmcg.miami'])).toBe('.tmcg.miami')
   })
 })

--- a/openframe-frontend-core/src/__tests__/platform-domains.test.ts
+++ b/openframe-frontend-core/src/__tests__/platform-domains.test.ts
@@ -127,6 +127,22 @@ describe('env override path', () => {
       expect(mod.getPlatformProductionUrl(k)).toBe('https://sentinel-flamingo.example')
     }
   })
+  it('normalizes a SCHEME-LESS override to https:// (Vercel stores bare hosts)', async () => {
+    vi.stubEnv('NEXT_PUBLIC_OPENMSP_URL', 'www.openmsp.ai') // no scheme, as in the shared-env store
+    vi.stubEnv('NEXT_PUBLIC_OPENFRAME_URL', 'hub.openframe.ai')
+    vi.resetModules()
+    const mod = await import('@/platform-domains')
+    expect(mod.getPlatformProductionUrl('openmsp')).toBe('https://www.openmsp.ai')
+    expect(mod.getPlatformProductionUrl('openframe')).toBe('https://hub.openframe.ai')
+  })
+  it('a scheme-less override still parses for hostOf + cookie-base derivation', async () => {
+    vi.stubEnv('NEXT_PUBLIC_OPENMSP_URL', 'www.openmsp.ai')
+    vi.resetModules()
+    const mod = await import('@/platform-domains')
+    // the whole point: hostOf no longer returns null on the (normalized) override
+    expect(mod.hostOf(mod.getPlatformProductionUrl('openmsp'))).toBe('www.openmsp.ai')
+    expect(mod.toRegistrableBaseDomain(mod.hostOf(mod.getPlatformProductionUrl('openmsp'))!)).toBe('openmsp.ai')
+  })
 })
 
 describe('registry integrity', () => {

--- a/openframe-frontend-core/src/components/vendor-display-button.tsx
+++ b/openframe-frontend-core/src/components/vendor-display-button.tsx
@@ -15,9 +15,10 @@ interface VendorDisplayButtonProps {
 export function VendorDisplayButton({ vendor, onClick, variant = 'default', externalUrl }: VendorDisplayButtonProps) {
   const handleClick = () => {
     if (externalUrl && vendor.slug) {
-      // Use environment variable or fallback to provided URL
-      const baseUrl = process.env.NEXT_PUBLIC_OPENMSP_URL || externalUrl
-      window.open(`${baseUrl}/vendor/${vendor.slug}`, '_blank', 'noopener,noreferrer')
+      // `externalUrl` is the caller-resolved platform base URL (the openmsp SSOT via
+      // getPlatformProductionUrl, scheme-normalized). The old `process.env.NEXT_PUBLIC_OPENMSP_URL`
+      // override is gone — it's stored scheme-less, which made this a relative window.open().
+      window.open(`${externalUrl}/vendor/${vendor.slug}`, '_blank', 'noopener,noreferrer')
     } else if (onClick && vendor.slug) {
       onClick(vendor.slug)
     }

--- a/openframe-frontend-core/src/platform-domains.ts
+++ b/openframe-frontend-core/src/platform-domains.ts
@@ -91,18 +91,31 @@ function envOverrideFor(key: string): string | null {
 }
 
 /**
+ * Ensure a URL string carries a scheme. Per-deploy `NEXT_PUBLIC_*_URL` overrides are
+ * stored SCHEME-LESS (bare host, e.g. `www.openmsp.ai` / `hub.openframe.ai`) — the
+ * canonical convention in the Vercel shared-env store. This normalizes them to a full
+ * `https://` URL so every downstream consumer (`hostOf`/`new URL`, hrefs, the cookie
+ * base-domain derivation, CSP) receives a parseable URL. Full-URL inputs (the registry
+ * `defaultUrl`s, any scheme'd override) pass through unchanged.
+ */
+function ensureScheme(url: string): string {
+  return url.includes('://') ? url : `https://${url}`
+}
+
+/**
  * Canonical production URL for a platform: env override wins, else the `defaultUrl`.
  * NEVER throws / undefined — the default guarantees a host (this is what keeps the
  * cookie base-domains, the reverse map, and CSP intact even with every override unset).
- * Byte-identical to the old cn.ts switch (incl. the unknown-key flamingo.run fallback).
+ * The result ALWAYS carries a scheme (`ensureScheme`), so the scheme-less env overrides
+ * resolve to valid URLs. Unknown-key fallback preserves cn.ts's flamingo.run default.
  */
 export function getPlatformProductionUrl(platform: string): string {
-  return (
+  const resolved =
     envOverrideFor(platform) ??
     byKey(platform)?.defaultUrl ??
     envOverrideFor('flamingo') ??
     'https://www.flamingo.run'
-  )
+  return ensureScheme(resolved)
 }
 
 // ── Single-owner host primitives ──

--- a/openframe-frontend-core/src/platform-domains.ts
+++ b/openframe-frontend-core/src/platform-domains.ts
@@ -97,9 +97,18 @@ function envOverrideFor(key: string): string | null {
  * `https://` URL so every downstream consumer (`hostOf`/`new URL`, hrefs, the cookie
  * base-domain derivation, CSP) receives a parseable URL. Full-URL inputs (the registry
  * `defaultUrl`s, any scheme'd override) pass through unchanged.
+ *
+ * EXPORTED as the single owner of the scheme-normalization rule (next.config.mjs keeps a
+ * byte-identical local copy ONLY because Next evaluates its config outside the TS module
+ * graph and cannot import this — see the comment there).
+ *
+ * Handles a (theoretical) protocol-relative `//host` too: strips the leading slashes so it
+ * doesn't become `https:////host` (empty-host → hostOf null → silent platform drop).
  */
-function ensureScheme(url: string): string {
-  return url.includes('://') ? url : `https://${url}`
+export function ensureScheme(url: string): string {
+  const trimmed = url.trim()
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return trimmed // already has a scheme
+  return `https://${trimmed.replace(/^\/+/, '')}` // bare host or protocol-relative `//host`
 }
 
 /**
@@ -232,20 +241,59 @@ export function getAllPlatformBaseDomains(): string[] {
   return Array.from(baseDomains)
 }
 
+// ── Cookie-domain guard + match (single owner; shared by the client cookie-domain.ts +
+//    server-only cookie-domain-server.ts resolvers, which previously hand-rolled both 3×) ──
+
+/**
+ * Hosts that must NOT receive a `Domain=` cookie → the caller returns undefined (host-only):
+ * localhost, loopback/private IPs, and any `*.vercel.app`. `vercel.app` is on the Public Suffix
+ * List, so browsers SILENTLY drop `Set-Cookie: Domain=.vercel.app` — which broke the PKCE verifier
+ * + session cookies on preview deploys. Host-only is sufficient there (the same preview host
+ * round-trips the OAuth chain); production hosts (`.flamingo.so`/`.openmsp.ai`/…) fall through.
+ */
+export function isNonCookieableHost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.startsWith('127.') ||
+    hostname.startsWith('192.168.') ||
+    hostname.startsWith('10.') ||
+    hostname.includes('.vercel.app')
+  )
+}
+
+/**
+ * Match a hostname against a set of registrable base domains → the dotted cookie `Domain`
+ * (`.flamingo.so`), or undefined when none contains the host. Accepts bases with or without a
+ * leading dot and always returns the dotted form. Single owner for the match loop both resolvers ran.
+ */
+export function matchCookieDomain(hostname: string, baseDomains: string[]): string | undefined {
+  for (const domain of baseDomains) {
+    const bare = domain.startsWith('.') ? domain.slice(1) : domain
+    if (hostname === bare || hostname.endsWith(`.${bare}`)) {
+      return domain.startsWith('.') ? domain : `.${domain}`
+    }
+  }
+  return undefined
+}
+
 // ── Module-load ordering self-check (NON-fatal — this module is imported by cn.ts → ~everything,
-// so a hard throw would be a total outage if the assertion were ever over-strict). A reorder that
-// moves flamingo-teaser/universal before flamingo (e.g. an IDE alphabetize) surfaces loudly in the
-// build + prod logs instead of silently cross-tabbing flamingo links to the wrong owner. The
-// authoritative guard is the reverse-map vitest (src/__tests__/platform-domains.test.ts). ⚠️ keep
-// `flamingo` before `flamingo-teaser`/`universal` in PLATFORM_DOMAINS.
+// so a hard throw would be a total outage if the assertion were ever over-strict). Checks the REAL
+// invariant — table order — STRUCTURALLY (findIndex), NOT via getPlatformByHostname on a hardcoded
+// host: the latter false-positives when NEXT_PUBLIC_FLAMINGO_URL is overridden to a non-default host
+// (flamingo's resolved host changes, so `www.flamingo.run` no longer reverse-maps to it though the
+// ordering is fine). The alias checks below ARE env-immune (aliasHostnames are unique per key). The
+// authoritative guard is the reverse-map vitest. ⚠️ keep `flamingo` before `flamingo-teaser`/`universal`.
+const _orderIdx = (k: PlatformDomainKey) => PLATFORM_DOMAINS.findIndex((e) => e.key === k)
 if (
-  getPlatformByHostname('www.flamingo.run') !== 'flamingo' ||
+  _orderIdx('flamingo') > _orderIdx('flamingo-teaser') ||
+  _orderIdx('flamingo') > _orderIdx('universal') ||
   getPlatformByHostname('flamingo.cx') !== 'flamingo-teaser' ||
   getPlatformByHostname('hub.openframe.ai') !== 'openframe'
 ) {
   // eslint-disable-next-line no-console
   console.error(
     '[platform-domains] ⚠️ PLATFORM_DOMAINS ordering invariant violated — `flamingo` must precede ' +
-      '`flamingo-teaser`/`universal`, and the openframe aliases must be intact. Do not reorder the table.',
+      '`flamingo-teaser`/`universal`, and the openframe/teaser aliases must be intact. Do not reorder the table.',
   )
 }


### PR DESCRIPTION
Follow-up to #1138 (the platform→domain SSOT). Two related hardening changes the hub consumes.

## 1. Scheme-less env normalization
The Vercel shared-env store keeps the `NEXT_PUBLIC_*_URL` platform overrides **scheme-less** (bare host, e.g. `www.openmsp.ai` / `hub.openframe.ai`) — the team convention. `new URL('hub.openframe.ai')` throws → `hostOf()` returned null → the platform silently dropped out of the reverse-map host resolution + the cookie base-domain set, and `getBaseUrl()` produced a relative href.

- `getPlatformProductionUrl()` now runs every resolved value through **`ensureScheme()`** (`value` has `://` ? unchanged : `https://` + value), so a bare-host override resolves to a valid URL. Scheme'd inputs (the registry `defaultUrl`s, any future scheme'd override) pass through untouched — the store can re-add a scheme later with zero code change.
- `ensureScheme` is **exported** (single owner of the rule) and hardened for a protocol-relative `//host` (strips leading slashes so it can't become `https:////host`).
- `vendor-display-button.tsx` drops its raw `process.env.NEXT_PUBLIC_OPENMSP_URL` read (it preferred the scheme-less env over the caller's `externalUrl` → relative `window.open`); the caller now passes the SSOT-resolved URL.

## 2. Cookie guard/match shell (single owner)
The hub's client (`cookie-domain.ts`) and server (`cookie-domain-server.ts`) cookie-domain resolvers each hand-rolled the localhost/private-IP/`*.vercel.app` guard + the base-domain match loop (3 copies total) plus a local `extractBaseDomain`. This PR adds the two primitives they now consume:

- **`isNonCookieableHost(hostname)`** — host-only guard (localhost / loopback / private IP / `*.vercel.app` PSL).
- **`matchCookieDomain(hostname, baseDomains)`** — hostname → dotted cookie `Domain`, else undefined.

(The hub-side fold lives in the paired hub PR.)

## Also
- The module-load ordering self-check is now **structural** (`findIndex`) instead of `getPlatformByHostname` on a hardcoded host — so a non-default `NEXT_PUBLIC_FLAMINGO_URL` override can't false-positive it; the env-immune alias checks stay.

**29/29 platform-domains tests pass** (added `ensureScheme` protocol-relative + cookie-helper coverage). SSO invariant unchanged (defaults still emit every base domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * URLs are now consistently normalized with proper HTTPS scheme prefixes.
  * Enhanced cookie domain handling for localhost, private IP addresses, and preview environments.

* **Changes**
  * Vendor button URL resolution behavior updated to use only the provided external URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->