### PR TITLE
fix(gateway): fail fast + cache tool lookup on WS upgrade (mesh-offline root cause)

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -25,12 +25,20 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
 
     @Override
     public Mono<Void> execute(URI url, WebSocketHandler handler) {
-        return delegate.execute(url, wrapHandler(url, handler));
+        return instrumentUpstream(url, delegate.execute(url, wrapHandler(url, handler)));
     }
 
     @Override
     public Mono<Void> execute(URI url, HttpHeaders headers, WebSocketHandler handler) {
-        return delegate.execute(url, headers, wrapHandler(url, handler));
+        return instrumentUpstream(url, delegate.execute(url, headers, wrapHandler(url, handler)));
+    }
+
+    // Log the upstream proxy outcome: a connect failure/timeout to a dead upstream (e.g. meshcentral or NATS) is otherwise invisible here — the inbound upgrade just never completes and the agent sees "No HTTP response".
+    private Mono<Void> instrumentUpstream(URI url, Mono<Void> proxy) {
+        boolean debugPath = loggingProperties.isDebugPath(url.getPath());
+        return proxy
+                .doOnSubscribe(s -> { if (debugPath) { log.debug("ws proxy: connecting to upstream {}", url); } })
+                .doOnError(ex -> log.warn("ws proxy: upstream connect/relay failed for {}: {}", url, ex.toString()));
     }
 
     private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler) {

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -36,9 +36,11 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
     // Log the upstream proxy outcome: a connect failure/timeout to a dead upstream (e.g. meshcentral or NATS) is otherwise invisible here — the inbound upgrade just never completes and the agent sees "No HTTP response".
     private Mono<Void> instrumentUpstream(URI url, Mono<Void> proxy) {
         boolean debugPath = loggingProperties.isDebugPath(url.getPath());
+        // Host+path only: the upstream URI can carry forwarded query params (e.g. an agent key), which must not be logged.
+        String safeUrl = url.getScheme() + "://" + url.getHost() + (url.getPort() < 0 ? "" : ":" + url.getPort()) + url.getPath();
         return proxy
-                .doOnSubscribe(s -> { if (debugPath) { log.debug("ws proxy: connecting to upstream {}", url); } })
-                .doOnError(ex -> log.warn("ws proxy: upstream connect/relay failed for {}: {}", url, ex.toString()));
+                .doOnSubscribe(s -> { if (debugPath) { log.debug("ws proxy: connecting to upstream {}", safeUrl); } })
+                .doOnError(ex -> log.warn("ws proxy: upstream connect/relay failed for {}: {}", safeUrl, ex.toString()));
     }
 
     private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler) {

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ToolWebSocketProxyUrlFilter.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ToolWebSocketProxyUrlFilter.java
@@ -1,5 +1,7 @@
 package com.openframe.gateway.config.ws;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.openframe.data.document.tool.IntegratedTool;
 import com.openframe.data.reactive.repository.tool.ReactiveIntegratedToolRepository;
 import com.openframe.data.service.TenantIdProvider;
@@ -15,12 +17,15 @@ import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
+import java.time.Duration;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -28,8 +33,17 @@ public abstract class ToolWebSocketProxyUrlFilter implements GatewayFilter, Orde
 
     public static final String ORIGINAL_AUTHORIZATION_ATTR = "originalAuthorization";
 
+    // Bounds the per-upgrade tool lookup so a stalled Mongo query fails fast instead of letting the WS upgrade hang to the gateway response-timeout.
+    private static final Duration LOOKUP_TIMEOUT = Duration.ofSeconds(5);
+
     private final ReactiveIntegratedToolRepository toolRepository;
     private final ToolUpstreamResolverRegistry upstreamRegistry;
+
+    // Cache resolved tools briefly so an agent reconnect storm doesn't put a Mongo lookup on every WS upgrade (configs change rarely).
+    private final Cache<String, IntegratedTool> toolCache = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofSeconds(60))
+            .build();
 
     /**
      * Shared multi-tenant routing mode. When true, a tool lookup with no resolved tenant must NOT
@@ -68,7 +82,17 @@ public abstract class ToolWebSocketProxyUrlFilter implements GatewayFilter, Orde
 
                     ServerWebExchange mutatedExchange = mutateExchange(exchange, tool);
                     return chain.filter(mutatedExchange);
-                });
+                })
+                // Without this, a lookup error/timeout left the WS upgrade hanging with no response written, so the agent saw "No HTTP response" and retried forever; fail fast with a real status instead.
+                .onErrorResume(ex -> abortUpgrade(exchange, toolId, ex));
+    }
+
+    private Mono<Void> abortUpgrade(ServerWebExchange exchange, String toolId, Throwable ex) {
+        HttpStatusCode status = (ex instanceof ResponseStatusException rse) ? rse.getStatusCode() : HttpStatus.SERVICE_UNAVAILABLE;
+        log.warn("Tool websocket upgrade aborted (tool={}, status={}): {}", toolId, status, ex.toString());
+        ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(status);
+        return response.setComplete();
     }
 
     protected ServerWebExchange mutateExchange(ServerWebExchange exchange, IntegratedTool tool) {
@@ -82,6 +106,14 @@ public abstract class ToolWebSocketProxyUrlFilter implements GatewayFilter, Orde
      * headers are never read; the unscoped {@code findByKey} is correct (one tenant only).
      */
     private Mono<IntegratedTool> getTool(String toolId, ServerHttpRequest request) {
+        String cacheKey = tenantRoutingEnabled
+                ? (TenantRoutingHeaders.tenantId(request) + "::" + toolId)
+                : toolId;
+        IntegratedTool cached = toolCache.getIfPresent(cacheKey);
+        if (cached != null) {
+            return Mono.just(cached);
+        }
+
         Mono<IntegratedTool> lookup = tenantRoutingEnabled
                 ? toolRepository.findByTenantIdAndKey(TenantRoutingHeaders.tenantId(request), toolId)
                 : toolRepository.findByKey(toolId);
@@ -94,7 +126,10 @@ public abstract class ToolWebSocketProxyUrlFilter implements GatewayFilter, Orde
                         return Mono.error(new IllegalArgumentException("Tool " + tool.getName() + " is not enabled"));
                     }
                     return Mono.just(tool);
-                });
+                })
+                .timeout(LOOKUP_TIMEOUT)
+                // Only successful (present + enabled) tools are cached; not-found / not-enabled stay uncached so they recover immediately once fixed.
+                .doOnNext(tool -> toolCache.put(cacheKey, tool));
     }
 
     protected abstract String getRequestToolId(String path);


### PR DESCRIPTION
## Problem

On tenant `mikart.openframe.ai`, ~half the fleet shows the MeshCentral agent **offline since ~Jun-18**: the agent's mesh WebSocket upgrade gets **no HTTP response at all** (`Connection FAILED: No HTTP response`, `authState=0`, never a 101), retrying every ~60s forever — while NATS and HTTPS on the same box work. Evidence across 4 machines: the **NATS route cleanly returns 502** (and recovers) but the **mesh route never returns any HTTP code** — always silent timeout.

## Root cause

The agent/api WebSocket routes (`/ws/tools/agent/{tool}/**`) resolve their upstream via a **per-upgrade reactive Mongo lookup** in `ToolWebSocketProxyUrlFilter` (`toolRepository.findByKey` / `findByTenantIdAndKey`). The filter had **no error handler**: on any lookup error/timeout (e.g. a transient Mongo blip) the error propagated with **no response written**, so the upgrade hung until the gateway `response-timeout` — the agent observes "No HTTP response." `/ws/nats` uses a **static** upstream (no lookup), which is why it's unaffected on the same box.

## Change

- **`onErrorResume`** on `filter()`: write a real status (`404` for not-found, `503` otherwise) and complete — a failed lookup now fails fast and visibly instead of hanging the upgrade.
- **`timeout(5s)`** on the lookup so a stalled Mongo query can't hang to the response-timeout.
- **Caffeine cache** (60s TTL, positive-only) so an agent reconnect storm doesn't put a Mongo lookup on every upgrade (removes the likely trigger). Not-found / not-enabled stay uncached so they recover immediately once fixed.

Applies to both `ToolAgentWebSocketProxyUrlFilter` and `ToolApiWebSocketProxyUrlFilter` (shared base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)