### PR TITLE
Add Fea Chat Skeleton's

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-ticket-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-ticket-list.tsx
@@ -9,10 +9,9 @@ export interface ChatTicketListProps extends React.HTMLAttributes<HTMLDivElement
   onTicketClick?: (ticketId: string) => void
   /** Show skeleton placeholder rows instead of tickets while loading. */
   isLoading?: boolean
+  /** Number of skeleton rows rendered while `isLoading`. Defaults to 5. */
+  skeletonCount?: number
 }
-
-/** Number of skeleton rows rendered while `isLoading`. */
-const SKELETON_ROW_COUNT = 4
 
 function getMask(top: boolean, bottom: boolean) {
   if (top && bottom) return 'linear-gradient(to bottom, transparent, black 64px, black calc(100% - 64px), transparent)'
@@ -22,7 +21,7 @@ function getMask(top: boolean, bottom: boolean) {
 }
 
 const ChatTicketList = React.forwardRef<HTMLDivElement, ChatTicketListProps>(
-  ({ className, tickets, onTicketClick, isLoading = false, ...props }, ref) => {
+  ({ className, tickets, onTicketClick, isLoading = false, skeletonCount = 5, ...props }, ref) => {
     const scrollRef = React.useRef<HTMLDivElement>(null)
     const [fadeTop, setFadeTop] = React.useState(false)
     const [fadeBottom, setFadeBottom] = React.useState(false)
@@ -44,7 +43,7 @@ const ChatTicketList = React.forwardRef<HTMLDivElement, ChatTicketListProps>(
         <div ref={ref} className={cn("flex flex-col gap-2 min-h-0", className)} {...props}>
           <p className="text-h5 text-ods-text-secondary shrink-0">Your Chats:</p>
           <div className="border border-ods-border rounded-md flex-1 min-h-0 overflow-hidden">
-            {Array.from({ length: SKELETON_ROW_COUNT }).map((_, i) => (
+            {Array.from({ length: skeletonCount }).map((_, i) => (
               // eslint-disable-next-line react/no-array-index-key
               <ChatTicketItem key={i} isLoading />
             ))}

--- a/openframe-frontend-core/src/components/chat/entity-cards/chat-ticket-item.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/chat-ticket-item.tsx
@@ -56,14 +56,14 @@ const ChatTicketItem = React.forwardRef<HTMLButtonElement, ChatTicketItemProps>(
             className,
           )}
         >
-          <div className="flex flex-col justify-center flex-1 min-w-0 gap-2">
+          <div className="flex flex-col justify-center flex-1 min-w-0 gap-1">
             {/* title line */}
             <Skeleton className="h-5 w-1/2" />
             {/* subtitle line */}
             <Skeleton className="h-4 w-1/3" />
           </div>
           {/* status tag */}
-          <Skeleton className="h-7 w-20 rounded-full shrink-0" />
+          <Skeleton className="h-8 w-20 rounded-r-md shrink-0" />
           {/* chevron box */}
           <Skeleton className="size-12 rounded-md shrink-0" />
         </div>

--- a/openframe-frontend-core/src/components/chat/model-display.tsx
+++ b/openframe-frontend-core/src/components/chat/model-display.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn';
 import type { ModelDisplayProps, ModelUsageBreakdown } from './types';
 import { AnthropicLogoGreyIcon, GeminiLogoGreyIcon, OpenaiLogoGreyIcon } from '../icons-v2-generated';
 import { HoverCard, HoverCardContent, HoverCardTrigger } from '../hover-card';
+import { Skeleton } from '../ui/skeleton';
 
 const getProviderIcon = (provider?: string) => {
   if (!provider) return null;
@@ -186,4 +187,38 @@ function BreakdownRow({
 
 ModelDisplay.displayName = 'ModelDisplay';
 
-export { ModelDisplay };
+export interface ModelDisplaySkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Also render the right-aligned "tokens used" tail placeholder. The token
+   *  tail only appears once `contextWindow` is known, so the default skeleton
+   *  shows just the left part (provider icon + model name). */
+  showTokens?: boolean;
+}
+
+/**
+ * Loading placeholder for the {@link ModelDisplay} inline pill. Mirrors its
+ * layout (provider icon + model name) so the footer doesn't shift when the
+ * real model metadata resolves. The "tokens used" tail is opt-in via
+ * `showTokens`, matching ModelDisplay (which only renders it once the context
+ * window is known).
+ */
+const ModelDisplaySkeleton = React.forwardRef<HTMLDivElement, ModelDisplaySkeletonProps>(
+  ({ className, showTokens = false, ...props }, ref) => (
+    <div
+      ref={ref}
+      aria-hidden
+      className={cn('flex items-center gap-1 text-sm', className)}
+      {...props}
+    >
+      {/* provider icon */}
+      <Skeleton className="w-4 h-5 rounded-sm shrink-0" />
+      {/* model name */}
+      <Skeleton className="h-5 w-24" />
+      {/* "X / Y tokens used" tail — only when tokens are expected */}
+      {showTokens && <Skeleton className="h-3 w-32 ml-auto" />}
+    </div>
+  ),
+);
+
+ModelDisplaySkeleton.displayName = 'ModelDisplaySkeleton';
+
+export { ModelDisplay, ModelDisplaySkeleton };

--- a/openframe-frontend-core/src/stories/ChatContainer.stories.tsx
+++ b/openframe-frontend-core/src/stories/ChatContainer.stories.tsx
@@ -9,7 +9,9 @@ import {
 } from '../components/chat/chat-container'
 import { ChatInput } from '../components/chat/chat-input'
 import { ChatMessageList } from '../components/chat/chat-message-list'
+import { ModelDisplay, ModelDisplaySkeleton } from '../components/chat/model-display'
 import type { Message } from '../components/chat/types/message.types'
+import { cn } from '../utils/cn'
 
 // =============================================================================
 // Mock messages — sample client-facing Fae conversation
@@ -59,10 +61,12 @@ function FaeChatShell({
   withTicketInfo = false,
   bare = false,
   fullWidth = false,
+  modelLoading = false,
 }: {
   withTicketInfo?: boolean
   bare?: boolean
   fullWidth?: boolean
+  modelLoading?: boolean
 }) {
   const [messages, setMessages] = useState<Message[]>(FAE_MESSAGES)
 
@@ -121,6 +125,22 @@ function FaeChatShell({
           placeholder="Message Fae..."
           fullWidth={fullWidth}
         />
+        {/* Model row below the composer — its width tracks the composer's, so
+            in `fullWidth` it spans the footer instead of the centered column.
+            Loaded state shows the real `ModelDisplay`; `modelLoading` swaps in
+            the skeleton placeholder. */}
+        <div
+          className={cn(
+            'mt-[var(--spacing-system-sf)]',
+            fullWidth ? 'w-full' : 'mx-auto w-full max-w-ods-content-narrow',
+          )}
+        >
+          {modelLoading ? (
+            <ModelDisplaySkeleton />
+          ) : (
+            <ModelDisplay provider="google" modelName="gemini-2.5" displayName="Google Gemini 3.5" />
+          )}
+        </div>
       </ChatFooter>
     </ChatContainer>
   )
@@ -183,4 +203,14 @@ export const FaeFullWidth: Story = {
  */
 export const FaeBareHeader: Story = {
   render: () => <FaeChatShell bare fullWidth />,
+}
+
+/**
+ * Model row in its loading state — `ModelDisplaySkeleton` stands in for the
+ * `ModelDisplay` pill below the composer until the model metadata resolves.
+ * Shows only the left part (provider icon + model name); the "tokens used"
+ * tail is opt-in via `showTokens`.
+ */
+export const FaeModelLoading: Story = {
+  render: () => <FaeChatShell modelLoading />,
 }


### PR DESCRIPTION
Add "Chat Lists" Skeleton.
Add "AI Model" Skeleton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading skeleton placeholder for model display information matching the final layout
  * Made skeleton row count customizable in chat ticket lists (defaults to 5)

* **Style**
  * Refined skeleton placeholder styling with improved spacing and updated visual proportions for status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->