### PR TITLE
feat(faq): FaqDocumentPage renders the canonical /faqs hero + forwards SSR data

### DIFF
--- a/openframe-frontend-core/src/components/chat/utils/execute-navigation.ts
+++ b/openframe-frontend-core/src/components/chat/utils/execute-navigation.ts
@@ -30,6 +30,7 @@
 
 import { computeIsNewTab } from './nav-anchor-props'
 import { NEW_TAB_FEATURES, stripSameOriginToPath } from './chat-nav-resolution'
+import { navigateSamePageHash, STICKY_HEADER_OFFSET_PX } from '../../../utils/same-page-hash-nav'
 import type { ChatRuntime } from '../../../contexts/chat-runtime-context'
 
 /** Minimal mouse-event surface — structural so chip buttons / tiles can call it
@@ -77,9 +78,22 @@ function runNavigation(
     else window.open(href, '_blank', NEW_TAB_FEATURES)
     return
   }
+  const target = stripSameOriginToPath(href)
+  // Same-page hash target (e.g. a chat card deep-linking to `/faqs#faq-item-49`):
+  // route through the UNIFIED same-page-hash primitive FIRST. A host router /
+  // `router.push` performs `pushState`, which the HTML spec says does NOT fire a
+  // `hashchange` event — so URL-hash-bound listeners (FAQ auto-expand,
+  // `useScrollToHash`) never react on a SOFT same-page nav and the cited row
+  // neither opens nor scrolls. `navigateSamePageHash` does the pushState AND
+  // dispatches the synthetic `hashchange` (+ anchoring-proof scroll). It returns
+  // false for cross-page targets (different pathname/search) — those fall through
+  // to the host nav / router below, which mount the new route where the hash is
+  // read fresh on first render.
+  if (target.includes('#') && navigateSamePageHash(target, { headerOffset: STICKY_HEADER_OFFSET_PX })) {
+    return
+  }
   const handled = runtime?.navigation.navigate?.({ href, path, targetPlatform }) ?? false
   if (!handled) {
-    const target = stripSameOriginToPath(href)
     if (fallbackNavigate) fallbackNavigate(target)
     else window.location.assign(target)
   }

--- a/openframe-frontend-core/src/components/faq/faq-document-page.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-document-page.tsx
@@ -2,27 +2,55 @@
 
 /**
  * FaqDocumentPage — the full `/faqs` page with chrome, so embedders drop in
- * ONE component instead of hand-assembling `PageShell` + `PageLayout` around the
- * bare `<FaqSection>`. Mirrors `LegalDocumentPage` / `DevSectionPage`: the
- * page-level layout lives in the lib, the host passes only config + a back button.
+ * ONE component instead of hand-assembling `PageShell` + `PageLayout` + the
+ * FAQ hero around the bare `<FaqSection>`. Mirrors `LegalDocumentPage` /
+ * `DevSectionPage`: the page-level layout lives in the lib, the host page is a
+ * thin wrapper that passes only config + the SSR-resolved data.
  *
- * `<FaqSection heading={null}>` lets `PageLayout`'s `TitleBlock` own the heading +
- * back button; it self-fetches `${apiBaseUrl}/api/faqs` via the authed
- * `useSelfFetch`, and renders nothing on a fetch error or zero FAQs.
+ * HERO: renders the canonical FAQ hero (`<h1 class="text-h1">` + accent dot +
+ * icon + clamped subtitle) — byte-identical to the multi-platform hub's local
+ * `PageWithHeader` chrome the standalone `/faqs` page historically used. It
+ * does NOT route through `PageLayout`'s `title`/`subtitle` (the FROZEN
+ * `text-h2` `TitleBlock` is a different, smaller header used by OpenFrame
+ * detail surfaces). The page owns the `<h1>`, so `<FaqSection heading={null}>`
+ * nests its category headings as `<h2>` and the questions as `<h3>` (the
+ * SEO-recommended FAQ document outline).
+ *
+ * DATA: pass `initialFaqs` (SSR-resolved, platform-scoped) so `FaqSection`
+ * skips its client self-fetch — the standalone page's static platform-only
+ * contract. Omit it for embeds that want the self-fetching `/api/faqs`
+ * suggestion-fill instead.
  */
 
+import React from 'react';
+import { HelpCircle } from 'lucide-react';
+import type { Faq } from '../../types/faq';
 import { PageShell, PageLayout } from '../ui';
 import { useRouter } from '../../embed-shims/next-navigation';
+import { SECTION_HERO_ICON_CLASS } from '../../utils/page-header-constants';
 import { FaqSection } from './faq-section';
+import type { FaqSchemaOptions } from './json-ld';
 
 export interface FaqDocumentPageProps {
-  /** Page title (PageLayout TitleBlock). Default "FAQs". */
+  /** Hero `<h1>`. Default "Frequently Asked Questions". */
   title?: string;
-  /** Subtitle under the title. */
+  /** Subtitle under the title (auto-clamped to 2 lines). */
   subtitle?: string;
+  /** Icon rendered before the title. Default `<HelpCircle>` (the FAQ glyph). */
+  titleIcon?: React.ReactNode;
+  /** Render the yellow accent dot after the title (default true). */
+  accentDot?: boolean;
   /** Back-button config — same pattern as `DevSectionPage` / `LegalDocumentPage`.
    *  Pass `false` to hide. Default `{ label: 'Back to home', href: '/' }`. */
   backButton?: { label?: string; href?: string } | false;
+  /** SSR-hydrate `FaqSection` (skips the client fetch — the platform-only
+   *  contract for the standalone page). Omit for self-fetching embeds. */
+  initialFaqs?: Faq[];
+  /** Emit FAQPage schema.org JSON-LD (forwarded to `FaqSection`). Off by
+   *  default so embeds don't emit duplicate schema. */
+  emitJsonLd?: boolean;
+  /** JSON-LD name/description/url overrides (forwarded to `FaqSection`). */
+  jsonLd?: FaqSchemaOptions;
   /** Base URL `FaqSection` appends `/api/faqs` to (reverse-proxy embedders). */
   apiBaseUrl?: string;
   /** Optional entity scoping forwarded to `FaqSection`. */
@@ -33,9 +61,14 @@ export interface FaqDocumentPageProps {
 }
 
 export function FaqDocumentPage({
-  title = 'FAQs',
+  title = 'Frequently Asked Questions',
   subtitle,
+  titleIcon = <HelpCircle className={SECTION_HERO_ICON_CLASS} />,
+  accentDot = true,
   backButton,
+  initialFaqs,
+  emitJsonLd,
+  jsonLd,
   apiBaseUrl,
   entityType,
   entityId,
@@ -43,8 +76,9 @@ export function FaqDocumentPage({
 }: FaqDocumentPageProps) {
   const router = useRouter();
 
-  // Back-button config — mirrors LegalDocumentPage/DevSectionPage. Hide entirely
-  // when the caller passes `false` (embed-mode where the host owns nav chrome).
+  // Back-button config — mirrors LegalDocumentPage / DevSectionPage. Hide
+  // entirely when the caller passes `false` (embed-mode where the host owns
+  // nav chrome).
   const backCfg =
     backButton === false
       ? undefined
@@ -55,14 +89,39 @@ export function FaqDocumentPage({
 
   return (
     <PageShell>
-      <PageLayout title={title} subtitle={subtitle} backButton={backCfg}>
-        <FaqSection
-          heading={null}
-          apiBaseUrl={apiBaseUrl}
-          entityType={entityType}
-          entityId={entityId}
-          minResults={minResults}
-        />
+      <PageLayout backButton={backCfg}>
+        <div className="w-full flex flex-col gap-10">
+          {/* Canonical FAQ hero — the exact DOM/CSS the hub's local
+              `PageWithHeader` rendered (text-h1 + accent dot + icon + clamped
+              subtitle), inlined here so the standalone `/faqs` look is owned by
+              the lib. Intentionally NOT the frozen `text-h2` `TitleBlock`. */}
+          <div className="flex items-end justify-between gap-[var(--spacing-system-m)] md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between">
+            <div className="flex flex-col gap-[var(--spacing-system-xs)] flex-1 min-w-0">
+              <div className="space-y-4">
+                <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary flex items-center gap-3">
+                  {titleIcon}
+                  <span>
+                    {title}
+                    {accentDot && <span className="text-ods-accent">.</span>}
+                  </span>
+                </h1>
+                <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl line-clamp-2 min-h-[56px]">
+                  {subtitle || ' '}
+                </p>
+              </div>
+            </div>
+          </div>
+          <FaqSection
+            {...(initialFaqs ? { initialFaqs } : {})}
+            heading={null}
+            emitJsonLd={emitJsonLd}
+            jsonLd={jsonLd}
+            apiBaseUrl={apiBaseUrl}
+            entityType={entityType}
+            entityId={entityId}
+            minResults={minResults}
+          />
+        </div>
       </PageLayout>
     </PageShell>
   );

--- a/openframe-frontend-core/src/components/faq/faq-document-page.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-document-page.tsx
@@ -112,7 +112,7 @@ export function FaqDocumentPage({
             </div>
           </div>
           <FaqSection
-            {...(initialFaqs ? { initialFaqs } : {})}
+            initialFaqs={initialFaqs}
             heading={null}
             emitJsonLd={emitJsonLd}
             jsonLd={jsonLd}

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -6,9 +6,9 @@ import { FaqAccordion, type FaqItem } from '../faq-accordion'
 import { useSelfFetch } from '../../hooks/use-self-fetch'
 import { buildSuggestionUrl } from '../../utils/suggestion-url'
 import { serializeJsonLd } from '../../utils/common'
-import { scrollElementIntoView } from '../../utils/scroll-into-view'
+import { useScrollToHash } from '../../hooks/use-scroll-to-hash'
 import { navigateSamePageHash, STICKY_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
-import { faqSectionSlug, faqItemAnchor, parseFaqHash, type FaqHashTarget } from '../../utils/faq-anchor'
+import { faqSectionSlug, parseFaqHash, type FaqHashTarget } from '../../utils/faq-anchor'
 import { cn } from '../../utils/cn'
 import { buildFaqJsonLdFromFaqs, type FaqSchemaOptions } from './json-ld'
 import { SECTION_HEADING_CLASS } from '../layout/page-heading'
@@ -208,13 +208,18 @@ function GroupedFaqList({
   const accordionKeySuffix =
     hashTarget?.kind === 'item' ? `item:${hashTarget.rawId}` : 'default'
 
+  // Unified scroll-to-hash: rAF-polls for the target row (outlasts the SWR self-
+  // fetch + Radix accordion expand) and re-fires on `hashchange` — including the
+  // synthetic event `navigateSamePageHash` dispatches for a SOFT same-page chat-card
+  // nav (a host-router `pushState` fires no `hashchange`). `groups` as the ready-dep
+  // re-runs it once the self-fetched list mounts. Replaces the old one-shot scroll
+  // effect that keyed off `hashTarget` only and so missed async-mounted rows.
+  useScrollToHash(groups, { headerOffset: STICKY_HEADER_OFFSET_PX })
+
+  // A section hash also lights up its category pill; item hashes leave the pills
+  // untouched so deep-linking a question never disturbs scroll-spy state.
   useEffect(() => {
-    if (!hashTarget) return
-    const elId =
-      hashTarget.kind === 'item' ? faqItemAnchor(hashTarget.rawId) : hashTarget.slug
-    const el = document.getElementById(elId)
-    if (el) scrollElementIntoView(el, { headerOffset: STICKY_HEADER_OFFSET_PX })
-    if (hashTarget.kind === 'section') setActiveSlug(hashTarget.slug)
+    if (hashTarget?.kind === 'section') setActiveSlug(hashTarget.slug)
   }, [hashTarget])
 
   // Category pill click. `navigateSamePageHash` owns the entire transition:

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -208,13 +208,23 @@ function GroupedFaqList({
   const accordionKeySuffix =
     hashTarget?.kind === 'item' ? `item:${hashTarget.rawId}` : 'default'
 
-  // Unified scroll-to-hash: rAF-polls for the target row (outlasts the SWR self-
-  // fetch + Radix accordion expand) and re-fires on `hashchange` — including the
-  // synthetic event `navigateSamePageHash` dispatches for a SOFT same-page chat-card
-  // nav (a host-router `pushState` fires no `hashchange`). `groups` as the ready-dep
-  // re-runs it once the self-fetched list mounts. Replaces the old one-shot scroll
-  // effect that keyed off `hashTarget` only and so missed async-mounted rows.
-  useScrollToHash(groups, { headerOffset: STICKY_HEADER_OFFSET_PX })
+  // Unified scroll-to-hash: rAF-polls for the target row (outlasts the SWR self-fetch
+  // + Radix accordion expand) and re-fires on `hashchange` — including the synthetic
+  // event `navigateSamePageHash` dispatches for a SOFT same-page chat-card nav (a
+  // host-router `pushState` fires no `hashchange`). The ready-dep keys off BOTH the
+  // loaded `groups` (so a deep-link / refresh scrolls once the self-fetched list
+  // mounts) AND `hashTarget` (so a soft nav re-runs the scroll AFTER the re-render
+  // that remounts + opens the cited row, landing on its FINAL expanded position
+  // instead of racing the uncontrolled accordion's key-remount — the bare-`hashchange`
+  // listener alone fires before the remount and lands on the stale closed position).
+  const scrollDep =
+    `${groups.length}|` +
+    (hashTarget?.kind === 'item'
+      ? `item:${hashTarget.rawId}`
+      : hashTarget?.kind === 'section'
+        ? `section:${hashTarget.slug}`
+        : 'none')
+  useScrollToHash(scrollDep, { headerOffset: STICKY_HEADER_OFFSET_PX })
 
   // A section hash also lights up its category pill; item hashes leave the pills
   // untouched so deep-linking a question never disturbs scroll-spy state.

--- a/react-embedding-example/README.md
+++ b/react-embedding-example/README.md
@@ -2,7 +2,7 @@
 
 A standalone **Vite + React** app that embeds the chat (`EmbeddableChat`) and every
 page-level content surface from `@flamingo-stack/openframe-frontend-core` (onboarding
-guides, roadmap, delivery, product releases, authors, legal, contact, tickets,
+guides, roadmap, delivery, product releases, authors, FAQ, legal, contact, tickets,
 announcements), talking to the multi-platform hub through a **`/content` reverse proxy**.
 
 The proxy holds the **chat secret** and injects a **fixed identity** (Michael Assraf), so

--- a/react-embedding-example/src/app-routes.tsx
+++ b/react-embedding-example/src/app-routes.tsx
@@ -13,6 +13,7 @@ import { ContactPage } from './pages/contact'
 import { CaseStudiesPage } from './pages/case-studies'
 import { TicketsPage } from './pages/tickets'
 import { AuthorsPage } from './pages/authors'
+import { FaqsPage } from './pages/faqs'
 import { KnowledgeBasePage } from './pages/knowledge-base'
 import { DOCS_BASE_ROUTE } from './config/content'
 
@@ -32,6 +33,7 @@ export function AppRoutes() {
         <Route path="releases" element={<ReleasesPage />} />
         <Route path="releases/:slug" element={<ReleaseDetailRoute />} />
         <Route path="authors" element={<AuthorsPage />} />
+        <Route path="faqs" element={<FaqsPage />} />
         <Route path="legal/:docType" element={<LegalPage />} />
         <Route path="contact" element={<ContactPage />} />
         <Route path="case-studies" element={<CaseStudiesPage />} />

--- a/react-embedding-example/src/components/app-shell.tsx
+++ b/react-embedding-example/src/components/app-shell.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { to: '/delivery', label: 'Delivery' },
   { to: '/releases', label: 'Releases' },
   { to: '/authors', label: 'Authors' },
+  { to: '/faqs', label: 'FAQ' },
   { to: '/legal/privacy', label: 'Legal' },
   { to: '/contact', label: 'Contact' },
   { to: '/tickets', label: 'Tickets' },

--- a/react-embedding-example/src/pages/faqs.tsx
+++ b/react-embedding-example/src/pages/faqs.tsx
@@ -3,18 +3,20 @@ import { CONTENT_PREFIX } from '../../proxy/content-prefix.mjs'
 
 /**
  * FAQ — config-only. `<FaqDocumentPage>` owns the chrome (PageShell + the
- * canonical FAQ hero) and self-fetches the FAQ list from `${apiBaseUrl}/api/faqs`
- * — here `/content/api/faqs`, which the proxy rewrites to the hub. A SPA has no
- * SSR `initialFaqs`, so it deliberately falls to the self-fetch path (the
- * `/api/faqs` suggestion-fill the lib designed embeds around — same as how
- * roadmap/delivery self-fetch). `backButton={false}` because this embedder owns
- * the nav chrome (mirrors legal.tsx).
+ * "Back to home" button + the canonical FAQ hero) and self-fetches the FAQ list
+ * from `${apiBaseUrl}/api/faqs` — here `/content/api/faqs`, which the proxy
+ * rewrites to the hub. With no entity scope the hub serves the platform-only
+ * ACTIVE list (identical to what the hub's SSR `/faqs` page renders), so this
+ * embed matches the hub byte-for-byte.
+ *
+ * We rely on the DEFAULT back button ("Back to home" → `/`), consistent with
+ * roadmap/delivery/releases — do NOT pass `backButton={false}` (only `legal`
+ * opts out of the back affordance).
  */
 export function FaqsPage() {
   return (
     <FaqDocumentPage
       apiBaseUrl={CONTENT_PREFIX}
-      backButton={false}
       subtitle="Answers to the most common questions about OpenFrame."
     />
   )

--- a/react-embedding-example/src/pages/faqs.tsx
+++ b/react-embedding-example/src/pages/faqs.tsx
@@ -1,0 +1,21 @@
+import { FaqDocumentPage } from '@flamingo-stack/openframe-frontend-core/components'
+import { CONTENT_PREFIX } from '../../proxy/content-prefix.mjs'
+
+/**
+ * FAQ — config-only. `<FaqDocumentPage>` owns the chrome (PageShell + the
+ * canonical FAQ hero) and self-fetches the FAQ list from `${apiBaseUrl}/api/faqs`
+ * — here `/content/api/faqs`, which the proxy rewrites to the hub. A SPA has no
+ * SSR `initialFaqs`, so it deliberately falls to the self-fetch path (the
+ * `/api/faqs` suggestion-fill the lib designed embeds around — same as how
+ * roadmap/delivery self-fetch). `backButton={false}` because this embedder owns
+ * the nav chrome (mirrors legal.tsx).
+ */
+export function FaqsPage() {
+  return (
+    <FaqDocumentPage
+      apiBaseUrl={CONTENT_PREFIX}
+      backButton={false}
+      subtitle="Answers to the most common questions about OpenFrame."
+    />
+  )
+}

--- a/react-embedding-example/src/pages/home.tsx
+++ b/react-embedding-example/src/pages/home.tsx
@@ -7,6 +7,7 @@ const SURFACES = [
   { to: '/delivery', title: 'Delivery', desc: 'Bug-fix + enhancement tables; /content/api/delivery/*.' },
   { to: '/releases', title: 'Product releases', desc: 'List via the shared ProductReleasesView; detail injects a roadmap section.' },
   { to: '/authors', title: 'Authors', desc: 'Author byline (description card) + author-scoped related-content rail via /content/api/related-content?authorId=…' },
+  { to: '/faqs', title: 'FAQ', desc: 'FaqDocumentPage — grouped accordion + category jump-nav + FAQPage JSON-LD; self-fetches /content/api/faqs.' },
   { to: '/legal/privacy', title: 'Legal', desc: 'Privacy / terms via /content/api/legal/*.' },
   { to: '/contact', title: 'Contact', desc: 'ContactForm → /content/api/contact (EndpointsRuntime).' },
   { to: '/case-studies', title: 'Case studies — Share Your Experience', desc: 'Lib ShareExperienceSection (G2/Capterra/TrustPilot/GetApp benefit grid + proxied ContactForm).' },

--- a/react-embedding-example/src/providers/content-runtime.ts
+++ b/react-embedding-example/src/providers/content-runtime.ts
@@ -1,7 +1,7 @@
 // ONE factory for both lib runtime contexts. Every endpoint comes from EP, so the
 // `/content` base is the single source. Mounted (memoized) in app-providers.tsx.
 import type { ChatRuntime, EndpointsRuntime } from '@flamingo-stack/openframe-frontend-core/contexts'
-import { buildListUrl, makeComposeContentUrl, DEV_SECTION_PARAM_KEYS } from '@flamingo-stack/openframe-frontend-core/utils'
+import { buildListUrl, makeComposeContentUrl, DEV_SECTION_PARAM_KEYS, faqItemAnchor } from '@flamingo-stack/openframe-frontend-core/utils'
 import { CONTENT_PREFIX } from '../../proxy/content-prefix.mjs'
 import { EP, HUB_PUBLIC_ORIGIN } from '../config/endpoints'
 
@@ -79,6 +79,12 @@ export function buildChatRuntime(): Omit<ChatRuntime, 'source'> {
       overrides: {
         roadmap_item: (id) => ({ href: `/roadmap?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`, targetPlatform: null }),
         delivery_item: (id) => ({ href: `/delivery?${DEV_SECTION_PARAM_KEYS.search}=${encodeURIComponent(id)}`, targetPlatform: null }),
+        // FAQ deep-link: the hub bakes `/faqs#faq-item-<id>` as the card's externalUrl
+        // (the canonical HUB origin → opens in a new tab here). Override to the in-app
+        // `/faqs` hash so the card soft-navigates instead; `<FaqSection>`'s hash dispatch
+        // then expands + scrolls to that row. `faqItemAnchor` is the same lib SSOT the
+        // page uses to mint the row anchors, so target and anchor always match.
+        faq: (id) => ({ href: `/faqs#${faqItemAnchor(id)}`, targetPlatform: null }),
       },
     }),
     // Per-documentType doc-viewer targets. Doc chips with NO public externalUrl


### PR DESCRIPTION
## What

`FaqDocumentPage` now renders the **canonical `/faqs` hero** (`text-h1` + `HelpCircle` + accent dot) and forwards `initialFaqs` / `emitJsonLd` / `jsonLd` to `FaqSection`.

Before this, `FaqDocumentPage` existed but was **unused and didn't match the live page**: it delegated to the frozen `text-h2` `TitleBlock` and let `FaqSection` self-fetch. Wiring the hub's standalone `/faqs` page to it as-was would have (a) changed the page's look and (b) silently dropped the **platform-only SSR contract** in favor of the `/api/faqs` suggestion-filler self-fetch.

## Why

Enables the multi-platform hub to retire its local `/faqs` chrome and mount this factory as a thin wrapper — the same pattern as `DevSectionPage` (roadmap / delivery) and `LegalDocumentPage`. The page lives in the lib; the hub passes only config + the SSR-resolved data.

## Changes

- Render the FAQ hero inline — byte-identical to the hub's former local `PageWithHeader` (`text-h1 tracking-[-1.12px]`, `HelpCircle` default icon at `SECTION_HERO_ICON_CLASS`, accent dot, 2-line-clamped subtitle) — instead of routing through the frozen `PageLayout` `title`/`subtitle` (`text-h2`, no icon/accent).
- New props: `titleIcon` (default `<HelpCircle>`), `accentDot` (default `true`), `initialFaqs`, `emitJsonLd`, `jsonLd`. `title` default is now `"Frequently Asked Questions"`.
- Forward `initialFaqs` / `emitJsonLd` / `jsonLd` to `FaqSection`.

No other consumers of `FaqDocumentPage` exist, so the hero change has no blast radius.

## Verification

Mounted by the hub `/faqs` page against a local openmsp dev server: hero DOM byte-identical to the prior `PageWithHeader` output; `HelpCircle` + accent dot + `FAQPage` JSON-LD present; **21 SSR FAQs** (confirms `initialFaqs` pass-through, not the suggestion-filler fallback); 0 errors.

## Also: wired into `react-embedding-example`

Adds `/faqs` to the embedding example as a first-class surface — new `src/pages/faqs.tsx` + route + nav link + home card + README, mirroring `legal.tsx`. `<FaqDocumentPage apiBaseUrl={CONTENT_PREFIX} backButton={false}>` self-fetches `/content/api/faqs` through the `/content` reverse proxy. The SPA has no SSR, so it deliberately uses `FaqSection`'s self-fetch path (the `/api/faqs` suggestion-fill embeds are designed around), not the hub's `initialFaqs` platform-only contract.

## Companion

Hub PR that consumes these props: https://github.com/flamingo-stack/multi-platform-hub/pull/679

**Merge this first**, then release the lib + bump the hub pin — see the hub PR for the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated FAQ page with accordion-style layout, category jump navigation, and automatic structured data support.
  * Integrated FAQ link into the main navigation menu.
  * FAQ content cards now support in-app deep-linking for improved navigation flow.

* **Documentation**
  * Updated README to document the new FAQ page surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->