### PR TITLE
add opt-in WebSocket frame logging for tool relays

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecorator.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecorator.java
@@ -1,0 +1,153 @@
+package com.openframe.gateway.config.ws;
+
+import lombok.extern.slf4j.Slf4j;
+import org.reactivestreams.Publisher;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.web.reactive.socket.CloseStatus;
+import org.springframework.web.reactive.socket.HandshakeInfo;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketMessage.Type;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Taps the relayed WebSocket frames for debug logging without consuming the payload buffers.
+ * Applied to the upstream (MeshCentral) session: {@link #receive()} carries frames FROM the
+ * upstream ("Mesh responses"), {@link #send(Publisher)} carries frames TO the upstream.
+ * <p>
+ * IMPORTANT: {@code getPayloadAsText()} and {@code getPayload().readableByteCount()} do NOT move
+ * the Netty buffer reader index and do NOT release it, so the same message still relays
+ * downstream intact. Never call a consuming/releasing read here.
+ * <p>
+ * Spring Framework 6.1's reactive stack does not ship a public {@code WebSocketSessionDecorator}
+ * (unlike the servlet stack), so this delegates to the wrapped {@link WebSocketSession} explicitly
+ * and only overrides {@link #receive()} / {@link #send(Publisher)} to tap the frames.
+ */
+@Slf4j
+public class LoggingWebSocketSessionDecorator implements WebSocketSession {
+
+    private final WebSocketSession webSocketSession;
+    private final String logPath;
+    private final String tenant;
+    private final WebSocketLoggingProperties props;
+
+    public LoggingWebSocketSessionDecorator(WebSocketSession webSocketSession, String logPath, String tenant,
+                                            WebSocketLoggingProperties props) {
+        this.webSocketSession = webSocketSession;
+        this.logPath = logPath;
+        this.tenant = tenant == null ? "-" : tenant;
+        this.props = props;
+    }
+
+    @Override
+    public Flux<WebSocketMessage> receive() {
+        return webSocketSession.receive()
+                .doOnNext(message -> logFrame("upstream->gw", message))
+                .doOnError(e -> log.debug("Debug ws frame upstream->gw stream error sessionId={} path={} tenant={} : {}",
+                        getId(), logPath, tenant, e.toString()));
+    }
+
+    @Override
+    public Mono<Void> send(Publisher<WebSocketMessage> messages) {
+        return webSocketSession.send(Flux.from(messages)
+                .doOnNext(message -> logFrame("gw->upstream", message)));
+    }
+
+    private void logFrame(String direction, WebSocketMessage message) {
+        if (!log.isDebugEnabled()) {
+            return;
+        }
+        try {
+            Type type = message.getType();
+            int bytes = message.getPayload().readableByteCount();
+            if (type == Type.TEXT) {
+                String shown = truncate(message.getPayloadAsText(), props.getMaxLoggedPayloadChars());
+                log.debug("Debug ws frame {} sessionId={} path={} tenant={} type={} bytes={} payload={}",
+                        direction, getId(), logPath, tenant, type, bytes, shown);
+            } else {
+                log.debug("Debug ws frame {} sessionId={} path={} tenant={} type={} bytes={}",
+                        direction, getId(), logPath, tenant, type, bytes);
+            }
+        } catch (Exception e) {
+            // Logging is best-effort and must never disrupt the proxied stream.
+            log.debug("Debug ws frame {} sessionId={} path={} : log tap failed: {}",
+                    direction, getId(), logPath, e.toString());
+        }
+    }
+
+    /**
+     * Renders the payload for the log line, appending a {@code ...(N chars)} suffix with the full
+     * length when the text exceeds {@code maxChars}; returns it unchanged when {@code maxChars <= 0}
+     * or it fits.
+     */
+    static String truncate(String text, int maxChars) {
+        return (maxChars > 0 && text.length() > maxChars)
+                ? text.substring(0, maxChars) + "...(" + text.length() + " chars)"
+                : text;
+    }
+
+    @Override
+    public String getId() {
+        return webSocketSession.getId();
+    }
+
+    @Override
+    public HandshakeInfo getHandshakeInfo() {
+        return webSocketSession.getHandshakeInfo();
+    }
+
+    @Override
+    public DataBufferFactory bufferFactory() {
+        return webSocketSession.bufferFactory();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return webSocketSession.getAttributes();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return webSocketSession.isOpen();
+    }
+
+    @Override
+    public Mono<Void> close() {
+        return webSocketSession.close();
+    }
+
+    @Override
+    public Mono<Void> close(CloseStatus status) {
+        return webSocketSession.close(status);
+    }
+
+    @Override
+    public Mono<CloseStatus> closeStatus() {
+        return webSocketSession.closeStatus();
+    }
+
+    @Override
+    public WebSocketMessage textMessage(String payload) {
+        return webSocketSession.textMessage(payload);
+    }
+
+    @Override
+    public WebSocketMessage binaryMessage(Function<DataBufferFactory, DataBuffer> payloadFactory) {
+        return webSocketSession.binaryMessage(payloadFactory);
+    }
+
+    @Override
+    public WebSocketMessage pingMessage(Function<DataBufferFactory, DataBuffer> payloadFactory) {
+        return webSocketSession.pingMessage(payloadFactory);
+    }
+
+    @Override
+    public WebSocketMessage pongMessage(Function<DataBufferFactory, DataBuffer> payloadFactory) {
+        return webSocketSession.pongMessage(payloadFactory);
+    }
+}

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -1,5 +1,6 @@
 package com.openframe.gateway.config.ws;
 
+import com.openframe.gateway.tenant.TenantRoutingHeaders;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -22,20 +23,35 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
 
     private final WebSocketClient delegate;
     private final WebSocketLoggingProperties loggingProperties;
+    private final boolean cleanupEnabled;
 
     @Override
     public Mono<Void> execute(URI url, WebSocketHandler handler) {
-        return delegate.execute(url, wrapHandler(url, handler));
+        return decorateConnection(url, null, delegate.execute(url, wrapHandler(url, null, handler)));
     }
 
     @Override
     public Mono<Void> execute(URI url, HttpHeaders headers, WebSocketHandler handler) {
-        return delegate.execute(url, headers, wrapHandler(url, handler));
+        String tenant = headers != null ? headers.getFirst(TenantRoutingHeaders.TENANT_ID_HEADER) : null;
+        return decorateConnection(url, tenant, delegate.execute(url, headers, wrapHandler(url, tenant, handler)));
     }
 
-    private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler) {
+    private Mono<Void> decorateConnection(URI url, String tenant, Mono<Void> connection) {
+        if (!loggingProperties.isFramePath(url.getPath())) {
+            return connection;
+        }
+        String tnt = tenant == null ? "-" : tenant;
+        return connection
+                .doOnSubscribe(s -> log.debug("Debug ws upstream connecting url={} tenant={}", url, tnt))
+                .doOnError(e -> log.warn("Debug ws upstream connection FAILED url={} tenant={} : {}",
+                        url, tnt, e.toString(), e))
+                .doOnSuccess(v -> log.debug("Debug ws upstream relay finished url={} tenant={}", url, tnt));
+    }
+
+    private WebSocketHandler wrapHandler(URI targetUrl, String tenant, WebSocketHandler handler) {
         String target = targetUrl.getPath();
-        boolean debugPath = loggingProperties.isDebugPath(targetUrl.getPath());
+        boolean debugPath = loggingProperties.isDebugPath(target);
+        boolean framePath = loggingProperties.isFramePath(target);
 
         return new WebSocketHandler() {
             @Override
@@ -49,8 +65,14 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                 if (debugPath) {
                     log.debug(LOG_PREFIX + "downstream proxy session opened", sessionId, target);
                 }
-                return handler.handle(proxySession)
+                WebSocketSession sessionToUse = framePath
+                        ? new LoggingWebSocketSessionDecorator(proxySession, target, tenant, loggingProperties)
+                        : proxySession;
+                return handler.handle(sessionToUse)
                         .doFinally(signal -> {
+                            if (!cleanupEnabled) {
+                                return;
+                            }
                             if (proxySession.isOpen()) {
                                 log.debug(LOG_PREFIX + "still open after relay completed (signal={}), closing",
                                         sessionId, target, signal);

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketGatewayConfig.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketGatewayConfig.java
@@ -61,11 +61,12 @@ public class WebSocketGatewayConfig {
             @Qualifier("reactorNettyWebSocketClient") WebSocketClient delegate,
             WebSocketLoggingProperties loggingProperties,
             @Value("${openframe.gateway.websocket.proxy-cleanup.enabled:false}") boolean cleanupEnabled) {
-        if (cleanupEnabled) {
-            log.info("WebSocket proxy session cleanup is ENABLED");
-            return new ProxySessionCleanupWebSocketClient(delegate, loggingProperties);
+        boolean frameLogging = loggingProperties.isFramePayloadLoggingEnabled();
+        if (cleanupEnabled || frameLogging) {
+            log.info("WebSocket proxy wrapper ENABLED (cleanup={}, frameLogging={})", cleanupEnabled, frameLogging);
+            return new ProxySessionCleanupWebSocketClient(delegate, loggingProperties, cleanupEnabled);
         }
-        log.info("WebSocket proxy session cleanup is DISABLED");
+        log.info("WebSocket proxy wrapper DISABLED");
         return delegate;
     }
 

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketLoggingProperties.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketLoggingProperties.java
@@ -12,11 +12,25 @@ import java.util.List;
 public class WebSocketLoggingProperties {
 
     private List<String> debugPathPrefixes = List.of("/ws/");
+    private List<String> framePathPrefixes = List.of();
+
+    private boolean framePayloadLoggingEnabled = false;
+
+    private int maxLoggedPayloadChars = 1024;
 
     public boolean isDebugPath(String path) {
         if (path == null || debugPathPrefixes == null) {
             return false;
         }
         return debugPathPrefixes.stream().anyMatch(path::startsWith);
+    }
+
+    public boolean isFramePath(String path) {
+        if (!framePayloadLoggingEnabled || path == null) {
+            return false;
+        }
+        List<String> prefixes = (framePathPrefixes == null || framePathPrefixes.isEmpty())
+                ? debugPathPrefixes : framePathPrefixes;
+        return prefixes != null && prefixes.stream().anyMatch(path::startsWith);
     }
 }

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecoratorTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecoratorTest.java
@@ -1,0 +1,40 @@
+package com.openframe.gateway.config.ws;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoggingWebSocketSessionDecoratorTest {
+
+    @Test
+    void shouldAppendLengthSuffixWhenTextExceedsMax() {
+        // Arrange
+        String text = "0123456789";
+
+        // Act
+        String shown = LoggingWebSocketSessionDecorator.truncate(text, 4);
+
+        // Assert
+        assertThat(shown).isEqualTo("0123...(10 chars)");
+    }
+
+    @Test
+    void shouldReturnTextUnchangedWhenWithinMax() {
+        // Arrange
+        String text = "short";
+
+        // Act / Assert
+        assertThat(LoggingWebSocketSessionDecorator.truncate(text, 1024)).isEqualTo("short");
+        assertThat(LoggingWebSocketSessionDecorator.truncate(text, 5)).isEqualTo("short");
+    }
+
+    @Test
+    void shouldReturnTextUnchangedWhenMaxIsNonPositive() {
+        // Arrange
+        String text = "0123456789";
+
+        // Act / Assert
+        assertThat(LoggingWebSocketSessionDecorator.truncate(text, 0)).isEqualTo(text);
+        assertThat(LoggingWebSocketSessionDecorator.truncate(text, -1)).isEqualTo(text);
+    }
+}

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketLoggingPropertiesTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketLoggingPropertiesTest.java
@@ -1,0 +1,47 @@
+package com.openframe.gateway.config.ws;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WebSocketLoggingPropertiesTest {
+
+    @Test
+    void shouldReturnFalseFromIsFramePathWhenFramePayloadLoggingDisabled() {
+        // Arrange
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(false);
+        props.setFramePathPrefixes(List.of("/ws/tools/agent/meshcentral-server/"));
+
+        // Act / Assert
+        assertThat(props.isFramePath("/ws/tools/agent/meshcentral-server/agent.ashx")).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueFromIsFramePathOnlyForConfiguredPrefixWhenEnabled() {
+        // Arrange
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(true);
+        props.setFramePathPrefixes(List.of("/ws/tools/agent/meshcentral-server/"));
+
+        // Act / Assert
+        assertThat(props.isFramePath("/ws/tools/agent/meshcentral-server/agent.ashx")).isTrue();
+        assertThat(props.isFramePath("/ws/nats")).isFalse();
+        assertThat(props.isFramePath(null)).isFalse();
+    }
+
+    @Test
+    void shouldFallBackToDebugPathPrefixesWhenFramePathPrefixesEmpty() {
+        // Arrange
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(true);
+        props.setDebugPathPrefixes(List.of("/ws/"));
+        props.setFramePathPrefixes(List.of());
+
+        // Act / Assert
+        assertThat(props.isFramePath("/ws/tools/agent/meshcentral-server/agent.ashx")).isTrue();
+        assertThat(props.isFramePath("/api/v1/health")).isFalse();
+    }
+}


### PR DESCRIPTION
## Description

Adds opt-in debug logging of the WebSocket frames and upstream connection events the
gateway proxies on its outbound leg, to diagnose the MeshCentral relay
(`/ws/tools/agent/meshcentral-server/agent.ashx`) — response payloads, connectivity, and
error states. Until now the gateway logged only session lifecycle and the resolved proxy
URI, never the relayed frames or upstream connection failures.

The feature is **off by default** and **path-scoped**: when disabled there is no behavior
change and no per-frame overhead. Verified with `mvn test -pl openframe-gateway-service-core`
(16 tests pass); the downstream `openframe-saas-gateway` builds and its 66 tests pass against
the locally-installed snapshot.

## Improvements

- New `LoggingWebSocketSessionDecorator` taps `receive()` (upstream→gateway — the "Mesh
  responses") and `send()` (gateway→upstream), logging frame direction, type, byte size and
  truncated TEXT payloads. Reads are non-consuming (don't move or release the Netty buffer)
  so the relay is unaffected, and the tap is best-effort — a logging failure can never
  disrupt the proxied stream.
- `ProxySessionCleanupWebSocketClient` now logs upstream connect / relay-finished (DEBUG) and
  connection failures (WARN), and wraps the upstream session on configured paths. Connection
  logging is scoped to the opt-in frame paths, and the existing session-cleanup behavior is
  decoupled behind its own flag.
- `WebSocketLoggingProperties` adds `frame-payload-logging-enabled` (default `false`),
  `frame-path-prefixes` (falls back to `debug-path-prefixes` when empty), and
  `max-logged-payload-chars` (default 1024).
- The proxy `WebSocketClient` wrapper bean is created when either proxy-cleanup or frame
  logging is enabled, and logs its resolved state once at startup.
- Guarded by `log.isDebugEnabled()`; BINARY frames are logged as size-only to avoid flooding
  logs with remote-desktop / file-transfer payloads.
- Unit tests cover path matching (`WebSocketLoggingPropertiesTest`) and payload truncation
  (`LoggingWebSocketSessionDecoratorTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional WebSocket frame logging for supported paths, with configurable path matching and payload length limits.
  * Improved gateway behavior to support tenant-aware WebSocket handling and selective logging when enabled.

* **Bug Fixes**
  * Logging now safely truncates long text payloads and avoids disrupting live connections if logging fails.
  * Cleanup behavior is now applied only when enabled, reducing unnecessary connection work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->