### PR TITLE
fix(changelog): render entry title through the markdown renderer

### DIFF
--- a/openframe-frontend-core/src/components/features/entity-summary-editor.tsx
+++ b/openframe-frontend-core/src/components/features/entity-summary-editor.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Sparkles } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { Label } from '../ui/label';
 import { Textarea } from '../ui/textarea';
 import { Badge } from '../ui/badge';
@@ -54,10 +55,7 @@ export function EntitySummaryEditor({
         <div className="flex items-center gap-2">
           <Label htmlFor="entity-summary">{label}</Label>
           {isAIGenerated && (
-            <Badge variant="secondary" className="flex items-center gap-1">
-              <Sparkles className="h-3 w-3" />
-              AI Generated
-            </Badge>
+            <AIGeneratedBadge />
           )}
           {summaryConfidence !== undefined && summaryConfidence !== null && (
             <ConfidenceBadge

--- a/openframe-frontend-core/src/components/features/highlight-video-combined-section.tsx
+++ b/openframe-frontend-core/src/components/features/highlight-video-combined-section.tsx
@@ -2,6 +2,7 @@
 
 import React, { ReactNode } from 'react';
 import { Sparkles, Upload } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { AIEnrichSection } from './ai-enrich';
 import { HighlightConfigSection } from './highlight-config-section';
 import { Label } from '../ui/label';
@@ -193,10 +194,7 @@ export function HighlightVideoCombinedSection({
           <div className="flex items-center gap-2">
             <Label>{previewLabel}</Label>
             {highlightVideoSource === 'ai_generated' && (
-              <Badge variant="secondary" className="flex items-center gap-1">
-                <Sparkles className="h-3 w-3" />
-                AI Generated
-              </Badge>
+              <AIGeneratedBadge />
             )}
             {highlightVideoDurationMs && (
               <Badge variant="outline" className="text-xs">

--- a/openframe-frontend-core/src/components/features/highlight-video-preview.tsx
+++ b/openframe-frontend-core/src/components/features/highlight-video-preview.tsx
@@ -2,6 +2,7 @@
 
 import React, { ReactNode } from 'react';
 import { Upload, Sparkles } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { Label } from '../ui/label';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -80,10 +81,7 @@ export function HighlightVideoPreview({
         <div className="flex items-center gap-2">
           <Label>{label}</Label>
           {highlightVideoSource === 'ai_generated' && (
-            <Badge variant="secondary" className="flex items-center gap-1">
-              <Sparkles className="h-3 w-3" />
-              AI Generated
-            </Badge>
+            <AIGeneratedBadge />
           )}
           {highlightVideoDurationMs && (
             <Badge variant="outline" className="text-xs">

--- a/openframe-frontend-core/src/components/features/highlight-video-section.tsx
+++ b/openframe-frontend-core/src/components/features/highlight-video-section.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { Sparkles, Upload } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { Label } from '../ui/label';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
@@ -195,10 +196,7 @@ export function HighlightVideoSection({
           <div className="flex items-center gap-2">
             <Label>Highlight Video</Label>
             {highlightVideoSource === 'ai_generated' && (
-              <Badge variant="secondary" className="flex items-center gap-1">
-                <Sparkles className="h-3 w-3" />
-                AI Generated
-              </Badge>
+              <AIGeneratedBadge />
             )}
             {highlightVideoDurationMs && (
               <Badge variant="outline" className="text-xs">

--- a/openframe-frontend-core/src/components/features/seo-editor-preview.tsx
+++ b/openframe-frontend-core/src/components/features/seo-editor-preview.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { Input, Textarea, Label, Button, Badge } from '../ui';
 import { ConfidenceBadge } from '../features';
 import { Globe, ExternalLink, Upload, X, Loader2, Sparkles } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { cn } from '../../utils';
 import Image from '../../embed-shims/next-image';
 // SSOT for the field cap (server-safe constant). The seo_title renders as the
@@ -114,10 +115,7 @@ export function SEOEditorPreview({
             </Label>
             {aiConfidenceSeoTitle !== undefined && (
               <>
-                <Badge variant="secondary" className="flex items-center gap-1">
-                  <Sparkles className="h-3 w-3" />
-                  AI Generated
-                </Badge>
+                <AIGeneratedBadge />
                 <ConfidenceBadge
                   confidence={aiConfidenceSeoTitle}
                   showLabel={true}
@@ -165,10 +163,7 @@ export function SEOEditorPreview({
             </Label>
             {aiConfidenceSeoKeywords !== undefined && (
               <>
-                <Badge variant="secondary" className="flex items-center gap-1">
-                  <Sparkles className="h-3 w-3" />
-                  AI Generated
-                </Badge>
+                <AIGeneratedBadge />
                 <ConfidenceBadge
                   confidence={aiConfidenceSeoKeywords}
                   showLabel={true}
@@ -197,10 +192,7 @@ export function SEOEditorPreview({
             </Label>
             {aiConfidenceSeoDescription !== undefined && (
               <>
-                <Badge variant="secondary" className="flex items-center gap-1">
-                  <Sparkles className="h-3 w-3" />
-                  AI Generated
-                </Badge>
+                <AIGeneratedBadge />
                 <ConfidenceBadge
                   confidence={aiConfidenceSeoDescription}
                   showLabel={true}

--- a/openframe-frontend-core/src/components/features/transcript-summary-editor.tsx
+++ b/openframe-frontend-core/src/components/features/transcript-summary-editor.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Sparkles } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { Label } from '../ui/label';
 import { Textarea } from '../ui/textarea';
 import { Badge } from '../ui/badge';
@@ -96,10 +97,7 @@ export function TranscriptSummaryEditor({
           <div className="flex items-center gap-2">
             <Label htmlFor="video-summary">{videoSummaryLabel}</Label>
             {isAIGenerated && (
-              <Badge variant="secondary" className="flex items-center gap-1">
-                <Sparkles className="h-3 w-3" />
-                AI Generated
-              </Badge>
+              <AIGeneratedBadge />
             )}
             {videoSummaryConfidence !== undefined && videoSummaryConfidence !== null && (
               <ConfidenceBadge
@@ -134,10 +132,7 @@ export function TranscriptSummaryEditor({
           <div className="flex items-center gap-2">
             <Label htmlFor="transcript">{transcriptLabel}</Label>
             {isAIGenerated && (
-              <Badge variant="secondary" className="flex items-center gap-1">
-                <Sparkles className="h-3 w-3" />
-                AI Generated
-              </Badge>
+              <AIGeneratedBadge />
             )}
             {transcriptConfidence !== undefined && transcriptConfidence !== null && (
               <ConfidenceBadge

--- a/openframe-frontend-core/src/components/features/video-source-selector.tsx
+++ b/openframe-frontend-core/src/components/features/video-source-selector.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback, useEffect } from 'react';
 import { Upload, Sparkles, X, Video, Loader2 } from 'lucide-react';
+import { AIGeneratedBadge } from '../ui/ai-generated-badge';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -201,10 +202,7 @@ export function VideoSourceSelector({
             <div className="flex items-center gap-2">
               <Label>{uploadLabel}</Label>
               {showAIBadge && isAIGenerated && (
-                <Badge variant="secondary" className="flex items-center gap-1">
-                  <Sparkles className="h-3 w-3" />
-                  AI Generated
-                </Badge>
+                <AIGeneratedBadge />
               )}
             </div>
             <Button

--- a/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
+++ b/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
@@ -402,7 +402,7 @@ export function ReleaseDetailPage({
           isBreaking
           hideTitle
           icon={<AlertTriangle className="h-6 w-6" />}
-          SimpleMarkdownRenderer={MarkdownRenderer}
+          MarkdownRenderer={MarkdownRenderer}
         />
         {/* Features / Bugs / Improvements use `previewFirst` — same
             progressive-disclosure pattern as the investor-update detail
@@ -415,21 +415,21 @@ export function ReleaseDetailPage({
           entries={featuresAdded || []}
           icon={<Sparkles className="h-6 w-6" />}
           previewFirst
-          SimpleMarkdownRenderer={MarkdownRenderer}
+          MarkdownRenderer={MarkdownRenderer}
         />
         <ReleaseChangelogSection
           title="Bugs Fixed"
           entries={bugFixed || []}
           icon={<Wrench className="h-6 w-6" />}
           previewFirst
-          SimpleMarkdownRenderer={MarkdownRenderer}
+          MarkdownRenderer={MarkdownRenderer}
         />
         <ReleaseChangelogSection
           title="Improvements"
           entries={improvements || []}
           icon={<TrendingUp className="h-6 w-6" />}
           previewFirst
-          SimpleMarkdownRenderer={MarkdownRenderer}
+          MarkdownRenderer={MarkdownRenderer}
         />
 
         {/* Video Bites Section - Only when VideoDisplaySection is not handling it */}

--- a/openframe-frontend-core/src/components/ui/ai-generated-badge.tsx
+++ b/openframe-frontend-core/src/components/ui/ai-generated-badge.tsx
@@ -1,0 +1,17 @@
+import { Badge } from './badge';
+import { Sparkles } from 'lucide-react';
+
+/**
+ * Canonical "AI Generated" chip (Sparkles + label). Single source of truth for
+ * every AI-generated indicator across the app — replaces the byte-identical
+ * inline `<Badge variant="secondary"><Sparkles/> AI Generated</Badge>` that was
+ * copy-pasted across the summary / video / SEO editors.
+ */
+export function AIGeneratedBadge({ className }: { className?: string }) {
+  return (
+    <Badge variant="secondary" className={`flex items-center gap-1${className ? ` ${className}` : ''}`}>
+      <Sparkles className="h-3 w-3" />
+      AI Generated
+    </Badge>
+  );
+}

--- a/openframe-frontend-core/src/components/ui/index.ts
+++ b/openframe-frontend-core/src/components/ui/index.ts
@@ -52,6 +52,7 @@ export * from './tab-navigation'
 // Feedback components
 export * from './alert'
 export * from './badge'
+export * from './ai-generated-badge'
 export * from './progress'
 export * from './release-changelog-section'
 export * from './status-badge'

--- a/openframe-frontend-core/src/components/ui/release-changelog-section.tsx
+++ b/openframe-frontend-core/src/components/ui/release-changelog-section.tsx
@@ -165,12 +165,17 @@ function ChangelogEntryList({
     <ul className="space-y-6">
       {entries.map((entry, index) => (
         <li key={index} className="border-l-2 border-ods-border pl-4 ml-0">
-          {/* Entry title — `text-h3` is body family + BOLD weight (per
-              ODS tokens: `--font-h3-weight: var(--font-weight-bold)`)
-              at 14/18px responsive. Same body size as the description
-              below, distinguished by weight — clean visual hierarchy
-              without inflating the body scale. */}
-          <p className="text-h3 text-ods-text-primary mb-2">{entry.title}</p>
+          {/* Entry title — run through the SAME markdown renderer as the
+              description so inline markdown (links like `[label](url)`,
+              emphasis) renders instead of showing as raw text, then pinned
+              back to the `text-h3` body+BOLD scale (per ODS tokens:
+              `--font-h3-weight: var(--font-weight-bold)`, 14/18px responsive)
+              so plain-text titles look exactly as before. `[&_p]:!my-0`
+              strips the renderer's paragraph margins; `mb-2` keeps the gap to
+              the description. */}
+          <div className="text-h3 text-ods-text-primary mb-2 [&_p]:!text-[length:var(--font-size-h3-body)] [&_p]:!leading-[var(--font-line-space-h3-body)] [&_p]:!font-bold [&_p]:!my-0 [&_p+p]:!mt-2">
+            <SimpleMarkdownRenderer content={entry.title} />
+          </div>
           {entry.description && (
             /* Entry description — body text matches the main release
                summary at the SAME 14/18px responsive `text-h4` scale.

--- a/openframe-frontend-core/src/components/ui/release-changelog-section.tsx
+++ b/openframe-frontend-core/src/components/ui/release-changelog-section.tsx
@@ -36,7 +36,7 @@ interface ReleaseChangelogSectionProps {
    *  the lib's `RichMarkdownRenderer` so changelog rich-link previews
    *  (YouTube, OG cards, etc.) work out of the box. Hosts that already
    *  wrap with a Supabase-aware preset can keep passing their own. */
-  SimpleMarkdownRenderer?: React.ComponentType<{ content: string }>;
+  MarkdownRenderer?: React.ComponentType<{ content: string }>;
 }
 
 // Collapsed height for the preview-first mode. ~120px shows the first
@@ -52,7 +52,7 @@ export function ReleaseChangelogSection({
   defaultCollapsed = true,
   previewFirst = false,
   icon,
-  SimpleMarkdownRenderer = RichMarkdownRenderer,
+  MarkdownRenderer = RichMarkdownRenderer,
 }: ReleaseChangelogSectionProps) {
   const [collapsed, setCollapsed] = useState(collapsible ? defaultCollapsed : false);
   const [previewExpanded, setPreviewExpanded] = useState(false);
@@ -126,7 +126,7 @@ export function ReleaseChangelogSection({
                 } : {}),
               }}
             >
-              <ChangelogEntryList entries={entries} SimpleMarkdownRenderer={SimpleMarkdownRenderer} />
+              <ChangelogEntryList entries={entries} MarkdownRenderer={MarkdownRenderer} />
             </div>
             {previewNeedsFade && (
               <button
@@ -142,7 +142,7 @@ export function ReleaseChangelogSection({
             )}
           </div>
         ) : (
-          <ChangelogEntryList entries={entries} SimpleMarkdownRenderer={SimpleMarkdownRenderer} />
+          <ChangelogEntryList entries={entries} MarkdownRenderer={MarkdownRenderer} />
         )
       )}
     </div>
@@ -156,10 +156,10 @@ export function ReleaseChangelogSection({
  */
 function ChangelogEntryList({
   entries,
-  SimpleMarkdownRenderer,
+  MarkdownRenderer,
 }: {
   entries: ChangelogEntry[];
-  SimpleMarkdownRenderer: React.ComponentType<{ content: string }>;
+  MarkdownRenderer: React.ComponentType<{ content: string }>;
 }) {
   return (
     <ul className="space-y-6">
@@ -174,18 +174,18 @@ function ChangelogEntryList({
               strips the renderer's paragraph margins; `mb-2` keeps the gap to
               the description. */}
           <div className="text-h3 text-ods-text-primary mb-2 [&_p]:!text-[length:var(--font-size-h3-body)] [&_p]:!leading-[var(--font-line-space-h3-body)] [&_p]:!font-bold [&_p]:!my-0 [&_p+p]:!mt-2">
-            <SimpleMarkdownRenderer content={entry.title} />
+            <MarkdownRenderer content={entry.title} />
           </div>
           {entry.description && (
             /* Entry description — body text matches the main release
                summary at the SAME 14/18px responsive `text-h4` scale.
-               The `SimpleMarkdownRenderer` forces its own `<p>` typography
+               The `MarkdownRenderer` forces its own `<p>` typography
                which would override `text-h4` on `lg+` viewports and
                inflate the changelog body to 20px. The `[&_p]:!` overrides
                pin every descendant `<p>` back to the h4 responsive tokens
                so the breakpoints stay aligned with the rest of the page. */
             <div className="text-h4 text-ods-text-primary [&_p]:!text-[length:var(--font-size-h4-body)] [&_p]:!leading-[var(--font-line-space-h4-body)] [&_p]:!font-medium">
-              <SimpleMarkdownRenderer content={entry.description} />
+              <MarkdownRenderer content={entry.description} />
             </div>
           )}
         </li>

--- a/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
@@ -36,37 +36,21 @@ export function TableCardSkeleton({
             ROW_HEIGHT_DESKTOP,
             rowClassName
           )}>
-            {columns.map((column) => {
-              // A header-less column is a leading/trailing action (icon) cell —
-              // render a small icon-shaped placeholder instead of a text bar.
-              const isAction = !column.label
-              return (
-                <div
-                  key={column.key}
-                  className={cn(
-                    'flex flex-col justify-center shrink-0',
-                    column.width || 'flex-1'
-                  )}
-                >
-                  {isAction ? (
-                    <div
-                      className={cn(
-                        'h-[18px] w-[18px] bg-ods-bg-surface rounded',
-                        column.align === 'center' ? 'mx-auto' : column.align === 'right' ? 'ml-auto' : ''
-                      )}
-                    />
-                  ) : (
-                    <>
-                      <div className="h-5 bg-ods-bg-surface rounded w-3/4 mb-1" />
-                      {/* second line simulates multi-line content on the primary column */}
-                      {index % 2 === 0 && column.key === primaryKey && (
-                        <div className="h-4 bg-ods-bg-surface rounded w-1/2 opacity-60" />
-                      )}
-                    </>
-                  )}
-                </div>
-              )
-            })}
+            {columns.map((column) => (
+              <div
+                key={column.key}
+                className={cn(
+                  'flex flex-col justify-center shrink-0',
+                  column.width || 'flex-1'
+                )}
+              >
+                <div className="h-5 bg-ods-bg-surface rounded w-3/4 mb-1" />
+                {/* second line simulates multi-line content on the primary column */}
+                {index % 2 === 0 && column.key === primaryKey && (
+                  <div className="h-4 bg-ods-bg-surface rounded w-1/2 opacity-60" />
+                )}
+              </div>
+            ))}
 
             {/* Actions skeleton */}
             {hasActions && (

--- a/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
@@ -16,6 +16,10 @@ export function TableCardSkeleton({
   className,
   rowClassName
 }: TableCardSkeletonProps) {
+  // The multi-line placeholder belongs to the primary text column — the wide,
+  // GROWING one (`flex-1` / `flex-[n]`), not necessarily the first column, which
+  // may be a narrow leading action/icon column. Falls back to the first column.
+  const primaryKey = (columns.find((c) => /flex-(1|\[)/.test(c.width || '')) ?? columns[0])?.key
   return (
     <>
       {Array.from({ length: rows }).map((_, index) => (
@@ -32,21 +36,37 @@ export function TableCardSkeleton({
             ROW_HEIGHT_DESKTOP,
             rowClassName
           )}>
-            {columns.map((column) => (
-              <div
-                key={column.key}
-                className={cn(
-                  'flex flex-col justify-center shrink-0',
-                  column.width || 'flex-1'
-                )}
-              >
-                <div className="h-5 bg-ods-bg-surface rounded w-3/4 mb-1" />
-                {/* Add second line for some columns to simulate multi-line content */}
-                {index % 2 === 0 && column.key === columns[0].key && (
-                  <div className="h-4 bg-ods-bg-surface rounded w-1/2 opacity-60" />
-                )}
-              </div>
-            ))}
+            {columns.map((column) => {
+              // A header-less column is a leading/trailing action (icon) cell —
+              // render a small icon-shaped placeholder instead of a text bar.
+              const isAction = !column.label
+              return (
+                <div
+                  key={column.key}
+                  className={cn(
+                    'flex flex-col justify-center shrink-0',
+                    column.width || 'flex-1'
+                  )}
+                >
+                  {isAction ? (
+                    <div
+                      className={cn(
+                        'h-[18px] w-[18px] bg-ods-bg-surface rounded',
+                        column.align === 'center' ? 'mx-auto' : column.align === 'right' ? 'ml-auto' : ''
+                      )}
+                    />
+                  ) : (
+                    <>
+                      <div className="h-5 bg-ods-bg-surface rounded w-3/4 mb-1" />
+                      {/* second line simulates multi-line content on the primary column */}
+                      {index % 2 === 0 && column.key === primaryKey && (
+                        <div className="h-4 bg-ods-bg-surface rounded w-1/2 opacity-60" />
+                      )}
+                    </>
+                  )}
+                </div>
+              )
+            })}
 
             {/* Actions skeleton */}
             {hasActions && (


### PR DESCRIPTION
## What
`ChangelogEntryList` only markdown-rendered an entry's **description**; the **title** was emitted as plain text (`<p>{entry.title}</p>`). So any markdown in a title rendered raw.

This surfaced on the Who-Am-I **fun facts** (which carry their single-line text in `title`): a fact like `I'm a die-hard [Beitar Jerusalem](https://en.wikipedia.org/wiki/Beitar_Jerusalem_F.C.) fan` showed the literal `[label](url)` instead of a link.

## Change
Render `entry.title` through the same `SimpleMarkdownRenderer` already used for the description, then pin it back to the `text-h3` body+BOLD scale (`--font-size-h3-body` / `--font-line-space-h3-body` / bold) with `[&_p]:!my-0` so **plain-text titles look identical** to before (product releases, investor updates, release detail).

## Risk
Backward-compatible: plain titles render the same text, just wrapped by the markdown renderer + pinned typography. Titles that happen to contain markdown characters now render as markdown (intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable **AI Generated** badge component and standardized its usage across editors and video/preview surfaces.
* **Bug Fixes**
  * Improved changelog entry titles to render rich markdown consistently (including links/emphasis) with heading-like styling that avoids paragraph-layout conflicts.
  * Fixed table skeleton placeholders so the optional second-line placeholder targets the intended primary text column (not always the first).
* **Improvements**
  * Updated changelog sections to consistently use the shared markdown renderer entry point across release detail views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->