### PR TITLE
feat(types): transcript provenance stamps in CustomerInterviewConfig

### DIFF
--- a/openframe-frontend-core/src/types/customer-interview.ts
+++ b/openframe-frontend-core/src/types/customer-interview.ts
@@ -15,6 +15,15 @@ export interface CustomerInterviewConfig {
   highlight_target_duration_seconds?: number
   /** Skip subtitle burning during highlight video generation */
   skipSubtitleBurning?: boolean
+  /**
+   * SERVER-OWNED: video URL the current transcript was generated from
+   * (stale-transcript guard). Stamped by the hub's transcription save path;
+   * never written by admin UIs — partial config PATCHes must not include it
+   * (the hub preserves it server-side).
+   */
+  transcript_source_video_url?: string
+  /** SERVER-OWNED: ISO timestamp of the transcription that produced the current transcript */
+  transcript_generated_at?: string
 }
 
 export interface CustomerInterview {


### PR DESCRIPTION
## Why

flamingo-stack/multi-platform-hub#615 introduces server-owned transcript provenance stamps in the entity `config` JSONB (`transcript_source_video_url`, `transcript_generated_at`) — the stale-transcript guard that prevents highlight videos from being cut with a previous video's transcript. `CustomerInterviewConfig` is the one enumerated config type in the lib, so the fields are declared here too ("across the board" per review feedback).

## What

Two optional fields on `CustomerInterviewConfig`, documented as **SERVER-OWNED**: stamped by the hub's transcription save path, never written by admin UIs (the hub preserves them server-side across partial config PATCHes, so the AI-generation auto-save can't erase them).

Type-only change — no runtime impact; rides the next node release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer interview transcripts now include metadata tracking for generation timestamp and source video reference, providing enhanced transparency into transcript origins and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->