### PR TITLE
refactor(logging): move to debug still opened sessions logging

### DIFF
--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
@@ -1,24 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included debug="true" scan="false">
 
-    <!--
-      DEV-ONLY variant of shared-logback-includes-logfmt.xml that shortens stack traces with
-      net.logstash.logback.stacktrace.ShortenedThrowableConverter (depth 30, maxLength 2048,
-      rootCauseFirst, inlineHash, framework-frame exclusions).
-
-      TEXT appenders use the `exShort` conversion word (registered in the parent
-      shared-logback-spring-logfmt-shortened.xml). Option order:
-      maxDepthPerThrowable, shortenedClassNameLength(full=no shortening), maxLength,
-      then keyword options (rootFirst, inlineHash), then frame-exclusion regexes.
-      %replace(...) flattens newlines so the whole trace stays on one logfmt line.
-
-      IMPORTANT: the conversion-word options are processed by logback's ${} variable-substitution
-      parser, which mis-handles a literal '$'. So the text exclusion regexes are written WITHOUT
-      '$' (CGLIB frames matched as substrings; no trailing-anchor on Thread.run). The JSON
-      <exclude> elements below are plain element text and keep the canonical '$' anchors.
-      Both lists target the same frames. Verified against logback 1.5.6 + logstash-encoder 8.0.
-    -->
-
     <!-- Console Appender in logfmt -->
     <appender name="ConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">

--- a/openframe-config-core/src/main/resources/logging/shared-logback-spring-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-spring-logfmt-shortened.xml
@@ -1,14 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  DEV-ONLY variant of shared-logback-spring-logfmt.xml.
-  Identical to the canonical file except it registers the `exShort` conversion word and
-  includes shared-logback-includes-logfmt-shortened.xml, which shortens stack traces
-  (ShortenedThrowableConverter: depth 30, maxLength 2048, rootCauseFirst, inlineHash,
-  framework-frame exclusions) on both the logfmt text appenders and the JSON appender.
-
-  Only configs/dev points its logging.config at this file. Once validated, fold the
-  shortened config into the canonical files for all envs and delete this fork.
--->
 <configuration debug="true" scan="false">
     <springProperty scope="context" name="SPRING_APP_NAME" source="spring.application.name"/>
     <springProperty scope="context" name="LOG_PATH" source="logging.file.path"/>

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -52,7 +52,7 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                 return handler.handle(proxySession)
                         .doFinally(signal -> {
                             if (proxySession.isOpen()) {
-                                log.warn(LOG_PREFIX + "still open after relay completed (signal={}), closing",
+                                log.debug(LOG_PREFIX + "still open after relay completed (signal={}), closing",
                                         sessionId, target, signal);
                                 proxySession.close(CloseStatus.GOING_AWAY)
                                         .timeout(CLOSE_TIMEOUT)


### PR DESCRIPTION
## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation comments from logging configuration files.
  * Adjusted logging verbosity to reduce noise in system logs by moving routine cleanup status messages to debug level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->