### PR TITLE
fix(gateway-service-core): scope WS frame logging to request path + readable binary payloads

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecorator.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecorator.java
@@ -17,12 +17,14 @@ import java.util.function.Function;
 
 /**
  * Taps the relayed WebSocket frames for debug logging without consuming the payload buffers.
- * Applied to the upstream (MeshCentral) session: {@link #receive()} carries frames FROM the
- * upstream ("Mesh responses"), {@link #send(Publisher)} carries frames TO the upstream.
+ * Applied to the client (agent &harr; gateway) session, where the original request path is known:
+ * {@link #receive()} carries frames the client sends toward the upstream tool, and
+ * {@link #send(Publisher)} carries the upstream tool's responses back to the client (the
+ * "Mesh responses" when proxying MeshCentral).
  * <p>
  * IMPORTANT: {@code getPayloadAsText()} and {@code getPayload().readableByteCount()} do NOT move
- * the Netty buffer reader index and do NOT release it, so the same message still relays
- * downstream intact. Never call a consuming/releasing read here.
+ * the Netty buffer reader index and do NOT release it, so the same message still relays intact.
+ * Never call a consuming/releasing read here.
  * <p>
  * Spring Framework 6.1's reactive stack does not ship a public {@code WebSocketSessionDecorator}
  * (unlike the servlet stack), so this delegates to the wrapped {@link WebSocketSession} explicitly
@@ -47,15 +49,15 @@ public class LoggingWebSocketSessionDecorator implements WebSocketSession {
     @Override
     public Flux<WebSocketMessage> receive() {
         return webSocketSession.receive()
-                .doOnNext(message -> logFrame("upstream->gw", message))
-                .doOnError(e -> log.debug("Debug ws frame upstream->gw stream error sessionId={} path={} tenant={} : {}",
+                .doOnNext(message -> logFrame("client->gw", message))
+                .doOnError(e -> log.debug("Debug ws frame client->gw stream error sessionId={} path={} tenant={} : {}",
                         getId(), logPath, tenant, e.toString()));
     }
 
     @Override
     public Mono<Void> send(Publisher<WebSocketMessage> messages) {
         return webSocketSession.send(Flux.from(messages)
-                .doOnNext(message -> logFrame("gw->upstream", message)));
+                .doOnNext(message -> logFrame("gw->client", message)));
     }
 
     private void logFrame(String direction, WebSocketMessage message) {
@@ -67,6 +69,10 @@ public class LoggingWebSocketSessionDecorator implements WebSocketSession {
             int bytes = message.getPayload().readableByteCount();
             if (type == Type.TEXT) {
                 String shown = truncate(message.getPayloadAsText(), props.getMaxLoggedPayloadChars());
+                log.debug("Debug ws frame {} sessionId={} path={} tenant={} type={} bytes={} payload={}",
+                        direction, getId(), logPath, tenant, type, bytes, shown);
+            } else if (props.isLogBinaryPayload()) {
+                String shown = toPrintablePreview(message.getPayload(), props.getMaxLoggedPayloadChars());
                 log.debug("Debug ws frame {} sessionId={} path={} tenant={} type={} bytes={} payload={}",
                         direction, getId(), logPath, tenant, type, bytes, shown);
             } else {
@@ -89,6 +95,31 @@ public class LoggingWebSocketSessionDecorator implements WebSocketSession {
         return (maxChars > 0 && text.length() > maxChars)
                 ? text.substring(0, maxChars) + "...(" + text.length() + " chars)"
                 : text;
+    }
+
+    /**
+     * Renders up to {@code maxChars} bytes of a binary payload as printable text WITHOUT consuming it:
+     * printable ASCII (0x20–0x7E) is kept verbatim, every other byte becomes {@code '.'}. This makes the
+     * many "binary" frames that are really JSON or ASCII (e.g. MeshCentral's command and {@code {"action":…}}
+     * frames) readable, while genuine binary (certs/nonces) degrades to dots. Absolute
+     * {@link DataBuffer#getByte(int)} reads do not move the reader index or release the buffer, so the same
+     * message still relays intact. Appends a {@code …(N bytes total)} suffix (deliberately the ellipsis
+     * char, so it stands out from the {@code '.'} placeholders) when truncated; {@code maxChars <= 0}
+     * renders the whole payload. Package-private static for unit testing.
+     */
+    static String toPrintablePreview(DataBuffer payload, int maxChars) {
+        int total = payload.readableByteCount();
+        int count = maxChars > 0 ? Math.min(total, maxChars) : total;
+        int start = payload.readPosition();
+        StringBuilder sb = new StringBuilder(count + 16);
+        for (int i = 0; i < count; i++) {
+            int b = payload.getByte(start + i) & 0xFF;
+            sb.append(b >= 0x20 && b < 0x7F ? (char) b : '.');
+        }
+        if (count < total) {
+            sb.append("…(").append(total).append(" bytes total)");
+        }
+        return sb.toString();
     }
 
     @Override

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -27,17 +27,21 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
 
     @Override
     public Mono<Void> execute(URI url, WebSocketHandler handler) {
-        return decorateConnection(url, null, delegate.execute(url, wrapHandler(url, null, handler)));
+        return decorateConnection(url, null, delegate.execute(url, wrapHandler(url, handler)));
     }
 
     @Override
     public Mono<Void> execute(URI url, HttpHeaders headers, WebSocketHandler handler) {
         String tenant = headers != null ? headers.getFirst(TenantRoutingHeaders.TENANT_ID_HEADER) : null;
-        return decorateConnection(url, tenant, delegate.execute(url, headers, wrapHandler(url, tenant, handler)));
+        return decorateConnection(url, tenant, delegate.execute(url, headers, wrapHandler(url, handler)));
     }
 
+    // Upstream connect/finish/failure logging. Gated by the global frame-logging switch rather than a
+    // path prefix: this runs at the WebSocketClient level where the URL is the rewritten upstream
+    // address, so per-path scoping is not meaningful here (frame logging itself is scoped on the
+    // original request path in WebSocketServiceSecurityDecorator).
     private Mono<Void> decorateConnection(URI url, String tenant, Mono<Void> connection) {
-        if (!loggingProperties.isFramePath(url.getPath())) {
+        if (!loggingProperties.isFramePayloadLoggingEnabled()) {
             return connection;
         }
         String tnt = tenant == null ? "-" : tenant;
@@ -48,10 +52,9 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                 .doOnSuccess(v -> log.debug("Debug ws upstream relay finished url={} tenant={}", url, tnt));
     }
 
-    private WebSocketHandler wrapHandler(URI targetUrl, String tenant, WebSocketHandler handler) {
+    private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler) {
         String target = targetUrl.getPath();
         boolean debugPath = loggingProperties.isDebugPath(target);
-        boolean framePath = loggingProperties.isFramePath(target);
 
         return new WebSocketHandler() {
             @Override
@@ -65,10 +68,7 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
                 if (debugPath) {
                     log.debug(LOG_PREFIX + "downstream proxy session opened", sessionId, target);
                 }
-                WebSocketSession sessionToUse = framePath
-                        ? new LoggingWebSocketSessionDecorator(proxySession, target, tenant, loggingProperties)
-                        : proxySession;
-                return handler.handle(sessionToUse)
+                return handler.handle(proxySession)
                         .doFinally(signal -> {
                             if (!cleanupEnabled) {
                                 return;

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketLoggingProperties.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketLoggingProperties.java
@@ -18,6 +18,13 @@ public class WebSocketLoggingProperties {
 
     private int maxLoggedPayloadChars = 1024;
 
+    /**
+     * When true, non-TEXT (BINARY/PING/PONG) frame payloads are hex-rendered, capped at
+     * {@link #maxLoggedPayloadChars} hex characters. OFF by default; needed to see binary tool
+     * protocols such as MeshCentral's agent.ashx tunnel. Can be high volume — keep the cap sane.
+     */
+    private boolean logBinaryPayload = false;
+
     public boolean isDebugPath(String path) {
         if (path == null || debugPathPrefixes == null) {
             return false;

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
@@ -1,6 +1,7 @@
 package com.openframe.gateway.config.ws;
 
 import com.openframe.gateway.metrics.GatewayTrafficMetrics;
+import com.openframe.gateway.tenant.TenantRoutingHeaders;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.reactive.socket.WebSocketHandler;
@@ -59,7 +60,11 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
 
                     Disposable disposable = scheduleSessionRemoveJob(session, path, sub, debugPath, effectiveSeconds);
                     processSessionClosedEvent(session, path, sub, disposable);
-                    return defaultWebSocketHandler.handle(session);
+
+                    WebSocketSession sessionToHandle = loggingProperties.isFramePath(path)
+                            ? new LoggingWebSocketSessionDecorator(session, path, tenantId(exchange), loggingProperties)
+                            : session;
+                    return defaultWebSocketHandler.handle(sessionToHandle);
                 } catch (Exception e) {
                     log.warn(LOG_PREFIX + "JWT expiration read failed, closing: {}", sessionId, path, sub, e.getMessage(), e);
                     sessionRegistry.remove(sessionId);
@@ -79,6 +84,10 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
         return Set.of(TOOLS_API_WS_ENDPOINT_PREFIX, TOOLS_AGENT_WS_ENDPOINT_PREFIX, NATS_WS_ENDPOINT_PATH, NATS_API_WS_ENDPOINT_PATH)
                 .stream()
                 .anyMatch(path::startsWith);
+    }
+
+    private static String tenantId(ServerWebExchange exchange) {
+        return exchange.getRequest().getHeaders().getFirst(TenantRoutingHeaders.TENANT_ID_HEADER);
     }
 
     private Disposable scheduleSessionRemoveJob(WebSocketSession session, String path, String sub, boolean debugPath, long secondsUntilExpiration) {

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecoratorTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/LoggingWebSocketSessionDecoratorTest.java
@@ -1,6 +1,10 @@
 package com.openframe.gateway.config.ws;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+
+import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,5 +40,38 @@ class LoggingWebSocketSessionDecoratorTest {
         // Act / Assert
         assertThat(LoggingWebSocketSessionDecorator.truncate(text, 0)).isEqualTo(text);
         assertThat(LoggingWebSocketSessionDecorator.truncate(text, -1)).isEqualTo(text);
+    }
+
+    @Test
+    void shouldRenderBinaryPayloadAsPrintableTextWithoutConsumingIt() {
+        // Arrange — 0x00,0x1e (non-printable, e.g. a 2-byte command prefix) + "Hi" + 0x00
+        DataBuffer buf = new DefaultDataBufferFactory().wrap(new byte[]{0x00, 0x1e, 'H', 'i', 0x00});
+        int positionBefore = buf.readPosition();
+        int readableBefore = buf.readableByteCount();
+
+        // Act
+        String shown = LoggingWebSocketSessionDecorator.toPrintablePreview(buf, 1024);
+
+        // Assert — printable chars kept, others become '.'
+        assertThat(shown).isEqualTo("..Hi.");
+        // non-consuming: the relay must still receive the full payload after the tap reads it
+        assertThat(buf.readPosition()).isEqualTo(positionBefore);
+        assertThat(buf.readableByteCount()).isEqualTo(readableBefore);
+    }
+
+    @Test
+    void shouldRenderJsonOverBinaryFrameAsReadableText() {
+        // A MeshCentral server->agent frame: JSON sent over a BINARY opcode.
+        DataBuffer buf = new DefaultDataBufferFactory().wrap("{\"action\":\"serverInfo\"}".getBytes(StandardCharsets.US_ASCII));
+
+        assertThat(LoggingWebSocketSessionDecorator.toPrintablePreview(buf, 1024)).isEqualTo("{\"action\":\"serverInfo\"}");
+    }
+
+    @Test
+    void shouldTruncatePrintablePreviewToMaxChars() {
+        DataBuffer buf = new DefaultDataBufferFactory().wrap(new byte[]{'a', 'b', 'c', 'd'});
+
+        // maxChars=2 renders 2 bytes, suffix shows the full byte count
+        assertThat(LoggingWebSocketSessionDecorator.toPrintablePreview(buf, 2)).isEqualTo("ab…(4 bytes total)");
     }
 }

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecoratorTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecoratorTest.java
@@ -1,0 +1,101 @@
+package com.openframe.gateway.config.ws;
+
+import com.openframe.gateway.metrics.GatewayTrafficMetrics;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.server.RequestPath;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.reactive.socket.CloseStatus;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.server.WebSocketService;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Guards the fix for the path-scoping bug: frame logging must be decided on the ORIGINAL gateway
+ * request path (available here), not the rewritten upstream URL the {@code WebSocketClient} sees.
+ */
+class WebSocketServiceSecurityDecoratorTest {
+
+    private static final String MESH_REQUEST_PATH = "/ws/tools/agent/meshcentral-server/agent.ashx";
+
+    @Test
+    void wrapsClientSessionForFrameLogging_whenRequestPathMatchesFramePrefix() {
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(true);
+        props.setFramePathPrefixes(List.of("/ws/tools/agent/meshcentral-server/"));
+
+        WebSocketSession proxied = handleAndCaptureProxiedSession(props, MESH_REQUEST_PATH);
+
+        // The proxy relay must receive the TAPPED client session — proving the wrap decision is made
+        // on the request path. (Before the fix it was checked against the upstream URL and never matched.)
+        assertThat(proxied).isInstanceOf(LoggingWebSocketSessionDecorator.class);
+    }
+
+    @Test
+    void doesNotWrapClientSession_whenRequestPathDoesNotMatchFramePrefix() {
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(true);
+        props.setFramePathPrefixes(List.of("/ws/tools/agent/tactical-rmm/"));
+
+        WebSocketSession proxied = handleAndCaptureProxiedSession(props, MESH_REQUEST_PATH);
+
+        assertThat(proxied).isNotInstanceOf(LoggingWebSocketSessionDecorator.class);
+    }
+
+    private WebSocketSession handleAndCaptureProxiedSession(WebSocketLoggingProperties props, String requestPath) {
+        WebSocketService defaultService = mock(WebSocketService.class);
+        RequestJwtClaimsReader jwtReader = mock(RequestJwtClaimsReader.class);
+        GatewayTrafficMetrics metrics = mock(GatewayTrafficMetrics.class);
+
+        WebSocketServiceSecurityDecorator decorator =
+                new WebSocketServiceSecurityDecorator(defaultService, jwtReader, metrics, props);
+
+        ServerWebExchange exchange = exchangeWithPath(requestPath);
+        when(jwtReader.getSubject(exchange)).thenReturn(Optional.of("agent_x"));
+        when(jwtReader.getExpiration(exchange)).thenReturn(Instant.now().plusSeconds(3600));
+
+        WebSocketSession clientSession = mock(WebSocketSession.class);
+        when(clientSession.getId()).thenReturn("session-1");
+        when(clientSession.closeStatus()).thenReturn(Mono.<CloseStatus>never());
+
+        WebSocketHandler proxyHandler = mock(WebSocketHandler.class);
+        ArgumentCaptor<WebSocketSession> proxiedSession = ArgumentCaptor.forClass(WebSocketSession.class);
+        when(proxyHandler.handle(proxiedSession.capture())).thenReturn(Mono.empty());
+
+        // Make the default WebSocketService invoke the security handler with our client session,
+        // mirroring how Spring's reactive stack drives the relay.
+        when(defaultService.handleRequest(eq(exchange), any(WebSocketHandler.class)))
+                .thenAnswer(invocation -> {
+                    WebSocketHandler securityHandler = invocation.getArgument(1);
+                    return securityHandler.handle(clientSession);
+                });
+
+        decorator.handleRequest(exchange, proxyHandler).block();
+
+        return proxiedSession.getValue();
+    }
+
+    private static ServerWebExchange exchangeWithPath(String path) {
+        ServerWebExchange exchange = mock(ServerWebExchange.class);
+        ServerHttpRequest request = mock(ServerHttpRequest.class);
+        RequestPath requestPath = mock(RequestPath.class);
+        when(requestPath.value()).thenReturn(path);
+        when(request.getPath()).thenReturn(requestPath);
+        when(request.getHeaders()).thenReturn(new HttpHeaders());
+        when(exchange.getRequest()).thenReturn(request);
+        return exchange;
+    }
+}


### PR DESCRIPTION
## Description

Follow-up to #1262. The opt-in WebSocket frame logging was gated on the **rewritten upstream URL**, which never matches the configured `/ws/...` prefixes for tool routes — MeshCentral's `/ws/tools/agent/meshcentral-server/agent.ashx` resolves upstream to `ws://meshcentral.<ns>…/<tenant>/agent.ashx`, so `isFramePath()` was always false and **no frames were ever logged**. This PR scopes the decision on the original request path and makes binary payloads readable.

Verified locally against a dev MeshCentral agent: frames now log in both directions on `/ws/tools/agent/meshcentral-server/agent.ashx` — the agent handshake (build/OS/cert) and the `{"action":…}` control JSON. `mvn test -pl openframe-gateway-service-core` → 21 tests pass.

## Improvements

- **Move the frame tap to the server leg.** `WebSocketServiceSecurityDecorator` wraps the client (agent↔gateway) session — which still has the original request path — and gates frame logging on `isFramePath(requestPath)`. The relayed frames flow through that session, with the upstream's responses on its `send()`.
- **`ProxySessionCleanupWebSocketClient` no longer taps frames.** Its upstream connect/finish/failure logging is now gated by the global `frame-payload-logging-enabled` flag (it only sees the rewritten URL, so per-path scoping there isn't meaningful).
- **Readable binary payloads.** New `log-binary-payload` (default `false`) renders non-TEXT frame payloads as printable text (printable ASCII kept, other bytes `.`) instead of hex — many "binary" frames are really JSON/ASCII (e.g. `{"action":"serverInfo"}` and MeshCentral command frames). Rendering is non-consuming via absolute `getByte` reads, capped by `max-logged-payload-chars`.
- **Tests** (`+202/−17`): regression guard that the wrap decision uses the request path (would have caught the bug), printable rendering, JSON-over-binary readability, and buffer non-consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket logs can now include readable previews of binary payloads when enabled.
  * Frame logging now uses clearer client-to-gateway terminology in log messages.

* **Bug Fixes**
  * Improved handling of non-text WebSocket frames so payload content is easier to inspect instead of showing only byte counts.
  * Tightened logging behavior so session wrapping is applied more consistently for secured WebSocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->