### PR TITLE
fix(comment-card): replace static hex colors with ODS theme tokens

### DIFF
--- a/openframe-frontend-core/src/components/comment-card.tsx
+++ b/openframe-frontend-core/src/components/comment-card.tsx
@@ -76,7 +76,7 @@ export function CommentCard({
   const showDeleteButton = canUserDeleteComment()
 
   return (
-    <div className="bg-ods-card border border-ods-border rounded-lg p-4 hover:border-[#FFC008] transition-all group overflow-hidden w-full max-w-full box-border" style={{ maxWidth: '100%', wordBreak: 'break-word' }}>
+    <div className="bg-ods-card border border-ods-border rounded-lg p-4 hover:border-ods-accent transition-all group overflow-hidden w-full max-w-full box-border" style={{ maxWidth: '100%', wordBreak: 'break-word' }}>
       {/* Comment Header */}
       <div className="flex flex-col gap-3 mb-3 min-[420px]:flex-row min-[420px]:items-center min-[420px]:justify-between min-[420px]:gap-2 w-full">
         {/* Row 1: Info + Timestamp */}

--- a/openframe-frontend-core/src/components/vendor-display-button.tsx
+++ b/openframe-frontend-core/src/components/vendor-display-button.tsx
@@ -31,7 +31,7 @@ export function VendorDisplayButton({ vendor, onClick, variant = 'default', exte
     return (
       <button 
         onClick={handleClick}
-        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#1A1A1A] border border-[#2A2A2A] hover:border-[#FFC008]/50 transition-colors"
+        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-ods-card border border-ods-border hover:border-ods-accent/50 transition-colors"
       >
         {logoUrl ? (
           <div className="w-5 h-5 rounded overflow-hidden flex-shrink-0">
@@ -44,13 +44,13 @@ export function VendorDisplayButton({ vendor, onClick, variant = 'default', exte
             />
           </div>
         ) : (
-          <div className="w-5 h-5 rounded bg-[#2A2A2A] flex items-center justify-center flex-shrink-0">
-            <span className="text-[#666666] text-[10px] font-medium">
+          <div className="w-5 h-5 rounded bg-ods-border flex items-center justify-center flex-shrink-0">
+            <span className="text-ods-text-secondary text-[10px] font-medium">
               {vendor.title.charAt(0).toUpperCase()}
             </span>
           </div>
         )}
-        <span className="text-sm font-medium text-white">
+        <span className="text-sm font-medium text-ods-text-primary">
           {vendor.title}
         </span>
       </button>
@@ -61,7 +61,7 @@ export function VendorDisplayButton({ vendor, onClick, variant = 'default', exte
   return (
     <button 
       onClick={handleClick}
-      className="flex items-center gap-2 bg-ods-card border border-ods-border rounded-lg py-2 px-3 hover:border-[#FFC008] transition-colors max-w-full overflow-hidden"
+      className="flex items-center gap-2 bg-ods-card border border-ods-border rounded-lg py-2 px-3 hover:border-ods-accent transition-colors max-w-full overflow-hidden"
     >
       {getVendorLogo(vendor) ? (
         <div className="w-8 h-8 bg-ods-card border border-ods-border rounded-lg flex items-center justify-center flex-shrink-0">


### PR DESCRIPTION
## Summary
- `CommentCard` and `VendorDisplayButton` (the vendor chip rendered inside profile "My Comments" cards) hardcoded the openmsp yellow accent `#FFC008` plus static dark greys (`#1A1A1A`, `#2A2A2A`, `#666666`, `text-white`), so colors ignored the per-platform ODS theme — e.g. flamingo platforms have a pink accent but still hovered yellow.
- Swapped every static color for the themed ODS tokens: `hover:border-ods-accent` (card + default chip hover), `bg-ods-card` / `border-ods-border` / `hover:border-ods-accent/50` (compact chip), `bg-ods-border` + `text-ods-text-secondary` (logo-fallback letter), `text-ods-text-primary` (vendor title).

## Notes
- All replacement utilities are already in active use across lib + hub (including the `/50` opacity-modified accent), so nothing new gets purged.
- Only other consumer of the compact variant is the flamingo-teaser home page — dark greys resolve identically there, and the hover accent now correctly follows its pink theme.
- className-only change; no type surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling across multiple interface components to use unified design system tokens and standardized color classes instead of hardcoded color values. Refined hover states, accent colors, and interactive element appearance to ensure consistent visual design throughout the application while maintaining alignment with design system standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->