### PR TITLE
fix(media): ODS theme tokens for media manager hover borders and letterbox backgrounds

### DIFF
--- a/openframe-frontend-core/src/components/features/media-gallery-manager.tsx
+++ b/openframe-frontend-core/src/components/features/media-gallery-manager.tsx
@@ -121,7 +121,7 @@ export function MediaGalleryManager({
     return (
       <Card
         key={index}
-        className="relative group border-ods-border hover:border-[#FFC008]/30 transition-colors"
+        className="relative group border-ods-border hover:border-ods-accent/30 transition-colors"
         draggable
         onDragStart={() => handleDragStart(index)}
         onDragOver={handleDragOver}
@@ -151,7 +151,7 @@ export function MediaGalleryManager({
         </div>
 
         {/* Media Content */}
-        <div className="aspect-video relative bg-[#1A1A1A] rounded-lg overflow-hidden">
+        <div className="aspect-video relative bg-ods-bg rounded-lg overflow-hidden">
           {mediaItem.media_type === 'video' || mediaItem.media_type === 'demo' ? (
             <video
               src={mediaItem.media_url}
@@ -195,7 +195,7 @@ export function MediaGalleryManager({
   const content = (
     <div className={`space-y-6 ${className}`}>
       {/* Upload Section */}
-      <div className="border-2 border-dashed border-ods-border rounded-lg p-6 text-center hover:border-[#FFC008]/50 transition-colors">
+      <div className="border-2 border-dashed border-ods-border rounded-lg p-6 text-center hover:border-ods-accent/50 transition-colors">
         <div className="flex flex-col items-center gap-4">
           <div className="w-12 h-12 rounded-full bg-ods-card flex items-center justify-center">
             {isUploading ? (

--- a/openframe-frontend-core/src/components/features/release-media-manager.tsx
+++ b/openframe-frontend-core/src/components/features/release-media-manager.tsx
@@ -122,7 +122,7 @@ export function ReleaseMediaManager({
   return (
     <div className={`space-y-4 ${className}`}>
       {/* Upload Section */}
-      <div className="border-2 border-dashed border-ods-border rounded-lg p-6 text-center hover:border-[#FFC008]/50 transition-colors">
+      <div className="border-2 border-dashed border-ods-border rounded-lg p-6 text-center hover:border-ods-accent/50 transition-colors">
         <div className="flex flex-col items-center gap-4">
           <div className="w-12 h-12 rounded-full bg-ods-card flex items-center justify-center">
             {uploadingIndex !== null ? (
@@ -180,7 +180,7 @@ export function ReleaseMediaManager({
                 onDragStart={handleDragStart(index)}
                 onDragOver={handleDragOver}
                 onDrop={handleDrop(index)}
-                className="relative group border border-ods-border rounded-lg overflow-hidden hover:border-[#FFC008]/30 transition-colors bg-ods-bg-secondary"
+                className="relative group border border-ods-border rounded-lg overflow-hidden hover:border-ods-accent/30 transition-colors bg-ods-bg-secondary"
               >
                 {/* Drag Handle */}
                 <div className="absolute top-2 left-2 opacity-0 group-hover:opacity-100 transition-opacity cursor-move z-10">
@@ -203,7 +203,7 @@ export function ReleaseMediaManager({
 
                 {/* Media Preview */}
                 {item.media_url && (
-                  <div className="aspect-video relative bg-[#1A1A1A]">
+                  <div className="aspect-video relative bg-ods-bg">
                     {item.media_type === 'video' || item.media_type === 'demo' ? (
                       <video
                         src={item.media_url}
@@ -224,7 +224,7 @@ export function ReleaseMediaManager({
                 )}
 
                 {item._uploading && (
-                  <div className="aspect-video bg-[#1A1A1A] flex items-center justify-center">
+                  <div className="aspect-video bg-ods-bg flex items-center justify-center">
                     <div className="flex flex-col items-center gap-2">
                       <Loader2 className="h-8 w-8 animate-spin text-ods-accent" />
                       <span className="text-sm text-ods-text-secondary">Uploading...</span>


### PR DESCRIPTION
## Summary
- Replace the hardcoded `#FFC008` yellow hover border on the **Upload Media** dropzone and media-card hover states with the per-platform `ods-accent` token, in both `ReleaseMediaManager` and `MediaGalleryManager`
- Replace the hardcoded `#1A1A1A` media-preview letterbox / uploading-placeholder backgrounds with `bg-ods-bg`

## Why
The dropzone (e.g. inside the hub's Create New Product Release modal) highlighted in a static yellow regardless of platform theme. `ods-accent` resolves to the platform accent (yellow on openmsp/openframe, pink on flamingo) and matches the accent-border pattern already used by `input.tsx` and `radio-group.tsx`. `bg-ods-bg` (#161616 dark) is visually indistinguishable from the old #1A1A1A and themes correctly in light mode.

Paired hub PR: flamingo-stack/multi-platform-hub#611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling across media management interfaces to use the new design system's color palette, ensuring consistent visual appearance throughout
  * Refreshed media cards and upload areas with updated border colors, hover effects, and background colors for improved visual cohesion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->