### PR TITLE
feat(help-center): unified header + shell prop + help-center-pages barrel

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -54,6 +54,12 @@
       "require": "./dist/components/onboarding-guides/index.cjs",
       "default": "./dist/components/onboarding-guides/index.js"
     },
+    "./components/help-center-pages": {
+      "types": "./dist/components/help-center-pages/index.d.ts",
+      "import": "./dist/components/help-center-pages/index.js",
+      "require": "./dist/components/help-center-pages/index.cjs",
+      "default": "./dist/components/help-center-pages/index.js"
+    },
     "./components/faq": {
       "types": "./dist/components/faq/index.d.ts",
       "import": "./dist/components/faq/index.js",

--- a/openframe-frontend-core/src/components/docs/doc-viewer.tsx
+++ b/openframe-frontend-core/src/components/docs/doc-viewer.tsx
@@ -78,6 +78,10 @@ export interface DocViewerProps {
   /** Override the default ODS palette. Optional — most callers should omit. */
   colorPalette?: typeof DEFAULT_DOC_VIEWER_PALETTE
   className?: string
+  /** Render the standalone `<PageShell>` (own `<main>` + bg + max-width). Default
+   *  true. Pass false when the host layout already provides the page container —
+   *  only the padding box renders, avoiding a nested `<main>`. */
+  shell?: boolean
 
   /** Initial doc path (URL `[...path]`). */
   docPath?: string
@@ -134,11 +138,10 @@ function DocViewerContent({
   renderSkeleton,
   chatSource,
   title,
-  titleIcon,
   subtitle,
-  accentDot,
   colorPalette = DEFAULT_DOC_VIEWER_PALETTE,
   className = "",
+  shell = true,
   docPath,
   sidebarLabel = "DOCUMENTATION",
   structureEndpoint,
@@ -264,39 +267,15 @@ function DocViewerContent({
       : 'No documents yet. Add content from the admin panel.'
   const resolvedEmptyText = emptyStateText || defaultEmptyText
 
-  return (
-    // Render through the shared wrapper chain (PageShell → PageLayout →
-    // `gap-10 flex-col`). PageLayout owns the back-button row; the inner
-    // `gap-10` div holds an inline title hero (same DOM `<DevSectionView>`'s
-    // hero renders) followed by the search bar + content grid.
-    //
-    // `colorPalette` / `className` / `bgStyle` flow through PageShell's
-    // contentClassName + an inner style-passthrough wrapper so legacy
-    // palette overrides still apply (none in the codebase today; the API
-    // surface is preserved).
-    <PageShell contentClassName={`${bgClass} ${className}`}>
+  // Unified header: title/subtitle route through the canonical (frozen)
+  // `PageLayout` `TitleBlock` (text-h2) — same as every other help-center page —
+  // so the docs hub shares one header. The `gap-10` column then holds the search
+  // bar + content grid. `colorPalette` / `className` / `bgStyle` flow through the
+  // shell's contentClassName + an inner style-passthrough wrapper.
+  const inner = (
       <div style={{ ...bgStyle, ...containerBgStyle }}>
-        <PageLayout backButton={backCfg ?? undefined}>
+        <PageLayout title={title} subtitle={subtitle} titleSize="h1" backButton={backCfg ?? undefined}>
           <div className="w-full flex flex-col gap-10">
-            {(title || titleIcon || subtitle) && (
-              <div className="space-y-4">
-                {(title || titleIcon) && (
-                  <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary flex items-center gap-3">
-                    {titleIcon}
-                    {title && (
-                      <span>
-                        {title}
-                        {accentDot && <span className="text-ods-accent">.</span>}
-                      </span>
-                    )}
-                  </h1>
-                )}
-                <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl line-clamp-2 min-h-[56px]">
-                  {subtitle || ' '}
-                </p>
-              </div>
-            )}
-
           {showAIChat && (
             <DocSearchBar
               placeholder={`Search ${sidebarLabel?.toLowerCase() || 'documents'}...`}
@@ -447,6 +426,14 @@ function DocViewerContent({
           </div>
         </PageLayout>
       </div>
-    </PageShell>
+  )
+
+  // `shell` true → standalone `<PageShell>`; false → padding-only box (no nested
+  // <main>) for hosts whose layout already provides the container. Both carry the
+  // palette/className via the same `page-shell-content` styling hook.
+  return shell ? (
+    <PageShell contentClassName={`${bgClass} ${className}`}>{inner}</PageShell>
+  ) : (
+    <div className={`page-shell-content ${bgClass} ${className}`.trim()}>{inner}</div>
   )
 }

--- a/openframe-frontend-core/src/components/faq/faq-document-page.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-document-page.tsx
@@ -2,19 +2,17 @@
 
 /**
  * FaqDocumentPage — the full `/faqs` page with chrome, so embedders drop in
- * ONE component instead of hand-assembling `PageShell` + `PageLayout` + the
- * FAQ hero around the bare `<FaqSection>`. Mirrors `LegalDocumentPage` /
- * `DevSectionPage`: the page-level layout lives in the lib, the host page is a
- * thin wrapper that passes only config + the SSR-resolved data.
+ * ONE component instead of hand-assembling `PageShell` + `PageLayout` around
+ * the bare `<FaqSection>`. Mirrors `LegalDocumentPage` / `DevSectionPage`: the
+ * page-level layout lives in the lib, the host page is a thin wrapper that
+ * passes only config + the SSR-resolved data.
  *
- * HERO: renders the canonical FAQ hero (`<h1 class="text-h1">` + accent dot +
- * icon + clamped subtitle) — byte-identical to the multi-platform hub's local
- * `PageWithHeader` chrome the standalone `/faqs` page historically used. It
- * does NOT route through `PageLayout`'s `title`/`subtitle` (the FROZEN
- * `text-h2` `TitleBlock` is a different, smaller header used by OpenFrame
- * detail surfaces). The page owns the `<h1>`, so `<FaqSection heading={null}>`
- * nests its category headings as `<h2>` and the questions as `<h3>` (the
- * SEO-recommended FAQ document outline).
+ * HERO: the title + subtitle route through the canonical (frozen) `PageLayout`
+ * `TitleBlock` with `titleSize="h1"` — the unified Help Center header (the
+ * `TitleBlock` element is always an `<h1>`; `titleSize` only sets its typography,
+ * here `text-h1`). The page owns that `<h1>`, so `<FaqSection heading={null}>`
+ * nests its category headings as `<h2>`/`<h3>` (the SEO-recommended FAQ document
+ * outline).
  *
  * DATA: pass `initialFaqs` (SSR-resolved, platform-scoped) so `FaqSection`
  * skips its client self-fetch — the standalone page's static platform-only
@@ -22,27 +20,25 @@
  * suggestion-fill instead.
  */
 
-import React from 'react';
-import { HelpCircle } from 'lucide-react';
 import type { Faq } from '../../types/faq';
 import { PageShell, PageLayout } from '../ui';
 import { useRouter } from '../../embed-shims/next-navigation';
-import { SECTION_HERO_ICON_CLASS } from '../../utils/page-header-constants';
 import { FaqSection } from './faq-section';
 import type { FaqSchemaOptions } from './json-ld';
 
 export interface FaqDocumentPageProps {
-  /** Hero `<h1>`. Default "Frequently Asked Questions". */
+  /** Page title (frozen `PageLayout` `TitleBlock`). Default "Frequently Asked Questions". */
   title?: string;
-  /** Subtitle under the title (auto-clamped to 2 lines). */
+  /** Subtitle under the title. */
   subtitle?: string;
-  /** Icon rendered before the title. Default `<HelpCircle>` (the FAQ glyph). */
-  titleIcon?: React.ReactNode;
-  /** Render the yellow accent dot after the title (default true). */
-  accentDot?: boolean;
   /** Back-button config — same pattern as `DevSectionPage` / `LegalDocumentPage`.
    *  Pass `false` to hide. Default `{ label: 'Back to home', href: '/' }`. */
   backButton?: { label?: string; href?: string } | false;
+  /** Render the standalone `<PageShell>` (own `<main>` + bg + max-width). Default
+   *  true. Pass false when the host layout already provides the page container
+   *  (e.g. openframe-frontend's `AppLayout` `<main>`) — only the padding box
+   *  renders, avoiding a nested `<main>`. */
+  shell?: boolean;
   /** SSR-hydrate `FaqSection` (skips the client fetch — the platform-only
    *  contract for the standalone page). Omit for self-fetching embeds. */
   initialFaqs?: Faq[];
@@ -63,8 +59,6 @@ export interface FaqDocumentPageProps {
 export function FaqDocumentPage({
   title = 'Frequently Asked Questions',
   subtitle,
-  titleIcon = <HelpCircle className={SECTION_HERO_ICON_CLASS} />,
-  accentDot = true,
   backButton,
   initialFaqs,
   emitJsonLd,
@@ -73,6 +67,7 @@ export function FaqDocumentPage({
   entityType,
   entityId,
   minResults,
+  shell = true,
 }: FaqDocumentPageProps) {
   const router = useRouter();
 
@@ -87,42 +82,20 @@ export function FaqDocumentPage({
           onClick: () => router.push(backButton?.href ?? '/'),
         };
 
-  return (
-    <PageShell>
-      <PageLayout backButton={backCfg}>
-        <div className="w-full flex flex-col gap-10">
-          {/* Canonical FAQ hero — the exact DOM/CSS the hub's local
-              `PageWithHeader` rendered (text-h1 + accent dot + icon + clamped
-              subtitle), inlined here so the standalone `/faqs` look is owned by
-              the lib. Intentionally NOT the frozen `text-h2` `TitleBlock`. */}
-          <div className="flex items-end justify-between gap-[var(--spacing-system-m)] md:flex-col md:items-start md:justify-start lg:flex-row lg:items-end lg:justify-between">
-            <div className="flex flex-col gap-[var(--spacing-system-xs)] flex-1 min-w-0">
-              <div className="space-y-4">
-                <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary flex items-center gap-3">
-                  {titleIcon}
-                  <span>
-                    {title}
-                    {accentDot && <span className="text-ods-accent">.</span>}
-                  </span>
-                </h1>
-                <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl line-clamp-2 min-h-[56px]">
-                  {subtitle || ' '}
-                </p>
-              </div>
-            </div>
-          </div>
-          <FaqSection
-            initialFaqs={initialFaqs}
-            heading={null}
-            emitJsonLd={emitJsonLd}
-            jsonLd={jsonLd}
-            apiBaseUrl={apiBaseUrl}
-            entityType={entityType}
-            entityId={entityId}
-            minResults={minResults}
-          />
-        </div>
-      </PageLayout>
-    </PageShell>
+  const inner = (
+    <PageLayout title={title} subtitle={subtitle} backButton={backCfg} titleSize="h1">
+      <FaqSection
+        initialFaqs={initialFaqs}
+        heading={null}
+        emitJsonLd={emitJsonLd}
+        jsonLd={jsonLd}
+        apiBaseUrl={apiBaseUrl}
+        entityType={entityType}
+        entityId={entityId}
+        minResults={minResults}
+      />
+    </PageLayout>
   );
+
+  return shell ? <PageShell>{inner}</PageShell> : <div className="page-shell-content">{inner}</div>;
 }

--- a/openframe-frontend-core/src/components/help-center-pages/delivery-page.tsx
+++ b/openframe-frontend-core/src/components/help-center-pages/delivery-page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+/**
+ * `<DeliveryPage>` — the full bug-fixes & enhancements (`delivery`) page:
+ * `DevSectionPage sectionKey="delivery"` chrome wrapping the self-contained
+ * `<DeliveryLists>` (Recently Completed + Active Tasks tables). Hosts configure
+ * only the two bucket api routes.
+ */
+
+import type { ReactNode } from 'react'
+import { DevSectionPage } from '../shared/dev-section'
+import { DeliveryLists } from '../shared/delivery'
+
+export interface DeliveryPageProps {
+  /** GET endpoint for the "Recently Completed" bucket. Default `/api/delivery/completed`. */
+  completedEndpoint?: string
+  /** GET endpoint for the "Active Tasks" bucket. Default `/api/delivery/in-progress`. */
+  inProgressEndpoint?: string
+  /** Back-button config. Pass `false` to hide. Default `{ href: '/' }`. */
+  backButton?: { label?: string; href?: string } | false
+  title?: string
+  subtitle?: string
+  /** Optional slot rendered below the lists, inside the page chrome. */
+  belowContent?: ReactNode
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container (forwarded to `DevSectionPage`). */
+  shell?: boolean
+}
+
+export function DeliveryPage({
+  completedEndpoint,
+  inProgressEndpoint,
+  backButton,
+  title,
+  subtitle,
+  belowContent,
+  shell,
+}: DeliveryPageProps) {
+  return (
+    <DevSectionPage sectionKey="delivery" backButton={backButton} title={title} subtitle={subtitle} shell={shell}>
+      <DeliveryLists completedApiEndpoint={completedEndpoint} inProgressApiEndpoint={inProgressEndpoint} />
+      {belowContent}
+    </DevSectionPage>
+  )
+}

--- a/openframe-frontend-core/src/components/help-center-pages/index.ts
+++ b/openframe-frontend-core/src/components/help-center-pages/index.ts
@@ -1,0 +1,41 @@
+'use client'
+
+/**
+ * Help Center pages — ready-made, full-page components (each owns the canonical
+ * `PageShell` + `PageLayout` chrome) so a host route is a one-line mount with NO
+ * local wrapper. Shared by openframe-frontend (self-fetch via the `/content`
+ * proxy, mounted under `/help-center/*`) and multi-platform-hub (SSR with
+ * server-fetched `initialData` + `generateMetadata`/JSON-LD kept in the server
+ * route). Endpoint config + SSR data + optional slots are passed as props.
+ *
+ * This barrel ALSO re-exports the already-existing full-pages (FAQ / Legal /
+ * Release detail / Onboarding detail / Docs / Tickets) so consumers have ONE
+ * import site for "help center pages". Re-exports are NAMED (not `export *`) to
+ * avoid TS2308 ambiguous-re-export collisions, and this barrel is intentionally
+ * NOT merged into the top-level `components/index.ts`.
+ */
+
+// New combined pages. (The Help Center *index* landing is intentionally NOT
+// here — it stays a host-local page; its links + icons are app-specific.)
+export { RoadmapPage, type RoadmapPageProps } from './roadmap-page'
+export { ProductReleasesListPage, type ProductReleasesListPageProps } from './product-releases-list-page'
+export { DeliveryPage, type DeliveryPageProps } from './delivery-page'
+export {
+  OnboardingGuidesCatalogPage,
+  type OnboardingGuidesCatalogPageProps,
+} from './onboarding-guides-catalog-page'
+
+// Existing full-pages re-exported for a single Help Center import site.
+export { FaqDocumentPage, type FaqDocumentPageProps } from '../faq'
+export { LegalDocumentPage, type LegalDocumentPageProps } from '../shared/legal-document'
+export {
+  ReleaseDetailPage,
+  type ReleaseDetailPageProps,
+  type VideoDisplaySectionProps,
+} from '../shared/product-release'
+export {
+  OnboardingGuideDetailView,
+  type OnboardingGuideDetailViewProps,
+} from '../onboarding-guides'
+export { DocsHubPage } from '../docs'
+export { HelpCenterList } from '../tickets'

--- a/openframe-frontend-core/src/components/help-center-pages/onboarding-guides-catalog-page.tsx
+++ b/openframe-frontend-core/src/components/help-center-pages/onboarding-guides-catalog-page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+/**
+ * `<OnboardingGuidesCatalogPage>` — the full `/onboarding-guides` catalog page:
+ * `DevSectionPage sectionKey="onboarding"` chrome wrapping the self-contained
+ * `<OnboardingGuidesCatalogView>` (RAG search + section pills + guide grid).
+ * Supports both SSR (`initialGuides`/`initialSections`) and self-fetch
+ * (`guidesEndpoint`/`sectionsEndpoint`) modes — forwarded to the view verbatim.
+ */
+
+import type { ReactNode } from 'react'
+import type { OnboardingGuide } from '../chat/types/entities/onboarding-guide'
+import { DevSectionPage } from '../shared/dev-section'
+import { OnboardingGuidesCatalogView } from '../onboarding-guides'
+
+type SectionSummary = { section: string; section_order: number; count: number }
+
+export interface OnboardingGuidesCatalogPageProps {
+  /** Self-fetch: GET list endpoint (the api route). Appends `?section=`. */
+  guidesEndpoint?: string
+  /** Self-fetch: GET section-summary endpoint (the api route). */
+  sectionsEndpoint?: string
+  /** Controlled / SSR: server-fetched guides + sections + active section. */
+  initialGuides?: OnboardingGuide[]
+  initialSections?: SectionSummary[]
+  initialSection?: string
+  /** Base path the catalog is mounted under (card href prefix + `?section=` push). */
+  basePath?: string
+  /** Back-button config. Pass `false` to hide. Default `{ href: '/' }`. */
+  backButton?: { label?: string; href?: string } | false
+  title?: string
+  subtitle?: string
+  /** Optional slot rendered below the catalog, inside the page chrome. */
+  belowContent?: ReactNode
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container (forwarded to `DevSectionPage`). */
+  shell?: boolean
+}
+
+export function OnboardingGuidesCatalogPage({
+  guidesEndpoint,
+  sectionsEndpoint,
+  initialGuides,
+  initialSections,
+  initialSection,
+  basePath,
+  backButton,
+  title,
+  subtitle,
+  belowContent,
+  shell,
+}: OnboardingGuidesCatalogPageProps) {
+  return (
+    <DevSectionPage sectionKey="onboarding" backButton={backButton} title={title} subtitle={subtitle} shell={shell}>
+      <OnboardingGuidesCatalogView
+        guidesEndpoint={guidesEndpoint}
+        sectionsEndpoint={sectionsEndpoint}
+        initialGuides={initialGuides}
+        initialSections={initialSections}
+        initialSection={initialSection}
+        basePath={basePath}
+      />
+      {belowContent}
+    </DevSectionPage>
+  )
+}

--- a/openframe-frontend-core/src/components/help-center-pages/product-releases-list-page.tsx
+++ b/openframe-frontend-core/src/components/help-center-pages/product-releases-list-page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+/**
+ * `<ProductReleasesListPage>` — the full `/releases` list page: `DevSectionPage
+ * sectionKey="releases"` chrome wrapping the self-contained `<ProductReleasesView>`.
+ * Hosts configure the api route + detail `basePath` (+ optional SSR `initialData`
+ * and a custom card-prop builder). Card → detail nav flows through
+ * `runtime.composeContentUrl`.
+ */
+
+import type { ReactNode } from 'react'
+import type { ProductRelease, ProductReleaseListResponse } from '../../types/product-release'
+import { DevSectionPage } from '../shared/dev-section'
+import { ProductReleasesView, type ProductReleaseCardExtras } from '../shared/product-release'
+
+export interface ProductReleasesListPageProps {
+  /** GET list endpoint (the api route). Default `/api/releases`. */
+  releasesEndpoint?: string
+  /** Fallback detail-href prefix when `composeContentUrl` is not wired. Default `/releases`. */
+  basePath?: string
+  /** Derive the per-card prop bundle (defaults to the lib's rich builder). */
+  buildCardProps?: (release: ProductRelease) => ProductReleaseCardExtras
+  /** Optional SSR hydrate for the first page (hub server-fetch). */
+  initialData?: ProductReleaseListResponse
+  /** Back-button config. Pass `false` to hide. Default `{ href: '/' }`. */
+  backButton?: { label?: string; href?: string } | false
+  title?: string
+  subtitle?: string
+  /** Optional slot rendered below the list, inside the page chrome. */
+  belowContent?: ReactNode
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container (forwarded to `DevSectionPage`). */
+  shell?: boolean
+}
+
+export function ProductReleasesListPage({
+  releasesEndpoint,
+  basePath,
+  buildCardProps,
+  initialData,
+  backButton,
+  title,
+  subtitle,
+  belowContent,
+  shell,
+}: ProductReleasesListPageProps) {
+  return (
+    <DevSectionPage sectionKey="releases" backButton={backButton} title={title} subtitle={subtitle} shell={shell}>
+      <ProductReleasesView
+        endpoint={releasesEndpoint}
+        basePath={basePath}
+        buildCardProps={buildCardProps}
+        initialData={initialData}
+      />
+      {belowContent}
+    </DevSectionPage>
+  )
+}

--- a/openframe-frontend-core/src/components/help-center-pages/roadmap-page.tsx
+++ b/openframe-frontend-core/src/components/help-center-pages/roadmap-page.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+/**
+ * `<RoadmapPage>` — the full `/roadmap` page: `DevSectionPage sectionKey="roadmap"`
+ * (PageShell + PageLayout + hero + search/status chrome) wrapping the
+ * self-contained `<RoadmapView>` list. Hosts configure only the api routes
+ * (+ optional SSR `initialItems`); both openframe-frontend and the hub mount
+ * this instead of hand-composing `DevSectionPage` + `RoadmapView`.
+ */
+
+import type { ReactNode } from 'react'
+import type { RoadmapItem } from '../chat/types/entities/roadmap-item'
+import { DevSectionPage } from '../shared/dev-section'
+import { RoadmapView } from '../shared/roadmap'
+import type { UseRoadmapVotingOptions } from '../shared/roadmap'
+
+export interface RoadmapPageProps {
+  /** GET list endpoint (the api route). Default `/api/roadmap`. */
+  roadmapEndpoint?: string
+  /** Per-task refresh URL builder (after a vote). Default `/api/roadmap/<id>`. */
+  buildRefreshUrl?: (taskId: string) => string
+  /** Vote POST endpoint, forwarded to `RoadmapView` via `votingOptions`. */
+  voteApiEndpoint?: string
+  /** Full voting options override — takes precedence over `voteApiEndpoint`. */
+  votingOptions?: UseRoadmapVotingOptions
+  /** Optional SSR hydrate (hub server-fetch) — skips the initial client fetch. */
+  initialItems?: RoadmapItem[]
+  /** Indent the grid (the hub's full-page roadmap look). Default off. */
+  showLeftMargin?: boolean
+  /** Back-button config. Pass `false` to hide. Default `{ href: '/' }`. */
+  backButton?: { label?: string; href?: string } | false
+  /** Override the hero title/subtitle (defaults from `OPENFRAME_DEV_SECTIONS`). */
+  title?: string
+  subtitle?: string
+  /** Optional slot rendered below the list, inside the page chrome — e.g. the
+   *  hub's related-content rail. */
+  belowContent?: ReactNode
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container (forwarded to `DevSectionPage`). */
+  shell?: boolean
+}
+
+export function RoadmapPage({
+  roadmapEndpoint,
+  buildRefreshUrl,
+  voteApiEndpoint,
+  votingOptions,
+  initialItems,
+  showLeftMargin,
+  backButton,
+  title,
+  subtitle,
+  belowContent,
+  shell,
+}: RoadmapPageProps) {
+  return (
+    <DevSectionPage sectionKey="roadmap" backButton={backButton} title={title} subtitle={subtitle} shell={shell}>
+      <RoadmapView
+        endpoint={roadmapEndpoint}
+        initialItems={initialItems}
+        showLeftMargin={showLeftMargin}
+        buildRefreshUrl={buildRefreshUrl}
+        votingOptions={votingOptions ?? (voteApiEndpoint ? { voteApiEndpoint } : undefined)}
+      />
+      {belowContent}
+    </DevSectionPage>
+  )
+}

--- a/openframe-frontend-core/src/components/layout/page-layout.tsx
+++ b/openframe-frontend-core/src/components/layout/page-layout.tsx
@@ -25,6 +25,12 @@
  * If a new design genuinely needs different chrome: build a SEPARATE new
  * component for it. Never mutate this one. If you believe an edit here is
  * unavoidable, STOP and get explicit human sign-off first.
+ *
+ * SANCTIONED EXCEPTION (2026-06, explicit human sign-off): the OPTIONAL
+ * `titleSize` prop, forwarded to `TitleBlock`. Defaults to `'h2'` — the frozen
+ * baseline is unchanged for every existing caller. `titleSize="h1"` opts the
+ * title up to `text-h1` (the unified Help Center pages). Additive + default-
+ * preserving; do NOT change the default or anything else here.
  * ========================================================================== */
 
 import React from 'react'
@@ -49,6 +55,9 @@ export interface PageLayoutProps {
   className?: string
   contentClassName?: string
   showHeader?: boolean
+  /** Title typography size, forwarded to `TitleBlock`. Default `'h2'` (frozen
+   *  baseline). Pass `'h1'` for the unified Help Center pages. */
+  titleSize?: 'h1' | 'h2'
 }
 
 /**
@@ -70,6 +79,7 @@ export function PageLayout({
   className,
   contentClassName,
   showHeader = true,
+  titleSize,
 }: PageLayoutProps) {
   const hasActions = actions && actions.length > 0
   const needsBottomPadding = hasActions && actionsVariant === 'primary-buttons'
@@ -88,6 +98,7 @@ export function PageLayout({
           menuActions={menuActions}
           selector={selector}
           variant={headerVariant}
+          titleSize={titleSize}
         />
       )}
 

--- a/openframe-frontend-core/src/components/layout/title-block.tsx
+++ b/openframe-frontend-core/src/components/layout/title-block.tsx
@@ -22,6 +22,13 @@
  * current output. If a new design needs different chrome, build a SEPARATE new
  * component — never mutate this one. If an edit here seems unavoidable, STOP
  * and get explicit human sign-off first.
+ *
+ * SANCTIONED EXCEPTION (2026-06, explicit human sign-off): the OPTIONAL
+ * `titleSize` prop. It defaults to `'h2'` — i.e. the frozen baseline above is
+ * unchanged for EVERY existing caller. A caller may pass `titleSize="h1"` to
+ * opt the title typography up to `text-h1` (used by the unified Help Center
+ * pages). This is additive and default-preserving; do NOT change the default or
+ * touch anything else here.
  * ========================================================================== */
 
 import React from 'react'
@@ -59,6 +66,10 @@ export interface TitleBlockProps {
    */
   variant?: 'plain' | 'card'
   className?: string
+  /** Title typography size. Default `'h2'` (the frozen baseline). Pass `'h1'` to
+   *  opt the title up to `text-h1` (the unified Help Center pages). Subtitle stays
+   *  `text-h6` either way. */
+  titleSize?: 'h1' | 'h2'
 }
 
 export function TitleBlock({
@@ -72,9 +83,11 @@ export function TitleBlock({
   selector,
   variant = 'plain',
   className,
+  titleSize = 'h2',
 }: TitleBlockProps) {
   const hasActions = actions && actions.length > 0
   const hasMenuActions = !!menuActions && menuActions.some(g => g.items.length > 0)
+  const titleClass = titleSize === 'h1' ? 'text-h1' : 'text-h2'
 
   return (
     <div
@@ -113,7 +126,7 @@ export function TitleBlock({
             )}
             <div className="flex flex-col justify-center min-w-0 flex-1">
               {title && (
-                <h1 className="text-h2 text-ods-text-primary truncate" title={title}>{title}</h1>
+                <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{title}</h1>
               )}
               {subtitle && (
                 <p className="text-h6 text-ods-text-secondary truncate" title={subtitle}>{subtitle}</p>
@@ -121,7 +134,7 @@ export function TitleBlock({
             </div>
           </div>
         ) : (
-          title && <h1 className="text-h2 text-ods-text-primary">{title}</h1>
+          title && <h1 className={cn(titleClass, 'text-ods-text-primary')}>{title}</h1>
         )}
       </div>
 

--- a/openframe-frontend-core/src/components/onboarding-guides/onboarding-guide-detail-view.tsx
+++ b/openframe-frontend-core/src/components/onboarding-guides/onboarding-guide-detail-view.tsx
@@ -74,6 +74,14 @@ export interface OnboardingGuideDetailViewProps {
   /** Base path the related-card hrefs default to when
    *  `runtime.composeContentUrl` is not wired. Default `/onboarding-guides`. */
   basePath?: string
+  /** Optional slot rendered inside the page chrome, BELOW the article + related
+   *  guides — e.g. the hub's cross-type related-content / FAQ rail. Lets the hub
+   *  mount this view directly (no local wrapper); embedders omit it. */
+  relatedContent?: ReactNode
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container — only the padding box renders,
+   *  avoiding a nested `<main>`. */
+  shell?: boolean
 }
 
 export function OnboardingGuideDetailView({
@@ -89,10 +97,16 @@ export function OnboardingGuideDetailView({
   backHref,
   backLabel = 'Back to Getting Started',
   basePath = '/onboarding-guides',
+  relatedContent,
+  shell = true,
 }: OnboardingGuideDetailViewProps) {
   const resolvedBackHref = backHref ?? basePath
   const runtime = useChatRuntime()
   const router = useRouter()
+  // `shell` true → standalone `<PageShell>`; false → padding-only box (no nested
+  // <main>) for hosts whose layout already provides the container.
+  const renderShell = (node: ReactNode) =>
+    shell ? <PageShell>{node}</PageShell> : <div className="page-shell-content">{node}</div>
 
   // Controlled (hub SSR `initialData`) OR self-fetch by slug (config-only embed).
   const url = initialData ? null : slug && guideEndpoint ? guideEndpoint(slug) : null
@@ -106,25 +120,19 @@ export function OnboardingGuideDetailView({
   })
 
   if (error || (!guide && !isLoading)) {
-    return (
-      <PageShell>
-        <LoadError message="Guide not found." onRetry={reload} />
-      </PageShell>
-    )
+    return renderShell(<LoadError message="Guide not found." onRetry={reload} />)
   }
   if (!guide) {
     // Skeleton (not a bare "Loading…") for parity with every other shared view —
     // catalog, roadmap, releases all render a skeleton on first load, so the detail
     // page shouldn't flash text then content. `bare` + `PageShell` so the loading
     // state matches the loaded page's full width / padding / min-height.
-    return (
-      <PageShell>
-        {/* Match the loaded page's top offset (TitleBlock's
-            `pt-[var(--spacing-system-l)]`) so content doesn't jump on load. */}
-        <div className="pt-[var(--spacing-system-l)]">
-          <DetailPageSkeleton bare showImageGallery={false} />
-        </div>
-      </PageShell>
+    return renderShell(
+      // Match the loaded page's top offset (TitleBlock's
+      // `pt-[var(--spacing-system-l)]`) so content doesn't jump on load.
+      <div className="pt-[var(--spacing-system-l)]">
+        <DetailPageSkeleton bare showImageGallery={false} />
+      </div>
     )
   }
 
@@ -149,11 +157,12 @@ export function OnboardingGuideDetailView({
   }
   const renderRelatedCardFn = renderRelatedCard ?? defaultRenderRelatedCard
 
-  return (
-    <PageShell>
-      <PageLayout backButton={{ label: backLabel, onClick: () => router.push(resolvedBackHref) }}>
-        <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary">{guide.title}</h1>
-
+  return renderShell(
+    <PageLayout
+        title={guide.title}
+        titleSize="h1"
+        backButton={{ label: backLabel, onClick: () => router.push(resolvedBackHref) }}
+      >
         {/* Tags — flat onboarding_guide_tags[] from entity_tags. */}
         <EntityTagBadges tags={(guide as any).onboarding_guide_tags} />
 
@@ -232,7 +241,9 @@ export function OnboardingGuideDetailView({
             </ul>
           </div>
         )}
+
+        {/* Host slot — cross-type related-content / FAQ rail. */}
+        {relatedContent}
       </PageLayout>
-    </PageShell>
   )
 }

--- a/openframe-frontend-core/src/components/shared/dev-section/dev-section-page.tsx
+++ b/openframe-frontend-core/src/components/shared/dev-section/dev-section-page.tsx
@@ -25,8 +25,6 @@ import {
   type OpenframeDevSectionKey,
 } from '../../../utils/dev-sections/openframe-dev-sections';
 
-const SECTION_HERO_ICON_CLASS = 'h-10 w-10 text-ods-accent';
-
 export interface DevSectionPageProps {
   sectionKey: OpenframeDevSectionKey;
   /** The page-specific list body (e.g. `<RoadmapList />`). */
@@ -48,6 +46,12 @@ export interface DevSectionPageProps {
   /** Override the hero subtitle/description. Defaults to
    *  `OPENFRAME_DEV_SECTIONS[sectionKey].hero.description`. */
   subtitle?: string;
+  /** Render the standalone `<PageShell>` (own `<main>` + bg + max-width). Default
+   *  `true` — the contract for marketing/hub surfaces with no app shell. Pass
+   *  `false` when the host layout already provides the page container (e.g.
+   *  openframe-frontend's `AppLayout` `<main>`): then only the
+   *  `page-shell-content` padding box is rendered, avoiding a nested `<main>`. */
+  shell?: boolean;
 }
 
 export function DevSectionPage({
@@ -57,10 +61,10 @@ export function DevSectionPage({
   backButton,
   title,
   subtitle,
+  shell = true,
 }: DevSectionPageProps) {
   const router = useRouter();
   const section = OPENFRAME_DEV_SECTIONS[sectionKey];
-  const Icon = section.icon;
 
   // Back-button config — mirrors LegalDocumentPage / ReleaseDetailPage.
   // Default: { label: 'Back to home', href: '/' }. Pass `false` to hide.
@@ -74,21 +78,27 @@ export function DevSectionPage({
           onClick: () => router.push((backButton ? backButton.href : undefined) ?? '/'),
         };
 
-  return (
-    <PageShell>
-      <PageLayout backButton={backCfg}>
-        <DevSectionView
-          sectionKey={sectionKey}
-          hero={{
-            icon: <Icon className={SECTION_HERO_ICON_CLASS} />,
-            title,
-            description: subtitle ?? section.hero.description,
-          }}
-          preControls={preControls}
-        >
-          {children}
-        </DevSectionView>
-      </PageLayout>
-    </PageShell>
+  const inner = (
+    // Unified header: title/description route through the canonical (frozen)
+    // `PageLayout` `TitleBlock` (text-h2) — same as FAQ / Legal / detail pages —
+    // so every help-center surface shares one header. `DevSectionView` then
+    // renders ONLY its search + filter controls (`showHeading={false}`), no
+    // duplicate title. (The hero icon is intentionally dropped: TitleBlock is
+    // frozen and renders title-only.)
+    <PageLayout
+      title={title ?? section.hero.title}
+      subtitle={subtitle ?? section.hero.description}
+      titleSize="h1"
+      backButton={backCfg}
+    >
+      <DevSectionView sectionKey={sectionKey} showHeading={false} preControls={preControls}>
+        {children}
+      </DevSectionView>
+    </PageLayout>
   );
+
+  // `shell` true → standalone `<PageShell>` (own <main> + bg + max-width).
+  // false → padding-only box (no nested <main>) for hosts whose layout already
+  // provides the container; both consume the host's `--page-shell-*` vars.
+  return shell ? <PageShell>{inner}</PageShell> : <div className="page-shell-content">{inner}</div>;
 }

--- a/openframe-frontend-core/src/components/shared/dev-section/dev-section-view.tsx
+++ b/openframe-frontend-core/src/components/shared/dev-section/dev-section-view.tsx
@@ -51,9 +51,15 @@ export interface DevSectionViewProps {
   /** The page-specific list body. Reads URL params written by this
    *  component (search input + filter pills). */
   children: ReactNode;
+  /** Render this component's own title heading (hero or compact `h2`). Default
+   *  `true` — the tab context renders the compact heading itself. Pass `false`
+   *  when the host already renders the title elsewhere (e.g. `DevSectionPage`
+   *  routes it through the unified `PageLayout` `TitleBlock`): then only the
+   *  search + filter controls + list render, with no duplicate heading. */
+  showHeading?: boolean;
 }
 
-export function DevSectionView({ sectionKey, hero, preControls, children }: DevSectionViewProps) {
+export function DevSectionView({ sectionKey, hero, preControls, children, showHeading = true }: DevSectionViewProps) {
   const section = OPENFRAME_DEV_SECTIONS[sectionKey];
   const router = useRouter();
   const pathname = usePathname();
@@ -94,24 +100,25 @@ export function DevSectionView({ sectionKey, hero, preControls, children }: DevS
 
   return (
     <div className="w-full flex flex-col gap-10">
-      {hero ? (
-        <div className="space-y-4">
-          <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary flex items-center gap-3">
-            {hero.icon}
-            {hero.title ?? section.hero.title}
-          </h1>
-          <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl">
-            {hero.description}
-          </p>
-        </div>
-      ) : (
-        <div className="flex items-center justify-between w-full">
-          <h2 className="font-['Azeret_Mono'] font-semibold text-[32px] md:text-[40px] lg:text-[48px] leading-[40px] md:leading-[48px] lg:leading-[56px] text-ods-text-primary tracking-[-0.64px] md:tracking-[-0.8px] lg:tracking-[-0.96px]">
-            {section.hero.title}
-            <span className="text-ods-accent">:</span>
-          </h2>
-        </div>
-      )}
+      {showHeading &&
+        (hero ? (
+          <div className="space-y-4">
+            <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary flex items-center gap-3">
+              {hero.icon}
+              {hero.title ?? section.hero.title}
+            </h1>
+            <p className="font-['DM_Sans'] font-medium text-[18px] leading-[28px] text-ods-text-secondary max-w-3xl">
+              {hero.description}
+            </p>
+          </div>
+        ) : (
+          <div className="flex items-center justify-between w-full">
+            <h2 className="font-['Azeret_Mono'] font-semibold text-[32px] md:text-[40px] lg:text-[48px] leading-[40px] md:leading-[48px] lg:leading-[56px] text-ods-text-primary tracking-[-0.64px] md:tracking-[-0.8px] lg:tracking-[-0.96px]">
+              {section.hero.title}
+              <span className="text-ods-accent">:</span>
+            </h2>
+          </div>
+        ))}
 
       {preControls}
 

--- a/openframe-frontend-core/src/components/shared/legal-document/legal-document-page.tsx
+++ b/openframe-frontend-core/src/components/shared/legal-document/legal-document-page.tsx
@@ -18,7 +18,7 @@
  */
 
 import type { ComponentType } from 'react';
-import { PageShell, PageLayout, PageHeading } from '../../ui';
+import { PageShell, PageLayout } from '../../ui';
 import { RichMarkdownRenderer } from '../../ui/rich-markdown-renderer';
 import { useRouter } from '../../../embed-shims/next-navigation';
 import { useLegalDocs, type LegalDocument } from './use-legal-docs';
@@ -63,6 +63,10 @@ export interface LegalDocumentPageProps {
   /** Back-button config — same pattern as `DevSectionPage`. Pass `false`
    *  to hide. Default `{ label: 'Back to home', href: '/' }`. */
   backButton?: { label?: string; href?: string } | false;
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container — only the padding box renders,
+   *  avoiding a nested `<main>`. */
+  shell?: boolean;
 }
 
 export function LegalDocumentPage({
@@ -78,6 +82,7 @@ export function LegalDocumentPage({
   apiEndpoint,
   MarkdownRenderer = RichMarkdownRenderer,
   backButton,
+  shell = true,
 }: LegalDocumentPageProps) {
   const router = useRouter();
   const { data, isLoading, error } = useLegalDocs(docType, { initialData, apiEndpoint });
@@ -97,28 +102,18 @@ export function LegalDocumentPage({
     data?.lastSynced != null ? formatLegalDate(data.lastSynced) : null;
   const effectiveLastUpdatedLabel = initialLastUpdatedLabel ?? fallbackLastUpdatedLabel;
 
-  // Title with accent-colon trailing dot — matches knowledge-hub typography
-  const customTitle = (
-    <div className="flex flex-col gap-4">
-      <PageHeading>
-        <span>{title}</span>
-        <span className="text-ods-accent">.</span>
-      </PageHeading>
-      <p className="font-['DM_Sans'] text-base md:text-lg text-ods-text-secondary max-w-2xl">
-        {effectiveLastUpdatedLabel ? `Last Updated: ${effectiveLastUpdatedLabel}` : fallbackDescription}
-        {data?.sourceFile && (
-          <span className="block text-sm mt-1 opacity-75">Source: {data.sourceFile}</span>
-        )}
-      </p>
-    </div>
-  );
+  // Subtitle routes through the frozen `PageLayout` `TitleBlock` (text-h2 title
+  // + subtitle) — unified header across all help-center pages. Shows the
+  // last-updated date when known, else the fallback description.
+  const subtitle = effectiveLastUpdatedLabel ? `Last Updated: ${effectiveLastUpdatedLabel}` : fallbackDescription;
 
-  return (
-    <PageShell>
-      <PageLayout backButton={backCfg}>
-        <div className="flex flex-col gap-4">{customTitle}</div>
+  const inner = (
+    <PageLayout title={title} subtitle={subtitle} backButton={backCfg} titleSize="h1">
+      {data?.sourceFile && (
+        <p className="font-['DM_Sans'] text-sm text-ods-text-secondary opacity-75">Source: {data.sourceFile}</p>
+      )}
 
-        <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 items-start flex-1">
+      <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 items-start flex-1">
           <div className="flex-1">
             <div className="w-full">
               <article className="space-y-2">
@@ -172,7 +167,8 @@ export function LegalDocumentPage({
             </div>
           </div>
         </div>
-      </PageLayout>
-    </PageShell>
+    </PageLayout>
   );
+
+  return shell ? <PageShell>{inner}</PageShell> : <div className="page-shell-content">{inner}</div>;
 }

--- a/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
+++ b/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, ComponentType } from 'react';
+import { useState, useEffect, ComponentType, type ReactNode } from 'react';
 import Link from '../../../embed-shims/next-link';
 import { useRouter } from '../../../embed-shims/next-navigation';
 import { Card, CardContent } from '../../ui/card';
@@ -108,6 +108,15 @@ export interface ReleaseDetailPageProps {
   /** Link target for the author name in the metadata grid — the host
    *  computes it (public author page; absent ⇒ plain text). */
   authorHref?: string;
+  /** Optional slot rendered inside the page chrome, BELOW the article body —
+   *  e.g. the hub's end-of-article author byline + related-content / FAQ rail.
+   *  Lets the hub mount this page directly (no local wrapper component) while
+   *  embedders that don't have those extras simply omit it. */
+  relatedContent?: ReactNode;
+  /** Render the standalone `<PageShell>`. Default true. Pass false when the host
+   *  layout already provides the page container — only the padding box renders,
+   *  avoiding a nested `<main>`. */
+  shell?: boolean;
 }
 
 // Default renderer = the lib's `RichMarkdownRenderer` so out-of-the-box
@@ -128,9 +137,15 @@ export function ReleaseDetailPage({
   VideoDisplaySection,
   roadmapApiEndpoint = '/api/roadmap',
   deliveryApiEndpoint = '/api/delivery',
-  backButton
+  backButton,
+  relatedContent,
+  shell = true
 }: ReleaseDetailPageProps) {
   const router = useRouter();
+  // `shell` true → standalone `<PageShell>`; false → padding-only box (no nested
+  // <main>) for hosts whose layout already provides the container.
+  const renderShell = (node: ReactNode) =>
+    shell ? <PageShell>{node}</PageShell> : <div className="page-shell-content">{node}</div>;
   // Use pre-fetched data if provided (admin preview), otherwise fetch via hook (public)
   const { data: fetchedRelease, error, isLoading } = useRelease(initialData ? undefined : slug);
   const release = (initialData || fetchedRelease) as Record<string, unknown> | undefined;
@@ -191,25 +206,21 @@ export function ReleaseDetailPage({
   if (!initialData && isLoading) {
     // `bare` + `PageShell` so the loading state matches the loaded page's full
     // width / padding / min-height (the wrapper supplies the page chrome).
-    return (
-      <PageShell>
-        {/* Match the loaded page's top offset (TitleBlock's
-            `pt-[var(--spacing-system-l)]`) so content doesn't jump on load. */}
-        <div className="pt-[var(--spacing-system-l)]">
-          <DetailPageSkeleton bare metadataColumns={4} showImageGallery={true} />
-        </div>
-      </PageShell>
+    return renderShell(
+      // Match the loaded page's top offset (TitleBlock's
+      // `pt-[var(--spacing-system-l)]`) so content doesn't jump on load.
+      <div className="pt-[var(--spacing-system-l)]">
+        <DetailPageSkeleton bare metadataColumns={4} showImageGallery={true} />
+      </div>
     );
   }
 
   if (error || !release) {
-    return (
-      <PageShell>
-        <div className="text-center py-16">
-          <h1 className="text-4xl font-bold text-ods-text-primary mb-4">Release Not Found</h1>
-          <p className="text-xl text-ods-text-secondary">The release you&apos;re looking for doesn&apos;t exist.</p>
-        </div>
-      </PageShell>
+    return renderShell(
+      <div className="text-center py-16">
+        <h1 className="text-4xl font-bold text-ods-text-primary mb-4">Release Not Found</h1>
+        <p className="text-xl text-ods-text-secondary">The release you&apos;re looking for doesn&apos;t exist.</p>
+      </div>
     );
   }
 
@@ -241,29 +252,16 @@ export function ReleaseDetailPage({
   const bugFixed = release.bugs_fixed as ChangelogEntry[] | undefined;
   const improvements = release.improvements as ChangelogEntry[] | undefined;
 
-  return (
-    <PageShell>
-      <PageLayout
+  return renderShell(
+    <PageLayout
+        title={releaseTitle}
+        subtitle={`Version: ${releaseVersion}`}
+        titleSize="h1"
         backButton={
           showBackButton ? { label: backLabel, onClick: () => router.push(backHref) } : undefined
         }
       >
       <div className="space-y-6 md:space-y-8">
-        {/* Title Block */}
-        <div className="flex flex-col md:flex-row md:items-end gap-4 w-full">
-          <div className="flex-1 flex flex-col gap-2">
-            {/* Title */}
-            <h1 className="text-h1 tracking-[-1.12px] text-ods-text-primary">
-              {releaseTitle}
-            </h1>
-
-            {/* Version */}
-            <p className="text-h4 text-ods-text-secondary">
-              Version: {releaseVersion}
-            </p>
-          </div>
-        </div>
-
         {/* Tags — flat product_release_tags[] from entity_tags */}
         <EntityTagBadges tags={release.product_release_tags as TagAssoc[] | undefined} />
 
@@ -568,7 +566,9 @@ export function ReleaseDetailPage({
           </div>
         )}
       </div>
+
+      {/* Host slot — end-of-article byline + related-content / FAQ rail. */}
+      {relatedContent}
       </PageLayout>
-    </PageShell>
   );
 }

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -59,9 +59,13 @@ export interface HelpCenterListProps {
    *  the `tickets` section copy ("Help Center"). Set this to brand the surface
    *  for an embed that wants its own label (e.g. "Support Tickets"). */
   title?: string
+  /** Render the standalone `<PageShell>` (forwarded to the internal
+   *  `DevSectionPage`). Default true. Pass false when the host layout already
+   *  provides the page container (avoids a nested `<main>`). */
+  shell?: boolean
 }
 
-export function HelpCenterList({ toast = defaultToast, backButton, title }: HelpCenterListProps = {}) {
+export function HelpCenterList({ toast = defaultToast, backButton, title, shell }: HelpCenterListProps = {}) {
   const identity = useChatIdentity()
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -93,6 +97,7 @@ export function HelpCenterList({ toast = defaultToast, backButton, title }: Help
         sectionKey="tickets"
         backButton={backButton}
         title={title}
+        shell={shell}
         preControls={<HelpCenterCreateFormSkeleton />}
       >
         <DevCardRowSkeletonList />
@@ -101,7 +106,7 @@ export function HelpCenterList({ toast = defaultToast, backButton, title }: Help
   }
   if (identity.authTier === 'anon' || !identity.user?.email) {
     return (
-      <DevSectionPage sectionKey="tickets" backButton={backButton} title={title}>
+      <DevSectionPage sectionKey="tickets" backButton={backButton} title={title} shell={shell}>
         <EmptyState
           type="generic"
           title="Sign in to manage tickets"
@@ -138,6 +143,7 @@ export function HelpCenterList({ toast = defaultToast, backButton, title }: Help
       sessionEmail={sessionEmail}
       backButton={backButton}
       title={title}
+      shell={shell}
     />
   )
 }
@@ -156,6 +162,7 @@ interface AuthedProps {
   sessionEmail: string
   backButton?: { label?: string; href?: string } | false
   title?: string
+  shell?: boolean
 }
 
 function HelpCenterListAuthed({
@@ -171,6 +178,7 @@ function HelpCenterListAuthed({
   sessionEmail,
   backButton,
   title,
+  shell,
 }: AuthedProps) {
   const queryClient = useQueryClient()
   const [optimisticTickets, setOptimisticTickets] = useState<OptimisticTicket[]>([])
@@ -398,7 +406,7 @@ function HelpCenterListAuthed({
   )
 
   return (
-    <DevSectionPage sectionKey="tickets" backButton={backButton} title={title} preControls={form}>
+    <DevSectionPage sectionKey="tickets" backButton={backButton} title={title} shell={shell} preControls={form}>
       {body}
     </DevSectionPage>
   )

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -86,6 +86,10 @@ export default defineConfig([
       'components/chat/index': 'src/components/chat/index.ts',
       'components/tickets/index': 'src/components/tickets/index.ts',
       'components/onboarding-guides/index': 'src/components/onboarding-guides/index.ts',
+      // Help Center pages subpath — ready-made full-page components (own
+      // PageShell + PageLayout) shared by openframe-frontend + the hub. Client
+      // bundle (the pages and the views they compose are all client components).
+      'components/help-center-pages/index': 'src/components/help-center-pages/index.ts',
       'components/contact/index': 'src/components/contact/index.ts',
       // Case-studies subpath — `<ShareExperienceSection>` (the review-CTA
       // block embedded in `/case-studies`). Mounts `<ContactForm>` whose


### PR DESCRIPTION
## Summary

Unifies the Help Center page chrome and ships a single import site for Help Center pages.

- **Unified header** — every Help Center surface (FAQ, Legal, Release detail, Onboarding detail, Docs hub, DevSection list pages) now routes its title/subtitle through the canonical frozen `PageLayout` → `TitleBlock`, opted up to `text-h1` via a new optional `titleSize` prop. The per-page inline `<h1>` heroes + hero icons are removed, so all surfaces share one header.
- **Frozen-component exception** — `titleSize` is the only change to `PageLayout`/`TitleBlock`. It is **additive and default-preserving** (`'h2'` default = unchanged baseline for every existing caller) and documented inline as a sanctioned exception on the FROZEN banners.
- **`shell` prop** — added across the pages/views. `true` (default) renders the standalone `PageShell` `<main>`; `false` renders only the padding box (`page-shell-content`) so hosts whose layout already provides the page container avoid a nested `<main>`.
- **`relatedContent` slots** — added to the release + onboarding detail views so the hub can mount them directly with no local wrapper.
- **New `components/help-center-pages` barrel** — ready-made full pages (`RoadmapPage`, `ProductReleasesListPage`, `DeliveryPage`, `OnboardingGuidesCatalogPage`) plus named re-exports of the existing full-pages, giving consumers one import site. Subpath export wired in `package.json` + `tsup.config.ts`.

## Test plan

- [x] `npm run type-check` passes clean (zero errors)
- [ ] Visual check of each Help Center page header across openframe-frontend + multi-platform-hub
- [ ] Verify `shell={false}` renders no nested `<main>` when mounted inside an app layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)