### PR TITLE
InfoCard: support optional per-item icon alongside value

### DIFF
--- a/openframe-frontend-core/src/components/ui/info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/info-card.tsx
@@ -29,6 +29,8 @@ export interface InfoCardData {
     label?: string
     value: string | string[]
     copyable?: boolean
+    /** Optional trailing icon/logo (e.g. an SVG) rendered next to the value */
+    icon?: React.ReactNode
   }>
   progress?: {
     value: number
@@ -83,6 +85,7 @@ export function InfoCard({ data, className = '' }: InfoCardProps) {
                   value={val}
                   showLabel={valIndex === 0}
                   copyable={item.copyable}
+                  icon={valIndex === 0 ? item.icon : undefined}
                   copyAriaLabel={`Copy ${item.label ?? 'value'} ${valIndex + 1}`}
                 />
               ))}
@@ -136,10 +139,11 @@ interface InfoCardValueRowProps {
   value: string
   showLabel: boolean
   copyable?: boolean
+  icon?: React.ReactNode
   copyAriaLabel: string
 }
 
-function InfoCardValueRow({ label, value, showLabel, copyable, copyAriaLabel }: InfoCardValueRowProps) {
+function InfoCardValueRow({ label, value, showLabel, copyable, icon, copyAriaLabel }: InfoCardValueRowProps) {
   const { copy, copied } = useCopyToClipboard()
 
   return (
@@ -155,6 +159,7 @@ function InfoCardValueRow({ label, value, showLabel, copyable, copyAriaLabel }: 
         >
           {value}
         </span>
+        {icon}
         {copyable && (
           <button
             type="button"

--- a/openframe-frontend-core/src/stories/InfoCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/InfoCard.stories.tsx
@@ -103,6 +103,28 @@ export const WithCopyableValues: Story = {
   ),
 }
 
+export const WithItemIcon: Story = {
+  args: {
+    data: {
+      items: [
+        { label: 'toolEventId', value: 'fleet_67890abcdef123456' },
+        { label: 'ingestDay', value: '2024-01-20' },
+        {
+          label: 'toolType',
+          value: 'Fleet',
+          icon: <ShieldCheckIcon size={16} className="text-ods-text-secondary" />,
+        },
+        { label: 'severity', value: 'ERROR' },
+      ],
+    },
+  },
+  render: (args) => (
+    <div className="w-96">
+      <InfoCard {...args} />
+    </div>
+  ),
+}
+
 export const WithFooter: Story = {
   args: {
     data: {


### PR DESCRIPTION
## Description
- Add an optional `icon?: ReactNode` to each InfoCardData item, rendered next to the value (shown on the first row for multi-value items). Lets a row pair a string value with an SVG/logo (e.g. a tool badge) without a custom layout.
- Adds a WithItemIcon story.

## Task
(Logs — Fix Wrong Component in Log Details)[https://app.clickup.com/t/9013925967/86agv44u1]