### PR TITLE
fix(docs): no empty/error flash on initial doc load

### DIFF
--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -287,6 +287,11 @@ export function useDocumentTree(
           // an error banner. The structure-arrives auto-select will fire
           // a targeted fetch for the first-folder README on the next render.
           if (path === folderIndexFile && selectedPath === '') {
+            // Superseded by the auto-select fetch the structure effect fires.
+            // Null the request id so the `finally` does NOT drop the spinner —
+            // otherwise there's a 1-frame gap (isLoadingContent false, content
+            // null) where the empty state flashes before the real fetch starts.
+            lastFetchedPath.current = null
             setError(null)
             setContent(null)
             return
@@ -306,6 +311,11 @@ export function useDocumentTree(
           const preStructureFolderLike =
             structure.length === 0 && !path.endsWith('.md')
           if (probeIsNoReadmeFolder || preStructureFolderLike) {
+            // Superseded by the targeted fetch (first-child / reclassified path)
+            // the structure effect fires. Null the request id so the `finally`
+            // keeps the spinner up instead of flashing an empty state for a
+            // frame before that fetch starts.
+            lastFetchedPath.current = null
             setError(null)
             setContent(null)
             return


### PR DESCRIPTION
## Symptom
On initial doc load, an empty "Select a document" / not-found state **flashes for a frame** before the doc renders (regression noticed after #1230 made no-README folders fetchable).

## Root cause
`use-document-tree.ts` fires a **speculative** content fetch in parallel with the structure fetch. When the speculative fetch is **silenced** (a 404 for the landing, a no-README folder, or any pre-structure folder-ish path), its `finally` set `isLoadingContent = false`. If that resolved **before** the structure, the next render had `isLoadingContent=false && isLoadingStructure=false && content=null` — a 1-frame window where the empty/not-found state showed, *before* the structure effect fired the real (auto-select / first-child) fetch.

## Fix
In each silenced-404 branch, null `lastFetchedPath` so the shared `finally` does **not** drop the spinner (it's a superseded request, exactly like the existing request-id guard models). The skeleton now stays up continuously until real content — or a genuine empty/error — resolves. No empty frame.

- 1 file, +10 lines. `tsc --noEmit` clean.
- Leaf docs were never affected (their speculative fetch is a 200); landing + no-README folders no longer flash.

## Ship
Hotfix on top of 0.0.307 — needs a release (0.0.308) + a hub `package.json` pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)