### PR TITLE
fix(faq): wrap long tokens in FAQ answers on mobile

### DIFF
--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -103,7 +103,11 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
               style={{ maxHeight, transition: 'max-height 0.35s ease-in-out, opacity 0.35s ease-in-out', opacity: isOpen ? 1 : 0 }}
               className="overflow-hidden group-hover:bg-[#1E1E1E]/30"
             >
-              <div ref={ref} className="px-6 md:px-8 pb-6 text-ods-text-primary text-h4">
+              {/* break-words: FAQ answers render as plain text, so a long URL or
+                  token has no wrap opportunity — and the parent is overflow-hidden,
+                  which would CLIP it past the viewport on mobile. Mirrors the
+                  markdown-renderer overflow-wrap fix. */}
+              <div ref={ref} className="px-6 md:px-8 pb-6 text-ods-text-primary text-h4 break-words">
                 {item.answer}
               </div>
             </div>


### PR DESCRIPTION
## What

FAQ answers render as plain text `{item.answer}` in `faq-accordion.tsx` (used live by `faq-section.tsx`), so a long URL/token in an answer has no wrap opportunity — and the content wrapper is `overflow-hidden`, which **clips** it past the viewport on narrow/mobile screens.

Same bug class as the markdown overflow fix (openframe-oss-lib#1218), but the answer div is not under `.simple-markdown-renderer`, so it does not inherit that root rule.

## Fix

Add `break-words` to the answer div so long tokens wrap.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
