### PR TITLE
fix(): remove thinking

### DIFF
--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -205,12 +205,6 @@ export interface UseNatsChatAdapterConfig {
   topics?: NatsMessageType[]
 
   /**
-   * Whether THINKING chunks are surfaced as segments. Default `false`
-   * (parity with the existing `useRealtimeChunkProcessor` default).
-   */
-  enableThinking?: boolean
-
-  /**
    * Mirrors `UseRealtimeChunkProcessorOptions.batchApprovalsEnabled`.
    * Default `true` — single batch card per APPROVAL_REQUEST with
    * `toolCalls[]`. Set `false` to fall back to legacy per-tool cards.
@@ -426,7 +420,6 @@ export function useNatsChatAdapter(
     publishUserMessage,
     fetchChunks,
     topics,
-    enableThinking,
     batchApprovalsEnabled,
     fetchDialogs,
     fetchDialogMessages,
@@ -614,7 +607,6 @@ export function useNatsChatAdapter(
       onApprove: accumApprove,
       onReject: accumReject,
     },
-    enableThinking,
     batchApprovalsEnabled,
   })
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
@@ -11,7 +11,6 @@ import {
   MessageSegmentAccumulator,
   createMessageSegmentAccumulator,
 } from '../utils/message-segment-accumulator'
-import { MESSAGE_TYPE } from '../types'
 import type { UseRealtimeChunkProcessorReturn, UseRealtimeChunkProcessorOptions, ChatApprovalStatus, PendingToolCallData, MessageSegment, SegmentsUpdateMetadata } from '../types'
 import { getCommandText } from '../utils/tool-call-helpers'
 
@@ -31,7 +30,6 @@ export function useRealtimeChunkProcessor(
     displayApprovalTypes = ['CLIENT'],
     approvalStatuses = {},
     initialState,
-    enableThinking = false,
     // Owned by the consumer (e.g. oss-tenant chat client / openframe-frontend
     // tickets view). Default ON so consumers that haven't wired the flag yet
     // get the new batch UI; pass `false` explicitly to fall back to legacy.
@@ -93,15 +91,6 @@ export function useRealtimeChunkProcessor(
 
   const processChunk = useCallback(
     (chunk: unknown) => {
-      if (
-        !enableThinking &&
-        chunk &&
-        typeof chunk === 'object' &&
-        (chunk as { type?: string }).type === MESSAGE_TYPE.THINKING
-      ) {
-        return
-      }
-
       const action = parseChunkToAction(chunk)
       if (!action) return
 
@@ -396,7 +385,7 @@ export function useRealtimeChunkProcessor(
           break
       }
     },
-    [callbacks, displayApprovalTypes, approvalStatuses, initialState, enableThinking]
+    [callbacks, displayApprovalTypes, approvalStatuses, initialState]
   )
 
   const getSegments = useCallback(() => {

--- a/openframe-frontend-core/src/components/chat/types/api.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/api.types.ts
@@ -233,12 +233,6 @@ export interface UseRealtimeChunkProcessorOptions {
     >
   }
   /**
-   * When true, THINKING chunks are processed into thinking segments. When false
-   * (default), they are dropped before parsing — they never enter the
-   * accumulator or store.
-   */
-  enableThinking?: boolean
-  /**
    * Consumer-owned (e.g. set in `openframe-oss-tenant` chat client via the
    * `'batch-approvals'` feature flag and forwarded here). The lib does NOT
    * default this to a batch-on behavior — when omitted it falls back to the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed the `enableThinking` configuration option from chat adapters. Thinking chunk handling now relies on default internal behavior instead of being user-configurable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->