### PR TITLE
DashboardInfoCard: responsive progress-ring size

### DIFF
--- a/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
@@ -16,6 +16,13 @@ import { Tag } from './tag'
  */
 export type DashboardInfoCardPercentageDisplay = 'auto' | 'plain' | 'tag'
 
+/**
+ * Size of the progress ring in px. A single number applies at all breakpoints;
+ * `{ base, lg }` renders a `base`-sized ring below the `lg` breakpoint (e.g.
+ * mobile) and an `lg`-sized ring from `lg` up.
+ */
+export type DashboardInfoCardProgressSize = number | { base: number; lg: number }
+
 export interface DashboardInfoCardProps {
   title?: string
   /** Node rendered in place of the title text. Takes precedence over `title`. */
@@ -35,6 +42,13 @@ export interface DashboardInfoCardProps {
    * Use `'wrap'` for overage/overflow semantics (excess rendered as a red arc).
    */
   progressOverflow?: CircularProgressOverflow
+  /**
+   * Size of the circular progress ring. Defaults to `CircularProgress`'s own
+   * default (56px) at all breakpoints. Pass a number for a fixed size, or
+   * `{ base, lg }` for a responsive ring (e.g. `{ base: 24, lg: 56 }` to match
+   * the Figma mobile spec). Stroke width scales proportionally with the size.
+   */
+  progressSize?: DashboardInfoCardProgressSize
   className?: string
   /**
    * Navigation URL — renders the card as a Next.js Link
@@ -58,6 +72,7 @@ export function DashboardInfoCard({
   progressVariant,
   percentageDisplay = 'auto',
   progressOverflow,
+  progressSize,
   className,
   href,
   tooltip,
@@ -89,6 +104,47 @@ export function DashboardInfoCard({
       <p className="text-h4 text-ods-text-secondary">
         ({percentage}%)
       </p>
+    )
+  }
+
+  const renderProgress = () => {
+    if (!showProgress || percentage === undefined) return null
+
+    // Keep the ring proportionally weighted (10px stroke at the 56px default).
+    const strokeFor = (size: number) => Math.max(2, Math.round((size * 10) / 56))
+
+    const common = {
+      percentage,
+      variant: progressVariant,
+      overflow: progressOverflow,
+      showLabel: false,
+    }
+
+    // Default: preserve the original 56px ring exactly.
+    if (progressSize === undefined) {
+      return <CircularProgress {...common} />
+    }
+
+    if (typeof progressSize === 'number') {
+      return <CircularProgress {...common} size={progressSize} strokeWidth={strokeFor(progressSize)} />
+    }
+
+    // Responsive: smaller ring below `lg`, larger from `lg` up.
+    return (
+      <>
+        <CircularProgress
+          {...common}
+          size={progressSize.base}
+          strokeWidth={strokeFor(progressSize.base)}
+          className="lg:hidden"
+        />
+        <CircularProgress
+          {...common}
+          size={progressSize.lg}
+          strokeWidth={strokeFor(progressSize.lg)}
+          className="hidden lg:block"
+        />
+      </>
     )
   }
 
@@ -125,14 +181,7 @@ export function DashboardInfoCard({
       </div>
 
       {/* Progress indicator */}
-      {showProgress && percentage !== undefined && (
-        <CircularProgress
-          percentage={percentage}
-          variant={progressVariant}
-          overflow={progressOverflow}
-          showLabel={false}
-        />
-      )}
+      {renderProgress()}
     </>
   )
 

--- a/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
@@ -28,6 +28,10 @@ const meta = {
       options: ['auto', 'plain', 'tag'],
       description: 'How the percentage renders (Tag vs plain text) — independent of the ring color',
     },
+    progressSize: {
+      control: { type: 'number' },
+      description: 'Ring diameter in px (number), or `{ base, lg }` for a responsive ring. Default 56.',
+    },
     href: { control: 'text', description: 'Navigation URL — renders as a Next.js Link with pointer cursor' },
     tooltip: { control: 'text', description: 'Tooltip content for the question-mark icon' },
     valueClassName: { control: 'text', description: 'Override className for the value text' },
@@ -272,6 +276,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="success"
         percentageDisplay="plain"
+        progressSize={{ base: 24, lg: 56 }}
       />
       <DashboardInfoCard
         title="Offline Devices"
@@ -280,6 +285,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="error"
         percentageDisplay="plain"
+        progressSize={{ base: 24, lg: 56 }}
       />
       <DashboardInfoCard
         title="Pending Devices"
@@ -288,6 +294,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="warning"
         percentageDisplay="plain"
+        progressSize={{ base: 24, lg: 56 }}
       />
       <DashboardInfoCard
         title="Archived Devices"
@@ -296,6 +303,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="info"
         percentageDisplay="plain"
+        progressSize={{ base: 24, lg: 56 }}
       />
     </div>
   ),
@@ -303,10 +311,40 @@ export const DeviceStatusesOverview: Story = {
     docs: {
       description: {
         story:
-          'Matches the Figma "Devices Overview" — green/red/amber/grey rings with neutral percentages via `percentageDisplay="plain"`.',
+          'Matches the Figma "Devices Overview" — green/red/amber/grey rings with neutral percentages via `percentageDisplay="plain"`, and a responsive ring (`progressSize={{ base: 24, lg: 56 }}`) that is 24px on mobile and 56px from the `lg` breakpoint up.',
       },
     },
   },
+}
+
+/**
+ * `progressSize` controls the ring diameter (stroke scales with it). Left: the
+ * 24px mobile spec. Right: the 56px desktop default. In production pass
+ * `progressSize={{ base: 24, lg: 56 }}` for the responsive switch.
+ */
+export const ProgressSizeComparison: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', width: '600px' }}>
+      <DashboardInfoCard
+        title="Online Devices (24px)"
+        value={160}
+        percentage={80}
+        showProgress
+        progressVariant="success"
+        percentageDisplay="plain"
+        progressSize={24}
+      />
+      <DashboardInfoCard
+        title="Online Devices (56px)"
+        value={160}
+        percentage={80}
+        showProgress
+        progressVariant="success"
+        percentageDisplay="plain"
+        progressSize={56}
+      />
+    </div>
+  ),
 }
 
 /**


### PR DESCRIPTION
## Description
- Add an optional `progressSize` prop (number | { base, lg }). Default is unchanged (56px ring), so existing consumers are unaffected. Passing `{ base: 24, lg: 56 }` renders a 24px ring below the `lg` breakpoint (mobile) and a 56px ring from `lg` up (Figma mobile spec). Stroke width scales proportionally with the size.
- Adds the `progressSize` Storybook control, a ProgressSizeComparison story, and wires the responsive size into DeviceStatusesOverview.

##Task
(Dashboard — Device Statuses update)[https://app.clickup.com/t/9013925967/86ahyn0fg]