### PR TITLE
feat(related-content): RelatedContentSection moved into lib + dual-mode suggestion sections

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -60,6 +60,12 @@
       "require": "./dist/components/faq/index.cjs",
       "default": "./dist/components/faq/index.js"
     },
+    "./components/related-content": {
+      "types": "./dist/components/related-content/index.d.ts",
+      "import": "./dist/components/related-content/index.js",
+      "require": "./dist/components/related-content/index.cjs",
+      "default": "./dist/components/related-content/index.js"
+    },
     "./components/faq/json-ld": {
       "types": "./dist/components/faq/json-ld.d.ts",
       "import": "./dist/components/faq/json-ld.js",

--- a/openframe-frontend-core/src/components/chat/entity-cards/onboarding-guide-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/onboarding-guide-card.tsx
@@ -55,6 +55,21 @@ export interface OnboardingGuideCardProps {
   className?: string
 }
 
+/** Markdown source → clean one-line preview prose. The guide cards preview
+ *  `video_summary || content`, and `content` is raw markdown — without this,
+ *  the clamped summary shows literal `**bold**` / `## heading` noise. */
+function stripMarkdownPreview(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[*_~`>]/g, '')
+    .replace(/^\s*[-+]\s+/gm, '')
+    .replace(/-{3,}/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 const HORIZONTAL_SIZE_TOKENS = {
   default: {
     padding: 'p-4',
@@ -236,7 +251,7 @@ export function OnboardingGuideCard({
               </div>
               <div className="min-h-[46px] md:min-h-[52px]">
                 <p className="font-['DM_Sans'] text-sm md:text-base text-ods-text-secondary leading-relaxed line-clamp-2">
-                  {(guide.video_summary || guide.content || '').trim()}
+                  {stripMarkdownPreview(guide.video_summary || guide.content || '')}
                 </p>
               </div>
             </div>
@@ -263,7 +278,7 @@ export function OnboardingGuideCard({
     const coverImage = guide.featured_image || guide.main_video_thumbnail || guide.og_image_url || null
     const compactCover = coverImage || placeholderUrl || null
     const hasVideoCover = !guide.featured_image && !!guide.main_video_thumbnail
-    const summary = (guide.video_summary || guide.content || '').trim()
+    const summary = stripMarkdownPreview(guide.video_summary || guide.content || '')
     const author = guide.author?.full_name?.trim() || ''
     const subtitleParts = [
       `Step ${guide.step_order}`,
@@ -319,7 +334,7 @@ export function OnboardingGuideCard({
 
   // size === 'default' — horizontal step-numbered card for related-rail.
   const t = HORIZONTAL_SIZE_TOKENS.default
-  const summary = (guide.video_summary || guide.content || '').trim()
+  const summary = stripMarkdownPreview(guide.video_summary || guide.content || '')
 
   return (
     <Link

--- a/openframe-frontend-core/src/components/chat/entity-cards/onboarding-guide-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/onboarding-guide-card.tsx
@@ -68,6 +68,11 @@ function stripMarkdownPreview(text: string): string {
     .replace(/-{3,}/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+    // Hard cap — line-clamp is the visual truncation, but a CSS-order
+    // conflict (display utilities vs -webkit-box) once silently killed it
+    // and dumped whole guides into the card. Never ship more than ~2 lines
+    // of source text regardless of CSS.
+    .replace(/^([\s\S]{240})[\s\S]+$/, '$1…')
 }
 
 const HORIZONTAL_SIZE_TOKENS = {
@@ -360,7 +365,7 @@ export function OnboardingGuideCard({
           <span className="truncate">{guide.section}</span>
         </span>
         {summary && (
-          <span className={`block font-['DM_Sans'] text-[14px] leading-[20px] text-ods-text-secondary ${t.summaryClamp}`}>
+          <span className={`font-['DM_Sans'] text-[14px] leading-[20px] text-ods-text-secondary ${t.summaryClamp}`}>
             {summary}
           </span>
         )}

--- a/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
@@ -22,6 +22,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useRequiredChatRuntime } from '../../../contexts/chat-runtime-context'
 import { embedAuthedFetch } from '../../../utils/embed-authed-fetch'
+import { extractItems, extractItemId } from '../../../utils/extract-items'
 
 export interface UseChatCardItemResult<T = unknown> {
   item: T | undefined
@@ -29,44 +30,8 @@ export interface UseChatCardItemResult<T = unknown> {
   isError: boolean
 }
 
-/** Extract the items array from each endpoint's response shape (some
- *  return `{ items }`, others `{ posts }`, etc.). Single normalization
- *  point — callers always read `Item[]`. */
-function extractItems(data: unknown): unknown[] {
-  if (!data || typeof data !== 'object') return []
-  const obj = data as Record<string, unknown>
-  if (Array.isArray(obj.items)) return obj.items
-  if (Array.isArray(obj.posts)) return obj.posts
-  if (Array.isArray(obj.campaigns)) return obj.campaigns
-  if (Array.isArray(obj.completed) || Array.isArray(obj.inProgress)) {
-    // Delivery endpoint splits into completed/inProgress arrays — flatten.
-    const completed = Array.isArray(obj.completed) ? obj.completed : []
-    const inProgress = Array.isArray(obj.inProgress) ? obj.inProgress : []
-    return [...completed, ...inProgress]
-  }
-  if (Array.isArray(obj.data)) return obj.data
-  if (Array.isArray(data)) return data
-  return []
-}
-
-/** Extract a stable id from a fetched item — different shapes use
- *  `id` vs `external_id`. Used by the chat loader to match the fetched
- *  array element back to the marker's id. */
-function extractItemId(type: string, item: unknown): string | null {
-  if (!item || typeof item !== 'object') return null
-  const obj = item as Record<string, unknown>
-  if (type === 'roadmap_item' || type === 'delivery_item' || type === 'internal_task') {
-    const ext = obj.external_id
-    if (typeof ext === 'string') return ext
-  }
-  // RoadmapItem-shaped responses use `id` to carry the external_id; the
-  // mapper renames external_id→id at the API boundary. Treat both id and
-  // external_id as primary-key candidates for these clickup-backed types.
-  const id = obj.id
-  if (typeof id === 'string') return id
-  if (typeof id === 'number') return String(id)
-  return null
-}
+// `extractItems` / `extractItemId` hoisted to `src/utils/extract-items.ts`
+// (shared with the related-content rail — react-query-free home).
 
 export function useChatCardItem<T = unknown>(
   type: string,

--- a/openframe-frontend-core/src/components/chat/types/entities/content-ref.ts
+++ b/openframe-frontend-core/src/components/chat/types/entities/content-ref.ts
@@ -1,23 +1,7 @@
 /**
- * ContentRef — the unified link/embed shape stored in JSONB columns
- * across investor updates, performance baselines, and any other entity
- * that surfaces "related content" rails.
- *
- * Lifted from `lib/data/investor-update-utils-shared.ts` in the hub
- * (the server-side data utils in the same file stay hub-side; only the
- * TYPE moves here).
+ * RELOCATED — the canonical `ContentRef` now lives at `src/types/content-ref.ts`
+ * (server-safe home, shared by the related-content rail + chat entities).
+ * This stub keeps the chat entities barrel + `entities/investor-update.ts`
+ * compiling unchanged. One definition package-wide.
  */
-
-export interface ContentRef {
-  type: string;
-  id: string;
-  slug: string;
-  url: string;
-  targetPlatform?: string | null;
-  title: string;
-  summary?: string;
-  image_url?: string;
-  image_bg_color?: string;
-  visibility: 'public' | 'internal';
-  display_order: number;
-}
+export type { ContentRef, ContentRefWithReason } from '../../../../types/content-ref';

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import type { Faq } from '../../types/faq'
 import { FaqAccordion, type FaqItem } from '../faq-accordion'
 import { useSelfFetch } from '../../hooks/use-self-fetch'
+import { buildSuggestionUrl } from '../../utils/suggestion-url'
 import { buildFaqJsonLdFromFaqs, type FaqSchemaOptions } from './json-ld'
 
 export interface FaqSectionProps {
@@ -28,16 +29,26 @@ export interface FaqSectionProps {
   /** Overrides for the JSON-LD's name/description/url. */
   jsonLd?: FaqSchemaOptions
   className?: string
+  /** Maps to /api/faqs `?count=` (the 5-tier fill target). Absent → param
+   *  not sent (server default applies). */
+  minResults?: number
+  /** Fetch-URL prefix for third-party embeds / reverse proxies
+   *  ('' = same-origin relative). */
+  apiBaseUrl?: string
 }
 
 const DEFAULT_HEADING_TEXT = 'Frequently Asked Questions'
 
-function buildFaqsUrl(entityType?: string, entityId?: number | string): string {
-  if (!entityType || entityId === undefined || entityId === null || entityId === '') {
-    return '/api/faqs'
-  }
-  const qs = new URLSearchParams({ entityType, entityId: String(entityId) })
-  return `/api/faqs?${qs.toString()}`
+/** URL composition shared with RelatedContentSection (`buildSuggestionUrl`)
+ *  — byte-identical to the historical `buildFaqsUrl` output when
+ *  `minResults`/`apiBaseUrl` are absent. */
+function buildFaqsUrl(
+  entityType?: string,
+  entityId?: number | string,
+  minResults?: number,
+  apiBaseUrl = '',
+): string {
+  return buildSuggestionUrl('/api/faqs', { apiBaseUrl, entityType, entityId, count: minResults })
 }
 
 function groupBySection(faqs: Faq[]): Array<{ section: string | null; items: FaqItem[] }> {
@@ -97,9 +108,16 @@ export function FaqSection({
   emitJsonLd = false,
   jsonLd,
   className,
+  minResults,
+  apiBaseUrl = '',
 }: FaqSectionProps) {
-  const url = buildFaqsUrl(entityType, entityId)
-  const initialData = initialFaqs ? { faqs: initialFaqs } : undefined
+  const url = buildFaqsUrl(entityType, entityId, minResults, apiBaseUrl)
+  // Memoized — useSelfFetch re-syncs on [initialData]; a fresh per-render
+  // wrapper object would setState-loop under re-rendering parents.
+  const initialData = useMemo<FaqsResponse | undefined>(
+    () => (initialFaqs ? { faqs: initialFaqs } : undefined),
+    [initialFaqs],
+  )
   const { data, isLoading, error } = useSelfFetch<FaqsResponse>(url, { initialData })
 
   const faqs = data?.faqs ?? []
@@ -116,7 +134,24 @@ export function FaqSection({
     return null
   }
 
+  // Embedded mode, zero FAQs after load: render nothing — an embedded host
+  // page (blog/case-study detail) must not show an empty section shell.
+  // The standalone /faqs page (heading set) keeps its existing behavior.
+  if (!isLoading && !error && faqs.length === 0 && !showHeading) {
+    return null
+  }
+
   if (isLoading && faqs.length === 0) {
+    // Embedded mode renders skeletons WITHOUT the standalone page shell —
+    // a host detail page already provides <main> + gutters; nesting them
+    // here would emit invalid markup and double padding.
+    if (!showHeading) {
+      return (
+        <div className={className}>
+          <FaqSkeleton />
+        </div>
+      )
+    }
     return (
       <main className={className ?? 'bg-ods-bg'}>
         <div className="max-w-[1920px] px-6 md:px-20 py-6 md:py-10 mx-auto">
@@ -136,23 +171,33 @@ export function FaqSection({
 
   const schema = emitJsonLd ? buildFaqJsonLdFromFaqs(faqs, jsonLd) : null
 
+  const groupNodes = groups.map(({ section, items }) => (
+    <div key={section || 'default'} className="space-y-4">
+      {section && (
+        <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary mb-3 md:mb-4">
+          {section}
+        </h2>
+      )}
+      <FaqAccordion items={items} />
+    </div>
+  ))
+
+  // Embedded mode (heading === null): no <main> page shell, no page gutters —
+  // the host page owns layout. Standalone mode keeps the historical markup.
+  const body = showHeading ? (
+    <main className={className ?? 'bg-ods-bg'}>
+      <div className="max-w-[1920px] px-6 md:px-20 py-6 md:py-10 mx-auto space-y-10">
+        {headingNode}
+        {groupNodes}
+      </div>
+    </main>
+  ) : (
+    <section className={className ?? 'space-y-10'}>{groupNodes}</section>
+  )
+
   return (
     <>
-      <main className={className ?? 'bg-ods-bg'}>
-        <div className="max-w-[1920px] px-6 md:px-20 py-6 md:py-10 mx-auto space-y-10">
-          {showHeading && headingNode}
-          {groups.map(({ section, items }) => (
-            <div key={section || 'default'} className="space-y-4">
-              {section && (
-                <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary mb-3 md:mb-4">
-                  {section}
-                </h2>
-              )}
-              <FaqAccordion items={items} />
-            </div>
-          ))}
-        </div>
-      </main>
+      {body}
       {schema && (
         <script
           type="application/ld+json"

--- a/openframe-frontend-core/src/components/index.ts
+++ b/openframe-frontend-core/src/components/index.ts
@@ -26,6 +26,7 @@ export * from './faq-accordion'
 // dedicated server-safe subpath "./components/faq/json-ld" (built without the
 // client banner under the server/universal block of tsup.config.ts).
 export * from './faq'
+export * from './related-content'
 export * from './filter-chip'
 export * from './footer'
 export * from './unified-filter-logic'

--- a/openframe-frontend-core/src/components/onboarding-guides/onboarding-guide-detail-view.tsx
+++ b/openframe-frontend-core/src/components/onboarding-guides/onboarding-guide-detail-view.tsx
@@ -19,7 +19,11 @@ import { type ComponentType, type ReactNode } from 'react'
 import { ArrowLeft } from 'lucide-react'
 
 import { Link } from '../../embed-shims'
-import { ArticleDetailLayout } from '../layout/article-detail-layout'
+// PageShell (max-w-[1920px]) — the guide detail content must share the SAME
+// container sizing as the related-content/FAQ rail the host page renders
+// below it (which uses the wide shell). ArticleDetailLayout (1280px) made
+// the detail block visibly narrower than the rail.
+import { PageShell } from '../layout/article-detail-layout'
 import { DetailPageSkeleton } from '../shared/detail-page-skeleton'
 import { EntityVideoSection } from '../features/entity-video-section'
 import { VideoBitesDisplay } from '../features/video-bites-display'
@@ -116,7 +120,7 @@ export function OnboardingGuideDetailView({
   const renderRelatedCardFn = renderRelatedCard ?? defaultRenderRelatedCard
 
   return (
-    <ArticleDetailLayout>
+    <PageShell>
       <div className="space-y-6 md:space-y-8">
         {/* Back link */}
         <Link
@@ -195,6 +199,6 @@ export function OnboardingGuideDetailView({
           </div>
         )}
       </div>
-    </ArticleDetailLayout>
+    </PageShell>
   )
 }

--- a/openframe-frontend-core/src/components/onboarding-guides/onboarding-guides-catalog-skeleton.tsx
+++ b/openframe-frontend-core/src/components/onboarding-guides/onboarding-guides-catalog-skeleton.tsx
@@ -1,46 +1,41 @@
 'use client'
 
-import { DevSectionPage } from '../shared/dev-section'
 import { OnboardingGuideCardSkeleton } from '../chat/entity-cards/onboarding-guide-card'
 
 /**
- * Page-level Suspense fallback for `/onboarding-guides`.
+ * Loading skeleton for `/onboarding-guides` — CHROME-LESS, exactly like the
+ * loaded `<OnboardingGuidesCatalogView>`. The HOST page owns the
+ * `<DevSectionPage sectionKey="onboarding">` shell (hero + back button);
+ * this component renders only what replaces the view: the search/pill
+ * placeholder block and the section card lists.
  *
- * Mirrors the loaded `<OnboardingGuidesCatalogView>` shape — both
- * mount the same `<DevSectionPage sectionKey="onboarding">` so the
- * hero, back button, and overall page scaffold render identically.
+ * HISTORY: this used to mount its own `<DevSectionPage>` — nested inside the
+ * page's shell that double-rendered the hero + back button during loading
+ * (the view was made chrome-less in the page restructure; the skeleton was
+ * missed). Keep BOTH chrome-less.
  *
- * The `preControls` slot reserves space for the search bar (h-12)
- * plus the section pill row (~74px including padding) so the
- * Suspense → loaded transition doesn't shift vertically.
- *
- * Card distribution `4 + 3 + 3 = 10` matches the typical openframe
- * onboarding dataset; per-card height (288 px) is byte-identical to
- * the loaded card so per-card shifts on resolve are zero.
+ * Wrapper mirrors the loaded view's `w-full flex flex-col gap-10`; per-card
+ * height matches the loaded catalog card so resolve shifts are zero.
  */
 export function OnboardingGuidesCatalogSkeleton() {
   return (
-    <DevSectionPage
-      sectionKey="onboarding"
-      preControls={
-        <div className="space-y-4 animate-pulse">
-          {/* Search input placeholder — matches `<SearchInput>` h-12. */}
-          <div className="h-12 w-full bg-ods-card border border-ods-border rounded-md" />
-          {/* Section pill row placeholder — same wrapper class set the
-              hub-side `<FilterSection>` uses (~74 px). */}
-          <div className="flex flex-wrap items-center gap-3 p-4 bg-ods-card border border-ods-border rounded-lg">
-            <div className="h-4 w-14 bg-ods-border/60 rounded" />
-            {[0, 1, 2, 3].map((i) => (
-              <div
-                key={i}
-                className="h-10 w-24 bg-ods-card border border-ods-border rounded-md"
-              />
-            ))}
-          </div>
+    <div className="w-full flex flex-col gap-10 animate-pulse">
+      {/* Search input placeholder — matches `<SearchInput>` h-12 — plus the
+          section pill row (~74 px incl. padding), same as the loaded
+          preControls block. */}
+      <div className="space-y-4">
+        <div className="h-12 w-full bg-ods-card border border-ods-border rounded-md" />
+        <div className="flex flex-wrap items-center gap-3 p-4 bg-ods-card border border-ods-border rounded-lg">
+          <div className="h-4 w-14 bg-ods-border/60 rounded" />
+          {[0, 1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="h-10 w-24 bg-ods-card border border-ods-border rounded-md"
+            />
+          ))}
         </div>
-      }
-    >
-      <div className="space-y-10 animate-pulse">
+      </div>
+      <div className="space-y-10">
         {[4, 3, 3].map((cardCount, sectionIdx) => (
           <section key={sectionIdx} className="space-y-4">
             <h2 className="text-h3 tracking-[-0.36px] text-ods-text-primary flex items-center gap-2">
@@ -57,6 +52,6 @@ export function OnboardingGuidesCatalogSkeleton() {
           </section>
         ))}
       </div>
-    </DevSectionPage>
+    </div>
   )
 }

--- a/openframe-frontend-core/src/components/related-content/index.ts
+++ b/openframe-frontend-core/src/components/related-content/index.ts
@@ -1,0 +1,9 @@
+// CLIENT subpath barrel — `@flamingo-stack/openframe-frontend-core/components/related-content`
+export {
+  RelatedContentSection,
+  type RelatedContentSectionProps,
+  type CardLinkProvider,
+  type CardLinkProviderProps,
+  type CardLinkAnchorProps,
+  type AdminCampaignCardSlot,
+} from './related-content-section'

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -52,7 +52,7 @@ import {
 import type { ContentRef, ContentRefWithReason } from '../../types/content-ref';
 import { useSelfFetch } from '../../hooks/use-self-fetch';
 import { extractItems } from '../../utils/extract-items';
-import { buildListUrl as libBuildListUrl } from '../../utils/list-url';
+import { buildListUrl as libBuildListUrl, canonicalContentRefType } from '../../utils/list-url';
 import { buildSuggestionUrl } from '../../utils/suggestion-url';
 import { decideNewTab } from '../chat/utils/decide-new-tab';
 // DEEP card imports — NOT the `../chat` barrel (the barrel statically reaches
@@ -441,9 +441,15 @@ export interface RelatedContentSectionProps {
    *  `contentRefs` is provided. */
   entityType?: string;
   entityId?: number | string;
-  /** Maps to the suggestion API's `count` param. Absent → param not sent
+  /** Maps to the suggestion API's `count` param — the PER-TYPE fill target
+   *  for every candidate type EXCEPT the host's own. Absent → param not sent
    *  (server default applies). */
   minResults?: number;
+  /** Maps to the suggestion API's `sameTypeCount` param — the budget for the
+   *  candidate type MATCHING the host's own `entityType` (same-type boost:
+   *  a blog post's rail leads with more blog posts). Absent → param not
+   *  sent (host's type uses the server's `count`). */
+  sameTypeMinResults?: number;
   /** SSR hydrate for suggestion mode — the server page ran the engine and
    *  drills the refs here; the first client fetch is skipped (useSelfFetch
    *  initialData contract). */
@@ -493,6 +499,7 @@ export function RelatedContentSection({
   entityType,
   entityId,
   minResults,
+  sameTypeMinResults,
   initialItems,
   title = 'Related Content',
   columns = 2,
@@ -517,6 +524,7 @@ export function RelatedContentSection({
           entityId,
           count: minResults,
           extraParams: {
+            sameTypeCount: sameTypeMinResults !== undefined ? String(sameTypeMinResults) : undefined,
             excludeTypes: excludeTypes && excludeTypes.length > 0 ? excludeTypes.join(',') : undefined,
           },
         })
@@ -558,7 +566,17 @@ export function RelatedContentSection({
   // Registered types in CONTENT_REF_GROUPS order, then any unregistered
   // types appended (same shape the investor-email builder uses — both
   // consume `orderContentRefTypes` so cross-surface ordering matches).
-  const orderedTypes = orderContentRefTypes(Object.keys(grouped));
+  // SAME-TYPE FIRST: when a host entityType is known (suggestion / SSR
+  // modes), its own content-type group is hoisted to the top — a blog
+  // post's rail leads with blog posts. Rail group keys are compared via
+  // the shared alias canonicalizer (blog_post_existing ↔ blog_post).
+  let orderedTypes = orderContentRefTypes(Object.keys(grouped));
+  if (entityType) {
+    const sameType = orderedTypes.filter((t) => canonicalContentRefType(t) === entityType);
+    if (sameType.length > 0) {
+      orderedTypes = [...sameType, ...orderedTypes.filter((t) => canonicalContentRefType(t) !== entityType)];
+    }
+  }
 
   return (
     <div className="space-y-8">

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -51,7 +51,7 @@ import {
 } from '../../utils/content-ref-groups';
 import type { ContentRef, ContentRefWithReason } from '../../types/content-ref';
 import { useSelfFetch } from '../../hooks/use-self-fetch';
-import { extractItems } from '../../utils/extract-items';
+import { extractItems, extractItemId } from '../../utils/extract-items';
 import { buildListUrl as libBuildListUrl, canonicalContentRefType } from '../../utils/list-url';
 import { buildSuggestionUrl } from '../../utils/suggestion-url';
 import { decideNewTab } from '../chat/utils/decide-new-tab';
@@ -389,7 +389,11 @@ function ContentGroup({
   // display_order). The list APIs return rows date-sorted, which would
   // otherwise scramble that ordering (same-platform items sinking below
   // newer cross-platform ones).
-  const itemById = new Map((items as any[]).map((it) => [String(it.id), it]));
+  // Shared extractor (NOT raw `.id`) — some API shapes key items differently
+  // (e.g. external_id types); raw access would silently drop valid items.
+  const itemById = new Map(
+    (items as any[]).map((it) => [extractItemId(type, it) ?? String((it as any)?.id), it]),
+  );
 
   const cards = refs
     .map((contentRef) => {

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -342,6 +342,7 @@ function ContentGroup({
   type,
   refs,
   columns,
+  forceGridLayout,
   buildUrl,
   resolveHref,
   LinkProvider,
@@ -351,6 +352,7 @@ function ContentGroup({
   type: string;
   refs: ContentRef[];
   columns: 2 | 3;
+  forceGridLayout?: boolean;
   buildUrl: (type: string, ids: string[]) => string | null;
   resolveHref: (ref: ContentRef) => { href: string | null; targetPlatform: string | null };
   LinkProvider: CardLinkProvider;
@@ -359,8 +361,14 @@ function ContentGroup({
 }) {
   const { items, isLoading } = useGroupItems(type, refs, buildUrl);
   const config = resolveGroupConfig(type);
-  const isListLayout = config.layout === 'list';
-  const cardSize = config.gridSize;
+  const isListLayout = !forceGridLayout && config.layout === 'list';
+  // Forced-grid hosts (wide PageContainer pages) collapse the list-width
+  // card variants to grid-appropriate sizes: product_release's only
+  // non-full-width variant is 'sm'; every other list-layout type renders
+  // its 'default' grid card. Config-driven sizes apply untouched otherwise.
+  const cardSize: CardSize = forceGridLayout
+    ? (type === 'product_release' ? 'sm' : 'default')
+    : config.gridSize;
 
   // Skeleton gate: `isLoading && !items` — SSR HTML and the client's first
   // paint render identical skeletons (useSelfFetch starts isLoading=true on
@@ -457,6 +465,14 @@ export interface RelatedContentSectionProps {
    */
   columns?: 2 | 3;
   /**
+   * Render EVERY group as a grid, overriding list-layout group configs —
+   * for wide hosts (program detail pages in a full-width PageContainer)
+   * where one-card-per-row list groups look oversized. List-width card
+   * variants collapse to grid sizes (product_release → 'sm', others →
+   * 'default'). Default: false (config-driven layouts).
+   */
+  forceGridLayout?: boolean;
+  /**
    * ContentRef.type values to exclude. Honored in ALL modes — controlled
    * mode post-filters (original behavior); suggestion mode ALSO forwards the
    * list verbatim as the API's `excludeTypes=` param so excluded types never
@@ -496,6 +512,7 @@ export function RelatedContentSection({
   initialItems,
   title = 'Related Content',
   columns = 2,
+  forceGridLayout,
   excludeTypes,
   apiBaseUrl = '',
   extras,
@@ -572,6 +589,7 @@ export function RelatedContentSection({
             type={type}
             refs={grouped[type]}
             columns={columns}
+            forceGridLayout={forceGridLayout}
             buildUrl={effectiveBuildListUrl}
             resolveHref={resolveHref}
             LinkProvider={LinkProvider}

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -158,7 +158,10 @@ function renderSkeletonForType(
     case 'investor_update':
       return <InvestorUpdateCardSkeleton size={legacySize} />;
     case 'onboarding_guide':
-      return <OnboardingGuideCardSkeleton size={legacySize} />;
+      // The rich catalog variant (hero + author grid, clamped description) —
+      // the step-numbered 'default' variant is for the guide detail page's
+      // "More in section" rail, not this full-width row.
+      return <OnboardingGuideCardSkeleton size={size === 'sm' ? 'sm' : 'catalog'} />;
     case 'marketing_campaign':
       return adminCampaignCard ? <adminCampaignCard.Skeleton size={legacySize} /> : null;
     case 'roadmap_item':
@@ -267,7 +270,9 @@ function CardForType({
     case 'investor_update':
       return <InvestorUpdateCard update={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
     case 'onboarding_guide':
-      return <OnboardingGuideCard guide={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+      // Catalog variant (see skeleton note) — full-width rich card with a
+      // line-clamped description instead of the step-numbered rail card.
+      return <OnboardingGuideCard guide={item} size={size === 'sm' ? 'sm' : 'catalog'} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
     case 'marketing_campaign':
       return adminCampaignCard ? <adminCampaignCard.Card campaign={item} /> : null;
     case 'roadmap_item':

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -200,7 +200,6 @@ function CardForType({
 }: {
   type: string;
   item: any;
-  contentRef: ContentRef;
   size: CardSize;
   href: string;
   targetPlatform: string | null;
@@ -352,6 +351,7 @@ function ContentGroup({
   LinkProvider,
   extras,
   adminCampaignCard,
+  heading,
 }: {
   type: string;
   refs: ContentRef[];
@@ -361,6 +361,10 @@ function ContentGroup({
   LinkProvider: CardLinkProvider;
   extras?: ChatCardDispatchExtras;
   adminCampaignCard?: AdminCampaignCardSlot;
+  /** Group heading, rendered INSIDE the group so a group that resolves to
+   *  nothing (fetch miss / unsupported type / missing program config) drops
+   *  its heading too — no orphaned titles. */
+  heading: React.ReactNode;
 }) {
   const { items, isLoading } = useGroupItems(type, refs, buildUrl);
   const config = resolveGroupConfig(type);
@@ -374,10 +378,15 @@ function ContentGroup({
     const skeletons = refs.map((r) => (
       <div key={r.id}>{renderSkeletonForType(type, cardSize, adminCampaignCard)}</div>
     ));
-    return isListLayout ? (
-      <div className="space-y-4">{skeletons}</div>
-    ) : (
-      <div className={gridClassFor(columns)}>{skeletons}</div>
+    return (
+      <div className="space-y-4">
+        {heading}
+        {isListLayout ? (
+          <div className="space-y-4">{skeletons}</div>
+        ) : (
+          <div className={gridClassFor(columns)}>{skeletons}</div>
+        )}
+      </div>
     );
   }
 
@@ -413,7 +422,6 @@ function ContentGroup({
               <CardForType
                 type={type}
                 item={item}
-                contentRef={contentRef}
                 size={cardSize}
                 href={href}
                 targetPlatform={targetPlatform}
@@ -430,10 +438,15 @@ function ContentGroup({
 
   if (cards.length === 0) return null;
 
-  return isListLayout ? (
-    <div className="space-y-4">{cards}</div>
-  ) : (
-    <div className={gridClassFor(columns)}>{cards}</div>
+  return (
+    <div className="space-y-4">
+      {heading}
+      {isListLayout ? (
+        <div className="space-y-4">{cards}</div>
+      ) : (
+        <div className={gridClassFor(columns)}>{cards}</div>
+      )}
+    </div>
   );
 }
 
@@ -540,14 +553,15 @@ export function RelatedContentSection({
   // even []) or when the entity scope is incomplete.
   // `includeTypes: []` is an explicit "nothing participates" — skip the fetch
   // entirely (an empty-string `types=` param would be dropped by the URL
-  // builder and read server-side as "all candidates").
+  // builder and read server-side as "all candidates") AND ignore SSR refs.
+  const suggestionsDisabled = includeTypes?.length === 0;
   const suggestUrl =
     contentRefs === undefined &&
     entityType &&
     entityId !== undefined &&
     entityId !== null &&
     entityId !== '' &&
-    includeTypes?.length !== 0
+    !suggestionsDisabled
       ? buildSuggestionUrl('/api/related-content', {
           apiBaseUrl,
           entityType,
@@ -564,8 +578,11 @@ export function RelatedContentSection({
   // and a fresh per-render object would loop setState under re-rendering
   // parents (the latent FaqSection bug, fixed there in the same change).
   const initialData = useMemo<RelatedContentResponse | undefined>(
-    () => (initialItems ? { refs: initialItems } : undefined),
-    [initialItems],
+    // An explicitly disabled rail (includeTypes: []) must ignore SSR-hydrated
+    // refs too — otherwise useSelfFetch(null, {initialData}) keeps serving
+    // initialItems and the "nothing participates" contract silently breaks.
+    () => (!suggestionsDisabled && initialItems ? { refs: initialItems } : undefined),
+    [initialItems, suggestionsDisabled],
   );
   const { data } = useSelfFetch<RelatedContentResponse>(suggestUrl, { initialData });
 
@@ -603,9 +620,13 @@ export function RelatedContentSection({
   // the shared alias canonicalizer (blog_post_existing ↔ blog_post).
   let orderedTypes = orderContentRefTypes(Object.keys(grouped));
   if (entityType) {
-    const sameType = orderedTypes.filter((t) => canonicalContentRefType(t) === entityType);
+    // Canonicalize BOTH sides — hosts pass registry vocab ('blog_post') but
+    // rail-vocab aliases ('blog_post_existing') are also legal inputs; a raw
+    // comparison would silently lose the same-type-first hoist for aliases.
+    const canonicalEntityType = canonicalContentRefType(entityType);
+    const sameType = orderedTypes.filter((t) => canonicalContentRefType(t) === canonicalEntityType);
     if (sameType.length > 0) {
-      orderedTypes = [...sameType, ...orderedTypes.filter((t) => canonicalContentRefType(t) !== entityType)];
+      orderedTypes = [...sameType, ...orderedTypes.filter((t) => canonicalContentRefType(t) !== canonicalEntityType)];
     }
   }
 
@@ -613,21 +634,22 @@ export function RelatedContentSection({
     <div className="space-y-8">
       <h2 className="text-2xl font-bold text-ods-text-primary">{title}</h2>
       {orderedTypes.map((type) => (
-        <div key={type} className="space-y-4">
-          <h3 className="font-['Azeret_Mono'] text-[14px] font-semibold uppercase text-ods-text-secondary tracking-wider">
-            {getContentRefLabelOrTitleCase(type)}
-          </h3>
-          <ContentGroup
-            type={type}
-            refs={grouped[type]}
-            columns={columns}
-            buildUrl={effectiveBuildListUrl}
-            resolveHref={resolveHref}
-            LinkProvider={LinkProvider}
-            extras={extras}
-            adminCampaignCard={adminCampaignCard}
-          />
-        </div>
+        <ContentGroup
+          key={type}
+          type={type}
+          refs={grouped[type]}
+          columns={columns}
+          buildUrl={effectiveBuildListUrl}
+          resolveHref={resolveHref}
+          LinkProvider={LinkProvider}
+          extras={extras}
+          adminCampaignCard={adminCampaignCard}
+          heading={
+            <h3 className="font-['Azeret_Mono'] text-[14px] font-semibold uppercase text-ods-text-secondary tracking-wider">
+              {getContentRefLabelOrTitleCase(type)}
+            </h3>
+          }
+        />
       ))}
     </div>
   );

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -480,6 +480,14 @@ export interface RelatedContentSectionProps {
    * list.
    */
   excludeTypes?: string[];
+  /**
+   * SUGGESTION-mode allow-list (rail vocabulary): which content types
+   * participate in this rail. Sent verbatim as the API's `types=` param —
+   * the SERVER intersects it with its own allowed candidate set, and
+   * platform policy gates (e.g. internal-only types) ALWAYS win: the client
+   * cannot request its way past them. Absent → all server-side candidates.
+   */
+  includeTypes?: string[];
   /** Fetch-URL prefix for third-party embeds / reverse proxies
    *  ('' = same-origin). Applied to BOTH the suggestion fetch and the
    *  default per-group list fetches. */
@@ -509,6 +517,7 @@ export function RelatedContentSection({
   entityId,
   minResults,
   sameTypeMinResults,
+  includeTypes,
   initialItems,
   title = 'Related Content',
   columns = 2,
@@ -525,8 +534,16 @@ export function RelatedContentSection({
 
   // Suggestion-mode fetch URL — null in controlled mode (contentRefs defined,
   // even []) or when the entity scope is incomplete.
+  // `includeTypes: []` is an explicit "nothing participates" — skip the fetch
+  // entirely (an empty-string `types=` param would be dropped by the URL
+  // builder and read server-side as "all candidates").
   const suggestUrl =
-    contentRefs === undefined && entityType && entityId !== undefined && entityId !== null && entityId !== ''
+    contentRefs === undefined &&
+    entityType &&
+    entityId !== undefined &&
+    entityId !== null &&
+    entityId !== '' &&
+    includeTypes?.length !== 0
       ? buildSuggestionUrl('/api/related-content', {
           apiBaseUrl,
           entityType,
@@ -534,6 +551,7 @@ export function RelatedContentSection({
           count: minResults,
           extraParams: {
             sameTypeCount: sameTypeMinResults !== undefined ? String(sameTypeMinResults) : undefined,
+            types: includeTypes !== undefined ? includeTypes.join(',') : undefined,
             excludeTypes: excludeTypes && excludeTypes.length > 0 ? excludeTypes.join(',') : undefined,
           },
         })

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -55,9 +55,13 @@ import { extractItems } from '../../utils/extract-items';
 import { buildListUrl as libBuildListUrl } from '../../utils/list-url';
 import { buildSuggestionUrl } from '../../utils/suggestion-url';
 import { decideNewTab } from '../chat/utils/decide-new-tab';
-// DEEP card imports — NOT the `../chat` barrel (it statically reaches
-// @tanstack/react-query via embeddable-chat + hooks; deep paths keep this
-// chunk react-query-free, which is the point of the useSelfFetch design).
+// DEEP card imports — NOT the `../chat` barrel (the barrel statically reaches
+// @tanstack/react-query via embeddable-chat + its hooks). Deep paths keep this
+// component's SOURCE graph react-query-free. Note: tsup's shared-chunk
+// splitting may still colocate the cards with chat hooks in one dist chunk
+// (react-query is a required peerDep, so resolution always succeeds) — the
+// guarantee that matters here is the RUNTIME one: nothing on this path ever
+// instantiates a QueryClient, so embedders need NO QueryClientProvider.
 import { BlogCard, BlogCardSkeleton } from '../chat/entity-cards/blog-card';
 import { CaseStudyCard, CaseStudyCardSkeleton } from '../chat/entity-cards/case-study-card';
 import { CustomerInterviewCard, CustomerInterviewCardSkeleton } from '../chat/entity-cards/customer-interview-card';

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+/**
+ * RelatedContentSection
+ *
+ * Renders content references grouped by type using the canonical card
+ * components. MOVED from the hub (`components/shared/related-content-card.tsx`)
+ * so any consuming app can embed it; the hub keeps a thin wrapper that
+ * pre-binds its host-specific injections (nav hook, URL recomposition,
+ * program configs, admin campaign card).
+ *
+ * THREE data modes (precedence top-down):
+ *   1. CONTROLLED — `contentRefs` provided (even `[]`): render exactly those
+ *      refs, no suggestion fetch (the original investor-update behavior).
+ *   2. SUGGESTION — `entityType` + `entityId` provided: self-fetch
+ *      `GET {apiBaseUrl}/api/related-content?entityType&entityId[&count][&excludeTypes]`
+ *      (the generic 5-tier engine's second web service). `minResults` maps to
+ *      `count`; absent → param not sent (server default applies). Each ref
+ *      carries a `reason` (data-only — never rendered, matching the
+ *      FaqSection/FaqWithReason precedent).
+ *   3. SSR-HYDRATED suggestion — also pass `initialItems` (the server page
+ *      called the engine directly); the first client fetch is skipped per the
+ *      `useSelfFetch` initialData contract.
+ *
+ * Group layout (list vs grid) + card size (lg vs default) come from
+ * `CONTENT_REF_GROUPS` in `../../utils/content-ref-groups` — single source of
+ * truth, no per-type logic in this file. Skeletons come from
+ * `renderSkeletonForType` so the placeholder height matches the loaded card
+ * exactly (zero layout shift on resolve).
+ *
+ * One API call per content type via the shared list-URL builder
+ * (`buildListUrl` — injectable; defaults to the lib's byte-parity-tested
+ * builder prefixed with `apiBaseUrl`). Fetching uses `useSelfFetch` (plain
+ * fetch, NO react-query) so third-party embedders need no QueryClientProvider;
+ * cards are imported via DEEP module paths (not the chat barrel) so this
+ * chunk never reaches `@tanstack/react-query`.
+ *
+ * LOCKSTEP NOTE: this file's per-type card/skeleton dispatch is the SIZED
+ * sibling of the chat-side `CHAT_CARD_REGISTRY` (`../chat/entity-cards/
+ * dispatch.tsx`), which renders compact `size='sm'` cards wired to the chat
+ * runtime. Two dispatchers by design — when registering a new fetch-mode
+ * content type, add it BOTH there and here (cards + skeleton + list URL).
+ */
+
+import React, { useMemo } from 'react';
+import {
+  CONTENT_REF_GROUPS,
+  getContentRefLabelOrTitleCase,
+  orderContentRefTypes,
+  type ContentRefGroupConfig,
+} from '../../utils/content-ref-groups';
+import type { ContentRef, ContentRefWithReason } from '../../types/content-ref';
+import { useSelfFetch } from '../../hooks/use-self-fetch';
+import { extractItems } from '../../utils/extract-items';
+import { buildListUrl as libBuildListUrl } from '../../utils/list-url';
+import { buildSuggestionUrl } from '../../utils/suggestion-url';
+import { decideNewTab } from '../chat/utils/decide-new-tab';
+// DEEP card imports — NOT the `../chat` barrel (it statically reaches
+// @tanstack/react-query via embeddable-chat + hooks; deep paths keep this
+// chunk react-query-free, which is the point of the useSelfFetch design).
+import { BlogCard, BlogCardSkeleton } from '../chat/entity-cards/blog-card';
+import { CaseStudyCard, CaseStudyCardSkeleton } from '../chat/entity-cards/case-study-card';
+import { CustomerInterviewCard, CustomerInterviewCardSkeleton } from '../chat/entity-cards/customer-interview-card';
+import { ProductReleaseCard, ProductReleaseCardSkeleton } from '../chat/entity-cards/product-release-card';
+import { buildProductReleaseCardProps } from '../chat/entity-cards/product-release-card-defaults';
+import { ProgramCard, ProgramCardSkeleton } from '../chat/entity-cards/program-card';
+import { InvestorUpdateCard, InvestorUpdateCardSkeleton } from '../chat/entity-cards/investor-update-card';
+import { OnboardingGuideCard, OnboardingGuideCardSkeleton } from '../chat/entity-cards/onboarding-guide-card';
+import { RoadmapCard, RoadmapCardSkeleton } from '../chat/entity-cards/roadmap-card';
+// Type-only — erased at build, no runtime dependency on the dispatch module.
+import type { ChatCardDispatchExtras } from '../chat/entity-cards/dispatch';
+
+type CardSize = 'lg' | 'default' | 'sm';
+
+/** Anchor prop bundle the per-card link surface receives — same shape the
+ *  hub's `useNavLink` returns and the chat dispatcher's anchor builders
+ *  produce. `null` = non-anchor mode (no URL). */
+export interface CardLinkAnchorProps {
+  href: string;
+  target?: '_blank';
+  rel?: 'noopener noreferrer';
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+}
+
+/** Render-prop component injection for the navigation decision — keeps hook
+ *  calls legal (hooks live INSIDE the injected component; `CardForType`
+ *  itself calls zero hooks). The hub injects a `useNavLink`-backed provider;
+ *  the default is hook-free (pure `decideNewTab`). MUST be defined at module
+ *  scope by hosts — an inline arrow would remount every card each render. */
+export interface CardLinkProviderProps {
+  href: string | null;
+  targetPlatform: string | null;
+  children: (linkProps: CardLinkAnchorProps | null) => React.ReactElement | null;
+}
+export type CardLinkProvider = React.ComponentType<CardLinkProviderProps>;
+
+/** Default link provider for standalone embeds: relative/-same-origin hrefs
+ *  stay same-tab, cross-origin pops a new tab (pure `decideNewTab` with no
+ *  platform context — `currentSource: ''` falls through to the origin
+ *  check). No router integration, no hooks. */
+function DefaultLinkPropsProvider({ href, targetPlatform, children }: CardLinkProviderProps): React.ReactElement | null {
+  if (!href) return children(null);
+  const newTab = decideNewTab({ href, targetPlatform, currentSource: '' });
+  return children(
+    newTab
+      ? { href, target: '_blank', rel: 'noopener noreferrer' }
+      : { href },
+  );
+}
+
+/** Default href resolution: trust the ref's stored url/targetPlatform as the
+ *  API composed them. The hub overrides this with its `buildContentURL`
+ *  re-composition so dev gets localhost and prod gets platform domains. */
+function defaultResolveHref(ref: ContentRef): { href: string | null; targetPlatform: string | null } {
+  return { href: ref.url || null, targetPlatform: ref.targetPlatform ?? null };
+}
+
+/** Host-injected renderer pair for the admin-only `marketing_campaign` type.
+ *  Absent (every non-hub embed) → the type renders nothing (its list URL
+ *  hits `/api/admin`, unreachable outside the hub anyway). */
+export interface AdminCampaignCardSlot {
+  Card: React.ComponentType<{ campaign: any }>;
+  Skeleton: React.ComponentType<{ size?: 'default' | 'sm' }>;
+}
+
+/**
+ * Per-type skeleton dispatch — returns the SAME colocated skeleton the
+ * resolved card renders, sized to match (zero layout shift on resolve).
+ * The chat-side `CHAT_CARD_REGISTRY` already does this via
+ * `entry.skeleton()`; this surface exposes the same discipline to the
+ * related-content rail.
+ */
+function renderSkeletonForType(
+  type: string,
+  size: CardSize,
+  adminCampaignCard?: AdminCampaignCardSlot,
+): React.ReactNode {
+  // Most card skeletons accept only `{default, sm}`. `'lg'` collapses to
+  // `'default'`. ProductReleaseCardSkeleton uses lg/sm pair.
+  const legacySize: 'default' | 'sm' = size === 'sm' ? 'sm' : 'default';
+  switch (type) {
+    case 'blog_post_existing':
+      return <BlogCardSkeleton size={legacySize} />;
+    case 'case_study':
+      return <CaseStudyCardSkeleton size={legacySize} />;
+    case 'customer_interview':
+      return <CustomerInterviewCardSkeleton size={legacySize} />;
+    case 'product_release':
+      return <ProductReleaseCardSkeleton size={size === 'sm' ? 'sm' : 'lg'} />;
+    case 'podcast':
+    case 'webinar':
+    case 'event':
+      return <ProgramCardSkeleton size={legacySize} />;
+    case 'investor_update':
+      return <InvestorUpdateCardSkeleton size={legacySize} />;
+    case 'onboarding_guide':
+      return <OnboardingGuideCardSkeleton size={legacySize} />;
+    case 'marketing_campaign':
+      return adminCampaignCard ? <adminCampaignCard.Skeleton size={legacySize} /> : null;
+    case 'roadmap_item':
+    case 'delivery_item':
+    case 'internal_task':
+      return <RoadmapCardSkeleton size={legacySize} />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Per-type card dispatch — renders the right card with the right size.
+ * Sized cards (`'lg'` / `'default'`) are unique to this rail — the chat
+ * dispatcher only renders `'sm'`, so we go directly through the per-type
+ * cards here.
+ *
+ * PURE FUNCTION COMPONENT WITH ZERO HOOK CALLS: the placeholder comes from a
+ * plain `extras.buildOgPlaceholderUrl` call (the chat `dispatch.tsx`
+ * pattern) and the anchor-prop bundle arrives via the `LinkProvider`
+ * render-prop from the parent — so per-card hook legality is owned by the
+ * injected provider component, not by this switch.
+ *
+ * `href` comes from the host's `resolveHref(ref)` (hub: live
+ * `buildContentURL` recomposition; default: the ref's stored url).
+ */
+function CardForType({
+  type,
+  item,
+  size,
+  href,
+  targetPlatform,
+  linkProps,
+  extras,
+  adminCampaignCard,
+}: {
+  type: string;
+  item: any;
+  contentRef: ContentRef;
+  size: CardSize;
+  href: string;
+  targetPlatform: string | null;
+  linkProps: CardLinkAnchorProps | null;
+  extras?: ChatCardDispatchExtras;
+  adminCampaignCard?: AdminCampaignCardSlot;
+}): React.ReactNode {
+  // Most card variants accept only `{default, sm}`. `'lg'` collapses to
+  // `'default'` for those. ProductReleaseCard uses its own lg/sm pair.
+  const legacySize: 'default' | 'sm' = size === 'sm' ? 'sm' : 'default';
+  // OG placeholder URL — injected into the pure-presentation cards so they
+  // render a branded fallback when the row's featured image is null. Plain
+  // function call (NOT a hook). Title is the universal field across all card
+  // item shapes used here.
+  const placeholderUrl =
+    extras?.buildOgPlaceholderUrl?.((item?.title as string | undefined) ?? '') ?? undefined;
+
+  // Top-level target/rel for cards that take them as separate props
+  // (BlogCard, CaseStudyCard, …). ProductReleaseCard takes the bundle as a
+  // single `anchorProps={...}` and uses `linkProps` directly. When the host
+  // didn't surface a URL, `linkProps` is null and the card stays in
+  // non-anchor mode.
+  const anchorAttrs: Pick<CardLinkAnchorProps, 'target' | 'rel'> = linkProps
+    ? { target: linkProps.target, rel: linkProps.rel }
+    : {};
+
+  switch (type) {
+    case 'blog_post_existing':
+      return <BlogCard post={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+    case 'case_study':
+      return <CaseStudyCard study={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+    case 'customer_interview':
+      return <CustomerInterviewCard interview={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+    case 'product_release': {
+      // Anchor-prop pattern: build product-release lg-variant props from the
+      // shared `buildProductReleaseCardProps` so this rail and the /releases
+      // catalog page render byte-identically. The card wraps in
+      // `<a {...anchorProps}>` ONLY when `anchorProps.href` is set — pass
+      // `undefined` (not an empty object) when href is empty so the card
+      // stays in non-anchor mode without rendering a dead <a> tag.
+      const releaseSize = size === 'sm' ? 'sm' : 'lg';
+      const buildReleaseProps = extras?.buildProductReleaseCardProps ?? buildProductReleaseCardProps;
+      const releaseProps = buildReleaseProps(item);
+      return (
+        <ProductReleaseCard
+          size={releaseSize}
+          title={item.title}
+          summary={item.summary}
+          version={item.version}
+          {...releaseProps}
+          anchorProps={linkProps ?? undefined}
+        />
+      );
+    }
+    case 'podcast':
+      return extras?.programConfigs?.podcast
+        ? <ProgramCard config={extras.programConfigs.podcast} item={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />
+        : null;
+    case 'webinar':
+      return extras?.programConfigs?.webinar
+        ? <ProgramCard config={extras.programConfigs.webinar} item={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />
+        : null;
+    case 'event':
+      return extras?.programConfigs?.event
+        ? <ProgramCard config={extras.programConfigs.event} item={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />
+        : null;
+    case 'investor_update':
+      return <InvestorUpdateCard update={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+    case 'onboarding_guide':
+      return <OnboardingGuideCard guide={item} size={legacySize} href={href} targetPlatform={targetPlatform} placeholderUrl={placeholderUrl} {...anchorAttrs} />;
+    case 'marketing_campaign':
+      return adminCampaignCard ? <adminCampaignCard.Card campaign={item} /> : null;
+    case 'roadmap_item':
+    case 'delivery_item':
+    case 'internal_task':
+      return (
+        <RoadmapCard
+          item={item}
+          href={href ?? ''}
+          targetPlatform={targetPlatform}
+          userVote={null}
+          onVote={() => {}}
+          size={legacySize}
+          cardType={type as 'roadmap_item' | 'delivery_item' | 'internal_task'}
+          {...anchorAttrs}
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+// =============================================================================
+// Fetch all items for a type in ONE server-sorted call, via the injectable
+// list-URL builder. `useSelfFetch` (URL = cache key) replaces the hub's old
+// react-query usage: `enabled` ≙ `url === null`, `!res.ok`/network error ≙
+// `error → items null → group renders nothing`. Accepted deltas vs
+// react-query: no retry/backoff, no focus refetch, no cross-mount cache.
+// =============================================================================
+
+function useGroupItems(
+  type: string,
+  refs: ContentRef[],
+  buildUrl: (type: string, ids: string[]) => string | null,
+) {
+  const ids = refs.map((r) => r.id);
+  const url = ids.length > 0 ? buildUrl(type, ids) : null;
+  const { data, isLoading } = useSelfFetch<unknown>(url);
+  const items = data != null ? extractItems(data) : null;
+  return { items, isLoading };
+}
+
+// =============================================================================
+// Per-group renderer — one API call, server-sorted, then render cards via the
+// dispatcher with per-type skeletons + per-type layout from CONTENT_REF_GROUPS.
+// =============================================================================
+
+/** Map columns prop → tailwind grid class. Only consulted for grid-layout
+ *  groups; list-layout groups stack vertically. */
+function gridClassFor(columns: 2 | 3): string {
+  return columns === 3
+    ? 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'
+    : 'grid grid-cols-1 sm:grid-cols-2 gap-6';
+}
+
+/** Resolve the group config for a type, falling back to a grid layout with
+ *  the default card size for unregistered types so the section still renders
+ *  rather than silently dropping them. The `label` field on the fallback is
+ *  intentionally a placeholder — the section heading goes through
+ *  `getContentRefLabelOrTitleCase(type)` instead so cross-surface labels
+ *  stay consistent between this rail and the investor-email builder. */
+function resolveGroupConfig(type: string): ContentRefGroupConfig {
+  return CONTENT_REF_GROUPS[type] ?? {
+    label: type,
+    order: 999,
+    layout: 'grid',
+    gridSize: 'default',
+  };
+}
+
+function ContentGroup({
+  type,
+  refs,
+  columns,
+  buildUrl,
+  resolveHref,
+  LinkProvider,
+  extras,
+  adminCampaignCard,
+}: {
+  type: string;
+  refs: ContentRef[];
+  columns: 2 | 3;
+  buildUrl: (type: string, ids: string[]) => string | null;
+  resolveHref: (ref: ContentRef) => { href: string | null; targetPlatform: string | null };
+  LinkProvider: CardLinkProvider;
+  extras?: ChatCardDispatchExtras;
+  adminCampaignCard?: AdminCampaignCardSlot;
+}) {
+  const { items, isLoading } = useGroupItems(type, refs, buildUrl);
+  const config = resolveGroupConfig(type);
+  const isListLayout = config.layout === 'list';
+  const cardSize = config.gridSize;
+
+  // Skeleton gate: `isLoading && !items` — SSR HTML and the client's first
+  // paint render identical skeletons (useSelfFetch starts isLoading=true on
+  // both sides), and once items exist they are never replaced by skeletons.
+  if (isLoading && !items) {
+    const skeletons = refs.map((r) => (
+      <div key={r.id}>{renderSkeletonForType(type, cardSize, adminCampaignCard)}</div>
+    ));
+    return isListLayout ? (
+      <div className="space-y-4">{skeletons}</div>
+    ) : (
+      <div className={gridClassFor(columns)}>{skeletons}</div>
+    );
+  }
+
+  if (!items || items.length === 0) return null;
+
+  // Match fetched items to refs (for url/visibility data).
+  const refMap = new Map(refs.map((r) => [String(r.id), r]));
+
+  // Items come back server-sorted (date descending). Render in that order.
+  const cards = items
+    .map((item: any) => {
+      const itemId = String(item.id);
+      const contentRef = refMap.get(itemId);
+      if (!contentRef) return null;
+      // Re-compose the URL via the host's resolver (hub: buildContentURL so
+      // dev gets localhost and prod the right platform domain; default: the
+      // ref's stored url as the API composed it).
+      const resolved = resolveHref(contentRef);
+      const href = resolved.href ?? '';
+      const targetPlatform = resolved.targetPlatform ?? contentRef.targetPlatform ?? null;
+      return (
+        <div key={itemId}>
+          <LinkProvider href={href || null} targetPlatform={targetPlatform}>
+            {(linkProps) => (
+              <CardForType
+                type={type}
+                item={item}
+                contentRef={contentRef}
+                size={cardSize}
+                href={href}
+                targetPlatform={targetPlatform}
+                linkProps={linkProps}
+                extras={extras}
+                adminCampaignCard={adminCampaignCard}
+              />
+            )}
+          </LinkProvider>
+        </div>
+      );
+    })
+    .filter(Boolean);
+
+  if (cards.length === 0) return null;
+
+  return isListLayout ? (
+    <div className="space-y-4">{cards}</div>
+  ) : (
+    <div className={gridClassFor(columns)}>{cards}</div>
+  );
+}
+
+// =============================================================================
+// Main component
+// =============================================================================
+
+interface RelatedContentResponse {
+  refs: ContentRefWithReason[];
+}
+
+export interface RelatedContentSectionProps {
+  /** CONTROLLED mode (the original behavior). When defined — even `[]` — no
+   *  suggestion fetch runs and exactly these refs render. */
+  contentRefs?: ContentRef[];
+  /** SUGGESTION mode (with `entityId`): self-fetch suggestions for this host
+   *  entity from `{apiBaseUrl}/api/related-content`. Ignored when
+   *  `contentRefs` is provided. */
+  entityType?: string;
+  entityId?: number | string;
+  /** Maps to the suggestion API's `count` param. Absent → param not sent
+   *  (server default applies). */
+  minResults?: number;
+  /** SSR hydrate for suggestion mode — the server page ran the engine and
+   *  drills the refs here; the first client fetch is skipped (useSelfFetch
+   *  initialData contract). */
+  initialItems?: ContentRefWithReason[];
+  /** Section title (default: "Related Content") */
+  title?: string;
+  /**
+   * Grid columns at desktop. 2 = denser cards / wider summary (original
+   * investor-update layout); 3 = more cards per row for dashboards.
+   * Only consulted for grid-layout groups. Default: 2.
+   */
+  columns?: 2 | 3;
+  /**
+   * ContentRef.type values to exclude. Honored in ALL modes — controlled
+   * mode post-filters (original behavior); suggestion mode ALSO forwards the
+   * list verbatim as the API's `excludeTypes=` param so excluded types never
+   * consume engine fill slots (`minResults` stays honored). The subtraction
+   * happens SERVER-side — this component never mirrors the hub's candidate
+   * list.
+   */
+  excludeTypes?: string[];
+  /** Fetch-URL prefix for third-party embeds / reverse proxies
+   *  ('' = same-origin). Applied to BOTH the suggestion fetch and the
+   *  default per-group list fetches. */
+  apiBaseUrl?: string;
+  /** Host injection bundle — REUSES the chat dispatcher's
+   *  `ChatCardDispatchExtras` (programConfigs, buildOgPlaceholderUrl,
+   *  buildProductReleaseCardProps override). Program groups render nothing
+   *  when their config is absent. */
+  extras?: ChatCardDispatchExtras;
+  /** Hub injects its `buildContentURL` recomposition; default uses the
+   *  ref's stored `url`/`targetPlatform` as the API composed them. */
+  resolveHref?: (ref: ContentRef) => { href: string | null; targetPlatform: string | null };
+  /** Hub injects its registry-driven entity-list-api builder; default = the
+   *  lib's `buildListUrl(type, ids, apiBaseUrl)`. */
+  buildListUrl?: (type: string, ids: string[]) => string | null;
+  /** Hub injects a `useNavLink`-backed render-prop provider; default = pure
+   *  anchor via `decideNewTab`. MUST be a module-scope component. */
+  LinkProvider?: CardLinkProvider;
+  /** Renderer pair for the admin-only `marketing_campaign` type. Absent →
+   *  the type renders nothing. */
+  adminCampaignCard?: AdminCampaignCardSlot;
+}
+
+export function RelatedContentSection({
+  contentRefs,
+  entityType,
+  entityId,
+  minResults,
+  initialItems,
+  title = 'Related Content',
+  columns = 2,
+  excludeTypes,
+  apiBaseUrl = '',
+  extras,
+  resolveHref = defaultResolveHref,
+  buildListUrl,
+  LinkProvider = DefaultLinkPropsProvider,
+  adminCampaignCard,
+}: RelatedContentSectionProps) {
+  // ── Hooks above EVERY early return (the original `if (!contentRefs.length)
+  // return null` guard moved below them). ──
+
+  // Suggestion-mode fetch URL — null in controlled mode (contentRefs defined,
+  // even []) or when the entity scope is incomplete.
+  const suggestUrl =
+    contentRefs === undefined && entityType && entityId !== undefined && entityId !== null && entityId !== ''
+      ? buildSuggestionUrl('/api/related-content', {
+          apiBaseUrl,
+          entityType,
+          entityId,
+          count: minResults,
+          extraParams: {
+            excludeTypes: excludeTypes && excludeTypes.length > 0 ? excludeTypes.join(',') : undefined,
+          },
+        })
+      : null;
+  // Memoize the initialData wrapper — useSelfFetch re-syncs on [initialData],
+  // and a fresh per-render object would loop setState under re-rendering
+  // parents (the latent FaqSection bug, fixed there in the same change).
+  const initialData = useMemo<RelatedContentResponse | undefined>(
+    () => (initialItems ? { refs: initialItems } : undefined),
+    [initialItems],
+  );
+  const { data } = useSelfFetch<RelatedContentResponse>(suggestUrl, { initialData });
+
+  // Default group fetcher: the lib's byte-parity-tested builder, prefixed for
+  // embeds. Memoized so group-fetch URLs stay value-stable across renders.
+  const effectiveBuildListUrl = useMemo(
+    () => buildListUrl ?? ((type: string, ids: string[]) => libBuildListUrl(type, ids, apiBaseUrl)),
+    [buildListUrl, apiBaseUrl],
+  );
+
+  const refs: ContentRef[] = contentRefs ?? data?.refs ?? [];
+
+  // Per-consumer type gating — drops refs whose `type` is in the exclude
+  // list. In suggestion mode the server already subtracted these (the param
+  // is forwarded above); the client filter stays as an idempotent guard and
+  // IS the mechanism in controlled mode (original behavior).
+  const exclude = new Set(excludeTypes || []);
+  const visibleRefs = exclude.size > 0 ? refs.filter((r) => !exclude.has(r.type)) : refs;
+  // Zero refs (still loading in suggestion mode, or genuinely empty) → no
+  // empty shell.
+  if (!visibleRefs.length) return null;
+
+  const grouped: Record<string, ContentRef[]> = {};
+  for (const ref of visibleRefs) {
+    if (!grouped[ref.type]) grouped[ref.type] = [];
+    grouped[ref.type].push(ref);
+  }
+
+  // Registered types in CONTENT_REF_GROUPS order, then any unregistered
+  // types appended (same shape the investor-email builder uses — both
+  // consume `orderContentRefTypes` so cross-surface ordering matches).
+  const orderedTypes = orderContentRefTypes(Object.keys(grouped));
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-2xl font-bold text-ods-text-primary">{title}</h2>
+      {orderedTypes.map((type) => (
+        <div key={type} className="space-y-4">
+          <h3 className="font-['Azeret_Mono'] text-[14px] font-semibold uppercase text-ods-text-secondary tracking-wider">
+            {getContentRefLabelOrTitleCase(type)}
+          </h3>
+          <ContentGroup
+            type={type}
+            refs={grouped[type]}
+            columns={columns}
+            buildUrl={effectiveBuildListUrl}
+            resolveHref={resolveHref}
+            LinkProvider={LinkProvider}
+            extras={extras}
+            adminCampaignCard={adminCampaignCard}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -342,7 +342,6 @@ function ContentGroup({
   type,
   refs,
   columns,
-  forceGridLayout,
   buildUrl,
   resolveHref,
   LinkProvider,
@@ -352,7 +351,6 @@ function ContentGroup({
   type: string;
   refs: ContentRef[];
   columns: 2 | 3;
-  forceGridLayout?: boolean;
   buildUrl: (type: string, ids: string[]) => string | null;
   resolveHref: (ref: ContentRef) => { href: string | null; targetPlatform: string | null };
   LinkProvider: CardLinkProvider;
@@ -361,14 +359,8 @@ function ContentGroup({
 }) {
   const { items, isLoading } = useGroupItems(type, refs, buildUrl);
   const config = resolveGroupConfig(type);
-  const isListLayout = !forceGridLayout && config.layout === 'list';
-  // Forced-grid hosts (wide PageContainer pages) collapse the list-width
-  // card variants to grid-appropriate sizes: product_release's only
-  // non-full-width variant is 'sm'; every other list-layout type renders
-  // its 'default' grid card. Config-driven sizes apply untouched otherwise.
-  const cardSize: CardSize = forceGridLayout
-    ? (type === 'product_release' ? 'sm' : 'default')
-    : config.gridSize;
+  const isListLayout = config.layout === 'list';
+  const cardSize = config.gridSize;
 
   // Skeleton gate: `isLoading && !items` — SSR HTML and the client's first
   // paint render identical skeletons (useSelfFetch starts isLoading=true on
@@ -465,14 +457,6 @@ export interface RelatedContentSectionProps {
    */
   columns?: 2 | 3;
   /**
-   * Render EVERY group as a grid, overriding list-layout group configs —
-   * for wide hosts (program detail pages in a full-width PageContainer)
-   * where one-card-per-row list groups look oversized. List-width card
-   * variants collapse to grid sizes (product_release → 'sm', others →
-   * 'default'). Default: false (config-driven layouts).
-   */
-  forceGridLayout?: boolean;
-  /**
    * ContentRef.type values to exclude. Honored in ALL modes — controlled
    * mode post-filters (original behavior); suggestion mode ALSO forwards the
    * list verbatim as the API's `excludeTypes=` param so excluded types never
@@ -512,7 +496,6 @@ export function RelatedContentSection({
   initialItems,
   title = 'Related Content',
   columns = 2,
-  forceGridLayout,
   excludeTypes,
   apiBaseUrl = '',
   extras,
@@ -589,7 +572,6 @@ export function RelatedContentSection({
             type={type}
             refs={grouped[type]}
             columns={columns}
-            forceGridLayout={forceGridLayout}
             buildUrl={effectiveBuildListUrl}
             resolveHref={resolveHref}
             LinkProvider={LinkProvider}

--- a/openframe-frontend-core/src/components/related-content/related-content-section.tsx
+++ b/openframe-frontend-core/src/components/related-content/related-content-section.tsx
@@ -383,15 +383,19 @@ function ContentGroup({
 
   if (!items || items.length === 0) return null;
 
-  // Match fetched items to refs (for url/visibility data).
-  const refMap = new Map(refs.map((r) => [String(r.id), r]));
+  // Index fetched rows by id, then render in REF order — refs carry the
+  // intended sequence (suggestion mode: the engine's tier order, so
+  // same-platform/tag-matched items lead; controlled mode: the curated
+  // display_order). The list APIs return rows date-sorted, which would
+  // otherwise scramble that ordering (same-platform items sinking below
+  // newer cross-platform ones).
+  const itemById = new Map((items as any[]).map((it) => [String(it.id), it]));
 
-  // Items come back server-sorted (date descending). Render in that order.
-  const cards = items
-    .map((item: any) => {
-      const itemId = String(item.id);
-      const contentRef = refMap.get(itemId);
-      if (!contentRef) return null;
+  const cards = refs
+    .map((contentRef) => {
+      const itemId = String(contentRef.id);
+      const item = itemById.get(itemId);
+      if (!item) return null;
       // Re-compose the URL via the host's resolver (hub: buildContentURL so
       // dev gets localhost and prod the right platform domain; default: the
       // ref's stored url as the API composed it).

--- a/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
+++ b/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
@@ -4,7 +4,10 @@ import { useState, useEffect, ComponentType } from 'react';
 import Link from '../../../embed-shims/next-link';
 import { useRouter } from '../../../embed-shims/next-navigation';
 import { Card, CardContent } from '../../ui/card';
-import { ArticleDetailLayout } from '../../layout/article-detail-layout';
+// PageShell (wide) — match the related-content/FAQ rail container the hub
+// renders below this view (was ArticleDetailLayout, 1280px — narrower than
+// the rail, see hub detail-container alignment decision 2026-06-10).
+import { PageShell } from '../../layout/article-detail-layout';
 import { BackButton } from '../../layout/back-button';
 import { ReleaseChangelogSection } from '../../ui/release-changelog-section';
 import { EntityTagBadges } from '../../features/entity-tag-badges';
@@ -220,7 +223,7 @@ export function ReleaseDetailPage({
   const improvements = release.improvements as ChangelogEntry[] | undefined;
 
   return (
-    <ArticleDetailLayout>
+    <PageShell>
       {/* Back button — desktop-only, matches DevSectionPage / LegalDocumentPage
           (TitleBlock renders the same `hidden md:inline-flex` BackButton). */}
       {showBackButton && (
@@ -590,6 +593,6 @@ export function ReleaseDetailPage({
           initialIndex={galleryIndex}
         />
       )}
-    </ArticleDetailLayout>
+    </PageShell>
   );
 }

--- a/openframe-frontend-core/src/types/content-ref.ts
+++ b/openframe-frontend-core/src/types/content-ref.ts
@@ -1,0 +1,34 @@
+/**
+ * ContentRef — the unified link/embed shape stored in JSONB columns
+ * across investor updates, performance baselines, and any other entity
+ * that surfaces "related content" rails.
+ *
+ * Lifted from `lib/data/investor-update-utils-shared.ts` in the hub
+ * (the server-side data utils in the same file stay hub-side; only the
+ * TYPE moves here). RELOCATED from `components/chat/types/entities/`
+ * to this server-safe home when `RelatedContentSection` moved into the
+ * lib — the chat path re-exports from here, so there is exactly ONE
+ * `ContentRef` definition package-wide.
+ */
+
+export interface ContentRef {
+  type: string;
+  id: string;
+  slug: string;
+  url: string;
+  targetPlatform?: string | null;
+  title: string;
+  summary?: string;
+  image_url?: string;
+  image_bg_color?: string;
+  visibility: 'public' | 'internal';
+  display_order: number;
+}
+
+/**
+ * A ContentRef as returned by the suggestion service (`/api/related-content`)
+ * — carries the 5-tier engine's placement reason. Widened to `string` here
+ * (the narrow reason union is hub-server vocabulary); data-only, never
+ * rendered by the rail.
+ */
+export type ContentRefWithReason = ContentRef & { reason: string };

--- a/openframe-frontend-core/src/types/index.ts
+++ b/openframe-frontend-core/src/types/index.ts
@@ -38,6 +38,7 @@ export * from './waitlist'
 
 // Business logic types
 export * from './faq'
+export * from './content-ref'
 export * from './report'
 export * from './stack'
 

--- a/openframe-frontend-core/src/utils/content-ref-groups.ts
+++ b/openframe-frontend-core/src/utils/content-ref-groups.ts
@@ -52,7 +52,7 @@ export const CONTENT_REF_GROUPS: Record<string, ContentRefGroupConfig> = {
   event:               { label: 'Events',              order: 6, layout: 'list', gridSize: 'default' },
   blog_post_existing:  { label: 'Blog Posts',          order: 7, layout: 'grid', gridSize: 'default' },
   customer_interview:  { label: 'Customer Interviews', order: 8, layout: 'grid', gridSize: 'default' },
-  onboarding_guide:    { label: 'Onboarding Guides',   order: 9, layout: 'grid', gridSize: 'default' },
+  onboarding_guide:    { label: 'Onboarding Guides',   order: 9, layout: 'list', gridSize: 'default' },
 }
 
 /** Human-readable label for a content_ref `type`. Returns null when the type

--- a/openframe-frontend-core/src/utils/content-ref-groups.ts
+++ b/openframe-frontend-core/src/utils/content-ref-groups.ts
@@ -1,0 +1,89 @@
+/**
+ * Content Ref Group Configuration
+ *
+ * Single source of truth for grouping content_refs by type. Used by both:
+ *  - components/related-content (detail page rail — lives in this lib)
+ *  - the hub's lib/utils/investor-email-utils.ts (email builder, via the
+ *    hub's re-export shim at lib/config/content-ref-groups.ts)
+ *
+ * Lives in utils/ (server-safe tsup block) so hub server-side code can
+ * import it.
+ *
+ * Each entry carries the metadata RelatedContentSection needs to render the
+ * group WITHOUT re-implementing per-type logic locally:
+ *   - `label`: section heading.
+ *   - `order`: source-stable ordering (lowest first).
+ *   - `layout`: 'list' (one-per-row, full-width cards) or 'grid' (responsive
+ *     column grid).
+ *   - `gridSize`: card-size variant passed to the per-type card dispatch.
+ *     `'lg'` matches the canonical large-card variant openframe + flamingo
+ *     apps already use; `'default'` is the legacy denser variant. New types
+ *     should pick `'lg'` whenever the card has a large variant.
+ *
+ * Adding a new content type = one entry here. RelatedContentSection picks up
+ * the new group automatically (no hardcoded set to update). NOTE: the hub's
+ * related-content SUGGESTION candidate list is DERIVED from these keys (minus
+ * an explicit exclusion knob) — a new entry here becomes a suggestion
+ * candidate iff it also resolves through the hub's TYPE_TO_ENTITY → RAG
+ * config chain (unresolvable entries are dropped loudly at module load).
+ */
+
+export type ContentRefLayout = 'list' | 'grid'
+
+/** Subset of `EntityCardSize` (entity-card dispatch) appropriate for
+ *  grid/list rendering in RelatedContentSection. Duplicated as a literal
+ *  union here to avoid a config→component import cycle. Kept in lockstep
+ *  with `EntityCardSize`; widen here when a new size is added there. */
+export type ContentRefGridSize = 'lg' | 'default' | 'sm'
+
+export interface ContentRefGroupConfig {
+  label: string
+  order: number
+  layout: ContentRefLayout
+  gridSize: ContentRefGridSize
+}
+
+export const CONTENT_REF_GROUPS: Record<string, ContentRefGroupConfig> = {
+  investor_update:     { label: 'Investor Updates',    order: 1, layout: 'grid', gridSize: 'default' },
+  product_release:     { label: 'Product Releases',    order: 2, layout: 'list', gridSize: 'lg' },
+  podcast:             { label: 'Podcasts',            order: 3, layout: 'list', gridSize: 'default' },
+  webinar:             { label: 'Webinars',            order: 4, layout: 'list', gridSize: 'default' },
+  case_study:          { label: 'Case Studies',        order: 5, layout: 'grid', gridSize: 'default' },
+  event:               { label: 'Events',              order: 6, layout: 'list', gridSize: 'default' },
+  blog_post_existing:  { label: 'Blog Posts',          order: 7, layout: 'grid', gridSize: 'default' },
+  customer_interview:  { label: 'Customer Interviews', order: 8, layout: 'grid', gridSize: 'default' },
+  onboarding_guide:    { label: 'Onboarding Guides',   order: 9, layout: 'grid', gridSize: 'default' },
+}
+
+/** Human-readable label for a content_ref `type`. Returns null when the type
+ *  isn't registered — caller decides the fallback. Use `getContentRefLabelOrTitleCase`
+ *  to get a consistent title-cased fallback across all surfaces. */
+export function getContentRefLabel(type: string): string | null {
+  return CONTENT_REF_GROUPS[type]?.label ?? null
+}
+
+/** Resolved label with a single shared fallback shape — title-cased version
+ *  of the raw type string for any unregistered type. Both RelatedContentSection
+ *  AND the investor-email builder consume this so cross-surface label rendering
+ *  for unregistered types is identical (no drift between "podcast guest" and
+ *  "Podcast Guest"). */
+export function getContentRefLabelOrTitleCase(type: string): string {
+  return (
+    CONTENT_REF_GROUPS[type]?.label ??
+    type.replace(/_/g, ' ').replace(/\b\w/g, (ch) => ch.toUpperCase())
+  )
+}
+
+/** Sort a set of present content_ref types into the canonical group order
+ *  (registered types first in CONTENT_REF_GROUPS `order`, then unregistered
+ *  types appended in insertion order). Used by RelatedContentSection AND the
+ *  investor-email builder so cross-surface ordering stays identical. */
+export function orderContentRefTypes(present: Iterable<string>): string[] {
+  const presentSet = new Set(present)
+  const registeredInOrder = Object.entries(CONTENT_REF_GROUPS)
+    .sort(([, a], [, b]) => a.order - b.order)
+    .map(([type]) => type)
+    .filter((type) => presentSet.has(type))
+  const unregistered = [...presentSet].filter((type) => !CONTENT_REF_GROUPS[type])
+  return [...registeredInOrder, ...unregistered]
+}

--- a/openframe-frontend-core/src/utils/extract-items.ts
+++ b/openframe-frontend-core/src/utils/extract-items.ts
@@ -1,0 +1,48 @@
+/**
+ * List-API response normalizers — HOISTED from
+ * `components/chat/hooks/use-chat-card-item.ts` (private copies) so the
+ * related-content rail can import them WITHOUT touching the chat hooks
+ * chunk (which reaches `@tanstack/react-query`). Pure + server-safe.
+ *
+ * The hub's `lib/utils/entity-list-api.ts` re-exports these — one
+ * implementation of response-shape normalization across both repos.
+ */
+
+/** Extract the items array from each endpoint's response shape (some
+ *  return `{ items }`, others `{ posts }`, etc.). Single normalization
+ *  point — callers always read `Item[]`. */
+export function extractItems(data: unknown): unknown[] {
+  if (!data || typeof data !== 'object') return []
+  const obj = data as Record<string, unknown>
+  if (Array.isArray(obj.items)) return obj.items
+  if (Array.isArray(obj.posts)) return obj.posts
+  if (Array.isArray(obj.campaigns)) return obj.campaigns
+  if (Array.isArray(obj.completed) || Array.isArray(obj.inProgress)) {
+    // Delivery endpoint splits into completed/inProgress arrays — flatten.
+    const completed = Array.isArray(obj.completed) ? obj.completed : []
+    const inProgress = Array.isArray(obj.inProgress) ? obj.inProgress : []
+    return [...completed, ...inProgress]
+  }
+  if (Array.isArray(obj.data)) return obj.data
+  if (Array.isArray(data)) return data
+  return []
+}
+
+/** Extract a stable id from a fetched item — different shapes use
+ *  `id` vs `external_id`. Used by the chat loader to match the fetched
+ *  array element back to the marker's id. */
+export function extractItemId(type: string, item: unknown): string | null {
+  if (!item || typeof item !== 'object') return null
+  const obj = item as Record<string, unknown>
+  if (type === 'roadmap_item' || type === 'delivery_item' || type === 'internal_task') {
+    const ext = obj.external_id
+    if (typeof ext === 'string') return ext
+  }
+  // RoadmapItem-shaped responses use `id` to carry the external_id; the
+  // mapper renames external_id→id at the API boundary. Treat both id and
+  // external_id as primary-key candidates for these clickup-backed types.
+  const id = obj.id
+  if (typeof id === 'string') return id
+  if (typeof id === 'number') return String(id)
+  return null
+}

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -235,7 +235,7 @@ export {
 // delegate here (byte-parity test guards the migration); embedders wire
 // `endpoints.buildListUrl = (t, ids) => buildListUrl(t, ids, '/content')`.
 // Pure + server-safe (the hub imports it server-side from this barrel).
-export { buildListUrl } from './list-url'
+export { buildListUrl, canonicalContentRefType } from './list-url'
 
 // Content-ref group registry (labels/order/layout per rail type) + list-API
 // response normalizers + the shared suggestion-fetch URL composer — all

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -237,6 +237,21 @@ export {
 // Pure + server-safe (the hub imports it server-side from this barrel).
 export { buildListUrl } from './list-url'
 
+// Content-ref group registry (labels/order/layout per rail type) + list-API
+// response normalizers + the shared suggestion-fetch URL composer — all
+// pure + server-safe; the hub re-exports these from its config/util shims.
+export {
+  CONTENT_REF_GROUPS,
+  getContentRefLabel,
+  getContentRefLabelOrTitleCase,
+  orderContentRefTypes,
+  type ContentRefGroupConfig,
+  type ContentRefLayout,
+  type ContentRefGridSize,
+} from './content-ref-groups'
+export { extractItems, extractItemId } from './extract-items'
+export { buildSuggestionUrl, type SuggestionUrlOptions } from './suggestion-url'
+
 // Embedder-configurable content-URL composer for the existing
 // `runtime.composeContentUrl` seam — relative href for host-served types,
 // hub origin for the rest. Pure + server-safe.

--- a/openframe-frontend-core/src/utils/list-url.ts
+++ b/openframe-frontend-core/src/utils/list-url.ts
@@ -37,6 +37,15 @@
  */
 const ALIASES: Record<string, string> = { blog_post_existing: 'blog_post' }
 
+/** Resolve a ContentRef rail-vocab type to its canonical `documentType`
+ *  (registry vocabulary) — `blog_post_existing` → `blog_post`, everything
+ *  else passes through. Exported so consumers comparing rail group keys to
+ *  registry entityTypes (e.g. the related-content rail's same-type-first
+ *  ordering) share THIS alias map instead of re-declaring it. */
+export function canonicalContentRefType(contentRefType: string): string {
+  return ALIASES[contentRefType] ?? contentRefType
+}
+
 /**
  * One builder per fetch-mode `contentRefType`, keyed by the canonical
  * `documentType`. Each body is copied VERBATIM from the matching hub

--- a/openframe-frontend-core/src/utils/suggestion-url.ts
+++ b/openframe-frontend-core/src/utils/suggestion-url.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared fetch-URL composer for the two suggestion sections (FaqSection +
+ * RelatedContentSection) — ONE owner of the entityType/entityId/count query
+ * shape so the sections can never drift. Pure + server-safe.
+ *
+ * Byte-parity contract with the original `buildFaqsUrl`: when only
+ * entityType/entityId are set, the param order is `entityType`, `entityId`;
+ * with nothing set, the bare `path` is returned (no `?`).
+ */
+export interface SuggestionUrlOptions {
+  /** Fetch-URL prefix for third-party embeds / reverse proxies
+   *  ('' = same-origin relative). */
+  apiBaseUrl?: string
+  /** Both required together for entity scope; partial → bare path. */
+  entityType?: string
+  entityId?: number | string
+  /** Maps to the server's `count` param. Undefined → param not sent
+   *  (server default applies). */
+  count?: number
+  /** Extra query params appended after the shared trio (e.g. the
+   *  related-content `excludeTypes` deny-list). Empty/undefined values
+   *  are skipped. */
+  extraParams?: Record<string, string | undefined>
+}
+
+export function buildSuggestionUrl(path: string, opts: SuggestionUrlOptions = {}): string {
+  const qs = new URLSearchParams()
+  const { entityType, entityId } = opts
+  if (entityType && entityId !== undefined && entityId !== null && entityId !== '') {
+    qs.set('entityType', entityType)
+    qs.set('entityId', String(entityId))
+  }
+  if (opts.count !== undefined) qs.set('count', String(opts.count))
+  for (const [key, value] of Object.entries(opts.extraParams ?? {})) {
+    if (value !== undefined && value !== '') qs.set(key, value)
+  }
+  const query = qs.toString()
+  return `${opts.apiBaseUrl ?? ''}${path}${query ? `?${query}` : ''}`
+}

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -87,6 +87,7 @@ export default defineConfig([
       // JSON-LD builder lives on a separate server-safe subpath
       // 'components/faq/json-ld' built in the server block above.
       'components/faq/index': 'src/components/faq/index.ts',
+      'components/related-content/index': 'src/components/related-content/index.ts',
       'components/ui/file-manager/index': 'src/components/ui/file-manager/index.ts',
       'components/features/index': 'src/components/features/index.ts',
       'components/toast/index': 'src/components/toast/index.ts',


### PR DESCRIPTION
## Summary
- **NEW `./components/related-content`** — `RelatedContentSection` moved from the hub. Three data modes: controlled `contentRefs` (original investor-update behavior), suggestion self-fetch (`entityType`/`entityId`/`minResults` → `GET /api/related-content`, `excludeTypes` forwarded for server-side subtraction), SSR-hydrated (`initialItems`). Host-injection props follow the ChatCardDispatchExtras precedent (`extras`, `resolveHref`, `buildListUrl`, `LinkProvider` render-prop, `adminCampaignCard`); `CardForType` is hook-free; `ref` prop renamed `contentRef` (React 18-safe); fetch layer = `useSelfFetch` (no QueryClientProvider needed); `apiBaseUrl` for third-party embeds.
- **ContentRef consolidation** — relocated the existing chat copy to `src/types/content-ref.ts` (+`ContentRefWithReason`); stub at the old chat path. One definition package-wide.
- **`content-ref-groups` moved from the hub** (+`onboarding_guide` entry); `extractItems`/`extractItemId` hoisted from `use-chat-card-item` to `src/utils/extract-items.ts`; NEW `buildSuggestionUrl` shared by both suggestion sections.
- **FaqSection** — `minResults` (→ `?count=`) + `apiBaseUrl`; memoized `initialData` (fixes a latent setState loop under re-rendering parents); embedded mode (`heading={null}`) now renders without the standalone page `<main>` shell and renders nothing when empty.

Pairs with the hub PR `feat/suggestion-engine` (generic 5-tier suggestion engine — FAQ + related-content share one util).

## Test plan
- `npm run type-check` clean
- Hub-side: FAQ parity gate (8-case before/after JSON diff), `/api/related-content` matrix, SSR embeds on blog/podcast/release pages, `/faqs` standalone unchanged on openmsp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embeddable Related Content section: grouped, type-aware rails, multiple data modes, and optional admin slot.

* **Enhancements**
  * Consistent related-content data shape for consumers.
  * FAQ section: configurable fetch params, improved embedded rendering and stable memoized initial data.
  * Improved suggestion fetching: robust URL builder, item extraction/ID handling, and type grouping/ordering registry.

* **Chores**
  * Build and package exports updated to expose the related-content entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->