### PR TITLE
DashboardInfoCard: decouple percentage style from ring color

### DIFF
--- a/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
@@ -6,6 +6,16 @@ import { CircularProgress, type CircularProgressOverflow, type CircularProgressV
 import { FloatingTooltip } from './floating-tooltip'
 import { Tag } from './tag'
 
+/**
+ * How the percentage is rendered next to the value:
+ * - `'auto'` (default): a colored `Tag` for `warning`/`error` variants, plain
+ *   "(NN%)" text otherwise. Preserves the original coupling to `progressVariant`.
+ * - `'plain'`: always plain "(NN%)" text, regardless of `progressVariant`. Use
+ *   when you want a colored progress ring but a neutral percentage (Figma).
+ * - `'tag'`: always a colored `Tag`.
+ */
+export type DashboardInfoCardPercentageDisplay = 'auto' | 'plain' | 'tag'
+
 export interface DashboardInfoCardProps {
   title?: string
   /** Node rendered in place of the title text. Takes precedence over `title`. */
@@ -14,6 +24,11 @@ export interface DashboardInfoCardProps {
   percentage?: number
   showProgress?: boolean
   progressVariant?: CircularProgressVariant
+  /**
+   * Controls how `percentage` is rendered (Tag vs plain text) independently of
+   * the progress-ring color. Default `'auto'`. See {@link DashboardInfoCardPercentageDisplay}.
+   */
+  percentageDisplay?: DashboardInfoCardPercentageDisplay
   /**
    * How the progress ring treats values over 100. Forwarded to `CircularProgress`.
    * Default: `'clamp'` — existing behavior (clamped to 0–100).
@@ -41,6 +56,7 @@ export function DashboardInfoCard({
   percentage,
   showProgress = false,
   progressVariant,
+  percentageDisplay = 'auto',
   progressOverflow,
   className,
   href,
@@ -51,6 +67,30 @@ export function DashboardInfoCard({
   const formattedValue = typeof value === 'number'
     ? value.toLocaleString()
     : value
+
+  const renderPercentage = () => {
+    if (percentage === undefined) return null
+
+    const asTag =
+      percentageDisplay === 'tag' ||
+      (percentageDisplay === 'auto' && (progressVariant === 'warning' || progressVariant === 'error'))
+
+    if (asTag) {
+      const tagVariant =
+        progressVariant === 'warning' || progressVariant === 'error'
+          ? progressVariant
+          : progressVariant === 'success'
+            ? 'success'
+            : 'grey'
+      return <Tag variant={tagVariant} label={`${percentage}%`} />
+    }
+
+    return (
+      <p className="text-h4 text-ods-text-secondary">
+        ({percentage}%)
+      </p>
+    )
+  }
 
   const cardContent = (
     <>
@@ -73,15 +113,7 @@ export function DashboardInfoCard({
               {subValue}
             </p>
           )}
-          {percentage !== undefined && (
-            progressVariant === 'warning' || progressVariant === 'error' ? (
-              <Tag variant={progressVariant} label={`${percentage}%`} />
-            ) : (
-              <p className="text-h4 text-ods-text-secondary">
-                ({percentage}%)
-              </p>
-            )
-          )}
+          {renderPercentage()}
           {tooltip && (
             <FloatingTooltip content={tooltip} side="top">
               <span className="cursor-help text-ods-text-secondary">

--- a/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
@@ -23,6 +23,11 @@ const meta = {
       options: ['success', 'warning', 'error', 'info', 'accent'],
       description: 'Color variant of the circular progress',
     },
+    percentageDisplay: {
+      control: { type: 'inline-radio' },
+      options: ['auto', 'plain', 'tag'],
+      description: 'How the percentage renders (Tag vs plain text) — independent of the ring color',
+    },
     href: { control: 'text', description: 'Navigation URL — renders as a Next.js Link with pointer cursor' },
     tooltip: { control: 'text', description: 'Tooltip content for the question-mark icon' },
     valueClassName: { control: 'text', description: 'Override className for the value text' },
@@ -228,6 +233,80 @@ export const OverflowComparison: Story = {
       </div>
     ),
   ],
+}
+
+/**
+ * `percentageDisplay="plain"` keeps a colored progress ring while rendering the
+ * percentage as neutral "(NN%)" text — decoupling ring color from the Tag.
+ */
+export const PlainPercentageWithColoredRing: Story = {
+  args: {
+    title: 'Offline Devices',
+    value: 20,
+    percentage: 10,
+    showProgress: true,
+    progressVariant: 'error',
+    percentageDisplay: 'plain',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Red ring (`progressVariant="error"`) with a plain grey "(10%)" instead of a red Tag, because `percentageDisplay="plain"`.',
+      },
+    },
+  },
+}
+
+/**
+ * Four counters with
+ * distinct ring colors (green / red / amber / grey) and plain "(NN%)" text.
+ */
+export const DeviceStatusesOverview: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: '1rem', width: '1100px' }}>
+      <DashboardInfoCard
+        title="Online Devices"
+        value={160}
+        percentage={80}
+        showProgress
+        progressVariant="success"
+        percentageDisplay="plain"
+      />
+      <DashboardInfoCard
+        title="Offline Devices"
+        value={20}
+        percentage={10}
+        showProgress
+        progressVariant="error"
+        percentageDisplay="plain"
+      />
+      <DashboardInfoCard
+        title="Pending Devices"
+        value={14}
+        percentage={7}
+        showProgress
+        progressVariant="warning"
+        percentageDisplay="plain"
+      />
+      <DashboardInfoCard
+        title="Archived Devices"
+        value={6}
+        percentage={3}
+        showProgress
+        progressVariant="info"
+        percentageDisplay="plain"
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Matches the Figma "Devices Overview" — green/red/amber/grey rings with neutral percentages via `percentageDisplay="plain"`.',
+      },
+    },
+  },
 }
 
 /**


### PR DESCRIPTION
## Description
- Add a `percentageDisplay` prop ('auto' | 'plain' | 'tag', default 'auto') so a colored progress ring (warning/error) can render a neutral "(NN%)" instead of being forced into a colored Tag. Default 'auto' preserves the existing behavior (Tag for warning/error, plain otherwise).
-Adds Storybook controls + PlainPercentageWithColoredRing and DeviceStatusesOverview stories.

[Dashboard — Device Statuses update](https://app.clickup.com/t/9013925967/86ahyn0fg)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new display option for dashboard percentage values, letting them appear as automatic, plain text, or tag-style labels.
  * Expanded dashboard examples with new card layouts showing neutral percentage text alongside colored progress rings.

* **Documentation**
  * Updated interactive story controls to showcase the new percentage display options and their visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->