### PR TITLE
fix(markdown): wrap long inline tokens on mobile (overflow-wrap at shared renderer root)

### DIFF
--- a/openframe-frontend-core/src/components/docs/doc-viewer.tsx
+++ b/openframe-frontend-core/src/components/docs/doc-viewer.tsx
@@ -369,7 +369,11 @@ function DocViewerContent({
                       : ''
                   } gap-8`}
                 >
-                  <div className={`w-full ${isMarkdownContent ? 'max-w-4xl mx-auto' : ''}`}>
+                  {/* min-w-0: grid items default to min-width:auto, which would
+                      let a long unbreakable token push this column past the
+                      track width. Pair with the inherited overflow-wrap:anywhere
+                      (app-globals.css) so content wraps instead of overflowing. */}
+                  <div className={`w-full min-w-0 ${isMarkdownContent ? 'max-w-4xl mx-auto' : ''}`}>
                     <article className="space-y-2">
                       {(isLoadingContent || isLoadingStructure) ? (
                         renderSkeleton(selectedNodeDocType)

--- a/openframe-frontend-core/src/components/ui/simple-markdown-renderer.tsx
+++ b/openframe-frontend-core/src/components/ui/simple-markdown-renderer.tsx
@@ -921,7 +921,10 @@ const SimpleMarkdownRendererImpl: React.FC<SimpleMarkdownRendererProps> = ({
   return (
     <div className={`simple-markdown-renderer ${className}`}>
       <style dangerouslySetInnerHTML={{ __html: mermaidStyles }} />
-      <div className="content-wrapper max-w-none break-words">
+      {/* `overflow-wrap: anywhere` is inherited from `.simple-markdown-renderer`
+          in app-globals.css — do NOT re-add `break-words` here, it would
+          override the cascade with the weaker `break-word` for this subtree. */}
+      <div className="content-wrapper max-w-none">
         <article className="prose prose-lg max-w-none">
           <ReactMarkdown
             remarkPlugins={[remarkGfm, remarkBreaks, ...(additionalRemarkPlugins ?? [])]}

--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -97,6 +97,30 @@ body {
   @apply transition-colors duration-300;
 }
 
+/* ──────────────────────────────────────────────────────────────────────────
+   Markdown content — long-token wrapping (single source of truth)
+
+   Both the rich AND simple markdown renderers wrap their output in
+   `.simple-markdown-renderer`. `overflow-wrap` is an INHERITED property, so
+   setting it here once cascades to every rendered text node — paragraphs, list
+   items, links, inline `code`, headings, blockquotes, table cells — with no
+   need to enumerate each element. This is what stops long unbreakable tokens
+   (URLs, `kubectl apply -f https://…/recommended.yaml`, commit hashes) from
+   overflowing the viewport on narrow/mobile screens. Fix lives at the shared
+   root so any future markdown element inherits it for free.
+
+   `anywhere` (not `break-word`) is deliberate: it counts the introduced break
+   opportunities in min-content sizing, so the box can shrink below its longest
+   word inside a flex/grid parent instead of forcing a horizontal blow-out of
+   the column. Fenced code blocks are unaffected — `<pre>` uses
+   `white-space: pre`, which ignores `overflow-wrap`, so they keep their own
+   `overflow-x-auto` horizontal scroll. DO NOT set a weaker
+   `overflow-wrap`/`break-words` on a descendant wrapper — it would override
+   this for that subtree (see simple-markdown-renderer's content-wrapper). */
+.simple-markdown-renderer {
+  overflow-wrap: anywhere;
+}
+
 /* Prevent zoom on mobile focus/touch events */
 @media screen and (max-width: 800px) {
   * {


### PR DESCRIPTION
## What

Long unbreakable tokens — URLs, inline `code` such as `kubectl apply -f https://…/recommended.yaml`, commit hashes — overflowed the viewport on narrow/mobile screens in rendered markdown. Reported on `/knowledge-base/openframe-cli/getting-started/first-steps`.

## Root cause

Both the rich and the simple markdown renderers wrap their output in the shared root class `.simple-markdown-renderer`, but **nothing set `overflow-wrap` on it**. The `prose prose-lg` classes on the article are inert — the `@tailwindcss/typography` plugin isn't installed — so there was no baseline wrapping rule. A long token with no break opportunity had nowhere to wrap and spilled past the screen edge.

## Fix (at the shared root, inherited — not per element)

`overflow-wrap` is an inherited property, so one rule on the shared root cascades to every rendered text node — paragraphs, list items, links, inline code, headings, table cells — for every current *and future* markdown element.

- **`src/styles/app-globals.css`** — `.simple-markdown-renderer { overflow-wrap: anywhere; }`. `anywhere` (not `break-word`) also shrinks min-content so a long token can't blow out a flex/grid column. Fenced code blocks are untouched: `<pre>` uses `white-space: pre`, which ignores `overflow-wrap`, so they keep their existing `overflow-x-auto` horizontal scroll.
- **`src/components/ui/simple-markdown-renderer.tsx`** — removed a stray `break-words` on `content-wrapper` that would override the inherited rule with the weaker `break-word` for its subtree (comment added so it isn't reintroduced).
- **`src/components/docs/doc-viewer.tsx`** — added `min-w-0` to the markdown grid cell (canonical grid/flex shrink guard) so the desktop `1fr 280px` column can't be pushed wide either.

## Breadth ("across the board")

The single root rule covers **both** renderers, so every markdown surface benefits: `/knowledge-base/*`, `/data-room/*`, `/privacy-policy`, `/terms-of-service` (all `RichMarkdownRenderer`), plus chat and other `SimpleMarkdownRenderer` surfaces.

## Before / after (300px width)

Before: the inline `code` token runs past the screen edge (clipped at the viewport boundary). After: it wraps and stays fully readable inside the screen. Verified against the exact DOM nesting (`.simple-markdown-renderer` → `content-wrapper` → `article` → `<p>` with long inline `<code>`) and the real CSS rule.

## Notes

- CSS ships directly from `src/styles/index.css` (no build artifact), so it's live on import.
- Reaches the hub apps via the normal lib release → hub version-pin bump.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text overflow issues where long unbreakable tokens in documentation viewers and markdown content would break page layouts.
  * Improved text wrapping for long identifiers and code elements to fit properly within containers.
  * Enhanced layout constraints to prevent content overflow in grid-based display areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->