### PR TITLE
fix(layout): drop redundant min-h-screen from PageShell/ArticleDetailLayout

### DIFF
--- a/openframe-frontend-core/src/components/layout/.article-detail-layout.md
+++ b/openframe-frontend-core/src/components/layout/.article-detail-layout.md
@@ -12,7 +12,7 @@ Unified page layout components providing two layout variants for consistent page
 - `children` — page content (no additional layout wrappers needed)
 - `schemas?` — optional JSON-LD `<script>` elements (breadcrumbs, article schema, etc.)
 
-Both components render a `<main>` element with `bg-ods-bg`, `min-h-screen`, responsive horizontal padding (`px-6` / `md:px-20`), and vertical padding (`py-6` / `md:py-10`).
+Both components render a `<main>` element with `bg-ods-bg`, responsive horizontal padding (`px-6` / `md:px-20`), and vertical padding (`py-6` / `md:py-10`). Neither forces `min-h-screen` — the root layout's `flex min-h-screen flex-col` → `flex-1` chain already anchors the footer to the bottom of the viewport on short pages.
 
 ## Usage Example
 

--- a/openframe-frontend-core/src/components/layout/article-detail-layout.tsx
+++ b/openframe-frontend-core/src/components/layout/article-detail-layout.tsx
@@ -30,10 +30,19 @@ interface LayoutProps {
 /**
  * Full-width page shell for list pages, dashboards, and other wide layouts.
  * Max width: 1920px.
+ *
+ * No `min-h-screen` here on purpose: the root layout already wraps page
+ * content in a `flex min-h-screen flex-col` → `flex-1` chain (app/layout.tsx),
+ * so the footer is pushed to the bottom of the viewport on short pages without
+ * this shell forcing its own 100vh. Adding `min-h-screen` here stacks a second
+ * full viewport INSIDE that growing `flex-1`, which only manifests as dead
+ * space when the shell is a hero section above sibling content
+ * (roadmap-and-releases). There is no case where the shell itself should fill
+ * the viewport.
  */
 export function PageShell({ children, schemas, contentClassName }: LayoutProps) {
   return (
-    <main className="bg-ods-bg min-h-screen">
+    <main className="bg-ods-bg">
       {schemas}
       <div className={cn('page-shell-content max-w-[1920px] mx-auto', contentClassName)}>
         {children}
@@ -51,7 +60,7 @@ export function PageShell({ children, schemas, contentClassName }: LayoutProps) 
  */
 export function ArticleDetailLayout({ children, schemas, contentClassName }: LayoutProps) {
   return (
-    <main className="bg-ods-bg min-h-screen">
+    <main className="bg-ods-bg">
       {schemas}
       <div className={cn('max-w-[1280px] mx-auto px-6 md:px-20 py-6 md:py-10', contentClassName)}>
         {children}

--- a/openframe-frontend-core/src/components/layout/page-with-header.tsx
+++ b/openframe-frontend-core/src/components/layout/page-with-header.tsx
@@ -15,7 +15,7 @@ import { PageHeader, type PageHeaderProps } from './page-header'
  * Renders the same JSX tree every consumer was hand-rolling individually
  * before this helper landed:
  *
- *   PageShell                         ← bg-ods-bg, min-h-screen, max-w-[1920px],
+ *   PageShell                         ← bg-ods-bg, max-w-[1920px],
  *                                       page-shell-px/pt/pb gutters
  *     PageLayout backButton           ← TitleBlock → PageHeader #1 (back-btn row
  *                                       only, pt-l + mb-l)


### PR DESCRIPTION
## Problem

`/roadmap-and-releases` (and any page using `PageWithHeader` as a hero **section** above sibling content) showed ~100vh of dead space between the hero cards and the next section.

## Root cause

`PageShell` and `ArticleDetailLayout` each rendered `<main className="bg-ods-bg min-h-screen">`. But the **root app layout already** wraps page content in a `flex min-h-screen flex-col` → `flex-1` chain (`app/layout.tsx`), which is what anchors the footer to the bottom of the viewport on short pages. The shells' own `min-h-screen` stacked a **second** forced 100vh *inside* that already-growing `flex-1`. On full pages it's invisible (the body fills the screen anyway); when the shell is just a hero with siblings below it, it surfaces as a full viewport of dead space.

## Fix

Remove `min-h-screen` from both `PageShell` and `ArticleDetailLayout`. Sticky-footer behavior is unchanged (the root `flex-1` chain owns it). There is no case where the shell itself should fill the viewport.

- `article-detail-layout.tsx` — drop `min-h-screen` from both `<main>`; document why.
- `page-with-header.tsx` / `.article-detail-layout.md` — fix stale docs that referenced `min-h-screen`.

## Scope

Applies to every page using these shells (list/detail/admin/article). Only behavioral change: genuinely-short pages no longer carry an extra forced 100vh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved layout structure by streamlining viewport height handling across main layout components, allowing them to properly integrate with the root layout's flex-based behavior.

* **Documentation**
  * Updated layout component documentation to reflect styling changes and behavior adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->