### PR TITLE
feat(push-button-selector): disabledReason on-hover tooltip + deselectable disabled options

### DIFF
--- a/openframe-frontend-core/src/components/features/push-button-selector.tsx
+++ b/openframe-frontend-core/src/components/features/push-button-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button, Badge } from "../ui";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../ui/tooltip";
 import { Check } from 'lucide-react';
 import React from 'react';
 
@@ -15,6 +16,7 @@ export interface SelectableOption {
   icon?: React.ReactNode;
   color?: string;
   disabled?: boolean;      // If true, option is shown grayed out and not selectable
+  disabledReason?: string; // Tooltip shown on hover when disabled — explains WHY it's unavailable
   section?: string;        // Optional section ID to group options
 }
 
@@ -151,19 +153,21 @@ export function PushButtonSelector({
   const renderOption = (option: SelectableOption) => {
     const isSelected = validSelectedIds.includes(option.id);
 
-    return (
+    const optionEl = (
       <div
         key={option.id}
         className={`
           p-4 rounded-lg border transition-all duration-200 group
           ${option.disabled
-            ? 'cursor-not-allowed opacity-40 bg-ods-card border-ods-border'
+            ? `${isSelected ? 'cursor-pointer' : 'cursor-not-allowed'} opacity-40 bg-ods-card border-ods-border`
             : isSelected
               ? 'cursor-pointer bg-ods-bg-secondary border-ods-accent shadow-sm'
               : 'cursor-pointer bg-ods-bg-primary border-ods-border hover:border-ods-border-hover hover:bg-ods-bg-hover'
           }
         `}
-        onClick={() => !option.disabled && toggleSelection(option.id)}
+        // Disabled options can't be newly SELECTED, but an already-selected one
+        // (e.g. it later became unavailable) must still be removable.
+        onClick={() => (!option.disabled || isSelected) && toggleSelection(option.id)}
       >
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -199,6 +203,18 @@ export function PushButtonSelector({
         </div>
       </div>
     );
+
+    // Disabled options explain WHY on hover via the unified Tooltip.
+    if (option.disabled && option.disabledReason) {
+      return (
+        <Tooltip key={option.id}>
+          <TooltipTrigger asChild>{optionEl}</TooltipTrigger>
+          <TooltipContent className="max-w-xs">{option.disabledReason}</TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return optionEl;
   };
 
   // Group options by section if sections are provided
@@ -271,6 +287,7 @@ export function PushButtonSelector({
   };
 
   return (
+    <TooltipProvider delayDuration={150}>
     <div className={`space-y-4 ${className}`}>
       {title && (
         <h3 className="text-h5 text-ods-text-primary">
@@ -319,5 +336,6 @@ export function PushButtonSelector({
         </div>
       )}
     </div>
+    </TooltipProvider>
   );
 }


### PR DESCRIPTION
## What

Adds an optional `disabledReason` to `SelectableOption` in `PushButtonSelector`, surfaced as the unified `Tooltip` on hover over a disabled option, and makes an already-selected option removable even when disabled.

## Why

The hub's new Slack multi-channel picker greys out channels the bot isn't a member of. Without this, users can't see *why* a channel is unavailable, and a previously-selected channel that later becomes unavailable (e.g. the bot was removed) would get stuck — un-clickable and impossible to deselect.

## Changes

- `SelectableOption.disabledReason?: string` — rendered via the existing unified `Tooltip` on hover when the option is disabled (wrapped in `TooltipProvider`).
- `onClick` now allows toggling a disabled option **only when it's already selected** (deselect-only), so stale selections can be removed; the cursor shows pointer in that case.

Generic and backward-compatible — new optional field, existing consumers unaffected.

## Consumed by

`flamingo-stack/multi-platform-hub` — multi-channel Slack publishing. **Merge + release this lib PR first**, then bump the hub's `@flamingo-stack/openframe-frontend-core` pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Disabled options now display explanatory tooltips on hover explaining unavailability.
  * Disabled options cannot be newly selected, but already-selected disabled options remain removable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->