### PR TITLE
fix(docs): eliminate README-folder content flicker on first load

### DIFF
--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -193,6 +193,16 @@ export function useDocumentTree(
         }
         pathToFetch = firstDocPath
       } else if (node && node.type === 'folder' && node.hasReadme) {
+        // `getContent(folder)` already resolves a README folder to its README,
+        // so the initial speculative fetch (which uses the bare folder path)
+        // ALREADY loaded this content. Re-fetching the `${folder}/README.md`
+        // variant is a redundant 2nd request whose in-flight `isLoadingContent`
+        // flashes the skeleton — content → skeleton → content — on first load.
+        // Skip it when the folder path was already the (speculatively) fetched
+        // path; the result (or its in-flight request) covers the README.
+        if (lastFetchedPath.current === selectedPath) {
+          return
+        }
         pathToFetch = `${selectedPath}/${folderIndexFile}`
       } else {
         pathToFetch = selectedPath


### PR DESCRIPTION
## Symptom
On **first load** of a README folder — the landing (`/knowledge-base` → `openframe-cli`), and section pages like `openframe-oss-tenant`, `architecture`, `development` (all README folders) — the doc **content flickers**: it renders, vanishes to the skeleton for a moment, then re-renders. Not on client-side browsing after load.

## Root cause (reproduced locally with server-side fetch logging)
`useDocumentTree` fires a **speculative** content fetch on mount using the bare folder path. `getContent(folder)` already resolves a README folder to its README, so that fetch returns the content. But the content effect *then* fetched the **`${folder}/README.md`** variant — a **different path**, so the request-id guard didn't dedupe it → a **redundant 2nd request** whose in-flight `isLoadingContent` re-shows the skeleton (~440 ms gap measured).

```
[content] path=openframe-oss-tenant            ← speculative (returns the README)
[content] path=openframe-oss-tenant/README.md  ← redundant 2nd fetch → skeleton flash
```

## Fix
Skip the `/README.md` fetch when the folder path was already the (speculatively) fetched path — the result, or its in-flight request, already covers the README. One file, +10 lines.

## Verified locally (paired worktree, dev server + browser)
- README-folder load now issues **ONE** content request (was two) → no skeleton flash; content renders correctly.
- Landing, no-README folders, and leaf docs unchanged (one real content fetch each).
- `tsc --noEmit` clean.

## Ship
Hotfix on top of 0.0.308 → needs a release (**0.0.309**) + a hub `package.json` pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved unnecessary loading placeholder flicker that occurred during initial page load when displaying README content in folders.

* **Performance**
  * Enhanced document loading efficiency by eliminating redundant fetch requests when README content is already available, delivering faster and smoother initial load experiences with reduced visual interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->