### PR TITLE
fix(docs): resolve relative doc links against the rendered doc path (no-README folders)

### DIFF
--- a/openframe-frontend-core/src/components/docs/doc-viewer.tsx
+++ b/openframe-frontend-core/src/components/docs/doc-viewer.tsx
@@ -214,11 +214,19 @@ function DocViewerContent({
     if (!content) return null
     return renderContent(content, {
       onInternalLinkClick: navigateToDoc,
-      currentPath: selectedPath,
+      // Relative-link base = the RENDERED document's path, NOT `selectedPath`.
+      // They diverge for a no-README folder: selection stays on the folder
+      // (e.g. `repo/diagrams`) while the body is its first descendant doc
+      // (e.g. `repo/diagrams/architecture/README.md`, via `findFirstDocPath`).
+      // Resolving `./sibling.mmd` against the folder would 404; resolving it
+      // against `content.path` lands in the descendant's directory. The DAL
+      // sets `content.path` to the served doc in all cases (file / README
+      // folder / first-child fallback), so this is correct everywhere.
+      currentPath: content.path,
       sourceId,
       onResolveLink: resolveLink,
     })
-  }, [content, selectedPath, renderContent, navigateToDoc, sourceId, resolveLink])
+  }, [content, renderContent, navigateToDoc, sourceId, resolveLink])
 
   // Selected node's documentType drives:
   //   - which skeleton the caller renders during fetch (markdown vs embed)


### PR DESCRIPTION
## Problem

Internal links to `.mmd` (and any) files in the doc viewer dead-click when the **navigated folder has no README**.

Example: https://hub.openframe.ai/knowledge-base/openframe-cli/diagrams — clicking "High-Level System Design", "Dependency Flow Between Modules", etc. did nothing. Selecting the deeper `…/diagrams/architecture` folder and clicking the same links worked.

## Root cause

`openframe-cli/diagrams` is a folder with `has_readme: false`. The viewer's no-README fallback (`useDocumentTree` → `findFirstDocPath`) renders the **first descendant doc** — `…/diagrams/architecture/README.md` — whose body links to its `.mmd` siblings as `./high-level-system-design.mmd`.

But `DocViewer` handed the renderer **`selectedPath`** (the navigated *folder*, `openframe-cli/diagrams`) as the relative-link base, not the path of the document actually being rendered. So `./high-level-system-design.mmd` resolved to `openframe-cli/diagrams/high-level-system-design.mmd` → doesn't exist → `not-found` → the click handler returns early without navigating.

Selecting `architecture` directly worked only because there `selectedPath` happened to equal the rendered doc's directory — exactly the "only works on the non-direct folder" symptom.

## Fix

One change: resolve relative links against **`content.path`** (the actually-served document) instead of `selectedPath`. The DAL sets `content.path` to the served doc in every case (file / README-folder / no-README first-child fallback).

This also aligns the interactive client resolver with the **already-correct** server-side SEO link rewriter (`doc-seo-content.tsx`), which explicitly resolves against `content.path` "not the URL `docPath`" for this exact reason. It fixes **both** `/knowledge-base` and `/data-room`, and **every** no-README folder (any link type, not just `.mmd`).

## Proof (local, openframe platform, real Chrome)

Automated browser run against `/knowledge-base/openframe-cli/diagrams`:

- ✅ No-README folder renders its descendant README body ("Architecture Diagrams")
- ✅ resolve-link POST sends `currentPath = "openframe-cli/diagrams/architecture/README.md"` (the fix; old code sent `"openframe-cli/diagrams"`)
- ✅ resolve-link → `type=file`, `resolvedPath = openframe-cli/diagrams/architecture/high-level-system-design.mmd`
- ✅ Clicking the link navigates to the `.mmd` and the **mermaid diagram renders**
- ✅ Regression: the previously-working direct `…/architecture` folder still resolves + navigates

Live API contrast on the same server:
- old base `openframe-cli/diagrams` → `type: "not-found"`
- fixed base `openframe-cli/diagrams/architecture/README.md` → `type: "file"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
