### PR TITLE
feat(media-gallery): shared MediaGalleryStrip + adopt in product-release detail

### DIFF
--- a/openframe-frontend-core/src/components/hero-image-uploader.tsx
+++ b/openframe-frontend-core/src/components/hero-image-uploader.tsx
@@ -149,7 +149,7 @@ export function HeroImageUploader({ imageUrl, onChange, uploadEndpoint, height =
         </div>
       ) : (
         <div
-          className={`w-full h-full border-2 border-dashed ${uploading ? 'border-[#FFC008]' : 'border-ods-border hover:border-[#FFC008]'} rounded-lg flex flex-col items-center justify-center cursor-pointer bg-[#1A1A1A]`}
+          className={`w-full h-full border-2 border-dashed ${uploading ? 'border-ods-accent' : 'border-ods-border hover:border-ods-accent'} rounded-lg flex flex-col items-center justify-center cursor-pointer bg-ods-bg`}
           style={{ height: heightStyle }}
           onClick={openDialog}
         >
@@ -160,7 +160,7 @@ export function HeroImageUploader({ imageUrl, onChange, uploadEndpoint, height =
               <ImageIcon className="h-12 w-12 text-ods-text-secondary" />
               <span className="text-ods-text-primary font-['DM_Sans'] text-[16px] font-medium mt-2">Upload cover image</span>
               <span className="text-ods-text-secondary font-['DM_Sans'] text-[14px] mt-1">Click to upload or drag and drop</span>
-              <span className="text-[#666666] font-['DM_Sans'] text-[12px]">PNG, JPEG, WebP, GIF up to 5MB</span>
+              <span className="text-ods-text-secondary font-['DM_Sans'] text-[12px]">PNG, JPEG, WebP, GIF up to 5MB</span>
             </>
           )}
         </div>

--- a/openframe-frontend-core/src/components/index.ts
+++ b/openframe-frontend-core/src/components/index.ts
@@ -95,6 +95,11 @@ export { DetailPageSkeleton, type DetailPageSkeletonProps } from './shared/detai
 // fallbackBio copy (the hub uses defaultAuthorFallbackBio()).
 export { ArticleAuthorByline, type ArticleAuthorBylineProps } from './shared/article-author-byline'
 
+// Read-only media gallery strip (horizontal scroll; images → lightbox, clips →
+// inline Video). Single source of truth for the detail-page media gallery —
+// used by product-release + What I Shipped detail pages.
+export { MediaGalleryStrip, type MediaGalleryStripItem, type MediaGalleryStripProps } from './shared/media-gallery-strip'
+
 // Author detail-page body (identity + socials + bio + expertise, rail as
 // children) — the one implementation behind /authors/[slug] and embedded
 // author pages.

--- a/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
+++ b/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
@@ -40,31 +40,44 @@ export function MediaGalleryStrip({ items, maxDisplay, className }: MediaGallery
 
   if (!items || items.length === 0) return null;
 
-  const display = maxDisplay ? items.slice(0, maxDisplay) : items;
+  // Explicit numeric check (clamped): `maxDisplay={0}` means "show none", which a
+  // truthy check would wrongly treat as "no cap → show all".
+  const display = typeof maxDisplay === 'number' ? items.slice(0, Math.max(0, maxDisplay)) : items;
   const galleryImages = display.filter((m) => isGalleryImage(m.media_type)).map((m) => m.media_url);
+
+  const tileClass =
+    'shrink-0 w-[240px] h-[200px] rounded-md overflow-hidden border border-ods-border bg-black transition-opacity';
 
   return (
     <>
       <div className={`flex gap-6 overflow-x-auto w-full ${className ?? ''}`}>
-        {display.map((mediaItem, index) => (
-          <div
-            key={mediaItem.id || index}
-            className="shrink-0 w-[240px] h-[200px] rounded-md overflow-hidden border border-ods-border bg-black cursor-pointer hover:opacity-80 transition-opacity"
-            onClick={() => {
-              if (isGalleryImage(mediaItem.media_type)) {
-                // Lightbox position = rank among image-only items (clips skipped).
-                setGalleryIndex(display.slice(0, index).filter((m) => isGalleryImage(m.media_type)).length);
-                setGalleryOpen(true);
-              }
-            }}
-          >
-            {isGalleryImage(mediaItem.media_type) ? (
-              <img src={mediaItem.media_url} alt={mediaItem.title || `Media ${index + 1}`} className="w-full h-full object-cover" />
-            ) : (
+        {display.map((mediaItem, index) => {
+          // Image tiles open the lightbox, so they're real <button>s — keyboard
+          // focusable + Enter/Space activatable. Clips render in <Video>, which
+          // owns its own controls, so their tile stays a plain container.
+          if (isGalleryImage(mediaItem.media_type)) {
+            return (
+              <button
+                key={mediaItem.id || index}
+                type="button"
+                className={`${tileClass} cursor-pointer hover:opacity-80`}
+                aria-label={`Open ${mediaItem.title || `media ${index + 1}`} in gallery`}
+                onClick={() => {
+                  // Lightbox position = rank among image-only items (clips skipped).
+                  setGalleryIndex(display.slice(0, index).filter((m) => isGalleryImage(m.media_type)).length);
+                  setGalleryOpen(true);
+                }}
+              >
+                <img src={mediaItem.media_url} alt={mediaItem.title || `Media ${index + 1}`} className="w-full h-full object-cover" />
+              </button>
+            );
+          }
+          return (
+            <div key={mediaItem.id || index} className={tileClass}>
               <Video url={mediaItem.media_url} layout="native" />
-            )}
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
 
       {galleryImages.length > 0 && (

--- a/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
+++ b/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import React, { useState } from 'react';
+import { Video } from '../features/video';
+import { ImageGalleryModal } from '../ui/image-gallery-modal';
+
+export interface MediaGalleryStripItem {
+  media_type: string;
+  media_url: string;
+  title?: string | null;
+  /** Stable key when present (e.g. release_media rows); falls back to index. */
+  id?: string;
+}
+
+/** Still-images open the lightbox; clips ('video'/'demo') play inline. */
+function isGalleryImage(mediaType: string): boolean {
+  return mediaType !== 'video' && mediaType !== 'demo';
+}
+
+export interface MediaGalleryStripProps {
+  items: MediaGalleryStripItem[];
+  /** Optional cap on tiles shown (e.g. product-release shows 5). Default: all. */
+  maxDisplay?: number;
+  className?: string;
+}
+
+/**
+ * Read-only media gallery — a horizontal-scroll strip of 240×200 tiles where
+ * still-images open an {@link ImageGalleryModal} lightbox and video clips play
+ * inline via {@link Video}. The lightbox index is the tile's rank among the
+ * IMAGE-only items (clips are skipped), so the modal opens on the correct image.
+ *
+ * Single source of truth for the detail-page media strip — replaces the markup
+ * that was hand-rolled inline in the product-release and "What I Shipped" detail
+ * pages (the release copy also had a raw-index lightbox bug this component fixes).
+ */
+export function MediaGalleryStrip({ items, maxDisplay, className }: MediaGalleryStripProps) {
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [galleryIndex, setGalleryIndex] = useState(0);
+
+  if (!items || items.length === 0) return null;
+
+  const display = maxDisplay ? items.slice(0, maxDisplay) : items;
+  const galleryImages = display.filter((m) => isGalleryImage(m.media_type)).map((m) => m.media_url);
+
+  return (
+    <>
+      <div className={`flex gap-6 overflow-x-auto w-full ${className ?? ''}`}>
+        {display.map((mediaItem, index) => (
+          <div
+            key={mediaItem.id || index}
+            className="shrink-0 w-[240px] h-[200px] rounded-md overflow-hidden border border-ods-border bg-black cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => {
+              if (isGalleryImage(mediaItem.media_type)) {
+                // Lightbox position = rank among image-only items (clips skipped).
+                setGalleryIndex(display.slice(0, index).filter((m) => isGalleryImage(m.media_type)).length);
+                setGalleryOpen(true);
+              }
+            }}
+          >
+            {isGalleryImage(mediaItem.media_type) ? (
+              <img src={mediaItem.media_url} alt={mediaItem.title || `Media ${index + 1}`} className="w-full h-full object-cover" />
+            ) : (
+              <Video url={mediaItem.media_url} layout="native" />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {galleryImages.length > 0 && (
+        <ImageGalleryModal
+          images={galleryImages}
+          isOpen={galleryOpen}
+          onClose={() => setGalleryOpen(false)}
+          initialIndex={galleryIndex}
+        />
+      )}
+    </>
+  );
+}

--- a/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
+++ b/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
@@ -13,7 +13,7 @@ import { ReleaseChangelogSection } from '../../ui/release-changelog-section';
 import { EntityTagBadges } from '../../features/entity-tag-badges';
 import { EntityMetadataAuthorCell } from '../../chat/entity-cards/entity-author-card';
 import type { EntityAuthor } from '../../../types/entity-author';
-import { ImageGalleryModal } from '../../ui/image-gallery-modal';
+import { MediaGalleryStrip } from '../media-gallery-strip';
 import { GitHubIcon } from '../../icons/github-icon';
 import { AlertTriangle, ExternalLink, BookMarked, Sparkles, TrendingUp, Wrench } from 'lucide-react';
 import { formatReleaseDate } from '../../../utils/date-formatters';
@@ -131,8 +131,6 @@ export function ReleaseDetailPage({
   // Use pre-fetched data if provided (admin preview), otherwise fetch via hook (public)
   const { data: fetchedRelease, error, isLoading } = useRelease(initialData ? undefined : slug);
   const release = (initialData || fetchedRelease) as Record<string, unknown> | undefined;
-  const [galleryOpen, setGalleryOpen] = useState(false);
-  const [galleryIndex, setGalleryIndex] = useState(0);
 
   // Back-button config — mirrors DevSectionPage / LegalDocumentPage.
   // Default: { label: 'Back to home', href: '/' }. Pass `false` to hide
@@ -307,29 +305,8 @@ export function ReleaseDetailPage({
           />
         </div>
 
-        {/* Image Gallery - Horizontal Scrolling */}
-        {releaseMedia && releaseMedia.length > 0 && (
-          <div className="flex gap-6 overflow-x-auto w-full">
-            {releaseMedia.slice(0, 5).map((mediaItem, index) => (
-              <div
-                key={mediaItem.id || index}
-                className="shrink-0 w-[240px] h-[200px] rounded-md overflow-hidden border border-ods-border bg-black cursor-pointer hover:opacity-80 transition-opacity"
-                onClick={() => {
-                  if (mediaItem.media_type !== 'video' && mediaItem.media_type !== 'demo') {
-                    setGalleryIndex(index);
-                    setGalleryOpen(true);
-                  }
-                }}
-              >
-                {mediaItem.media_type === 'video' || mediaItem.media_type === 'demo' ? (
-                  <Video url={mediaItem.media_url} layout="native" />
-                ) : (
-                  <img src={mediaItem.media_url} alt={mediaItem.title || `Media ${index + 1}`} className="w-full h-full object-cover" />
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+        {/* Image gallery — shared strip + lightbox (images) / inline clips. */}
+        <MediaGalleryStrip items={releaseMedia ?? []} maxDisplay={5} />
 
         {/* Summary */}
         {releaseSummary && (
@@ -580,16 +557,6 @@ export function ReleaseDetailPage({
           </div>
         )}
       </div>
-
-      {/* Gallery Modal */}
-      {releaseMedia && releaseMedia.filter((m) => m.media_type !== 'video' && m.media_type !== 'demo').length > 0 && (
-        <ImageGalleryModal
-          images={releaseMedia.filter((m) => m.media_type !== 'video' && m.media_type !== 'demo').map((m) => m.media_url)}
-          isOpen={galleryOpen}
-          onClose={() => setGalleryOpen(false)}
-          initialIndex={galleryIndex}
-        />
-      )}
     </PageShell>
   );
 }


### PR DESCRIPTION
## Shared `MediaGalleryStrip`

Extracts the hand-rolled detail-page **media gallery** into ONE reusable component and wires it into the detail pages that each had their own copy.

`MediaGalleryStrip` (`src/components/shared/media-gallery-strip.tsx`, exported from the `components` barrel): a horizontal-scroll strip of 240×200 tiles where still-images open the `ImageGalleryModal` lightbox and `video`/`demo` clips play inline via `<Video>`. The lightbox index is the tile's rank among the **image-only** items (clips skipped), so the modal opens on the correct image.

### Adopted in
- **Product-release detail page** (`shared/product-release/release-detail-page.tsx`) — replaces its inline strip + lightbox + gallery state. This also **fixes a lightbox-index bug** in the old copy: it used the raw tile index instead of the image-only rank, so clicking an image positioned after a clip opened the wrong one.
- **What I Shipped detail page** (hub) — adopts the same component in the companion hub PR **flamingo-stack/multi-platform-hub#634**.

### Deliberately not changed (different patterns)
`event-detail-page` (images-only grid + `getOptimizedEventImageUrl`), `program-card` and `roadmap-card` (card-level / `screenshots: string[]`) use `ImageGalleryModal` differently — no inline clips, image optimization, or different data shape. They're not the same strip and are left as-is.

### Release / consumer order ⚠️
The hub pins an exact `@flamingo-stack/openframe-frontend-core` version. **Merge this PR → release the lib → bump the hub pin** in #634 before its Vercel build can resolve `MediaGalleryStrip` from npm (yalc covers dev).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable horizontal, scrollable media gallery strip component with optional display limiting, image tile handling, and inline video/demo rendering.

* **Refactor**
  * Updated the release detail page to use the new shared media gallery strip instead of its previous per-page gallery/lightbox behavior.

* **Bug Fixes**
  * Fixed maxDisplay behavior so `maxDisplay={0}` results in no tiles shown.

* **Style**
  * Refreshed hero image uploader empty-state colors to use design tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->