### PR TITLE
Features: add reusable WarningBlock + PathsDisplay enhancements

### DIFF
--- a/openframe-frontend-core/src/components/features/index.ts
+++ b/openframe-frontend-core/src/components/features/index.ts
@@ -48,6 +48,7 @@ export * from './social-links-manager'
 export * from './start-with-openframe-button'
 export * from './status-filter-component'
 export * from './tags-selector'
+export * from './warning-block'
 // Unified video primitives — single source of truth across all platforms.
 // `<Video>` replaces the deleted `<VideoPlayer>` + `<YouTubeEmbed>` pair;
 // `<EntityVideoSection>` + `<VideoBitesDisplay>` are the public detail-page

--- a/openframe-frontend-core/src/components/features/paths-display.tsx
+++ b/openframe-frontend-core/src/components/features/paths-display.tsx
@@ -169,7 +169,10 @@ export function getOpenFramePaths(platform: OpenFramePathsPlatform): string[] {
  * the agent (works even if the agent didn't install correctly).
  */
 export const OPENFRAME_DOCTOR_COMMANDS: Record<OpenFramePathsPlatform, string> = {
-  windows: 'cd ~; wget github.com/openframe-client; openframe-client doctor',
+  // PowerShell: Invoke-WebRequest / .\openframe-client.exe, mirroring the
+  // Windows install command pattern.
+  windows:
+    "Set-Location ~; Invoke-WebRequest -Uri 'github.com/openframe-client' -OutFile 'openframe-client.exe'; .\\openframe-client.exe doctor",
   darwin: 'cd ~; wget github.com/openframe-client; openframe-client doctor',
   linux: 'cd ~; wget github.com/openframe-client; openframe-client doctor'
 } as const

--- a/openframe-frontend-core/src/components/features/paths-display.tsx
+++ b/openframe-frontend-core/src/components/features/paths-display.tsx
@@ -39,6 +39,13 @@ export interface PathsDisplayProps {
    * Size of the copy icon (default: 'w-6 h-6')
    */
   copyIconSize?: string
+
+  /**
+   * Optional icon rendered at the start of every row, before the path text.
+   * Useful for showing a platform logo next to a command (e.g. the Windows
+   * logo beside "Run PowerShell as Local Administrator").
+   */
+  leadingIcon?: React.ReactNode
 }
 
 /**
@@ -77,7 +84,8 @@ export function PathsDisplay({
   description,
   className,
   showCopyButtons = true,
-  copyIconSize = 'w-6 h-6'
+  copyIconSize = 'w-6 h-6',
+  leadingIcon
 }: PathsDisplayProps) {
   if (!paths || paths.length === 0) {
     return null
@@ -101,6 +109,9 @@ export function PathsDisplay({
             key={path}
             className="flex items-center gap-4 p-4 border-b border-ods-border last:border-b-0"
           >
+            {leadingIcon && (
+              <span className="shrink-0 text-ods-text-primary">{leadingIcon}</span>
+            )}
             <span className="flex-1 min-w-0 text-h4 text-ods-text-primary truncate">
               {path}
             </span>
@@ -151,4 +162,21 @@ export type OpenFramePathsPlatform = keyof typeof OPENFRAME_PATHS
  */
 export function getOpenFramePaths(platform: OpenFramePathsPlatform): string[] {
   return [...OPENFRAME_PATHS[platform]]
+}
+
+/**
+ * Doctor command per platform. Run to diagnose installation issues and repair
+ * the agent (works even if the agent didn't install correctly).
+ */
+export const OPENFRAME_DOCTOR_COMMANDS: Record<OpenFramePathsPlatform, string> = {
+  windows: 'cd ~; wget github.com/openframe-client; openframe-client doctor',
+  darwin: 'cd ~; wget github.com/openframe-client; openframe-client doctor',
+  linux: 'cd ~; wget github.com/openframe-client; openframe-client doctor'
+} as const
+
+/**
+ * Get the OpenFrame doctor command for a specific platform
+ */
+export function getOpenFrameDoctorCommand(platform: OpenFramePathsPlatform): string {
+  return OPENFRAME_DOCTOR_COMMANDS[platform]
 }

--- a/openframe-frontend-core/src/components/features/warning-block.tsx
+++ b/openframe-frontend-core/src/components/features/warning-block.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import React from 'react'
+import { cn } from '../../utils/cn'
+
+export interface WarningBlockProps {
+  /** Text rendered inside the highlighted warning banner header. */
+  title: React.ReactNode
+  /**
+   * Icon shown at the start of the banner. Defaults to a triangle alert icon.
+   * Pass `null` to hide the icon entirely.
+   */
+  icon?: React.ReactNode
+  /**
+   * Body content rendered below the banner — description paragraphs, one or more
+   * `PathsDisplay` lists, command rows, etc. Fully composable so a single block
+   * can mix text and multiple path groups (see the New Device warning blocks).
+   */
+  children?: React.ReactNode
+  /** Extra classes for the outer card container. */
+  className?: string
+}
+
+const DEFAULT_ICON = <AlertTriangle className="h-6 w-6" />
+
+/**
+ * WarningBlock - a card with a highlighted "attention / warning" banner header
+ * followed by arbitrary body content.
+ *
+ * The banner reproduces the ODS warning callout (warning color on a muted
+ * warning background). Body content is fully composable: pass description
+ * paragraphs, one or more `PathsDisplay` lists, command rows, etc. as children.
+ *
+ * Spacing follows the ODS scale: card padding 16px / gap 12px, banner padding
+ * 12px / gap 16px. Typography uses `text-h3`, which is responsive (14px on
+ * mobile, 18px from `md` up) and bold by design-token default.
+ */
+export function WarningBlock({ title, icon = DEFAULT_ICON, children, className }: WarningBlockProps) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3 rounded-[6px] border border-ods-border bg-ods-card p-4',
+        className
+      )}
+    >
+      <div className="flex items-start gap-4 overflow-hidden rounded-[6px] bg-ods-warning-secondary p-3 text-ods-warning">
+        {icon != null && <span className="shrink-0">{icon}</span>}
+        <p className="min-w-0 flex-1 text-h3">{title}</p>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/openframe-frontend-core/src/stories/WarningBlock.stories.tsx
+++ b/openframe-frontend-core/src/stories/WarningBlock.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { OSTypeIcon } from '../components/features/os-type-badge';
+import { OPENFRAME_DOCTOR_COMMANDS, PathsDisplay } from '../components/features/paths-display';
+import { WarningBlock } from '../components/features/warning-block';
+
+const meta = {
+  title: 'Features/WarningBlock',
+  component: WarningBlock,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A card with a highlighted "attention / warning" banner header followed by composable body content. Body is passed as children, so a single block can mix description paragraphs with one or more `PathsDisplay` lists (see the New Device warning blocks). Typography is responsive via ODS tokens (14px on mobile, 18px from `md` up).',
+      },
+    },
+  },
+  argTypes: {
+    title: { control: 'text' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 720 }}>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof WarningBlock>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const copyPath = (path: string) => {
+  if (typeof navigator !== 'undefined' && navigator.clipboard) {
+    void navigator.clipboard.writeText(path);
+  }
+};
+
+/** Minimal usage — a banner title with a single description paragraph. */
+export const Default: Story = {
+  args: {
+    title: 'Administrator privileges are required to install the OpenFrame agent.',
+    children: (
+      <p className="text-h4 text-ods-text-primary">
+        Run the command with the appropriate permissions for your platform.
+      </p>
+    ),
+  },
+};
+
+/**
+ * Antivirus warning from the New Device screen — description, a `PathsDisplay`
+ * list of exclusion folders, then a closing paragraph.
+ */
+export const AntivirusWarning: Story = {
+  args: {
+    title: 'Your antivirus may block OpenFrame installation. This is a false positive.',
+    children: (
+      <>
+        <PathsDisplay
+          title="If blocked, add these folders to your antivirus exclusions list:"
+          paths={['C:\\Program Files\\OpenFrame\\', 'C:\\Users\\[Username]\\AppData\\Local\\OpenFrame\\']}
+          onCopyPath={copyPath}
+        />
+        <p className="text-h4 text-ods-text-primary">
+          Or temporarily disable protection during installation. OpenFrame is safe open-source software.
+          Blocks happen because new software needs time to build reputation with security vendors.
+        </p>
+      </>
+    ),
+  },
+};
+
+/**
+ * Doctor mode warning from the New Device screen — description plus a single
+ * copyable command row.
+ */
+export const DoctorMode: Story = {
+  args: {
+    title: 'Device not appearing or stuck pending?',
+    children: (
+      <>
+        <p className="text-h4 text-ods-text-primary">
+          Run the doctor command to diagnose installation issues and repair the agent. It works even if
+          the agent didn&apos;t install correctly.
+        </p>
+        <PathsDisplay
+          paths={[OPENFRAME_DOCTOR_COMMANDS.windows]}
+          onCopyPath={copyPath}
+        />
+      </>
+    ),
+  },
+};
+
+/**
+ * Administrator privileges warning — a platform-specific instruction row (no
+ * copy button) framed by description paragraphs.
+ */
+export const AdministratorPrivileges: Story = {
+  args: {
+    title: 'Administrator privileges are required to install the OpenFrame agent.',
+    children: (
+      <>
+        <p className="text-h4 text-ods-text-primary">
+          Run the command with the appropriate permissions for your platform:
+        </p>
+        <PathsDisplay
+          paths={['Run PowerShell as Local Administrator']}
+          showCopyButtons={false}
+          leadingIcon={<OSTypeIcon osType="windows" size="w-6 h-6" />}
+        />
+        <p className="text-h4 text-ods-text-primary">
+          Without elevated privileges, the installation will fail silently. Right-click PowerShell and
+          select &quot;Run as administrator,&quot; or contact your IT admin if you don&apos;t have local
+          admin rights.
+        </p>
+      </>
+    ),
+  },
+};
+
+/** All three New Device warning blocks stacked, matching the Figma layout. */
+export const NewDeviceBlocks: Story = {
+  args: { title: '' },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <WarningBlock title="Administrator privileges are required to install the OpenFrame agent.">
+        <p className="text-h4 text-ods-text-primary">
+          Run the command with the appropriate permissions for your platform:
+        </p>
+        <PathsDisplay
+          paths={['Run PowerShell as Local Administrator']}
+          showCopyButtons={false}
+          leadingIcon={<OSTypeIcon osType="windows" size="w-6 h-6" />}
+        />
+        <p className="text-h4 text-ods-text-primary">
+          Without elevated privileges, the installation will fail silently. Right-click PowerShell and
+          select &quot;Run as administrator,&quot; or contact your IT admin if you don&apos;t have local
+          admin rights.
+        </p>
+      </WarningBlock>
+
+      <WarningBlock title="Your antivirus may block OpenFrame installation. This is a false positive.">
+        <PathsDisplay
+          title="If blocked, add these folders to your antivirus exclusions list:"
+          paths={['C:\\Program Files\\OpenFrame\\', 'C:\\Users\\[Username]\\AppData\\Local\\OpenFrame\\']}
+          onCopyPath={copyPath}
+        />
+        <p className="text-h4 text-ods-text-primary">
+          Or temporarily disable protection during installation. OpenFrame is safe open-source software.
+          Blocks happen because new software needs time to build reputation with security vendors.
+        </p>
+      </WarningBlock>
+
+      <WarningBlock title="Device not appearing or stuck pending?">
+        <p className="text-h4 text-ods-text-primary">
+          Run the doctor command to diagnose installation issues and repair the agent. It works even if
+          the agent didn&apos;t install correctly.
+        </p>
+        <PathsDisplay
+          paths={[OPENFRAME_DOCTOR_COMMANDS.windows]}
+          onCopyPath={copyPath}
+        />
+      </WarningBlock>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Description
Add WarningBlock: a card with an ODS warning banner header and composable body content (description paragraphs + one or more PathsDisplay lists), covering the New Device warning blocks.

Enhance PathsDisplay with an optional leadingIcon prop (e.g. platform logo next to a command) and add OPENFRAME_DOCTOR_COMMANDS + getOpenFrameDoctorCommand alongside OPENFRAME_PATHS.

Add Features/WarningBlock story reproducing all three New Device blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new warning card component for showing alert-style messages with optional icons and body content.
  * Enhanced path displays with an optional leading icon on each row.
  * Added support for retrieving platform-specific “doctor” command text.
* **Documentation**
  * Added Storybook examples for the new warning card, including several common usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->