### PR TITLE
feat(faq): consolidate FAQ rendering — one flat accordion with category chips

### DIFF
--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -8,6 +8,10 @@ export interface FaqItem {
   id: number | string
   question: string
   answer: string
+  /** Optional category label rendered as a neutral chip under the question
+   *  (NOT a heading — keeps the document outline to h2/h3 only). Mirrors the
+   *  hub's FaqSectionBadge recipe so admin + public chips stay identical. */
+  badge?: string
 }
 
 interface FaqAccordionProps {
@@ -76,9 +80,16 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
               aria-expanded={isOpen}
               className="flex w-full items-center justify-between px-6 md:px-8 py-6 text-left focus:outline-none transition-colors cursor-pointer"
             >
-              <h3>
-                {item.question}
-              </h3>
+              <div className="flex min-w-0 flex-col gap-2 pr-4">
+                <h3>
+                  {item.question}
+                </h3>
+                {item.badge && (
+                  <span className="w-fit shrink-0 px-2 py-1 rounded text-xs font-medium font-['DM_Sans'] bg-ods-border text-ods-text-secondary">
+                    {item.badge}
+                  </span>
+                )}
+              </div>
               <div className="flex-shrink-0">
                 <ChevronButton
                   aria-label={isOpen ? 'Collapse question' : 'Expand question'}

--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -2,15 +2,18 @@
 
 import React, { useRef, useState, useEffect, useCallback } from 'react'
 import { ChevronButton } from './ui/chevron-button'
+import { StatusBadge } from './ui/status-badge'
+import { TAG_BADGE_CLASS } from './features/entity-tag-badges'
 import { cn } from "../utils/cn"
 
 export interface FaqItem {
   id: number | string
   question: string
   answer: string
-  /** Optional category label rendered as a neutral chip under the question
-   *  (NOT a heading — keeps the document outline to h2/h3 only). Mirrors the
-   *  hub's FaqSectionBadge recipe so admin + public chips stay identical. */
+  /** Optional category label (faq.section = tag name) rendered under the
+   *  question as the product's standard tag badge — the same StatusBadge
+   *  card skin EntityTagBadges uses everywhere (never a heading, so the
+   *  document outline stays h2/h3 only). */
   badge?: string
 }
 
@@ -80,14 +83,16 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
               aria-expanded={isOpen}
               className="flex w-full items-center justify-between px-6 md:px-8 py-6 text-left focus:outline-none transition-colors cursor-pointer"
             >
-              <div className="flex min-w-0 flex-col gap-2 pr-4">
+              <div className="flex min-w-0 flex-col items-start gap-2 pr-4">
                 <h3>
                   {item.question}
                 </h3>
                 {item.badge && (
-                  <span className="w-fit shrink-0 px-2 py-1 rounded text-xs font-medium font-['DM_Sans'] bg-ods-border text-ods-text-secondary">
-                    {item.badge}
-                  </span>
+                  <StatusBadge
+                    text={item.badge.toUpperCase()}
+                    variant="card"
+                    className={TAG_BADGE_CLASS}
+                  />
                 )}
               </div>
               <div className="flex-shrink-0">

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -19,11 +19,27 @@ export interface FaqSectionProps {
   entityType?: string
   entityId?: number | string
   /**
-   * Page heading. Pass null to render in embedded mode (no <h1>, error branch
-   * suppresses any banner). React node so platforms can drill their local
-   * <PageHeading> component without the lib referencing platform state.
+   * Heading node. `undefined` → variant default (page: <h1>, embedded: <h2>
+   * "Frequently Asked Questions"); `null` → no heading. React node so
+   * platforms can drill their local <PageHeading> component without the lib
+   * referencing platform state.
    */
   heading?: React.ReactNode | null
+  /**
+   * Layout variant.
+   *   - 'page' — the standalone /faqs surface: <main> shell + page gutters,
+   *     FAQs GROUPED by `faq.section` with one <h2> per section.
+   *   - 'embedded' — a section inside a host page (entity detail rails, the
+   *     global nested-page block): no shell, ONE flat accordion with each
+   *     row's `faq.section` rendered as a neutral chip (never a heading) and
+   *     a single default <h2> above. Exactly one FAQ block per page — the
+   *     per-tag heading loop is page-variant-only.
+   * Back-compat default: `heading === null` → 'embedded', else 'page' (the
+   * pre-variant discriminator, kept so older embedders don't shift layout
+   * until they opt in — they DO pick up the flat chip list, which is the
+   * point of the consolidation).
+   */
+  variant?: 'page' | 'embedded'
   /** Inject FAQPage schema.org JSON-LD as a <script>. Off by default so embeds
    *  don't emit duplicate schema. */
   emitJsonLd?: boolean
@@ -106,6 +122,7 @@ export function FaqSection({
   entityType,
   entityId,
   heading,
+  variant,
   emitJsonLd = false,
   jsonLd,
   className,
@@ -122,23 +139,30 @@ export function FaqSection({
   const { data, isLoading, error } = useSelfFetch<FaqsResponse>(url, { initialData })
 
   const faqs = data?.faqs ?? []
-  const showHeading = heading !== null
+  const isEmbedded = variant ? variant === 'embedded' : heading === null
   const headingNode =
-    heading === undefined
-      ? <h1 className="text-h1 tracking-[-0.04em] text-ods-text-primary">{DEFAULT_HEADING_TEXT}</h1>
-      : heading
+    heading === undefined ? (
+      isEmbedded ? (
+        // Embedded default is an <h2> — a host page already owns the <h1>,
+        // and the schema/heading pair must read "Frequently Asked Questions"
+        // (one FAQ heading per page, never tag/section names).
+        <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary">{DEFAULT_HEADING_TEXT}</h2>
+      ) : (
+        <h1 className="text-h1 tracking-[-0.04em] text-ods-text-primary">{DEFAULT_HEADING_TEXT}</h1>
+      )
+    ) : (
+      heading
+    )
 
-  const groups = groupBySection(faqs)
-
-  // Embedded mode (no heading): degrade silently on error.
-  if (error && !showHeading) {
+  // Embedded mode: degrade silently on error.
+  if (error && isEmbedded) {
     return null
   }
 
   // Embedded mode, zero FAQs after load: render nothing — an embedded host
   // page (blog/case-study detail) must not show an empty section shell.
-  // The standalone /faqs page (heading set) keeps its existing behavior.
-  if (!isLoading && !error && faqs.length === 0 && !showHeading) {
+  // The standalone /faqs page keeps its existing behavior.
+  if (!isLoading && !error && faqs.length === 0 && isEmbedded) {
     return null
   }
 
@@ -146,7 +170,7 @@ export function FaqSection({
     // Embedded mode renders skeletons WITHOUT the standalone page shell —
     // a host detail page already provides <main> + gutters; nesting them
     // here would emit invalid markup and double padding.
-    if (!showHeading) {
+    if (isEmbedded) {
       return (
         <div className={className}>
           <FaqSkeleton />
@@ -172,28 +196,40 @@ export function FaqSection({
 
   const schema = emitJsonLd ? buildFaqJsonLdFromFaqs(faqs, jsonLd) : null
 
-  const groupNodes = groups.map(({ section, items }) => (
-    <div key={section || 'default'} className="space-y-4">
-      {section && (
-        <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary mb-3 md:mb-4">
-          {section}
-        </h2>
-      )}
-      <FaqAccordion items={items} />
-    </div>
-  ))
-
-  // Embedded mode (heading === null): no <main> page shell, no page gutters —
-  // the host page owns layout. Standalone mode keeps the historical markup.
-  const body = showHeading ? (
+  // Embedded: ONE flat accordion — `faq.section` becomes a per-row chip, NOT
+  // a heading, so the host page's outline stays h2("Frequently Asked
+  // Questions") + h3(questions). Order is the server's (post-specific first,
+  // then reused) — grouping by section here would destroy it.
+  const body = isEmbedded ? (
+    <section className={className ?? 'space-y-6'}>
+      {headingNode}
+      <FaqAccordion
+        items={faqs.map((faq) => ({
+          id: faq.id,
+          question: faq.question,
+          answer: faq.answer,
+          badge: faq.section || undefined,
+        }))}
+      />
+    </section>
+  ) : (
+    // Page variant (standalone /faqs): historical markup — <main> shell,
+    // page gutters, FAQs grouped by section with one <h2> per section.
     <main className={className ?? 'bg-ods-bg'}>
       <div className="max-w-[1920px] px-6 md:px-20 py-6 md:py-10 mx-auto space-y-10">
         {headingNode}
-        {groupNodes}
+        {groupBySection(faqs).map(({ section, items }) => (
+          <div key={section || 'default'} className="space-y-4">
+            {section && (
+              <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary mb-3 md:mb-4">
+                {section}
+              </h2>
+            )}
+            <FaqAccordion items={items} />
+          </div>
+        ))}
       </div>
     </main>
-  ) : (
-    <section className={className ?? 'space-y-10'}>{groupNodes}</section>
   )
 
   return (

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -26,18 +26,14 @@ export interface FaqSectionProps {
    */
   heading?: React.ReactNode | null
   /**
-   * Layout variant.
+   * Shell variant — the FAQ LIST itself renders identically everywhere (ONE
+   * flat accordion, `faq.section` as a per-row chip, never a heading):
    *   - 'page' — the standalone /faqs surface: <main> shell + page gutters,
-   *     FAQs GROUPED by `faq.section` with one <h2> per section.
+   *     default <h1> heading.
    *   - 'embedded' — a section inside a host page (entity detail rails, the
-   *     global nested-page block): no shell, ONE flat accordion with each
-   *     row's `faq.section` rendered as a neutral chip (never a heading) and
-   *     a single default <h2> above. Exactly one FAQ block per page — the
-   *     per-tag heading loop is page-variant-only.
+   *     global nested-page block): bare <section>, default <h2> heading.
    * Back-compat default: `heading === null` → 'embedded', else 'page' (the
-   * pre-variant discriminator, kept so older embedders don't shift layout
-   * until they opt in — they DO pick up the flat chip list, which is the
-   * point of the consolidation).
+   * pre-variant discriminator).
    */
   variant?: 'page' | 'embedded'
   /** Inject FAQPage schema.org JSON-LD as a <script>. Off by default so embeds
@@ -68,20 +64,15 @@ function buildFaqsUrl(
   return buildSuggestionUrl('/api/faqs', { apiBaseUrl, entityType, entityId, count: minResults })
 }
 
-function groupBySection(faqs: Faq[]): Array<{ section: string | null; items: FaqItem[] }> {
-  const map = new Map<string, FaqItem[]>()
-  for (const faq of faqs) {
-    const key = faq.section || ''
-    let arr = map.get(key)
-    if (!arr) {
-      arr = []
-      map.set(key, arr)
-    }
-    arr.push({ id: faq.id, question: faq.question, answer: faq.answer })
-  }
-  return Array.from(map.entries()).map(([section, items]) => ({
-    section: section || null,
-    items,
+/** ONE list shape for every surface — standalone /faqs and embeds render the
+ *  IDENTICAL flat accordion (`faq.section` = per-row chip, never a heading),
+ *  so the two can't drift visually. */
+function toAccordionItems(faqs: Faq[]): FaqItem[] {
+  return faqs.map((faq) => ({
+    id: faq.id,
+    question: faq.question,
+    answer: faq.answer,
+    badge: faq.section || undefined,
   }))
 }
 
@@ -196,38 +187,22 @@ export function FaqSection({
 
   const schema = emitJsonLd ? buildFaqJsonLdFromFaqs(faqs, jsonLd) : null
 
-  // Embedded: ONE flat accordion — `faq.section` becomes a per-row chip, NOT
-  // a heading, so the host page's outline stays h2("Frequently Asked
-  // Questions") + h3(questions). Order is the server's (post-specific first,
-  // then reused) — grouping by section here would destroy it.
+  // ONE flat accordion on EVERY surface — `faq.section` becomes a per-row
+  // chip, NOT a heading, so the page outline stays heading + h3(questions).
+  // Order is the server's (post-specific first, then reused) — grouping by
+  // section here would destroy it. The variants differ ONLY in shell:
+  // standalone /faqs keeps its <main> + page gutters, embeds render bare.
+  const accordion = <FaqAccordion items={toAccordionItems(faqs)} />
   const body = isEmbedded ? (
-    <section className={className ?? 'space-y-6'}>
+    <section className={className ?? 'space-y-10'}>
       {headingNode}
-      <FaqAccordion
-        items={faqs.map((faq) => ({
-          id: faq.id,
-          question: faq.question,
-          answer: faq.answer,
-          badge: faq.section || undefined,
-        }))}
-      />
+      {accordion}
     </section>
   ) : (
-    // Page variant (standalone /faqs): historical markup — <main> shell,
-    // page gutters, FAQs grouped by section with one <h2> per section.
     <main className={className ?? 'bg-ods-bg'}>
       <div className="max-w-[1920px] px-6 md:px-20 py-6 md:py-10 mx-auto space-y-10">
         {headingNode}
-        {groupBySection(faqs).map(({ section, items }) => (
-          <div key={section || 'default'} className="space-y-4">
-            {section && (
-              <h2 className="text-h2 tracking-[-0.04em] text-ods-text-primary mb-3 md:mb-4">
-                {section}
-              </h2>
-            )}
-            <FaqAccordion items={items} />
-          </div>
-        ))}
+        {accordion}
       </div>
     </main>
   )

--- a/openframe-frontend-core/src/components/features/entity-tag-badges.tsx
+++ b/openframe-frontend-core/src/components/features/entity-tag-badges.tsx
@@ -19,7 +19,10 @@ interface EntityTagBadgesProps {
 
 // The ONE tag-badge skin (OpenFrame design): rounded-rect, font-mono uppercase
 // StatusBadge on ods-card + ods-border. Clickable badges add the accent hover.
-const BADGE_CLASS = 'bg-ods-card border border-ods-border'
+// Exported so other tag-shaped chips (e.g. FaqAccordion's section badge)
+// render the IDENTICAL skin without re-declaring it.
+export const TAG_BADGE_CLASS = 'bg-ods-card border border-ods-border'
+const BADGE_CLASS = TAG_BADGE_CLASS
 
 /**
  * THE single tag-badge renderer for the whole product (hub + lib). Renders the


### PR DESCRIPTION
## Summary

Implements the FAQ consolidation for [ClickUp 86aj034yj](https://app.clickup.com/t/86aj034yj): every FAQ surface now renders ONE flat accordion — `faq.section` becomes a per-row neutral chip (same recipe as the hub's admin `FaqSectionBadge`) instead of per-section `<h2>` tag-name headings.

- `FaqItem` gains an optional `badge` rendered as a chip under the question (`<span>`, never a heading — the outline stays heading + `<h3>` questions)
- `FaqSection` gains a `variant` prop (`'page' | 'embedded'`, back-compat derived from `heading === null`); the section-grouped rendering branch is **deleted** so standalone `/faqs` and embeds cannot drift visually
- Variants differ only in shell: `page` = `<main>` + gutters + default `<h1>`, `embedded` = bare `<section>` + default `<h2>`; hosts can drill their own heading node (the hub drills its `SECTION_HEADING_CLASS` h2)
- Embedded keeps degrade-silently semantics (error/empty → render nothing)

Published as `0.0.260`. Hub counterpart: flamingo-stack/multi-platform-hub branch `claude/brave-elion-b00276`.

## Verification

Verified live against the hub dev server (flamingo): blog detail, /blog list (global block), /faqs standalone — single "Frequently Asked Questions" heading per surface, zero tag-name headings, chips on every row, FAQPage JSON-LD mainEntity == rendered questions (10/10), 3 reloads → identical order. Lib `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FAQ items can include an optional badge displayed as a neutral chip beneath the question.
  * FAQ sections support a configurable display variant: "page" or "embedded".

* **Improvements**
  * FAQ rendering simplified to a single unified accordion; section names are shown as per-item badges instead of separate section headers.
  * Shared tag badge styling extracted for consistent reuse across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->