### PR TITLE
feat(types): add hubspot_email_id/hubspot_email_url to ProductRelease

### DIFF
--- a/openframe-frontend-core/src/types/product-release.ts
+++ b/openframe-frontend-core/src/types/product-release.ts
@@ -124,6 +124,12 @@ export interface ProductRelease {
   status: 'draft' | 'published' | 'archived'
   published_at: string | null
   author_id: string | null
+
+  // HubSpot marketing email (mirrors InvestorUpdate). `hubspot_email_id` is the
+  // stored HubSpot email id; `hubspot_email_url` is computed by the admin GET
+  // route from the production portal id (never persisted).
+  hubspot_email_id?: string | null
+  hubspot_email_url?: string | null
   /**
    * Hydrated by `getRelease` (detail) and `getReleases` (list) via
    * `hydrateAuthor` in the hub DAL. Optional so admin form + every existing


### PR DESCRIPTION
## What
Adds two optional fields to the `ProductRelease` type, mirroring `InvestorUpdate`:
- `hubspot_email_id?: string | null` — persisted HubSpot marketing-email id
- `hubspot_email_url?: string | null` — computed by the admin GET route from the production portal id (never persisted)

## Why
Enables the **Product Release Email Creator** in the hub (companion PR), which lets the product-release admin push a release to HubSpot as a marketing email — exactly like investor updates.

## Notes
- Type-only change; no runtime/behavior impact in the lib.
- **Merge order:** this lib PR should merge first; the hub then pins the new lib version (prod/Vercel installs the lib from npm).

Companion hub PR: flamingo-stack/multi-platform-hub `claude/sweet-blackburn-4c4724`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product releases now support additional optional marketing email details, including an email ID and a link to the email.
  * These fields align release records with other update types, helping keep email-related information consistent across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->