### PR TITLE
feat(nav+dev-center): one same-page-hash primitive + hash-anchored scroll for roadmap/delivery rows

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
@@ -100,6 +100,12 @@ export interface RoadmapCardProps {
   cardType?: 'roadmap_item' | 'delivery_item' | 'internal_task'
   size?: CardSize
   className?: string
+  /** DOM `id` applied to the card's outer element. `RoadmapGrid` sets
+   *  `roadmap-<external_id>` so chat-card deep-links
+   *  (`?search=<id>#roadmap-<id>`) have a target for `useScrollToHash`
+   *  to scroll to. `scroll-mt-24` on the outer element keeps the card
+   *  BELOW the sticky chrome. */
+  id?: string
   // Default-branch vote controls (ignored in `sm`):
   userVote?: VoteType | null
   onVote?: (voteType: 'up' | 'down') => void
@@ -116,6 +122,7 @@ export function RoadmapCard({
   size = 'default',
   cardType = 'roadmap_item',
   className,
+  id,
   userVote,
   onVote,
   isVoting = false,
@@ -233,7 +240,7 @@ export function RoadmapCard({
   }
 
   return (
-    <div className={`bg-ods-card border border-ods-border rounded-[6px] p-[24px] flex flex-col gap-[16px] hover:border-ods-accent transition-all h-full ${className ?? ''}`}>
+    <div id={id} className={`bg-ods-card border border-ods-border rounded-[6px] p-[24px] flex flex-col gap-[16px] hover:border-ods-accent transition-all h-full scroll-mt-24 ${className ?? ''}`}>
       <div className="flex gap-[16px] items-center w-full">
         <div className="w-16 h-16 rounded-lg flex items-center justify-center flex-shrink-0 bg-ods-bg border border-ods-border">
           {iconSrc ? (

--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -334,7 +334,9 @@ export function useDocumentTree(
     // don't need the 300ms "wait-for-fetch" bandaid — the canonical helper
     // owns pushState + synthetic `hashchange` (so any in-doc TOC / accordion
     // bound to the URL hash re-renders) + the anchoring-proof tween in one
-    // sync call. Cross-doc nav (different cleanPath) falls through to the
+    // sync call. `headerOffset: 80` matches the cross-doc path below so
+    // anchors land BELOW the docs sticky header on every same-doc internal
+    // link click. Cross-doc nav (different cleanPath) falls through to the
     // existing fetch-then-scroll path below.
     const pathForSelection = stripFolderIndexFromPath(cleanPath, folderIndexFile)
     if (
@@ -342,7 +344,10 @@ export function useDocumentTree(
       options?.fromInternalLink &&
       pathForSelection === selectedPathRef.current
     ) {
-      navigateSamePageHash(`${normalizedBaseRoute}/${cleanPath}${anchor}`)
+      navigateSamePageHash(
+        `${normalizedBaseRoute}/${cleanPath}${anchor}`,
+        { headerOffset: 80 },
+      )
       return
     }
 
@@ -387,7 +392,8 @@ export function useDocumentTree(
       return
     }
 
-    const pathForSelection = stripFolderIndexFromPath(cleanPath, folderIndexFile)
+    // `pathForSelection` was already computed above (inside the
+    // same-doc-anchor shortcut check); reuse it here for cross-doc nav.
     const urlPath = pathForSelection
 
     lastFetchedPath.current = null

--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -10,12 +10,12 @@ import {
 } from '../../utils/doc-tree-nav'
 import { useDocNavigation } from './doc-navigation-context'
 import { scrollElementIntoView } from '../../utils/scroll-into-view'
-import { navigateSamePageHash } from '../../utils/same-page-hash-nav'
+import { navigateSamePageHash, HUB_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
 
 function scrollToContent() {
   const article = document.querySelector('article') as HTMLElement | null
   if (article) {
-    scrollElementIntoView(article, { headerOffset: 80 })
+    scrollElementIntoView(article, { headerOffset: HUB_HEADER_OFFSET_PX })
   } else {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
@@ -334,7 +334,7 @@ export function useDocumentTree(
     // don't need the 300ms "wait-for-fetch" bandaid — the canonical helper
     // owns pushState + synthetic `hashchange` (so any in-doc TOC / accordion
     // bound to the URL hash re-renders) + the anchoring-proof tween in one
-    // sync call. `headerOffset: 80` matches the cross-doc path below so
+    // sync call. `headerOffset: HUB_HEADER_OFFSET_PX` matches the cross-doc path below so
     // anchors land BELOW the docs sticky header on every same-doc internal
     // link click. Cross-doc nav (different cleanPath) falls through to the
     // existing fetch-then-scroll path below.
@@ -366,7 +366,7 @@ export function useDocumentTree(
       options?.fromInternalLink &&
       pathForSelection === selectedPathRef.current
     ) {
-      navigateSamePageHash(anchor, { headerOffset: 80 })
+      navigateSamePageHash(anchor, { headerOffset: HUB_HEADER_OFFSET_PX })
       return
     }
 
@@ -375,7 +375,7 @@ export function useDocumentTree(
         setTimeout(() => {
           const el = document.getElementById(anchor.substring(1))
           if (el) {
-            scrollElementIntoView(el, { headerOffset: 80 })
+            scrollElementIntoView(el, { headerOffset: HUB_HEADER_OFFSET_PX })
           } else {
             scrollToContent()
           }

--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -338,16 +338,26 @@ export function useDocumentTree(
     // anchors land BELOW the docs sticky header on every same-doc internal
     // link click. Cross-doc nav (different cleanPath) falls through to the
     // existing fetch-then-scroll path below.
+    //
+    // We pass the BARE-hash form to the helper rather than reconstructing
+    // a full `${normalizedBaseRoute}/${cleanPath}${anchor}` path: the
+    // helper's pathname check compares against `window.location.pathname`,
+    // which carries the FOLDER-INDEX-STRIPPED form (`/docs/foo` for
+    // `foo/README.md`, `/docs` for the root index). Handing it `cleanPath`
+    // — the raw resolved path — produces e.g. `/docs/foo/README.md` and
+    // the compare fails → helper returns false → silent dead-click. The
+    // bare-hash form sidesteps that entirely: the helper reconstructs
+    // `pathname + search + hash` from `window.location`, so the compare
+    // is trivially equal. Covers bare `#anchor` links (resolve to
+    // `cleanPath=''`) AND folder-index links (`foo/README.md` resolving
+    // to the current `/docs/foo`).
     const pathForSelection = stripFolderIndexFromPath(cleanPath, folderIndexFile)
     if (
       anchor &&
       options?.fromInternalLink &&
       pathForSelection === selectedPathRef.current
     ) {
-      navigateSamePageHash(
-        `${normalizedBaseRoute}/${cleanPath}${anchor}`,
-        { headerOffset: 80 },
-      )
+      navigateSamePageHash(anchor, { headerOffset: 80 })
       return
     }
 

--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils/doc-tree-nav'
 import { useDocNavigation } from './doc-navigation-context'
 import { scrollElementIntoView } from '../../utils/scroll-into-view'
+import { navigateSamePageHash } from '../../utils/same-page-hash-nav'
 
 function scrollToContent() {
   const article = document.querySelector('article') as HTMLElement | null
@@ -328,6 +329,22 @@ export function useDocumentTree(
     const hashIndex = path.indexOf('#')
     const anchor = hashIndex !== -1 ? path.substring(hashIndex) : ''
     const cleanPath = path.replace(/\/$/, '').split('#')[0]
+
+    // Same-doc-different-anchor shortcut. Content is already mounted, so we
+    // don't need the 300ms "wait-for-fetch" bandaid — the canonical helper
+    // owns pushState + synthetic `hashchange` (so any in-doc TOC / accordion
+    // bound to the URL hash re-renders) + the anchoring-proof tween in one
+    // sync call. Cross-doc nav (different cleanPath) falls through to the
+    // existing fetch-then-scroll path below.
+    const pathForSelection = stripFolderIndexFromPath(cleanPath, folderIndexFile)
+    if (
+      anchor &&
+      options?.fromInternalLink &&
+      pathForSelection === selectedPathRef.current
+    ) {
+      navigateSamePageHash(`${normalizedBaseRoute}/${cleanPath}${anchor}`)
+      return
+    }
 
     const scrollAfterNav = () => {
       if (anchor) {

--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -351,7 +351,16 @@ export function useDocumentTree(
     // is trivially equal. Covers bare `#anchor` links (resolve to
     // `cleanPath=''`) AND folder-index links (`foo/README.md` resolving
     // to the current `/docs/foo`).
-    const pathForSelection = stripFolderIndexFromPath(cleanPath, folderIndexFile)
+    // Bare-hash internal links (`[Click](#section)`) come in as
+    // `path === '#section'`, so `cleanPath` becomes `''` and the naive
+    // strip-then-compare misses the same-doc shortcut on every NON-root
+    // doc (selectedPath is e.g. `'foo/bar'`, not `''`). For that case the
+    // current doc IS the same-doc target by definition — short-circuit
+    // pathForSelection to the current selection so the shortcut fires.
+    const pathForSelection =
+      anchor && options?.fromInternalLink && cleanPath === ''
+        ? selectedPathRef.current
+        : stripFolderIndexFromPath(cleanPath, folderIndexFile)
     if (
       anchor &&
       options?.fromInternalLink &&

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -221,19 +221,28 @@ function GroupedFaqList({
   }, [hashTarget])
 
   // Category pill click. `navigateSamePageHash` owns the entire transition:
-  // pushState → synthetic `hashchange` → `scrollElementIntoView` tween with
-  // `FAQ_NAV_HEADER_OFFSET` so the section heading lands BELOW the sticky
-  // category nav on the FIRST tween (covers the same-target re-click case,
-  // where the `hashTarget` effect at L214 is a no-op because the state
-  // reference is equal). For DIFFERENT-target clicks the helper's synthetic
-  // `hashchange` re-fires that effect, which re-scrolls with the same
-  // offset and cancels this tween (singleton) — both paths land at the
-  // same position. The effect is still required for back/forward + direct
-  // URL edits, where the helper isn't in the call chain.
+  // replaceState → synthetic `hashchange` → `scrollElementIntoView` tween
+  // with `FAQ_NAV_HEADER_OFFSET` so the section heading lands BELOW the
+  // sticky category nav on the FIRST tween (covers the same-target
+  // re-click case, where the `hashTarget` effect at L214 is a no-op
+  // because the state reference is equal). For DIFFERENT-target clicks
+  // the helper's synthetic `hashchange` re-fires that effect, which
+  // re-scrolls with the same offset and cancels this tween (singleton)
+  // — both paths land at the same position. The effect is still
+  // required for back/forward + direct URL edits, where the helper
+  // isn't in the call chain.
+  //
+  // `history: 'replace'` matches the pre-helper behavior: category pills
+  // are a TOC, not a navigation step, so the Back button leaves the
+  // FAQ page in one step regardless of how many categories the user
+  // clicked through.
   const handleJump = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
       e.preventDefault()
-      navigateSamePageHash('#' + slug, { headerOffset: FAQ_NAV_HEADER_OFFSET })
+      navigateSamePageHash('#' + slug, {
+        headerOffset: FAQ_NAV_HEADER_OFFSET,
+        history: 'replace',
+      })
     },
     [],
   )

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -7,7 +7,7 @@ import { useSelfFetch } from '../../hooks/use-self-fetch'
 import { buildSuggestionUrl } from '../../utils/suggestion-url'
 import { serializeJsonLd } from '../../utils/common'
 import { scrollElementIntoView } from '../../utils/scroll-into-view'
-import { navigateSamePageHash } from '../../utils/same-page-hash-nav'
+import { navigateSamePageHash, STICKY_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
 import { faqSectionSlug, faqItemAnchor, parseFaqHash, type FaqHashTarget } from '../../utils/faq-anchor'
 import { cn } from '../../utils/cn'
 import { buildFaqJsonLdFromFaqs, type FaqSchemaOptions } from './json-ld'
@@ -98,9 +98,6 @@ function groupFaqsBySection(faqs: Faq[]): FaqGroup[] {
   return groups
 }
 
-/** The standard hub sticky-header height — same offset `useNavLink`'s hash
- *  scroll uses, so a category jump lands below the header, not under it. */
-const FAQ_NAV_HEADER_OFFSET = 96
 
 /** Map key for the uncategorized bucket — `group.slug` is null for it, so
  *  every per-group map (default-open ids, accordion keys) uses this sentinel
@@ -161,7 +158,7 @@ function GroupedFaqList({
         }
         if (bestId) setActiveSlug(bestId)
       },
-      { rootMargin: `-${FAQ_NAV_HEADER_OFFSET}px 0px -55% 0px`, threshold: 0 },
+      { rootMargin: `-${STICKY_HEADER_OFFSET_PX}px 0px -55% 0px`, threshold: 0 },
     )
     for (const group of navGroups) {
       const el = group.slug ? document.getElementById(group.slug) : null
@@ -216,13 +213,13 @@ function GroupedFaqList({
     const elId =
       hashTarget.kind === 'item' ? faqItemAnchor(hashTarget.rawId) : hashTarget.slug
     const el = document.getElementById(elId)
-    if (el) scrollElementIntoView(el, { headerOffset: FAQ_NAV_HEADER_OFFSET })
+    if (el) scrollElementIntoView(el, { headerOffset: STICKY_HEADER_OFFSET_PX })
     if (hashTarget.kind === 'section') setActiveSlug(hashTarget.slug)
   }, [hashTarget])
 
   // Category pill click. `navigateSamePageHash` owns the entire transition:
   // replaceState → synthetic `hashchange` → `scrollElementIntoView` tween
-  // with `FAQ_NAV_HEADER_OFFSET` so the section heading lands BELOW the
+  // with `STICKY_HEADER_OFFSET_PX` so the section heading lands BELOW the
   // sticky category nav on the FIRST tween (covers the same-target
   // re-click case, where the `hashTarget` effect at L214 is a no-op
   // because the state reference is equal). For DIFFERENT-target clicks
@@ -240,7 +237,7 @@ function GroupedFaqList({
     (e: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
       e.preventDefault()
       navigateSamePageHash('#' + slug, {
-        headerOffset: FAQ_NAV_HEADER_OFFSET,
+        headerOffset: STICKY_HEADER_OFFSET_PX,
         history: 'replace',
       })
     },

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -221,18 +221,19 @@ function GroupedFaqList({
   }, [hashTarget])
 
   // Category pill click. `navigateSamePageHash` owns the entire transition:
-  // pushState → synthetic `hashchange` → `scrollElementIntoView` tween. The
-  // synthetic event re-fires the hash-dispatch effect above, which also
-  // updates `activeSlug` (for `kind === 'section'`) and re-scrolls — the
-  // double-scroll is benign because `scrollElementIntoView` is a singleton
-  // tween that cancels its prior call. NO manual `scrollElementIntoView`,
-  // NO manual `replaceState` here — those were redundant with the helper.
+  // pushState → synthetic `hashchange` → `scrollElementIntoView` tween with
+  // `FAQ_NAV_HEADER_OFFSET` so the section heading lands BELOW the sticky
+  // category nav on the FIRST tween (covers the same-target re-click case,
+  // where the `hashTarget` effect at L214 is a no-op because the state
+  // reference is equal). For DIFFERENT-target clicks the helper's synthetic
+  // `hashchange` re-fires that effect, which re-scrolls with the same
+  // offset and cancels this tween (singleton) — both paths land at the
+  // same position. The effect is still required for back/forward + direct
+  // URL edits, where the helper isn't in the call chain.
   const handleJump = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
       e.preventDefault()
-      navigateSamePageHash(
-        window.location.pathname + window.location.search + '#' + slug,
-      )
+      navigateSamePageHash('#' + slug, { headerOffset: FAQ_NAV_HEADER_OFFSET })
     },
     [],
   )

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -7,6 +7,7 @@ import { useSelfFetch } from '../../hooks/use-self-fetch'
 import { buildSuggestionUrl } from '../../utils/suggestion-url'
 import { serializeJsonLd } from '../../utils/common'
 import { scrollElementIntoView } from '../../utils/scroll-into-view'
+import { navigateSamePageHash } from '../../utils/same-page-hash-nav'
 import { faqSectionSlug, faqItemAnchor, parseFaqHash, type FaqHashTarget } from '../../utils/faq-anchor'
 import { cn } from '../../utils/cn'
 import { buildFaqJsonLdFromFaqs, type FaqSchemaOptions } from './json-ld'
@@ -219,14 +220,19 @@ function GroupedFaqList({
     if (hashTarget.kind === 'section') setActiveSlug(hashTarget.slug)
   }, [hashTarget])
 
+  // Category pill click. `navigateSamePageHash` owns the entire transition:
+  // pushState → synthetic `hashchange` → `scrollElementIntoView` tween. The
+  // synthetic event re-fires the hash-dispatch effect above, which also
+  // updates `activeSlug` (for `kind === 'section'`) and re-scrolls — the
+  // double-scroll is benign because `scrollElementIntoView` is a singleton
+  // tween that cancels its prior call. NO manual `scrollElementIntoView`,
+  // NO manual `replaceState` here — those were redundant with the helper.
   const handleJump = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>, slug: string) => {
       e.preventDefault()
-      setActiveSlug(slug)
-      scrollElementIntoView(document.getElementById(slug), {
-        headerOffset: FAQ_NAV_HEADER_OFFSET,
-      })
-      if (typeof history !== 'undefined') history.replaceState(null, '', `#${slug}`)
+      navigateSamePageHash(
+        window.location.pathname + window.location.search + '#' + slug,
+      )
     },
     [],
   )

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
@@ -36,7 +36,7 @@ import { EmptyState } from '../../empty-state';
 import { LoadError } from '../../ui/error-state';
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys';
 import { contentFetch } from '../../../utils/embed-content-fetch';
-import { scrollElementIntoView } from '../../../utils/scroll-into-view';
+import { useScrollToHash } from '../../../hooks/use-scroll-to-hash';
 
 const DEFAULT_COMPLETED_ENDPOINT = '/api/delivery/completed';
 const DEFAULT_IN_PROGRESS_ENDPOINT = '/api/delivery/in-progress';
@@ -131,25 +131,11 @@ export function DeliveryLists({
   const filteredInProgress = data?.inProgress || [];
 
   // Deep-link hash dispatch — `?search=<id>#delivery-<id>` from a chat
-  // card or a linked-delivery card on a ticket. After items render, scroll
-  // the row with the matching DOM id into view (sticky-header offset 96 —
-  // same value `useNavLink`'s hash scroll uses so the row lands BELOW the
-  // sticky chrome). Re-runs on `hashchange` (browser back/forward,
-  // synthetic dispatch from `navigateSamePageHash`) so repeat clicks
-  // re-scroll. Gated on `data` so we don't try to scroll to an element
-  // that hasn't rendered yet — first paint happens AFTER the fetch.
-  useEffect(() => {
-    if (!data) return;
-    const refresh = () => {
-      const hash = window.location.hash.slice(1);
-      if (!hash) return;
-      const el = document.getElementById(hash);
-      if (el) scrollElementIntoView(el, { headerOffset: 96 });
-    };
-    refresh();
-    window.addEventListener('hashchange', refresh);
-    return () => window.removeEventListener('hashchange', refresh);
-  }, [data]);
+  // card or a linked-delivery card on a ticket. Shared hook owns the
+  // poll-until-mount + hashchange-listener wiring (same instance used
+  // by RoadmapView). 96 matches the sticky-header offset every
+  // hash-scroll surface in the app uses.
+  useScrollToHash(data, { headerOffset: 96 });
 
   const showCompleted = true;
   const showInProgress = true;

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
@@ -36,6 +36,7 @@ import { EmptyState } from '../../empty-state';
 import { LoadError } from '../../ui/error-state';
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys';
 import { contentFetch } from '../../../utils/embed-content-fetch';
+import { scrollElementIntoView } from '../../../utils/scroll-into-view';
 
 const DEFAULT_COMPLETED_ENDPOINT = '/api/delivery/completed';
 const DEFAULT_IN_PROGRESS_ENDPOINT = '/api/delivery/in-progress';
@@ -128,6 +129,27 @@ export function DeliveryLists({
 
   const filteredCompleted = data?.completed || [];
   const filteredInProgress = data?.inProgress || [];
+
+  // Deep-link hash dispatch — `?search=<id>#delivery-<id>` from a chat
+  // card or a linked-delivery card on a ticket. After items render, scroll
+  // the row with the matching DOM id into view (sticky-header offset 96 —
+  // same value `useNavLink`'s hash scroll uses so the row lands BELOW the
+  // sticky chrome). Re-runs on `hashchange` (browser back/forward,
+  // synthetic dispatch from `navigateSamePageHash`) so repeat clicks
+  // re-scroll. Gated on `data` so we don't try to scroll to an element
+  // that hasn't rendered yet — first paint happens AFTER the fetch.
+  useEffect(() => {
+    if (!data) return;
+    const refresh = () => {
+      const hash = window.location.hash.slice(1);
+      if (!hash) return;
+      const el = document.getElementById(hash);
+      if (el) scrollElementIntoView(el, { headerOffset: 96 });
+    };
+    refresh();
+    window.addEventListener('hashchange', refresh);
+    return () => window.removeEventListener('hashchange', refresh);
+  }, [data]);
 
   const showCompleted = true;
   const showInProgress = true;

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-lists.tsx
@@ -35,6 +35,7 @@ import { DeliveryTable } from './delivery-table';
 import { EmptyState } from '../../empty-state';
 import { LoadError } from '../../ui/error-state';
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys';
+import { STICKY_HEADER_OFFSET_PX } from '../../../utils/same-page-hash-nav';
 import { contentFetch } from '../../../utils/embed-content-fetch';
 import { useScrollToHash } from '../../../hooks/use-scroll-to-hash';
 
@@ -135,7 +136,7 @@ export function DeliveryLists({
   // poll-until-mount + hashchange-listener wiring (same instance used
   // by RoadmapView). 96 matches the sticky-header offset every
   // hash-scroll surface in the app uses.
-  useScrollToHash(data, { headerOffset: 96 });
+  useScrollToHash(data, { headerOffset: STICKY_HEADER_OFFSET_PX });
 
   const showCompleted = true;
   const showInProgress = true;

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
@@ -60,6 +60,13 @@ export interface DeliveryRowProps {
   /** Small uppercase caption rendered above the title. Used by the
    *  linked-delivery card variant ("LINKED DELIVERY"). */
   caption?: string
+  /** DOM `id` applied to the row's outer element. `DeliveryTable`
+   *  always sets `delivery-<external_id>` so chat-card deep-links
+   *  (`?search=<id>#delivery-<id>`) and the ticket linked-card path
+   *  both have a target for `useScrollToHash` to scroll to. Always
+   *  paired with `scroll-mt-24` on the outer element so the row lands
+   *  BELOW the sticky chrome after the scroll. */
+  id?: string
   className?: string
 }
 
@@ -67,6 +74,7 @@ export function DeliveryRow({
   item,
   href,
   caption,
+  id,
   className,
 }: DeliveryRowProps) {
   const taskType = item.taskType as keyof typeof TASK_TYPE_LABELS
@@ -121,6 +129,11 @@ export function DeliveryRow({
 
   const baseClass = cn(
     'block p-[12px] md:p-[16px] no-underline text-inherit transition-colors duration-150',
+    // `scroll-mt-24` is paid for whether `id` is set or not (it's a
+    // single Tailwind utility, no runtime cost). Keeping it
+    // unconditional means a future caller adding `id` doesn't also
+    // have to remember to ask for the offset.
+    'scroll-mt-24',
     href && 'hover:bg-ods-bg-hover cursor-pointer',
     className,
   )
@@ -133,11 +146,11 @@ export function DeliveryRow({
     // losing TanStack-Query state on back, leaving /tickets stuck on
     // its skeleton.
     return (
-      <Link href={href} className={baseClass} prefetch={false}>
+      <Link href={href} id={id} className={baseClass} prefetch={false}>
         {inner}
       </Link>
     )
   }
 
-  return <div className={baseClass}>{inner}</div>
+  return <div id={id} className={baseClass}>{inner}</div>
 }

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
@@ -19,6 +19,7 @@
 
 import { DeliveryRow } from './delivery-row';
 import type { DeliveryItem } from '../../../types/delivery';
+import { devSectionAnchorId } from '../../../utils/dev-sections/dev-section-param-keys';
 
 interface DeliveryTableProps {
   items: DeliveryItem[];
@@ -104,7 +105,7 @@ export function DeliveryTable({ items, isLoading = false }: DeliveryTableProps) 
             key={item.id}
             className="border-b border-ods-border last:border-b-0"
           >
-            <DeliveryRow item={item} id={`delivery-${item.id}`} />
+            <DeliveryRow item={item} id={devSectionAnchorId('delivery', item.id)} />
           </div>
         ))}
       </div>

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
@@ -95,19 +95,16 @@ export function DeliveryTable({ items, isLoading = false }: DeliveryTableProps) 
     <div className="bg-ods-card border border-ods-border rounded-[6px] overflow-hidden w-full">
       <div className="w-full">
         {items.map((item) => (
-          // DOM id mirrors the URL anchor `buildDevSectionUrl('delivery',
-          // <id>)` produces (`#delivery-<external_id>`). The page's
-          // `hashchange` effect (`delivery-lists.tsx`) reads this and
-          // calls `scrollElementIntoView` on the matching node so the
-          // chat-inline delivery card AND the linked-card-from-ticket
-          // deep-link both scroll the user straight to the row.
-          // `scroll-mt-24` keeps the row BELOW the sticky chrome.
+          // DOM id lives on DeliveryRow's own outer element (no wrapper
+          // div). Anchor mirrors `buildDevSectionUrl('delivery', <id>)`
+          // → `#delivery-<external_id>`; `useScrollToHash` in
+          // `delivery-lists.tsx` finds the row by id and scrolls. The
+          // outer wrapper here ONLY exists for the row separators.
           <div
             key={item.id}
-            id={`delivery-${item.id}`}
-            className="border-b border-ods-border last:border-b-0 scroll-mt-24"
+            className="border-b border-ods-border last:border-b-0"
           >
-            <DeliveryRow item={item} />
+            <DeliveryRow item={item} id={`delivery-${item.id}`} />
           </div>
         ))}
       </div>

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-table.tsx
@@ -95,9 +95,17 @@ export function DeliveryTable({ items, isLoading = false }: DeliveryTableProps) 
     <div className="bg-ods-card border border-ods-border rounded-[6px] overflow-hidden w-full">
       <div className="w-full">
         {items.map((item) => (
+          // DOM id mirrors the URL anchor `buildDevSectionUrl('delivery',
+          // <id>)` produces (`#delivery-<external_id>`). The page's
+          // `hashchange` effect (`delivery-lists.tsx`) reads this and
+          // calls `scrollElementIntoView` on the matching node so the
+          // chat-inline delivery card AND the linked-card-from-ticket
+          // deep-link both scroll the user straight to the row.
+          // `scroll-mt-24` keeps the row BELOW the sticky chrome.
           <div
             key={item.id}
-            className="border-b border-ods-border last:border-b-0"
+            id={`delivery-${item.id}`}
+            className="border-b border-ods-border last:border-b-0 scroll-mt-24"
           >
             <DeliveryRow item={item} />
           </div>

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
@@ -134,20 +134,19 @@ function RoadmapGridSingle({
   return (
     <div className={`grid grid-cols-1 md:grid-cols-2 gap-6 ${showLeftMargin ? 'md:ml-[120px]' : ''}`}>
       {items.map((item) => (
-        // DOM id mirrors the URL anchor `buildDevSectionUrl('roadmap',
-        // <id>)` produces (`#roadmap-<external_id>`). The view's
-        // `hashchange` effect (`roadmap-view.tsx`) reads this and calls
-        // `scrollElementIntoView` on the matching node so chat-card
-        // deep-links land the user on the targeted card.
-        // `scroll-mt-24` keeps the card BELOW the sticky chrome.
-        <div key={item.id} id={`roadmap-${item.id}`} className="scroll-mt-24">
-          <RoadmapCard
-            item={item}
-            userVote={getVote(item.id)}
-            onVote={(voteType) => onVote(item.id, voteType)}
-            isVoting={votingTasks.has(item.id)}
-          />
-        </div>
+        // DOM id + sticky-header scroll offset live ON RoadmapCard's own
+        // outer element (no wrapper div). Anchor mirrors
+        // `buildDevSectionUrl('roadmap', <id>)` → `#roadmap-<external_id>`;
+        // `useScrollToHash` in `roadmap-view.tsx` finds the card by id
+        // and scrolls.
+        <RoadmapCard
+          key={item.id}
+          item={item}
+          id={`roadmap-${item.id}`}
+          userVote={getVote(item.id)}
+          onVote={(voteType) => onVote(item.id, voteType)}
+          isVoting={votingTasks.has(item.id)}
+        />
       ))}
     </div>
   );

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
@@ -134,13 +134,20 @@ function RoadmapGridSingle({
   return (
     <div className={`grid grid-cols-1 md:grid-cols-2 gap-6 ${showLeftMargin ? 'md:ml-[120px]' : ''}`}>
       {items.map((item) => (
-        <RoadmapCard
-          key={item.id}
-          item={item}
-          userVote={getVote(item.id)}
-          onVote={(voteType) => onVote(item.id, voteType)}
-          isVoting={votingTasks.has(item.id)}
-        />
+        // DOM id mirrors the URL anchor `buildDevSectionUrl('roadmap',
+        // <id>)` produces (`#roadmap-<external_id>`). The view's
+        // `hashchange` effect (`roadmap-view.tsx`) reads this and calls
+        // `scrollElementIntoView` on the matching node so chat-card
+        // deep-links land the user on the targeted card.
+        // `scroll-mt-24` keeps the card BELOW the sticky chrome.
+        <div key={item.id} id={`roadmap-${item.id}`} className="scroll-mt-24">
+          <RoadmapCard
+            item={item}
+            userVote={getVote(item.id)}
+            onVote={(voteType) => onVote(item.id, voteType)}
+            isVoting={votingTasks.has(item.id)}
+          />
+        </div>
       ))}
     </div>
   );

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-grid.tsx
@@ -33,6 +33,7 @@ import {
   AccordionContent,
 } from '../../ui';
 import { cn } from '../../../utils/cn';
+import { devSectionAnchorId } from '../../../utils/dev-sections/dev-section-param-keys';
 import { contentFetch } from '../../../utils/embed-content-fetch';
 import type { RoadmapItem } from '../../chat/types/entities/roadmap-item';
 
@@ -142,7 +143,7 @@ function RoadmapGridSingle({
         <RoadmapCard
           key={item.id}
           item={item}
-          id={`roadmap-${item.id}`}
+          id={devSectionAnchorId('roadmap', item.id)}
           userVote={getVote(item.id)}
           onVote={(voteType) => onVote(item.id, voteType)}
           isVoting={votingTasks.has(item.id)}

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
@@ -10,7 +10,7 @@
  * vote endpoint via `votingOptions`. Optional `initialItems` hydrates SSR.
  */
 
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 
 import { useSearchParams } from '../../../embed-shims'
 import { LoadError } from '../../ui/error-state'
@@ -20,6 +20,7 @@ import { RoadmapGrid } from './roadmap-grid'
 import { RoadmapGridSkeleton } from './roadmap-grid-skeleton'
 import type { UseRoadmapVotingOptions } from './use-roadmap-voting'
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys'
+import { scrollElementIntoView } from '../../../utils/scroll-into-view'
 
 const DEFAULT_ENDPOINT = '/api/roadmap'
 // Defaults sourced from the ONE param-key registry the chrome (OPENFRAME_DEV_SECTIONS) also
@@ -76,6 +77,27 @@ export function RoadmapView({
     { initialData },
   )
   const items = data?.items ?? []
+
+  // Deep-link hash dispatch — `?search=<id>#roadmap-<id>` from a chat card.
+  // After items render, scroll the card with the matching DOM id into
+  // view (sticky-header offset 96 — same value `useNavLink`'s hash scroll
+  // uses so the card lands BELOW the sticky chrome). Re-runs on
+  // `hashchange` (browser back/forward + synthetic dispatch from
+  // `navigateSamePageHash`) so repeat clicks re-scroll. Gated on
+  // `items.length` so we don't try to scroll to an element that hasn't
+  // rendered yet — first paint happens AFTER the fetch.
+  useEffect(() => {
+    if (items.length === 0) return
+    const refresh = () => {
+      const hash = window.location.hash.slice(1)
+      if (!hash) return
+      const el = document.getElementById(hash)
+      if (el) scrollElementIntoView(el, { headerOffset: 96 })
+    }
+    refresh()
+    window.addEventListener('hashchange', refresh)
+    return () => window.removeEventListener('hashchange', refresh)
+  }, [items.length])
 
   if (error) {
     return <LoadError message="Failed to load roadmap." onRetry={reload} />

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
@@ -81,23 +81,27 @@ export function RoadmapView({
   // Deep-link hash dispatch — `?search=<id>#roadmap-<id>` from a chat card.
   // After items render, scroll the card with the matching DOM id into
   // view (sticky-header offset 96 — same value `useNavLink`'s hash scroll
-  // uses so the card lands BELOW the sticky chrome). Re-runs on
-  // `hashchange` (browser back/forward + synthetic dispatch from
-  // `navigateSamePageHash`) so repeat clicks re-scroll.
+  // uses so the card lands BELOW the sticky chrome). Re-runs on:
+  //   - `hashchange` (browser back/forward + synthetic dispatch from
+  //     `navigateSamePageHash` for SAME-search-param hash-only nav)
+  //   - `data` reference change — `useSelfFetch` returns a new `data`
+  //     when search/status changes refetch. Chat-card-to-chat-card
+  //     navigation (`/roadmap?search=A#roadmap-A` → `/roadmap?search=B
+  //     #roadmap-B`) goes through `router.push` (NOT
+  //     `navigateSamePageHash`, because the search param differs), and
+  //     `router.push` does NOT fire `hashchange`. So the only signal we
+  //     have that the URL changed is the next fetch's new `data` ref.
+  //     Using `items.length` as the dep was the bug — 1→1 doesn't
+  //     trigger React's deep comparison.
   //
-  // RACE NOTE: roadmap-grid renders cards inside Radix `<AccordionItem>`s,
-  // and Radix UNMOUNTS the contents of a collapsed accordion. On first
-  // paint every quarter is collapsed; an effect in `roadmap-grid.tsx`
-  // then expands every quarter when `hasActiveFilters` is true (which
-  // it is when the chat URL carries `?search=<id>`). So when our hash
-  // dispatch runs the moment items first arrive, `getElementById`
-  // returns null because the card isn't in the DOM yet — the accordion
-  // is still expanding. Naive `useEffect([items.length])` ran once and
-  // gave up. Poll the DOM via `requestAnimationFrame` for ~1 second
-  // (60 frames) until the row appears, then scroll. Cheap (no DOM
-  // mutation observer) and SSR-safe. The poll terminates as soon as
-  // the target exists OR we exhaust the frame budget — same retry
-  // pattern other React apps use for "wait for async-mounted child."
+  // RACE NOTE: roadmap-grid renders cards inside Radix `<AccordionItem>`s
+  // and Radix UNMOUNTS collapsed accordion contents. On first paint every
+  // quarter is collapsed; an effect in `roadmap-grid.tsx` expands them
+  // when `hasActiveFilters` is true (the chat URL carries `?search=<id>`).
+  // So when we run the dispatch the moment new data arrives,
+  // `getElementById` returns null — the card isn't in the DOM yet.
+  // Poll via `requestAnimationFrame` for ~1 second (60 frames) until the
+  // row appears, then scroll. Cheap (no MutationObserver), SSR-safe.
   useEffect(() => {
     if (items.length === 0) return
     const tryScrollToHash = () => {
@@ -117,7 +121,7 @@ export function RoadmapView({
     tryScrollToHash()
     window.addEventListener('hashchange', tryScrollToHash)
     return () => window.removeEventListener('hashchange', tryScrollToHash)
-  }, [items.length])
+  }, [data])
 
   if (error) {
     return <LoadError message="Failed to load roadmap." onRetry={reload} />

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
@@ -83,20 +83,40 @@ export function RoadmapView({
   // view (sticky-header offset 96 — same value `useNavLink`'s hash scroll
   // uses so the card lands BELOW the sticky chrome). Re-runs on
   // `hashchange` (browser back/forward + synthetic dispatch from
-  // `navigateSamePageHash`) so repeat clicks re-scroll. Gated on
-  // `items.length` so we don't try to scroll to an element that hasn't
-  // rendered yet — first paint happens AFTER the fetch.
+  // `navigateSamePageHash`) so repeat clicks re-scroll.
+  //
+  // RACE NOTE: roadmap-grid renders cards inside Radix `<AccordionItem>`s,
+  // and Radix UNMOUNTS the contents of a collapsed accordion. On first
+  // paint every quarter is collapsed; an effect in `roadmap-grid.tsx`
+  // then expands every quarter when `hasActiveFilters` is true (which
+  // it is when the chat URL carries `?search=<id>`). So when our hash
+  // dispatch runs the moment items first arrive, `getElementById`
+  // returns null because the card isn't in the DOM yet — the accordion
+  // is still expanding. Naive `useEffect([items.length])` ran once and
+  // gave up. Poll the DOM via `requestAnimationFrame` for ~1 second
+  // (60 frames) until the row appears, then scroll. Cheap (no DOM
+  // mutation observer) and SSR-safe. The poll terminates as soon as
+  // the target exists OR we exhaust the frame budget — same retry
+  // pattern other React apps use for "wait for async-mounted child."
   useEffect(() => {
     if (items.length === 0) return
-    const refresh = () => {
+    const tryScrollToHash = () => {
       const hash = window.location.hash.slice(1)
       if (!hash) return
-      const el = document.getElementById(hash)
-      if (el) scrollElementIntoView(el, { headerOffset: 96 })
+      let frames = 0
+      const tick = () => {
+        const el = document.getElementById(hash)
+        if (el) {
+          scrollElementIntoView(el, { headerOffset: 96 })
+          return
+        }
+        if (frames++ < 60) requestAnimationFrame(tick)
+      }
+      tick()
     }
-    refresh()
-    window.addEventListener('hashchange', refresh)
-    return () => window.removeEventListener('hashchange', refresh)
+    tryScrollToHash()
+    window.addEventListener('hashchange', tryScrollToHash)
+    return () => window.removeEventListener('hashchange', tryScrollToHash)
   }, [items.length])
 
   if (error) {

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
@@ -10,17 +10,17 @@
  * vote endpoint via `votingOptions`. Optional `initialItems` hydrates SSR.
  */
 
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { useSearchParams } from '../../../embed-shims'
 import { LoadError } from '../../ui/error-state'
 import { useSelfFetch } from '../../../hooks/use-self-fetch'
+import { useScrollToHash } from '../../../hooks/use-scroll-to-hash'
 import type { RoadmapItem } from '../../chat/types/entities/roadmap-item'
 import { RoadmapGrid } from './roadmap-grid'
 import { RoadmapGridSkeleton } from './roadmap-grid-skeleton'
 import type { UseRoadmapVotingOptions } from './use-roadmap-voting'
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys'
-import { scrollElementIntoView } from '../../../utils/scroll-into-view'
 
 const DEFAULT_ENDPOINT = '/api/roadmap'
 // Defaults sourced from the ONE param-key registry the chrome (OPENFRAME_DEV_SECTIONS) also
@@ -79,49 +79,13 @@ export function RoadmapView({
   const items = data?.items ?? []
 
   // Deep-link hash dispatch — `?search=<id>#roadmap-<id>` from a chat card.
-  // After items render, scroll the card with the matching DOM id into
-  // view (sticky-header offset 96 — same value `useNavLink`'s hash scroll
-  // uses so the card lands BELOW the sticky chrome). Re-runs on:
-  //   - `hashchange` (browser back/forward + synthetic dispatch from
-  //     `navigateSamePageHash` for SAME-search-param hash-only nav)
-  //   - `data` reference change — `useSelfFetch` returns a new `data`
-  //     when search/status changes refetch. Chat-card-to-chat-card
-  //     navigation (`/roadmap?search=A#roadmap-A` → `/roadmap?search=B
-  //     #roadmap-B`) goes through `router.push` (NOT
-  //     `navigateSamePageHash`, because the search param differs), and
-  //     `router.push` does NOT fire `hashchange`. So the only signal we
-  //     have that the URL changed is the next fetch's new `data` ref.
-  //     Using `items.length` as the dep was the bug — 1→1 doesn't
-  //     trigger React's deep comparison.
-  //
-  // RACE NOTE: roadmap-grid renders cards inside Radix `<AccordionItem>`s
-  // and Radix UNMOUNTS collapsed accordion contents. On first paint every
-  // quarter is collapsed; an effect in `roadmap-grid.tsx` expands them
-  // when `hasActiveFilters` is true (the chat URL carries `?search=<id>`).
-  // So when we run the dispatch the moment new data arrives,
-  // `getElementById` returns null — the card isn't in the DOM yet.
-  // Poll via `requestAnimationFrame` for ~1 second (60 frames) until the
-  // row appears, then scroll. Cheap (no MutationObserver), SSR-safe.
-  useEffect(() => {
-    if (items.length === 0) return
-    const tryScrollToHash = () => {
-      const hash = window.location.hash.slice(1)
-      if (!hash) return
-      let frames = 0
-      const tick = () => {
-        const el = document.getElementById(hash)
-        if (el) {
-          scrollElementIntoView(el, { headerOffset: 96 })
-          return
-        }
-        if (frames++ < 60) requestAnimationFrame(tick)
-      }
-      tick()
-    }
-    tryScrollToHash()
-    window.addEventListener('hashchange', tryScrollToHash)
-    return () => window.removeEventListener('hashchange', tryScrollToHash)
-  }, [data])
+  // Shared hook owns the poll-until-mount + hashchange-listener wiring
+  // (same instance used by DeliveryLists). The rAF poll inside the hook
+  // handles the Radix `<AccordionItem>` lazy-unmount: on first paint
+  // every quarter is collapsed; an effect in `roadmap-grid.tsx` expands
+  // them when `hasActiveFilters` is true (chat URL carries `?search=<id>`).
+  // The card mounts one tick after `data` lands; the hook waits.
+  useScrollToHash(data, { headerOffset: 96 })
 
   if (error) {
     return <LoadError message="Failed to load roadmap." onRetry={reload} />

--- a/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
+++ b/openframe-frontend-core/src/components/shared/roadmap/roadmap-view.tsx
@@ -21,6 +21,7 @@ import { RoadmapGrid } from './roadmap-grid'
 import { RoadmapGridSkeleton } from './roadmap-grid-skeleton'
 import type { UseRoadmapVotingOptions } from './use-roadmap-voting'
 import { DEV_SECTION_PARAM_KEYS } from '../../../utils/dev-sections/dev-section-param-keys'
+import { STICKY_HEADER_OFFSET_PX } from '../../../utils/same-page-hash-nav'
 
 const DEFAULT_ENDPOINT = '/api/roadmap'
 // Defaults sourced from the ONE param-key registry the chrome (OPENFRAME_DEV_SECTIONS) also
@@ -85,7 +86,7 @@ export function RoadmapView({
   // every quarter is collapsed; an effect in `roadmap-grid.tsx` expands
   // them when `hasActiveFilters` is true (chat URL carries `?search=<id>`).
   // The card mounts one tick after `data` lands; the hook waits.
-  useScrollToHash(data, { headerOffset: 96 })
+  useScrollToHash(data, { headerOffset: STICKY_HEADER_OFFSET_PX })
 
   if (error) {
     return <LoadError message="Failed to load roadmap." onRetry={reload} />

--- a/openframe-frontend-core/src/components/tickets/help-center-card.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-card.tsx
@@ -59,6 +59,12 @@ export interface HelpCenterCardProps {
    *  (`HelpCenterList`) reads via `actions.replyErrorFor(external_id)`. */
   replyError?: TicketDetailDrawerProps['replyError']
   onClearReplyError?: TicketDetailDrawerProps['onClearReplyError']
+  /** DOM `id` applied to the row's outer element. Parent (`HelpCenterList`)
+   *  sets `ticket-<external_id>` so `useScrollToHash` can deep-link from
+   *  a chat card's `?ticket=<id>#ticket-<id>` URL. The sticky-header
+   *  offset is already baked in via `STICKY_HEADER_OFFSET_PX` so the row
+   *  lands BELOW the chrome regardless of whether `id` is set. */
+  id?: string
 }
 
 export function HelpCenterCard({
@@ -73,6 +79,7 @@ export function HelpCenterCard({
   onActionCollapsed,
   replyError,
   onClearReplyError,
+  id,
 }: HelpCenterCardProps) {
   const optimistic = isOptimistic(ticket)
   const rawStatus = (ticket.status ?? 'OPEN').toUpperCase()
@@ -149,6 +156,7 @@ export function HelpCenterCard({
   return (
     <div
       ref={rowRef}
+      id={id}
       style={{ scrollMarginTop: STICKY_HEADER_OFFSET_PX }}
       className={`border-b border-ods-border last:border-b-0 ${optimistic ? 'opacity-60' : ''}`}
       aria-busy={optimistic || undefined}

--- a/openframe-frontend-core/src/components/tickets/help-center-card.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-card.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import { StatusBadge, type StatusBadgeProps } from '../ui'
 import { formatRelativeTime } from '../../utils/date-utils'
 import { scrollElementIntoView } from '../../utils/scroll-into-view'
+import { STICKY_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
 import { getStatusColorScheme } from '../chat/utils/agent-status-message'
 import { DevCardRowContent } from '../shared/dev-section/dev-card-row'
 import {
@@ -27,23 +28,6 @@ import {
 } from './ticket-detail-drawer'
 import type { AnyTicket } from './types'
 import { isOptimistic } from './types'
-
-/** Sticky page-chrome offset, applied two ways from this ONE constant:
- *
- *   1. As `scrollMarginTop` inline style on the wrapper — so any
- *      anchor-driven or `scrollIntoView()`-driven scroll (browser
- *      `#hash` navigation, Tab-focus into the card) lands BELOW the
- *      sticky header.
- *   2. As `headerOffset` passed to `scrollElementIntoView(...)` — for
- *      the click-to-expand `window.scrollTo` path, which pre-computes
- *      its target pixel and ignores CSS `scroll-margin-top`.
- *
- *  Single source of truth: change 96 here and BOTH paths follow. The
- *  previous code combined a `scroll-mt-24` (=96px) Tailwind class
- *  with this constant — two declarations, one comment binding them,
- *  drift hazard. Now there's nothing to keep in sync.
- */
-const STICKY_HEADER_OFFSET_PX = 96
 
 export interface HelpCenterCardProps {
   ticket: AnyTicket

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -36,6 +36,8 @@ import { DevCardRowSkeletonList } from '../shared/dev-section/dev-card-row'
 import { UnifiedPagination } from '../unified-pagination'
 import { useChatIdentity } from '../chat/hooks/use-chat-identity'
 import { useScrollToHash } from '../../hooks/use-scroll-to-hash'
+import { STICKY_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
+import { devSectionAnchorId } from '../../utils/dev-sections/dev-section-param-keys'
 import { toast as defaultToast } from '../../hooks/use-toast'
 import { useTicketsList } from './hooks/use-tickets-list'
 import { useTicketActions } from './hooks/use-ticket-actions'
@@ -273,7 +275,7 @@ function HelpCenterListAuthed({
   // (`/tickets?ticket=X#ticket-X`) — drawer opens AND row scrolls into
   // view. Shared `useScrollToHash` polls until the row mounts (handles
   // the SWR fetch race), uses the canonical `scrollElementIntoView` tween.
-  useScrollToHash(tickets, { headerOffset: 96 })
+  useScrollToHash(tickets, { headerOffset: STICKY_HEADER_OFFSET_PX })
   const hasActiveFilters = search !== '' || (status !== '' && status !== 'all')
   const hasResults = merged.length > 0
 
@@ -353,6 +355,7 @@ function HelpCenterListAuthed({
               {merged.map((ticket) => (
                 <HelpCenterCard
                   key={ticket.id}
+                  id={devSectionAnchorId('ticket', ticket.external_id)}
                   ticket={ticket}
                   expanded={expandedTicketId === ticket.id}
                   onToggle={toggleRow}

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -35,6 +35,7 @@ import { DevSectionPage } from '../shared/dev-section'
 import { DevCardRowSkeletonList } from '../shared/dev-section/dev-card-row'
 import { UnifiedPagination } from '../unified-pagination'
 import { useChatIdentity } from '../chat/hooks/use-chat-identity'
+import { useScrollToHash } from '../../hooks/use-scroll-to-hash'
 import { toast as defaultToast } from '../../hooks/use-toast'
 import { useTicketsList } from './hooks/use-tickets-list'
 import { useTicketActions } from './hooks/use-ticket-actions'
@@ -264,6 +265,15 @@ function HelpCenterListAuthed({
   )
 
   const merged: AnyTicket[] = [...optimisticTickets, ...tickets]
+
+  // Deep-link hash dispatch — `/tickets#ticket-<external_id>` from a
+  // chat card (or any other in-app link). The `?ticket=<external_id>`
+  // query param keeps owning drawer auto-open; this hook owns the
+  // scroll-to-row independently. Both can fire on the same URL
+  // (`/tickets?ticket=X#ticket-X`) — drawer opens AND row scrolls into
+  // view. Shared `useScrollToHash` polls until the row mounts (handles
+  // the SWR fetch race), uses the canonical `scrollElementIntoView` tween.
+  useScrollToHash(tickets, { headerOffset: 96 })
   const hasActiveFilters = search !== '' || (status !== '' && status !== 'all')
   const hasResults = merged.length > 0
 

--- a/openframe-frontend-core/src/components/tickets/ticket-center.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-center.tsx
@@ -25,6 +25,7 @@ import { RefreshCw } from 'lucide-react'
 import { useChatIdentity } from '../chat/hooks/use-chat-identity'
 import { toast as defaultToast } from '../../hooks/use-toast'
 import { formatRelativeTime } from '../../utils/date-utils'
+import { devSectionAnchorId } from '../../utils/dev-sections/dev-section-param-keys'
 import { TicketOpenForm } from './ticket-open-form'
 import { TicketRow } from './ticket-row'
 import { useTicketsList } from './hooks/use-tickets-list'
@@ -168,6 +169,7 @@ function TicketCenterAuthed({
             {merged.map((ticket) => (
               <TicketRow
                 key={ticket.id}
+                id={devSectionAnchorId('ticket', ticket.external_id)}
                 ticket={ticket}
                 expanded={expandedTicketId === ticket.id}
                 onToggle={toggleRow}

--- a/openframe-frontend-core/src/components/tickets/ticket-row.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-row.tsx
@@ -48,6 +48,11 @@ export interface TicketRowProps {
   /** Called after a successful close/reopen so the parent can collapse
    *  the drawer (status flipped — current action set is now stale). */
   onActionCollapsed: TicketDetailDrawerProps['onActionCollapsed']
+  /** DOM `id` applied to the row's outer element. Parents that surface
+   *  a deep-link target set `ticket-<external_id>` so `useScrollToHash`
+   *  resolves it. `scroll-mt-24` is already baked into the outer
+   *  element regardless. */
+  id?: string
 }
 
 export function TicketRow({
@@ -60,6 +65,7 @@ export function TicketRow({
   onClose,
   onReopen,
   onActionCollapsed,
+  id,
 }: TicketRowProps) {
   // Optimistic placeholders have no drawer — the real id hasn't
   // arrived yet, so action targets would be undefined.
@@ -123,7 +129,7 @@ export function TicketRow({
   }
 
   return (
-    <div ref={rowRef} className="scroll-mt-24">
+    <div ref={rowRef} id={id} className="scroll-mt-24">
       <Collapsible
         open={expanded && !optimistic}
         className="border-b border-ods-border last:border-b-0"

--- a/openframe-frontend-core/src/hooks/index.ts
+++ b/openframe-frontend-core/src/hooks/index.ts
@@ -28,6 +28,11 @@ export * from './use-access-code-integration'
 // OG placeholder URL builder hook (requires host-supplied URL builder)
 export * from './use-og-placeholder'
 
+// Deep-link "scroll to URL hash" after data loads. Pairs with URL
+// composers that emit `?<filter>=<id>#<prefix>-<id>` — the filter
+// narrows the list, the hash scrolls the matching DOM id.
+export * from './use-scroll-to-hash'
+
 // Invisible bot-protection client primitive (honeypot ref + submit-timing).
 // Pairs with the server-safe decision fn in `utils/humanity-signals`.
 export * from './use-humanity-signals'

--- a/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
+++ b/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react'
 import { scrollElementIntoView } from '../utils/scroll-into-view'
+import { normalizeHashFragment } from '../utils/same-page-hash-nav'
 
 export interface UseScrollToHashOptions {
   /** Pixels to subtract from the target element's `top` so it lands
@@ -66,7 +67,14 @@ export function useScrollToHash(
     if (typeof window === 'undefined') return
     if (readyDep === null || readyDep === false) return
     const tryScrollToHash = () => {
-      const hash = window.location.hash.slice(1)
+      // `normalizeHashFragment` heals a malformed multi-fragment hash
+      // (e.g. `#delivery-1#delivery-1`) down to the first segment so
+      // `getElementById` resolves. The pushState path of
+      // `navigateSamePageHash` ALSO normalizes — so a click within the
+      // app no longer produces a bad URL — but deep-link entries
+      // (sharing the bad URL in Slack, browser-restored tab, etc.)
+      // still scroll correctly via this fallback.
+      const hash = normalizeHashFragment(window.location.hash).slice(1)
       if (!hash) return
       let frames = 0
       const tick = () => {

--- a/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
+++ b/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
@@ -4,59 +4,25 @@ import { useEffect } from 'react'
 import { scrollElementIntoView } from '../utils/scroll-into-view'
 import { normalizeHashFragment } from '../utils/same-page-hash-nav'
 
+/** ~1s at 60fps — long enough to outlast Radix accordion expand + SWR
+ *  mount, short enough that a missed anchor doesn't hang the page. */
+const MAX_POLL_FRAMES = 60
+
 export interface UseScrollToHashOptions {
-  /** Pixels to subtract from the target element's `top` so it lands
-   *  BELOW sticky chrome. Defaults to 0; pass `96` for the standard hub
-   *  sticky header (same offset `useNavLink` uses). */
+  /** Pixels to subtract for sticky chrome. */
   headerOffset?: number
 }
 
 /**
- * Run the deep-link "scroll to `window.location.hash` anchor" routine
- * once the page's data is ready. Pairs with URL composers that emit
- * `?<filter>=<id>#<prefix>-<id>` (e.g. `buildDevSectionUrl` for
- * roadmap/delivery rows) — the URL filter narrows the list, the hash
- * scrolls the matching DOM id.
+ * Scroll the page to `window.location.hash` once `readyDep` resolves
+ * to a truthy value. Polls via rAF for ~1s so lazy-mounted rows (Radix
+ * accordion, SWR fetch) have time to render. Re-runs on `readyDep`
+ * reference change AND on `hashchange` (browser back/forward + the
+ * synthetic event `navigateSamePageHash` dispatches).
  *
- * Re-runs on:
- *   - `readyDep` reference change. `router.push`-driven chat-card-to-
- *     chat-card navigation (search param differs) doesn't fire
- *     `hashchange`, so the only signal we get that the URL changed is
- *     the next fetch's new data ref. Using `items.length` as the dep
- *     was a bug trap — 1 → 1 doesn't trigger React's referential check.
- *     For pages that have NO async fetch (the destination element is in
- *     the initial render — `#community` on the blog page, section pills
- *     on the vendor page), pass nothing — the default `true` makes the
- *     hook run on mount + every `hashchange`.
- *   - native `hashchange` (browser back/forward) AND the synthetic
- *     `HashChangeEvent` `navigateSamePageHash` dispatches for the
- *     same-pathname-same-search case.
- *
- * Polls via `requestAnimationFrame` for ~1 second (60 frames) until the
- * target element mounts. The poll handles two race classes:
- *   1. Lazy-mounted containers (Radix `<AccordionItem>` UNMOUNTS
- *      collapsed contents; the roadmap grid is rendered inside one and
- *      a separate effect expands quarters when filters are active —
- *      one tick after `data` lands).
- *   2. Late layout shifts (images/web-fonts loading after first paint
- *      change the row's pixel `top`; `scrollElementIntoView`'s own
- *      per-frame `getBoundingClientRect` recompute handles this once
- *      the element exists, but the initial "find the element" step
- *      needs to wait for the element to be present in the first place).
- *
- * Skipped when `readyDep == null || readyDep === false` so callers can
- * gate on "fetch has completed" or "auth has resolved" by passing those
- * values directly.
- *
- * Cheap (no MutationObserver), SSR-safe (guarded `window` reads).
- *
- * @example fetch-gated (delivery / roadmap / any list with async data)
- *   const { data } = useSelfFetch(url)
- *   useScrollToHash(data, { headerOffset: 96 })
- *
- * @example always-ready (blog / vendor sections / any page whose anchor
- *   target is in the initial SSR render)
- *   useScrollToHash(undefined, { headerOffset: 80 })  // or just `useScrollToHash({ headerOffset: 80 })` via positional default
+ * Skipped when `readyDep == null || readyDep === false`. Default
+ * `true` makes the hook run on mount for pages whose target is in the
+ * initial SSR render.
  */
 export function useScrollToHash(
   readyDep: unknown = true,
@@ -66,29 +32,43 @@ export function useScrollToHash(
   useEffect(() => {
     if (typeof window === 'undefined') return
     if (readyDep === null || readyDep === false) return
+    let rafId: number | null = null
+    const cancelPoll = () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId)
+        rafId = null
+      }
+    }
     const tryScrollToHash = () => {
       // `normalizeHashFragment` heals a malformed multi-fragment hash
-      // (e.g. `#delivery-1#delivery-1`) down to the first segment so
-      // `getElementById` resolves. The pushState path of
-      // `navigateSamePageHash` ALSO normalizes — so a click within the
-      // app no longer produces a bad URL — but deep-link entries
-      // (sharing the bad URL in Slack, browser-restored tab, etc.)
-      // still scroll correctly via this fallback.
+      // so `getElementById` resolves on deep-link entries that bypass
+      // `navigateSamePageHash`'s own normalize.
       const hash = normalizeHashFragment(window.location.hash).slice(1)
       if (!hash) return
+      // Cancel any in-flight poll from a prior invocation so two
+      // concurrent ticks can't both call scrollElementIntoView.
+      cancelPoll()
       let frames = 0
       const tick = () => {
         const el = document.getElementById(hash)
         if (el) {
+          rafId = null
           scrollElementIntoView(el, { headerOffset })
           return
         }
-        if (frames++ < 60) requestAnimationFrame(tick)
+        if (frames++ < MAX_POLL_FRAMES) {
+          rafId = requestAnimationFrame(tick)
+        } else {
+          rafId = null
+        }
       }
       tick()
     }
     tryScrollToHash()
     window.addEventListener('hashchange', tryScrollToHash)
-    return () => window.removeEventListener('hashchange', tryScrollToHash)
+    return () => {
+      window.removeEventListener('hashchange', tryScrollToHash)
+      cancelPoll()
+    }
   }, [readyDep, headerOffset])
 }

--- a/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
+++ b/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
@@ -12,17 +12,21 @@ export interface UseScrollToHashOptions {
 
 /**
  * Run the deep-link "scroll to `window.location.hash` anchor" routine
- * once the page's data has loaded. Pairs with URL composers that emit
+ * once the page's data is ready. Pairs with URL composers that emit
  * `?<filter>=<id>#<prefix>-<id>` (e.g. `buildDevSectionUrl` for
  * roadmap/delivery rows) — the URL filter narrows the list, the hash
  * scrolls the matching DOM id.
  *
  * Re-runs on:
- *   - `data` reference change. `router.push`-driven chat-card-to-chat-
- *     card navigation (search param differs) doesn't fire `hashchange`,
- *     so the only signal we get that the URL changed is the next
- *     fetch's new data ref. Using `items.length` as the dep was a bug
- *     trap — 1 → 1 doesn't trigger React's referential check.
+ *   - `readyDep` reference change. `router.push`-driven chat-card-to-
+ *     chat-card navigation (search param differs) doesn't fire
+ *     `hashchange`, so the only signal we get that the URL changed is
+ *     the next fetch's new data ref. Using `items.length` as the dep
+ *     was a bug trap — 1 → 1 doesn't trigger React's referential check.
+ *     For pages that have NO async fetch (the destination element is in
+ *     the initial render — `#community` on the blog page, section pills
+ *     on the vendor page), pass nothing — the default `true` makes the
+ *     hook run on mount + every `hashchange`.
  *   - native `hashchange` (browser back/forward) AND the synthetic
  *     `HashChangeEvent` `navigateSamePageHash` dispatches for the
  *     same-pathname-same-search case.
@@ -39,19 +43,28 @@ export interface UseScrollToHashOptions {
  *      the element exists, but the initial "find the element" step
  *      needs to wait for the element to be present in the first place).
  *
+ * Skipped when `readyDep == null || readyDep === false` so callers can
+ * gate on "fetch has completed" or "auth has resolved" by passing those
+ * values directly.
+ *
  * Cheap (no MutationObserver), SSR-safe (guarded `window` reads).
  *
- * @example
+ * @example fetch-gated (delivery / roadmap / any list with async data)
  *   const { data } = useSelfFetch(url)
  *   useScrollToHash(data, { headerOffset: 96 })
+ *
+ * @example always-ready (blog / vendor sections / any page whose anchor
+ *   target is in the initial SSR render)
+ *   useScrollToHash(undefined, { headerOffset: 80 })  // or just `useScrollToHash({ headerOffset: 80 })` via positional default
  */
 export function useScrollToHash(
-  data: unknown,
+  readyDep: unknown = true,
   options?: UseScrollToHashOptions,
 ): void {
   const headerOffset = options?.headerOffset ?? 0
   useEffect(() => {
-    if (typeof window === 'undefined' || data == null) return
+    if (typeof window === 'undefined') return
+    if (readyDep === null || readyDep === false) return
     const tryScrollToHash = () => {
       const hash = window.location.hash.slice(1)
       if (!hash) return
@@ -69,5 +82,5 @@ export function useScrollToHash(
     tryScrollToHash()
     window.addEventListener('hashchange', tryScrollToHash)
     return () => window.removeEventListener('hashchange', tryScrollToHash)
-  }, [data, headerOffset])
+  }, [readyDep, headerOffset])
 }

--- a/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
+++ b/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
@@ -1,0 +1,73 @@
+'use client'
+
+import { useEffect } from 'react'
+import { scrollElementIntoView } from '../utils/scroll-into-view'
+
+export interface UseScrollToHashOptions {
+  /** Pixels to subtract from the target element's `top` so it lands
+   *  BELOW sticky chrome. Defaults to 0; pass `96` for the standard hub
+   *  sticky header (same offset `useNavLink` uses). */
+  headerOffset?: number
+}
+
+/**
+ * Run the deep-link "scroll to `window.location.hash` anchor" routine
+ * once the page's data has loaded. Pairs with URL composers that emit
+ * `?<filter>=<id>#<prefix>-<id>` (e.g. `buildDevSectionUrl` for
+ * roadmap/delivery rows) — the URL filter narrows the list, the hash
+ * scrolls the matching DOM id.
+ *
+ * Re-runs on:
+ *   - `data` reference change. `router.push`-driven chat-card-to-chat-
+ *     card navigation (search param differs) doesn't fire `hashchange`,
+ *     so the only signal we get that the URL changed is the next
+ *     fetch's new data ref. Using `items.length` as the dep was a bug
+ *     trap — 1 → 1 doesn't trigger React's referential check.
+ *   - native `hashchange` (browser back/forward) AND the synthetic
+ *     `HashChangeEvent` `navigateSamePageHash` dispatches for the
+ *     same-pathname-same-search case.
+ *
+ * Polls via `requestAnimationFrame` for ~1 second (60 frames) until the
+ * target element mounts. The poll handles two race classes:
+ *   1. Lazy-mounted containers (Radix `<AccordionItem>` UNMOUNTS
+ *      collapsed contents; the roadmap grid is rendered inside one and
+ *      a separate effect expands quarters when filters are active —
+ *      one tick after `data` lands).
+ *   2. Late layout shifts (images/web-fonts loading after first paint
+ *      change the row's pixel `top`; `scrollElementIntoView`'s own
+ *      per-frame `getBoundingClientRect` recompute handles this once
+ *      the element exists, but the initial "find the element" step
+ *      needs to wait for the element to be present in the first place).
+ *
+ * Cheap (no MutationObserver), SSR-safe (guarded `window` reads).
+ *
+ * @example
+ *   const { data } = useSelfFetch(url)
+ *   useScrollToHash(data, { headerOffset: 96 })
+ */
+export function useScrollToHash(
+  data: unknown,
+  options?: UseScrollToHashOptions,
+): void {
+  const headerOffset = options?.headerOffset ?? 0
+  useEffect(() => {
+    if (typeof window === 'undefined' || data == null) return
+    const tryScrollToHash = () => {
+      const hash = window.location.hash.slice(1)
+      if (!hash) return
+      let frames = 0
+      const tick = () => {
+        const el = document.getElementById(hash)
+        if (el) {
+          scrollElementIntoView(el, { headerOffset })
+          return
+        }
+        if (frames++ < 60) requestAnimationFrame(tick)
+      }
+      tick()
+    }
+    tryScrollToHash()
+    window.addEventListener('hashchange', tryScrollToHash)
+    return () => window.removeEventListener('hashchange', tryScrollToHash)
+  }, [data, headerOffset])
+}

--- a/openframe-frontend-core/src/utils/.source-icons.md
+++ b/openframe-frontend-core/src/utils/.source-icons.md
@@ -27,7 +27,7 @@ const iconName = getSourceIconName('github-commits')
 
 // Get display label for a chip strip
 const label = getSourceLabel('hubspot-tickets-anon')
-// → 'Known Issues'
+// → 'Tickets'
 
 // Map a documentType emitted by the LLM to its table ID
 const tableId = defaultTableIdForDocumentType('slack_message')

--- a/openframe-frontend-core/src/utils/dev-sections/dev-section-param-keys.ts
+++ b/openframe-frontend-core/src/utils/dev-sections/dev-section-param-keys.ts
@@ -19,3 +19,17 @@ export const DEV_SECTION_PARAM_KEYS = {
   /** Delivery (bug-fix / enhancement) task-type filter. */
   deliveryTaskType: 'task_type',
 } as const
+
+/** Section keys that participate in `<section>-<id>` anchor IDs.
+ *  The URL composer (`appendSearchAndHash` in hub `dev-section-url.ts`)
+ *  and the row components (`DeliveryRow`, `RoadmapCard`, `HelpCenterCard`)
+ *  both call `devSectionAnchorId` so the DOM `id` and the URL hash stay
+ *  in lockstep — adding a new section means adding the literal here
+ *  ONCE, not at every render site. */
+export type DevSectionAnchorKind = 'roadmap' | 'delivery' | 'ticket'
+
+/** Compose the canonical `<section>-<id>` anchor id used by the dev-center
+ *  rows + URL composer. */
+export function devSectionAnchorId(section: DevSectionAnchorKind, id: string): string {
+  return `${section}-${id}`
+}

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -246,6 +246,12 @@ export {
   scrollElementIntoView,
 } from './scroll-into-view'
 
+// Same-page hash navigation — owns pushState + synthetic hashchange +
+// anchoring-proof scroll. Pair of `scrollElementIntoView`. Used by the
+// hub's `useUnifiedNav` + chat-runtime `navigate`, AND by every
+// embeddable surface that drives state off the URL hash.
+export { navigateSamePageHash } from './same-page-hash-nav'
+
 // Shared list-API URL builder — the single source for the per-type chat
 // entity-card fetch shapes. The hub's 12 RAG mapper `listApi` closures
 // delegate here (byte-parity test guards the migration); embedders wire

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -258,6 +258,7 @@ export {
   navigateSamePageHash,
   normalizeHashFragment,
   STICKY_HEADER_OFFSET_PX,
+  HUB_HEADER_OFFSET_PX,
   type NavigateSamePageHashOptions,
 } from './same-page-hash-nav'
 

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -44,7 +44,11 @@ export * from './release-cover'
 // Dev-center URL param keys — the ONE source for the `?search=` / `?status=` / … keys the
 // chrome registry writes and the list views read; re-exported so embedders (and the hub's
 // dev-section-url helper) build deep-links with the same keys instead of a bare literal.
-export { DEV_SECTION_PARAM_KEYS } from './dev-sections/dev-section-param-keys'
+export {
+  DEV_SECTION_PARAM_KEYS,
+  devSectionAnchorId,
+  type DevSectionAnchorKind,
+} from './dev-sections/dev-section-param-keys'
 // Dynamic icon registry — single source of truth lives at
 // components/chat/utils/icon-registry. Re-exported here so existing
 // `@flamingo-stack/openframe-frontend-core/utils` callers (hub admin
@@ -250,7 +254,12 @@ export {
 // anchoring-proof scroll. Pair of `scrollElementIntoView`. Used by the
 // hub's `useUnifiedNav` + chat-runtime `navigate`, AND by every
 // embeddable surface that drives state off the URL hash.
-export { navigateSamePageHash, type NavigateSamePageHashOptions } from './same-page-hash-nav'
+export {
+  navigateSamePageHash,
+  normalizeHashFragment,
+  STICKY_HEADER_OFFSET_PX,
+  type NavigateSamePageHashOptions,
+} from './same-page-hash-nav'
 
 // Shared list-API URL builder — the single source for the per-type chat
 // entity-card fetch shapes. The hub's 12 RAG mapper `listApi` closures

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -250,7 +250,7 @@ export {
 // anchoring-proof scroll. Pair of `scrollElementIntoView`. Used by the
 // hub's `useUnifiedNav` + chat-runtime `navigate`, AND by every
 // embeddable surface that drives state off the URL hash.
-export { navigateSamePageHash } from './same-page-hash-nav'
+export { navigateSamePageHash, type NavigateSamePageHashOptions } from './same-page-hash-nav'
 
 // Shared list-API URL builder — the single source for the per-type chat
 // entity-card fetch shapes. The hub's 12 RAG mapper `listApi` closures

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -67,6 +67,18 @@ export interface NavigateSamePageHashOptions {
    *  chrome. Defaults to 0 — matches the prior contract. Pass `80` for
    *  the standard hub header, `96` for the FAQ category nav. */
   headerOffset?: number
+  /** How to reflect the hash change in browser history.
+   *  - `'push'` (default) — `history.pushState`. Each click adds a new
+   *    entry; the Back button rewinds through the click trail. Right for
+   *    cross-page CTAs (chat-runtime hash hand-off, useUnifiedNav) where
+   *    each click is a discrete navigation step.
+   *  - `'replace'` — `history.replaceState`. Overwrites the current
+   *    entry; the Back button leaves the page in one step regardless of
+   *    how many sibling sections / categories the user clicked. Right
+   *    for in-page section navigators (FAQ category pills, vendor
+   *    sticky section nav) where the surface is a TOC, not a
+   *    navigation step. Matches their pre-helper behavior. */
+  history?: 'push' | 'replace'
 }
 
 export function navigateSamePageHash(
@@ -74,7 +86,7 @@ export function navigateSamePageHash(
   options: NavigateSamePageHashOptions = {},
 ): boolean {
   if (typeof window === 'undefined') return false
-  const { headerOffset = 0 } = options
+  const { headerOffset = 0, history: historyMode = 'push' } = options
   // Bare-hash form (`#section-slug`): treat as same-page nav. Reconstruct
   // the full `pathname + search + hash` so the rest of the function — URL
   // compare, pushState, getElementById — operates on a single
@@ -96,7 +108,11 @@ export function navigateSamePageHash(
   if (!id && normalizedTarget !== current) return false
   if (normalizedTarget !== current) {
     const oldURL = window.location.href
-    window.history.pushState(null, '', normalizedTarget)
+    if (historyMode === 'replace') {
+      window.history.replaceState(null, '', normalizedTarget)
+    } else {
+      window.history.pushState(null, '', normalizedTarget)
+    }
     // Synthetic `hashchange` so listeners (FAQ section auto-expand, any
     // other page bound to the URL hash) re-render WITHOUT having to know
     // they're being navigated by `router.push` vs the browser. Dispatch

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -1,6 +1,26 @@
 import { scrollElementIntoView } from './scroll-into-view'
 
 /**
+ * Take only the FIRST hash segment from a fragment that may contain extra
+ * `#` characters. Per WHATWG URL parsing, anything after the first `#` is
+ * the fragment, so a malformed href like `?q=a#delivery-1#delivery-1`
+ * arrives in `URL.hash` as the literal `#delivery-1#delivery-1`. No real
+ * DOM id contains `#`, so this is always a bug at the composer site — we
+ * heal the URL here at the navigation surface, AND in `useScrollToHash`
+ * for the deep-link entry path. Exported so any future hash-aware
+ * surface can apply the SAME invariant.
+ *
+ * `'' → ''`, `'#' → '#'`, `'#a' → '#a'`, `'#a#b' → '#a'`.
+ */
+export function normalizeHashFragment(hash: string): string {
+  if (!hash) return ''
+  // `hash` always starts with '#' (it's `URL.hash`); the FIRST `#` is the
+  // delimiter, so find the SECOND `#` (the malformed one) and trim.
+  const second = hash.indexOf('#', 1)
+  return second < 0 ? hash : hash.slice(0, second)
+}
+
+/**
  * Same-page hash navigation, shared by every same-tab nav surface in the
  * hub AND every embeddable surface in the lib (FAQ section, ticket cards,
  * doc-tree, HubSpot ticket embed, …). Co-located with `scrollElementIntoView`
@@ -123,8 +143,29 @@ export function navigateSamePageHash(
   // than the raw caller string. This also keeps `current === next` exact-
   // match comparisons honest — the caller's "pathname/search/hash" string
   // and `window.location.*` may differ in encoding but resolve identically.
-  const next = url.pathname + url.search + url.hash
-  const id = url.hash && url.hash !== '#' ? url.hash.slice(1) : ''
+  //
+  // Defensive normalize: a hash MUST NOT contain another '#' (no real DOM id
+  // contains a hash character — `getElementById` would never match). Per
+  // WHATWG, the URL parser puts everything after the FIRST '#' into
+  // `hash`, so a caller-built href like `/x?q=a#delivery-1#delivery-1`
+  // arrives here with `url.hash === '#delivery-1#delivery-1'`. Strip
+  // everything from the second '#' on so:
+  //   1. the pushState URL is clean (browser bar no longer carries the
+  //      duplicate fragment that gets quoted around the web on share);
+  //   2. `getElementById(id)` below resolves correctly.
+  // Dev-mode warn surfaces the call site so the upstream composer can be
+  // fixed at the source; production silently heals.
+  const normalizedHash = normalizeHashFragment(url.hash)
+  if (process.env.NODE_ENV === 'development' && normalizedHash !== url.hash) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[navigateSamePageHash] target URL has a malformed fragment "${url.hash}" — ` +
+        `normalizing to "${normalizedHash}". Find the composer that appended a hash ` +
+        `onto an already-hashed URL and fix it at the source.`,
+    )
+  }
+  const next = url.pathname + url.search + normalizedHash
+  const id = normalizedHash && normalizedHash !== '#' ? normalizedHash.slice(1) : ''
   // Hash-less targets are only ours on an EXACT URL match (a re-click on
   // the current page, where router.push is a no-op — scroll to top is the
   // expected feedback). A same-page nav that merely REMOVES the hash falls

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -1,9 +1,13 @@
 import { scrollElementIntoView } from './scroll-into-view'
 
-/** Standard hub sticky-header offset (px). Shared by every `useScrollToHash`
- *  caller AND by per-row click-to-expand `scrollElementIntoView` calls so
- *  the anchor lands at the same Y regardless of entry point. */
+/** Pages with a section-nav STRIP on top of the global hub header
+ *  (dev-center roadmap/delivery/tickets, FAQ category-pill nav).
+ *  Anchor lands BELOW both layers. */
 export const STICKY_HEADER_OFFSET_PX = 96
+
+/** Pages with only the global hub header (docs, blog, vendor detail).
+ *  Anchor lands BELOW the header bar. */
+export const HUB_HEADER_OFFSET_PX = 80
 
 /**
  * Take only the FIRST hash segment from a fragment that may contain extra

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -1,0 +1,74 @@
+import { scrollElementIntoView } from './scroll-into-view'
+
+/**
+ * Same-page hash navigation, shared by every same-tab nav surface in the
+ * hub AND every embeddable surface in the lib (FAQ section, ticket cards,
+ * doc-tree, HubSpot ticket embed, …). Co-located with `scrollElementIntoView`
+ * because the two are a pair: the helper owns "set the URL, notify
+ * listeners, run the anchoring-proof tween" — one primitive, one altitude.
+ *
+ * Returns `true` when `target` (an origin-stripped path like
+ * `/openframe#top` or `/faqs#faq-item-42`) points at the CURRENT page —
+ * same pathname + search — AND either carries a hash or matches the
+ * current URL exactly (a re-click). In that case this helper owns the
+ * navigation: it reflects the hash in the URL bar via `history.pushState`
+ * (App Router syncs native history calls) and drives
+ * `scrollElementIntoView` to the anchor — or to the page top when the
+ * anchor is unknown/absent.
+ *
+ * WHY NOT `router.push` FOR THESE: Next.js performs hash scrolling as an
+ * INSTANT jump (it suppresses CSS smooth behavior during navigation), so
+ * the first click on a hash CTA never animated — and once the URL matched
+ * exactly, `router.push` was a complete no-op. Net effect was the
+ * "Get Beta Access scrolls smoothly only on the second try" bug.
+ *
+ * Returns `false` for cross-page targets — callers fall through to
+ * `router.push` exactly as before.
+ *
+ * WHY THIS HELPER DISPATCHES A SYNTHETIC `hashchange` EVENT:
+ * `history.pushState` does NOT fire `hashchange` (per HTML spec — the
+ * event fires only on browser-driven hash navigation: back/forward,
+ * manual URL edit, direct `location.hash` assignment). Pages that depend
+ * on the event to re-render — the FAQ section auto-expanding the cited
+ * Q&A, any future page driving accordion / tab / section state off the
+ * URL hash — would otherwise see the URL update but never react. Firing
+ * the event ourselves keeps this helper the SINGLE source of "the hash
+ * changed → re-render listeners → smooth-tween scroll" — no per-page
+ * polling, no per-page Next.js router-event subscription, no per-page
+ * `popstate` fallback. Every embed and every host page inherits the
+ * behavior from the same primitive.
+ */
+export function navigateSamePageHash(target: string): boolean {
+  if (typeof window === 'undefined') return false
+  const url = new URL(target, window.location.origin)
+  if (url.pathname !== window.location.pathname || url.search !== window.location.search) {
+    return false
+  }
+  const current = window.location.pathname + window.location.search + window.location.hash
+  const id = url.hash && url.hash !== '#' ? url.hash.slice(1) : ''
+  // Hash-less targets are only ours on an EXACT URL match (a re-click on
+  // the current page, where router.push is a no-op — scroll to top is the
+  // expected feedback). A same-page nav that merely REMOVES the hash falls
+  // through to the router untouched.
+  if (!id && target !== current) return false
+  if (target !== current) {
+    const oldURL = window.location.href
+    window.history.pushState(null, '', target)
+    // Synthetic `hashchange` so listeners (FAQ section auto-expand, any
+    // other page bound to the URL hash) re-render WITHOUT having to know
+    // they're being navigated by `router.push` vs the browser. Dispatch
+    // BEFORE the scroll so the page settles its new layout (accordion
+    // expanding, etc.) and `scrollElementIntoView`'s per-frame target
+    // recompute lands on the post-layout position, not the stale one.
+    window.dispatchEvent(new HashChangeEvent('hashchange', {
+      oldURL,
+      newURL: window.location.href,
+    }))
+  }
+  const el = id ? document.getElementById(id) : null
+  // Missing/absent anchor → tween to page top. documentElement's top is 0
+  // by definition, so ONE tween path covers both cases (no cancellable
+  // native `window.scrollTo({behavior:'smooth'})` anywhere on this path).
+  scrollElementIntoView(el ?? document.documentElement, { behavior: 'smooth' })
+  return true
+}

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -1,129 +1,58 @@
 import { scrollElementIntoView } from './scroll-into-view'
 
+/** Standard hub sticky-header offset (px). Shared by every `useScrollToHash`
+ *  caller AND by per-row click-to-expand `scrollElementIntoView` calls so
+ *  the anchor lands at the same Y regardless of entry point. */
+export const STICKY_HEADER_OFFSET_PX = 96
+
 /**
  * Take only the FIRST hash segment from a fragment that may contain extra
- * `#` characters. Per WHATWG URL parsing, anything after the first `#` is
- * the fragment, so a malformed href like `?q=a#delivery-1#delivery-1`
- * arrives in `URL.hash` as the literal `#delivery-1#delivery-1`. No real
- * DOM id contains `#`, so this is always a bug at the composer site — we
- * heal the URL here at the navigation surface, AND in `useScrollToHash`
- * for the deep-link entry path. Exported so any future hash-aware
- * surface can apply the SAME invariant.
+ * `#` characters. `'' → ''`, `'#a' → '#a'`, `'#a#b' → '#a'`.
  *
- * `'' → ''`, `'#' → '#'`, `'#a' → '#a'`, `'#a#b' → '#a'`.
+ * No real DOM id contains `#`, so a multi-fragment hash is always a bug at
+ * the composer site; `navigateSamePageHash` + `useScrollToHash` both call
+ * this so URL bar and `getElementById` stay in sync.
  */
 export function normalizeHashFragment(hash: string): string {
   if (!hash) return ''
-  // `hash` always starts with '#' (it's `URL.hash`); the FIRST `#` is the
-  // delimiter, so find the SECOND `#` (the malformed one) and trim.
   const second = hash.indexOf('#', 1)
   return second < 0 ? hash : hash.slice(0, second)
 }
 
-/**
- * Same-page hash navigation, shared by every same-tab nav surface in the
- * hub AND every embeddable surface in the lib (FAQ section, ticket cards,
- * doc-tree, HubSpot ticket embed, …). Co-located with `scrollElementIntoView`
- * because the two are a pair: the helper owns "set the URL, notify
- * listeners, run the anchoring-proof tween" — one primitive, one altitude.
- *
- * Returns `true` when `target` points at the CURRENT page — same pathname
- * + search — AND either carries a hash or matches the current URL exactly
- * (a re-click). In that case this helper owns the navigation: it reflects
- * the hash in the URL bar via `history.pushState` (App Router syncs native
- * history calls) and drives `scrollElementIntoView` to the anchor — or to
- * the page top when the anchor is unknown/absent.
- *
- * `target` accepts two forms:
- *   - **Origin-stripped path** (`/openframe#top`, `/faqs#faq-item-42`) for
- *     cross-page-aware callers — the helper checks pathname/search match
- *     before claiming the nav.
- *   - **Bare hash** (`#section-slug`, `#faq-item-42`) for same-page-only
- *     callers (FAQ pills, vendor section nav, doc-tree internal anchors)
- *     that already know they're scrolling within the current page. The
- *     helper reconstructs `pathname + search + hash` internally so callers
- *     don't have to. (DRY — three identical
- *     `pathname + search + '#' + id` reconstructions were the precursor to
- *     this overload.)
- *
- * WHY NOT `router.push` FOR THESE: Next.js performs hash scrolling as an
- * INSTANT jump (it suppresses CSS smooth behavior during navigation), so
- * the first click on a hash CTA never animated — and once the URL matched
- * exactly, `router.push` was a complete no-op. Net effect was the
- * "Get Beta Access scrolls smoothly only on the second try" bug.
- *
- * Returns `false` for cross-page targets — callers fall through to
- * `router.push` exactly as before.
- *
- * WHY THIS HELPER DISPATCHES A SYNTHETIC `hashchange` EVENT:
- * `history.pushState` does NOT fire `hashchange` (per HTML spec — the
- * event fires only on browser-driven hash navigation: back/forward,
- * manual URL edit, direct `location.hash` assignment). Pages that depend
- * on the event to re-render — the FAQ section auto-expanding the cited
- * Q&A, any future page driving accordion / tab / section state off the
- * URL hash — would otherwise see the URL update but never react. Firing
- * the event ourselves keeps this helper the SINGLE source of "the hash
- * changed → re-render listeners → smooth-tween scroll" — no per-page
- * polling, no per-page Next.js router-event subscription, no per-page
- * `popstate` fallback. Every embed and every host page inherits the
- * behavior from the same primitive.
- *
- * ## Sticky-header offsets
- *
- * Pages with a sticky header (the hub's site header, the FAQ category
- * nav, the docs sticky header) need to subtract that chrome from the
- * scroll target so the anchor lands below the header, not under it.
- * Callers pass `headerOffset` via the second argument; this overrides
- * the default 0. Pages that ALSO bind a `hashchange` listener that
- * re-scrolls with their own offset (FAQ section's `hashTarget` effect
- * is the canonical example) can rely on the listener — but the explicit
- * `headerOffset` here makes the helper land in the right place on the
- * FIRST tween, before the listener fires, which matters for same-target
- * re-clicks where the listener is a no-op (`hashTarget` reference
- * equality short-circuits).
- */
 export interface NavigateSamePageHashOptions {
-  /** Pixels to subtract from the anchor's `top` so it lands BELOW sticky
-   *  chrome. Defaults to 0 — matches the prior contract. Pass `80` for
-   *  the standard hub header, `96` for the FAQ category nav. */
+  /** Pixels to subtract for sticky chrome. */
   headerOffset?: number
-  /** How to reflect the hash change in browser history.
-   *  - `'push'` (default) — `history.pushState`. Each click adds a new
-   *    entry; the Back button rewinds through the click trail. Right for
-   *    cross-page CTAs (chat-runtime hash hand-off, useUnifiedNav) where
-   *    each click is a discrete navigation step.
-   *  - `'replace'` — `history.replaceState`. Overwrites the current
-   *    entry; the Back button leaves the page in one step regardless of
-   *    how many sibling sections / categories the user clicked. Right
-   *    for in-page section navigators (FAQ category pills, vendor
-   *    sticky section nav) where the surface is a TOC, not a
-   *    navigation step. Matches their pre-helper behavior. */
+  /** `'push'` (default) — new history entry; `'replace'` — overwrite
+   *  current entry (use for TOC-style in-page navigators). */
   history?: 'push' | 'replace'
 }
 
+/**
+ * Same-page hash navigation primitive: pushState + synthetic `hashchange`
+ * + anchoring-proof smooth scroll. Replaces `router.push` for hash CTAs
+ * (Next.js suppresses smooth-scroll during navigation; `router.push` on
+ * an exact-URL match is a no-op). Returns `true` when the helper claimed
+ * the nav (same pathname + search); `false` for cross-page targets so
+ * callers fall through to `router.push`.
+ *
+ * `target` accepts an origin-stripped path (`/x#anchor`) or a bare hash
+ * (`#anchor`); bare-hash callers don't need to reconstruct `pathname +
+ * search` themselves.
+ */
 export function navigateSamePageHash(
   target: string,
   options: NavigateSamePageHashOptions = {},
 ): boolean {
   if (typeof window === 'undefined') return false
   const { headerOffset = 0, history: historyMode = 'push' } = options
-  // Bare-hash form (`#section-slug`): treat as same-page nav. Reconstruct
-  // the full `pathname + search + hash` so the rest of the function — URL
-  // compare, pushState, getElementById — operates on a single
-  // canonical string.
   const normalizedTarget =
     target.startsWith('#')
       ? window.location.pathname + window.location.search + target
       : target
-  // `new URL(absoluteUrl, base)` IGNORES `base` per RFC 3986 — an absolute
-  // cross-origin target (e.g. `https://attacker.com/page?foo=bar#x`) that
-  // happens to share the current page's pathname/search would otherwise
-  // pass the same-page check below and then `history.pushState` would
-  // throw `SecurityError` (pushState enforces same-origin). Use
-  // `window.location.href` as base so the parse always anchors to the
-  // current document, and explicitly reject cross-origin URLs up-front so
-  // the caller cleanly falls through to `router.push`. Wrap in try/catch
-  // for malformed inputs.
+  // `new URL(absoluteUrl, base)` ignores `base` per RFC 3986; an absolute
+  // cross-origin target sharing pathname/search would otherwise pass the
+  // check below and trip pushState's same-origin enforcement. Parse with
+  // an explicit base so malformed inputs cleanly fall through.
   let url: URL
   try {
     url = new URL(normalizedTarget, window.location.href)
@@ -138,38 +67,18 @@ export function navigateSamePageHash(
     return false
   }
   const current = window.location.pathname + window.location.search + window.location.hash
-  // Reconstruct from the PARSED url so the value we hand to pushState is
-  // origin-stripped and normalized (encoding, leading slashes, etc.) rather
-  // than the raw caller string. This also keeps `current === next` exact-
-  // match comparisons honest — the caller's "pathname/search/hash" string
-  // and `window.location.*` may differ in encoding but resolve identically.
-  //
-  // Defensive normalize: a hash MUST NOT contain another '#' (no real DOM id
-  // contains a hash character — `getElementById` would never match). Per
-  // WHATWG, the URL parser puts everything after the FIRST '#' into
-  // `hash`, so a caller-built href like `/x?q=a#delivery-1#delivery-1`
-  // arrives here with `url.hash === '#delivery-1#delivery-1'`. Strip
-  // everything from the second '#' on so:
-  //   1. the pushState URL is clean (browser bar no longer carries the
-  //      duplicate fragment that gets quoted around the web on share);
-  //   2. `getElementById(id)` below resolves correctly.
-  // Dev-mode warn surfaces the call site so the upstream composer can be
-  // fixed at the source; production silently heals.
+  // Heal a malformed multi-fragment hash so the URL bar is clean and
+  // `getElementById` resolves. Dev-warn fingers the upstream composer.
   const normalizedHash = normalizeHashFragment(url.hash)
   if (process.env.NODE_ENV === 'development' && normalizedHash !== url.hash) {
     // eslint-disable-next-line no-console
     console.warn(
-      `[navigateSamePageHash] target URL has a malformed fragment "${url.hash}" — ` +
-        `normalizing to "${normalizedHash}". Find the composer that appended a hash ` +
-        `onto an already-hashed URL and fix it at the source.`,
+      `[navigateSamePageHash] malformed fragment "${url.hash}" → normalizing to "${normalizedHash}". Fix the upstream composer.`,
     )
   }
   const next = url.pathname + url.search + normalizedHash
   const id = normalizedHash && normalizedHash !== '#' ? normalizedHash.slice(1) : ''
-  // Hash-less targets are only ours on an EXACT URL match (a re-click on
-  // the current page, where router.push is a no-op — scroll to top is the
-  // expected feedback). A same-page nav that merely REMOVES the hash falls
-  // through to the router untouched.
+  // Hash-less targets are only ours on an EXACT URL re-click.
   if (!id && next !== current) return false
   if (next !== current) {
     const oldURL = window.location.href
@@ -178,29 +87,22 @@ export function navigateSamePageHash(
     } else {
       window.history.pushState(null, '', next)
     }
-    // Synthetic `hashchange` so listeners (FAQ section auto-expand, any
-    // other page bound to the URL hash) re-render WITHOUT having to know
-    // they're being navigated by `router.push` vs the browser. Dispatch
-    // BEFORE the scroll so the page settles its new layout (accordion
-    // expanding, etc.) and `scrollElementIntoView`'s per-frame target
-    // recompute lands on the post-layout position, not the stale one.
+    // Synthetic `hashchange` — `pushState` doesn't fire it (HTML spec),
+    // so URL-hash-bound listeners (FAQ auto-expand, etc.) wouldn't react.
     window.dispatchEvent(new HashChangeEvent('hashchange', {
       oldURL,
       newURL: window.location.href,
     }))
   }
   const el = id ? document.getElementById(id) : null
-  // Missing/absent anchor → tween to page top. documentElement's top is 0
-  // by definition, so ONE tween path covers both cases (no cancellable
-  // native `window.scrollTo({behavior:'smooth'})` anywhere on this path).
-  // Dev-only warn when an explicit anchor was requested but not found —
-  // helps catch typo'd citation links / deleted FAQ items in QA.
   if (id && !el && process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line no-console
     console.warn(
-      `[navigateSamePageHash] anchor "#${id}" not found on this page — scrolling to top.`,
+      `[navigateSamePageHash] anchor "#${id}" not found — scrolling to top.`,
     )
   }
+  // Missing anchor → tween to page top. `documentElement` is at 0 by
+  // definition, so one tween covers both branches.
   scrollElementIntoView(el ?? document.documentElement, {
     behavior: 'smooth',
     headerOffset,

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -7,14 +7,24 @@ import { scrollElementIntoView } from './scroll-into-view'
  * because the two are a pair: the helper owns "set the URL, notify
  * listeners, run the anchoring-proof tween" — one primitive, one altitude.
  *
- * Returns `true` when `target` (an origin-stripped path like
- * `/openframe#top` or `/faqs#faq-item-42`) points at the CURRENT page —
- * same pathname + search — AND either carries a hash or matches the
- * current URL exactly (a re-click). In that case this helper owns the
- * navigation: it reflects the hash in the URL bar via `history.pushState`
- * (App Router syncs native history calls) and drives
- * `scrollElementIntoView` to the anchor — or to the page top when the
- * anchor is unknown/absent.
+ * Returns `true` when `target` points at the CURRENT page — same pathname
+ * + search — AND either carries a hash or matches the current URL exactly
+ * (a re-click). In that case this helper owns the navigation: it reflects
+ * the hash in the URL bar via `history.pushState` (App Router syncs native
+ * history calls) and drives `scrollElementIntoView` to the anchor — or to
+ * the page top when the anchor is unknown/absent.
+ *
+ * `target` accepts two forms:
+ *   - **Origin-stripped path** (`/openframe#top`, `/faqs#faq-item-42`) for
+ *     cross-page-aware callers — the helper checks pathname/search match
+ *     before claiming the nav.
+ *   - **Bare hash** (`#section-slug`, `#faq-item-42`) for same-page-only
+ *     callers (FAQ pills, vendor section nav, doc-tree internal anchors)
+ *     that already know they're scrolling within the current page. The
+ *     helper reconstructs `pathname + search + hash` internally so callers
+ *     don't have to. (DRY — three identical
+ *     `pathname + search + '#' + id` reconstructions were the precursor to
+ *     this overload.)
  *
  * WHY NOT `router.push` FOR THESE: Next.js performs hash scrolling as an
  * INSTANT jump (it suppresses CSS smooth behavior during navigation), so
@@ -37,10 +47,43 @@ import { scrollElementIntoView } from './scroll-into-view'
  * polling, no per-page Next.js router-event subscription, no per-page
  * `popstate` fallback. Every embed and every host page inherits the
  * behavior from the same primitive.
+ *
+ * ## Sticky-header offsets
+ *
+ * Pages with a sticky header (the hub's site header, the FAQ category
+ * nav, the docs sticky header) need to subtract that chrome from the
+ * scroll target so the anchor lands below the header, not under it.
+ * Callers pass `headerOffset` via the second argument; this overrides
+ * the default 0. Pages that ALSO bind a `hashchange` listener that
+ * re-scrolls with their own offset (FAQ section's `hashTarget` effect
+ * is the canonical example) can rely on the listener — but the explicit
+ * `headerOffset` here makes the helper land in the right place on the
+ * FIRST tween, before the listener fires, which matters for same-target
+ * re-clicks where the listener is a no-op (`hashTarget` reference
+ * equality short-circuits).
  */
-export function navigateSamePageHash(target: string): boolean {
+export interface NavigateSamePageHashOptions {
+  /** Pixels to subtract from the anchor's `top` so it lands BELOW sticky
+   *  chrome. Defaults to 0 — matches the prior contract. Pass `80` for
+   *  the standard hub header, `96` for the FAQ category nav. */
+  headerOffset?: number
+}
+
+export function navigateSamePageHash(
+  target: string,
+  options: NavigateSamePageHashOptions = {},
+): boolean {
   if (typeof window === 'undefined') return false
-  const url = new URL(target, window.location.origin)
+  const { headerOffset = 0 } = options
+  // Bare-hash form (`#section-slug`): treat as same-page nav. Reconstruct
+  // the full `pathname + search + hash` so the rest of the function — URL
+  // compare, pushState, getElementById — operates on a single
+  // canonical string.
+  const normalizedTarget =
+    target.startsWith('#')
+      ? window.location.pathname + window.location.search + target
+      : target
+  const url = new URL(normalizedTarget, window.location.origin)
   if (url.pathname !== window.location.pathname || url.search !== window.location.search) {
     return false
   }
@@ -50,10 +93,10 @@ export function navigateSamePageHash(target: string): boolean {
   // the current page, where router.push is a no-op — scroll to top is the
   // expected feedback). A same-page nav that merely REMOVES the hash falls
   // through to the router untouched.
-  if (!id && target !== current) return false
-  if (target !== current) {
+  if (!id && normalizedTarget !== current) return false
+  if (normalizedTarget !== current) {
     const oldURL = window.location.href
-    window.history.pushState(null, '', target)
+    window.history.pushState(null, '', normalizedTarget)
     // Synthetic `hashchange` so listeners (FAQ section auto-expand, any
     // other page bound to the URL hash) re-render WITHOUT having to know
     // they're being navigated by `router.push` vs the browser. Dispatch
@@ -69,6 +112,17 @@ export function navigateSamePageHash(target: string): boolean {
   // Missing/absent anchor → tween to page top. documentElement's top is 0
   // by definition, so ONE tween path covers both cases (no cancellable
   // native `window.scrollTo({behavior:'smooth'})` anywhere on this path).
-  scrollElementIntoView(el ?? document.documentElement, { behavior: 'smooth' })
+  // Dev-only warn when an explicit anchor was requested but not found —
+  // helps catch typo'd citation links / deleted FAQ items in QA.
+  if (id && !el && process.env.NODE_ENV === 'development') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[navigateSamePageHash] anchor "#${id}" not found on this page — scrolling to top.`,
+    )
+  }
+  scrollElementIntoView(el ?? document.documentElement, {
+    behavior: 'smooth',
+    headerOffset,
+  })
   return true
 }

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -95,23 +95,47 @@ export function navigateSamePageHash(
     target.startsWith('#')
       ? window.location.pathname + window.location.search + target
       : target
-  const url = new URL(normalizedTarget, window.location.origin)
-  if (url.pathname !== window.location.pathname || url.search !== window.location.search) {
+  // `new URL(absoluteUrl, base)` IGNORES `base` per RFC 3986 — an absolute
+  // cross-origin target (e.g. `https://attacker.com/page?foo=bar#x`) that
+  // happens to share the current page's pathname/search would otherwise
+  // pass the same-page check below and then `history.pushState` would
+  // throw `SecurityError` (pushState enforces same-origin). Use
+  // `window.location.href` as base so the parse always anchors to the
+  // current document, and explicitly reject cross-origin URLs up-front so
+  // the caller cleanly falls through to `router.push`. Wrap in try/catch
+  // for malformed inputs.
+  let url: URL
+  try {
+    url = new URL(normalizedTarget, window.location.href)
+  } catch {
+    return false
+  }
+  if (
+    url.origin !== window.location.origin ||
+    url.pathname !== window.location.pathname ||
+    url.search !== window.location.search
+  ) {
     return false
   }
   const current = window.location.pathname + window.location.search + window.location.hash
+  // Reconstruct from the PARSED url so the value we hand to pushState is
+  // origin-stripped and normalized (encoding, leading slashes, etc.) rather
+  // than the raw caller string. This also keeps `current === next` exact-
+  // match comparisons honest — the caller's "pathname/search/hash" string
+  // and `window.location.*` may differ in encoding but resolve identically.
+  const next = url.pathname + url.search + url.hash
   const id = url.hash && url.hash !== '#' ? url.hash.slice(1) : ''
   // Hash-less targets are only ours on an EXACT URL match (a re-click on
   // the current page, where router.push is a no-op — scroll to top is the
   // expected feedback). A same-page nav that merely REMOVES the hash falls
   // through to the router untouched.
-  if (!id && normalizedTarget !== current) return false
-  if (normalizedTarget !== current) {
+  if (!id && next !== current) return false
+  if (next !== current) {
     const oldURL = window.location.href
     if (historyMode === 'replace') {
-      window.history.replaceState(null, '', normalizedTarget)
+      window.history.replaceState(null, '', next)
     } else {
-      window.history.pushState(null, '', normalizedTarget)
+      window.history.pushState(null, '', next)
     }
     // Synthetic `hashchange` so listeners (FAQ section auto-expand, any
     // other page bound to the URL hash) re-render WITHOUT having to know

--- a/openframe-frontend-core/src/utils/source-icons.ts
+++ b/openframe-frontend-core/src/utils/source-icons.ts
@@ -128,7 +128,13 @@ export const SOURCE_LABELS_BY_TABLE: Record<string, string> = {
 
   // HubSpot
   'hubspot-tickets':             'HubSpot Tickets',
-  'hubspot-tickets-anon':        'Known Issues',
+  // Anon + self share the "Tickets" root so the chip vocabulary is
+  // uniform across logged-out (everyone's resolved support tickets,
+  // anonymized → "Tickets") and logged-in (user-scoped → "My Tickets")
+  // surfaces. The full-PII `hubspot-tickets` entry above is product-hub
+  // internal only (admin view), kept as "HubSpot Tickets" to flag the
+  // distinct scope.
+  'hubspot-tickets-anon':        'Tickets',
   'hubspot-tickets-self':        'My Tickets',
 
   // Communications


### PR DESCRIPTION
## Summary

Consolidates same-page hash navigation onto ONE primitive (`navigateSamePageHash`), extends hash-anchored scroll to roadmap + delivery list rows, and unifies the FAQ pill click + doc-tree internal anchors onto the same primitive.

## Commits (7)

### Same-page hash nav consolidation

1. **`feat(utils): same-page hash nav primitive`** — Moves `navigateSamePageHash` from the hub into the lib so every embeddable surface (FAQ section, ticket cards, doc-tree, HubSpot ticket embed, future embeddables) inherits the same "set URL, notify listeners, run anchoring-proof tween" behavior. **Critical addition vs the hub draft**: dispatches a synthetic `HashChangeEvent` after `pushState`. Per HTML spec, `pushState` does NOT fire `hashchange` — only browser-driven hash nav does. Pages that depend on the event to re-render (FAQ section auto-expand, vendor section nav, any future tab/accordion bound to URL hash) would otherwise see the URL update but never react.

2. **`refactor(faq): category pill click delegates`** — `handleJump` was doing manual `scrollElementIntoView` + manual `replaceState`. Now one `navigateSamePageHash` call.

3. **`refactor(docs): use-document-tree same-doc shortcut`** — `navigateToDoc`'s same-doc-different-anchor case had its own copy: manual `pushState` + 300ms `setTimeout` bandaid + manual `scrollElementIntoView`. Now delegates. Cross-doc nav keeps the fetch-then-scroll path. Knowledge-base / data-room anchor clicks within the same doc now scroll smoothly with NO 300ms delay.

4. **`fix(hash-nav): apply review fixes`** + **`fix(hash-nav): doc-tree pathname-compare regression + history-mode option`** — Reviewer-driven cleanups: bare-hash form, `headerOffset`/`history: 'push'|'replace'` options, build-break fix.

### Hash-anchored scroll for dev-center rows (new)

5. **`feat(dev-center): hash-anchored scroll for roadmap + delivery rows`** — Chat-inline `delivery_item` / `roadmap_item` cards (and the linked-card on a HubSpot ticket) compose URLs through hub's `buildDevSectionUrl`, which now produces `?search=<id>#<section>-<id>`. The `?search=` narrows the list; the `#delivery-<id>` / `#roadmap-<id>` anchor is the new piece — this commit gives those anchors a target.
   - `DeliveryLists` + `RoadmapView` each bind a `hashchange` effect, gated on items being loaded, that calls the canonical `scrollElementIntoView(el, { headerOffset: 96 })` on the matching DOM node.
   - Re-runs on browser back/forward AND on the synthetic `hashchange` `navigateSamePageHash` dispatches — chat-embedded surfaces get the scroll for free.

6. **`feat(dev-center): row/card DOM ids matching #<section>-<id> hash anchor`** — Each DeliveryTable row wraps in `<div id="delivery-<external_id>" className="scroll-mt-24">`. Each RoadmapGrid card wraps the same way with `id="roadmap-<external_id>"`. Writer (hub mapper) + reader (lib effect) + target (this DOM id) stay in lockstep through one section key.

## Test plan

- [ ] On `/faqs#faq-item-N` click another FAQ chat card → URL pushes → accordion remounts open → scroll lands on OPEN FAQ.
- [ ] Bare `/faqs` → click a category pill → smooth tween + pill highlights.
- [ ] On `/knowledge-base/foo/bar` click an internal `#anchor` link → smooth scroll, NO 300ms delay.
- [ ] `/openframe` "Get Beta Access" CTA still smooth-tweens (helper's primary regression case).
- [ ] Chat card for a delivery_item → `/bug-fixes-and-enhancements?search=<id>#delivery-<id>` → filter applies → page scrolls to the row.
- [ ] Same for roadmap card → `/roadmap?search=<id>#roadmap-<id>` → quarter accordion auto-expands (search active) → scroll lands on the card.
- [ ] Linked-delivery card on a HubSpot ticket → same scroll behavior on the destination list.
- [ ] Browser back/forward between hash-bearing URLs replays correctly.
- [ ] Slack channel-privacy filter still fail-CLOSES under all paths.

## Hub dependency

Hub PR follows once this releases. Hub side:
- Bumps `package.json` pin to the new lib version
- Deletes hub-local `lib/utils/same-page-hash-nav.ts` (moved to lib)
- Switches imports in `use-nav-link.tsx` + `hub-runtime-provider.tsx` to `@flamingo-stack/openframe-frontend-core/utils`
- Vendor section nav (`vendor-detail-content.tsx`), blog section (`blog-section.tsx`) delegate to lib helper
- Mapper: `buildDevSectionUrl` extended to append `#<section>-<id>` to delivery + roadmap URLs
- Ticket card URL fix: `hubspot_ticket_self` → `/tickets?ticket=<id>&search=<id>` (was hardcoded `null`)
- Pre-builds `delivery_item:<linked-id>` ref alongside ticket ref so the LLM-emitted linked-delivery card resolves to clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deep-linking support enabling direct URL navigation to specific items (deliverables, roadmaps, tickets, and help center articles)
  * Improved same-page navigation with intelligent scroll positioning that accounts for sticky headers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->