### PR TITLE
Align FeFeatureFlags with multiTenant Mongo

### DIFF
--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/featureflags/FeFeatureFlags.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/featureflags/FeFeatureFlags.java
@@ -1,5 +1,6 @@
 package com.openframe.data.document.featureflags;
 
+import com.openframe.data.document.TenantScoped;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,6 +8,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.LocalDateTime;
@@ -14,25 +16,23 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Per-cluster document holding DB-side overrides for frontend feature flags.
+ * Per-tenant document holding DB-side overrides for frontend feature flags.
  * Any property present in {@link #flags} takes precedence over the value
  * configured in {@code openframe.fe-feature-flag.*}; missing properties fall
  * back to the yml configuration default.
  *
- * <p>The Mongo {@code _id} is the cluster id ({@code openframe.cluster-id}),
- * so the collection naturally supports the future migration of all tenants
- * into a single shared cluster.
+ * <p>The document is {@link TenantScoped} via {@link #tenantId}, so the
+ * collection holds one document per tenant and naturally supports all tenants
+ * sharing a single cluster.
  */
 @Document(collection = "fe_feature_flags")
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class FeFeatureFlags {
-
-    /** Cluster id — used as the Mongo {@code _id} (one document per cluster). */
+public class FeFeatureFlags implements TenantScoped {
     @Id
-    private String clusterId;
+    private String id;
 
     @Builder.Default
     private Map<String, Boolean> flags = new LinkedHashMap<>();
@@ -42,4 +42,7 @@ public class FeFeatureFlags {
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @Indexed
+    private String tenantId;
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/featureflags/FeFeatureFlagsRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/featureflags/FeFeatureFlagsRepository.java
@@ -4,6 +4,16 @@ import com.openframe.data.document.featureflags.FeFeatureFlags;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface FeFeatureFlagsRepository extends MongoRepository<FeFeatureFlags, String> {
+
+    /**
+     * Returns the current tenant's overrides document, if any. Since
+     * {@link FeFeatureFlags} is {@code TenantScoped}, the tenant aspect injects
+     * the {@code tenantId} criterion automatically, so this resolves to the
+     * single document belonging to the running pod's tenant.
+     */
+    Optional<FeFeatureFlags> findFirstBy();
 }

--- a/openframe-fe-feature-flags/src/main/java/com/openframe/featureflags/FeFeatureFlagService.java
+++ b/openframe-fe-feature-flags/src/main/java/com/openframe/featureflags/FeFeatureFlagService.java
@@ -4,8 +4,9 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.openframe.data.document.featureflags.FeFeatureFlags;
 import com.openframe.data.repository.featureflags.FeFeatureFlagsRepository;
+import com.openframe.data.service.TenantIdProvider;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -27,25 +28,18 @@ import java.util.Map;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class FeFeatureFlagService {
 
     private static final Duration CACHE_TTL = Duration.ofMinutes(5);
 
     private final FeFeatureFlagProperties properties;
     private final FeFeatureFlagsRepository repository;
-    private final String clusterId;
+    private final TenantIdProvider tenantIdProvider;
 
     private final Cache<String, Map<String, Boolean>> overridesCache = Caffeine.newBuilder()
             .expireAfterWrite(CACHE_TTL)
             .build();
-
-    public FeFeatureFlagService(FeFeatureFlagProperties properties,
-                                FeFeatureFlagsRepository repository,
-                                @Value("${openframe.cluster-id}") String clusterId) {
-        this.properties = properties;
-        this.repository = repository;
-        this.clusterId = clusterId;
-    }
 
     /**
      * Returns the effective flag map (defaults merged with DB overrides).
@@ -64,14 +58,14 @@ public class FeFeatureFlagService {
     }
 
     private Map<String, Boolean> loadOverrides() {
-        return overridesCache.get(clusterId, key -> {
+        return overridesCache.get(tenantIdProvider.getTenantId(), key -> {
             try {
-                return repository.findById(key)
+                return repository.findFirstBy()
                         .map(FeFeatureFlags::getFlags)
                         .filter(m -> !m.isEmpty())
                         .orElse(Collections.emptyMap());
             } catch (Exception e) {
-                log.warn("Failed to load fe_feature_flags overrides for cluster {}: {}", key, e.getMessage());
+                log.warn("Failed to load fe_feature_flags overrides for tenant {}: {}", key, e.getMessage());
                 return Collections.emptyMap();
             }
         });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature flag overrides now resolve per tenant, allowing tenant-specific settings to be applied automatically.

* **Bug Fixes**
  * Improved override lookup so the correct feature-flag document is selected for the active tenant.
  * Added support for tenant-based queries to make feature-flag retrieval more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->