### PR TITLE
feat(platform): add serves_all_content + tracks_activity to PlatformRecord

### DIFF
--- a/openframe-frontend-core/src/types/platform.ts
+++ b/openframe-frontend-core/src/types/platform.ts
@@ -11,6 +11,12 @@ export interface PlatformRecord {
   description?: string;
   is_active: boolean;
   is_internal: boolean; // Whether this is an internal admin platform vs public-facing
+  // Universal-viewer: when true, content DALs return ALL platforms' rows (applyFilter=false),
+  // decoupled from is_internal. Read by getPlatformContentScopeMode (hub lib/platform-utils.ts).
+  serves_all_content: boolean;
+  // When false, skip activity-tracking + HubSpot sync for this platform's principals
+  // (formerly keyed on is_internal). Read by platformTracksActivity (hub lib/platform-utils.ts).
+  tracks_activity: boolean;
   // Chat (Ask AI) wiring — populated only for platforms that host a chat surface.
   // `chat_source_id` is the doc-source binding (`chat_admin_personas.chat_source_id`).
   // `chat_source_rag_tables_version` is the per-platform RAG-table override version


### PR DESCRIPTION
## What

Adds two boolean fields to `PlatformRecord` (`openframe-frontend-core/src/types/platform.ts`):

- **`serves_all_content`** — the platform is a *universal viewer* (aggregates content from every platform) vs scoped to its own content.
- **`tracks_activity`** — visitor-activity / HubSpot sync runs for the platform.

## Why

These decouple the three concerns that `platforms.is_internal` previously conflated — auth wall, content scope, activity tracking — so **company-hub** can be served externally without coupling those behaviors together. The hub (`multi-platform-hub`) reads both fields.

## ⚠️ Merge order

The hub PR (flamingo-stack/multi-platform-hub#625) reads these fields and its Vercel `next build` will fail until this lib change is **merged → released to npm → hub version pin bumped**. **Merge + release this first.**

## DB

Matching prod columns `platforms.serves_all_content` / `tracks_activity` already exist (backfilled behavior-preserving: `= is_internal` / `= NOT is_internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
