### PR TITLE
hotfix(embeds): unbreak main — rename OGLinkPreview ErrorBoundary collision

### DIFF
--- a/openframe-frontend-core/src/components/embeds/index.ts
+++ b/openframe-frontend-core/src/components/embeds/index.ts
@@ -10,7 +10,7 @@ export type { GoogleSheetsViewerProps } from './google-sheets-viewer'
 export { FigmaEmbed } from './figma-embed'
 export type { FigmaEmbedProps } from './figma-embed'
 
-export { OGLinkPreview, ErrorBoundary } from './og-link-preview'
+export { OGLinkPreview, OGLinkErrorBoundary } from './og-link-preview'
 export type {
   OGLinkPreviewProps,
   OGData,

--- a/openframe-frontend-core/src/components/embeds/og-link-preview.tsx
+++ b/openframe-frontend-core/src/components/embeds/og-link-preview.tsx
@@ -36,8 +36,14 @@ interface ErrorBoundaryState {
  * Tiny error boundary tailored for OG link previews — caught errors quietly
  * fall back to the `fallback` prop (typically a plain hyperlink) so a single
  * broken third-party preview can't crash a whole article view.
+ *
+ * Named `OGLinkErrorBoundary` (not the generic `ErrorBoundary`) because the
+ * lib already exports a separate `ErrorBoundary` from
+ * `components/features/error-boundary.tsx`. The top-level `components/index.ts`
+ * barrel re-exports both `./embeds` and `./features` via `export *`, so a
+ * second `ErrorBoundary` here collides as TS2308.
  */
-export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class OGLinkErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props)
     this.state = { hasError: false }


### PR DESCRIPTION
## What broke

PR #1204 (OGLinkPreview lift) merged at 16:18:52Z **before** the rename fix-up commit `refactor/og-link-preview-lift@38bfbea7` reached the branch. Main now fails the Test Node CI step:

\`\`\`
src/components/index.ts(7,1): error TS2308: Module './embeds' has already
exported a member named 'ErrorBoundary'. Consider explicitly re-exporting
to resolve the ambiguity.
\`\`\`

The lib already exports a generic \`ErrorBoundary\` from \`components/features/error-boundary.tsx\`. The newly-lifted OGLinkPreview file shipped its own inline \`ErrorBoundary\` (carried over verbatim from the hub copy). The top-level \`components/index.ts\` re-exports both \`./embeds\` and \`./features\` via \`export *\`, so the two names collide.

## Fix

- Rename the OG-specific class \`ErrorBoundary\` → \`OGLinkErrorBoundary\` inside the lifted file.
- Update the \`components/embeds/index.ts\` barrel re-export accordingly.

Only 2 files touched, ~8 LOC.

## Downstream

The hub follow-up PR that consumes the lib's \`OGLinkPreview\` will import \`OGLinkErrorBoundary\` from \`@flamingo-stack/openframe-frontend-core/components/embeds\` instead of the generic name. The new name is unambiguous which is the right long-term shape regardless.

## Test plan

- [ ] CI green: \`Test Node (openframe-frontend-core)\` passes.
- [ ] Spot-check: \`OGLinkPreview\` + \`OGLinkErrorBoundary\` are exported from \`components/embeds\` barrel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)