### PR TITLE
feat(chat-cards): register 'faq' documentType in inline-card dispatch

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
@@ -74,6 +74,7 @@ import { MingoIcon } from '../../icons'
 import { EyeIcon } from '../../icons-v2-generated/interface/eye-icon'
 import { ArrowRightUpIcon } from '../../icons-v2-generated/arrows/arrow-right-up-icon'
 import { TagIcon } from '../../icons-v2-generated/shopping/tag-icon'
+import { QuestionCircleIcon } from '../../icons-v2-generated/signs-and-symbols/question-circle-icon'
 import { SlackLogoGreyIcon } from '../../icons-v2-generated/brand-logos/slack-logo-grey-icon'
 import { FileContentIcon } from '../../icons-v2-generated/documents/file-content-icon'
 import { ChartBar01VerIcon } from '../../icons-v2-generated/charts/chart-bar-01-ver-icon'
@@ -350,6 +351,39 @@ function HubspotTicketChatCard({
         icon: <TagIcon size={20} />,
       })}
       menuAriaLabel="Ticket actions"
+    />
+  )
+}
+
+/** FAQ Q&A — title=question, body=answer preview, optional section pill.
+ *  No-fetch card: every field the renderer needs already lives on the
+ *  ChatRef (hub's `FAQ_MAPPER.toRetrievedDoc` populates `title` /
+ *  `preview` / `url` / `targetPlatform`, and the section name is threaded
+ *  through `metadata.section` for the badge). The card itself stays pure
+ *  presentation — same shape as `SlackChatCard` / `HubspotTicketChatCard`. */
+function FaqChatCard({
+  chatRef,
+  isNewTab,
+  discuss,
+}: {
+  chatRef: ChatRef
+  isNewTab: boolean
+  discuss?: CardDiscussAction
+}) {
+  const section =
+    typeof chatRef.metadata?.section === 'string'
+      ? (chatRef.metadata.section as string).trim()
+      : undefined
+  const statusLabel = section && section.length > 0 ? section : 'FAQ'
+  return (
+    <MingoInfoCard
+      title={chatRef.title}
+      description={chatRef.preview ?? undefined}
+      icon={<QuestionCircleIcon size={24} />}
+      status={{ label: statusLabel, variant: 'grey' }}
+      anchorProps={buildAnchorProps(chatRef.url, isNewTab)}
+      menuGroups={cardMenuGroups(chatRef.url, discuss)}
+      menuAriaLabel="FAQ actions"
     />
   )
 }
@@ -1119,6 +1153,14 @@ const CHAT_CARD_REGISTRY: Record<string, ChatCardRegistryEntry> = {
     render: (chatRef, opts) => (
       <SlackChatCard chatRef={chatRef} isNewTab={opts.isNewTab}
           discuss={opts.discuss} />
+    ),
+  },
+  faq: {
+    mode: 'no-fetch',
+    label: 'FAQ',
+    bareInline: true,
+    render: (chatRef, opts) => (
+      <FaqChatCard chatRef={chatRef} isNewTab={opts.isNewTab} discuss={opts.discuss} />
     ),
   },
   hubspot_ticket: {


### PR DESCRIPTION
## Summary

Closes the cards-not-rendering follow-up from [multi-platform-hub#645](https://github.com/flamingo-stack/multi-platform-hub/pull/645). `[card://faq:<id>]` markers were falling through to plain text because `'faq'` wasn't in `CHAT_CARD_REGISTRY` in `components/chat/entity-cards/dispatch.tsx`.

Two minimal additions:

1. `FaqChatCard` — pure-presentation component, same shape as `SlackChatCard` / `HubspotTicketChatCard`. `MingoInfoCard` shell with `QuestionCircleIcon` glyph, grey badge ("Pricing"/"AI Safety"/etc. from `chatRef.metadata.section` when threaded, else "FAQ" fallback).
2. `'faq'` registry entry — no-fetch mode (ChatRef already carries everything from the hub's `FAQ_MAPPER.toRetrievedDoc`).

## Why

The hub already wires FAQ end-to-end as a RAG source (chat search returns FAQ rows, server emits `[card://faq:<id>]` markers, both ref-map keys are populated). The only missing piece is the lib-side dispatch case — without it, `chat-message-enhanced.tsx` renders the marker as raw text, which the user sees as a wall of plain prose with no clickable cards.

## Dependency

Hub PR will land in the same release window — bumps `package.json` pin once this releases.

## Test plan

- [ ] After deploy + hub pin bump: ask any chat-source platform (openframe / flamingo / openmsp) about an FAQ topic. The answer should now render FAQ rows as compact cards with question / answer preview / question-mark glyph / badge — not plain text.
- [ ] Click the card → opens `/faqs#faq-item-<id>` on the FAQ's bound platform.
- [ ] Modifier-click → new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FAQ chat card type for displaying frequently asked questions. Questions are shown with icons, titles, previews, and direct links, with section categorization for better organization of content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->