### PR TITLE
fix(): time tracker panel emtpy state

### DIFF
--- a/openframe-frontend-core/src/components/features/time-tracker/time-tracker-panel.tsx
+++ b/openframe-frontend-core/src/components/features/time-tracker/time-tracker-panel.tsx
@@ -11,6 +11,7 @@ import {
   ArrowRightUpIcon,
   CheckCircleIcon,
   Chevron02RightIcon,
+  ClockHistoryIcon,
   DotsLoaderIcon,
   PauseIcon,
   PlayIcon,
@@ -198,20 +199,24 @@ export function TimeTrackerPanel({
 
       {/* Last entries + footer */}
       <div className="flex flex-col gap-[var(--spacing-system-m)]">
-        <div className="flex flex-col gap-[var(--spacing-system-xs)]">
-          <p className="font-mono text-h6 uppercase tracking-wide text-ods-text-secondary">Last Entries</p>
-          <div className="overflow-hidden rounded-md border border-ods-border bg-ods-card">
-            {visibleEntries.length === 0 ? (
-              <div className="flex items-center justify-center px-[var(--spacing-system-m)] py-[var(--spacing-system-l)]">
-                <p className="text-h6 text-ods-text-secondary">No tracked sessions yet</p>
-              </div>
-            ) : (
-              visibleEntries.map((entry) => (
-                <LastEntryRow key={entry.id} entry={entry} onClick={handleEntryClick} />
-              ))
-            )}
+        {visibleEntries.length === 0 ? (
+          <div className="flex min-h-[268px] flex-col items-center justify-center gap-[var(--spacing-system-l)] p-[var(--spacing-system-l)] text-center text-ods-text-secondary">
+            <ClockHistoryIcon className="size-6" />
+            <div className="flex flex-col">
+              <p className="text-h4 font-medium">No time logged</p>
+              <p className="text-h6">Last entries will appear here</p>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-[var(--spacing-system-xs)]">
+            <p className="font-mono text-h6 uppercase tracking-wide text-ods-text-secondary">Last Entries</p>
+            <div className="overflow-hidden rounded-md border border-ods-border bg-ods-card">
+              {visibleEntries.map((entry) => (
+                <LastEntryRow key={entry.id} entry={entry} onClick={handleEntryClick} />
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="grid grid-cols-2 gap-[var(--spacing-system-m)]">
           <Button

--- a/openframe-frontend-core/src/stories/TimeTracker.stories.tsx
+++ b/openframe-frontend-core/src/stories/TimeTracker.stories.tsx
@@ -265,7 +265,7 @@ export const PanelFinishGate: Story = {
   },
 }
 
-/** Empty last-entries state. */
+/** Empty last-entries state — clock-history icon with a "No time logged / Last entries will appear here" placeholder (no list header or border). */
 export const PanelNoEntries: Story = {
   render: function PanelNoEntriesRender() {
     const host = useTimeTrackerHost({ status: 'ready', lastEntries: [] })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the time-tracker panel’s empty state for recent entries with a clearer, centered placeholder and clock-style icon.
  * Refined the messaging shown when no time has been logged yet, making the “Last Entries” area easier to understand.
  * Kept the existing entries list and container styling for when recent activity is available.

* **Documentation**
  * Clarified the example story comment to better describe the empty-state appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->