### PR TITLE
fix(chat): restore composer focus ring & empty placeholder position

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-composer.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-composer.tsx
@@ -183,10 +183,12 @@ export function ChatComposer({
             // (`bg-ods-bg`, `border-b`) sits flush above the input; the card
             // owns the border / radius / focus ring. No `overflow-hidden` so the
             // picker popover can float above the input (chips get `rounded-t`).
-            // `has-[textarea:focus]` (not `focus-within`) so the accent border
-            // reacts ONLY to the composer textarea — not the picker's search
-            // input or item buttons, which also live inside this card.
-            <div className="rounded-md border border-ods-border bg-ods-card transition-colors has-[textarea:focus]:border-ods-accent">
+            // `has-[[data-editor]:focus]` (not `focus-within`) so the accent
+            // border reacts ONLY to the composer editor — not the picker's search
+            // input or item buttons, which also live inside this card. The editor
+            // is a `contentEditable` div (`data-editor`), not a `<textarea>`, so we
+            // target its data attribute rather than the element name.
+            <div className="rounded-md border border-ods-border bg-ods-card transition-colors has-[[data-editor]:focus]:border-ods-accent">
               {selected.length > 0 && (
                 <ChatContextChipStrip
                   items={selected}

--- a/openframe-frontend-core/src/components/chat/chat-input.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-input.tsx
@@ -517,7 +517,11 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>((allProps, ref) => {
                   // (~35.5px incl. vertical-align overhead): the LINE drives row
                   // height (deterministic 48px, no overflow) AND the near-zero slack
                   // keeps the chip centered. ~4px gap between wrapped chip rows.
-                  "text-h4 text-ods-text-primary !leading-9",
+                  // `min-h-9` pins that single-line box even when EMPTY: a non-editable
+                  // (`contentEditable=false`, i.e. disabled/sending) empty div would
+                  // otherwise collapse to 0px, and `items-center` would re-center the
+                  // shorter wrapper in the row — dropping the `top-0` placeholder down.
+                  "min-h-9 text-h4 text-ods-text-primary !leading-9",
                   "scrollbar-thin scrollbar-track-transparent scrollbar-thumb-ods-border/30 hover:scrollbar-thumb-ods-text-secondary/30",
                   isDisabled && "cursor-not-allowed",
                 )}


### PR DESCRIPTION
## Summary
- Focus accent border now targets the contentEditable editor via `data-editor` (the composer uses a `contentEditable` div, not a `<textarea>`), so the accent border reacts only to the composer editor — not the picker's search input or item buttons.
- Pin the editor box with `min-h-9` so an empty non-editable (disabled/sending) state no longer collapses to 0px and drops the `top-0` placeholder down via `items-center` re-centering.

## Files
- `src/components/chat/chat-composer.tsx`
- `src/components/chat/chat-input.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer focus styling so the active border highlights correctly when the editor is focused.
  * Stabilized the empty chat input placeholder height to prevent the first line from collapsing or shifting when no text is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->