### PR TITLE
DashboardInfoCard: support md breakpoint in responsive progressSize

### DIFF
--- a/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
@@ -17,11 +17,15 @@ import { Tag } from './tag'
 export type DashboardInfoCardPercentageDisplay = 'auto' | 'plain' | 'tag'
 
 /**
- * Size of the progress ring in px. A single number applies at all breakpoints;
- * `{ base, lg }` renders a `base`-sized ring below the `lg` breakpoint (e.g.
- * mobile) and an `lg`-sized ring from `lg` up.
+ * Size of the progress ring in px. A single number applies at all breakpoints.
+ * The responsive form sets `base` (mobile) plus optional `md` / `lg` overrides
+ * that take effect from the Tailwind `md` (768px) / `lg` (1024px) breakpoints
+ * up — e.g. `{ base: 24, md: 56 }` is 24px on mobile and 56px on tablet and
+ * desktop, while `{ base: 24, lg: 56 }` keeps the smaller ring through tablet.
  */
-export type DashboardInfoCardProgressSize = number | { base: number; lg: number }
+export type DashboardInfoCardProgressSize =
+  | number
+  | { base: number; md?: number; lg?: number }
 
 export interface DashboardInfoCardProps {
   title?: string
@@ -45,8 +49,9 @@ export interface DashboardInfoCardProps {
   /**
    * Size of the circular progress ring. Defaults to `CircularProgress`'s own
    * default (56px) at all breakpoints. Pass a number for a fixed size, or
-   * `{ base, lg }` for a responsive ring (e.g. `{ base: 24, lg: 56 }` to match
-   * the Figma mobile spec). Stroke width scales proportionally with the size.
+   * `{ base, md?, lg? }` for a responsive ring (e.g. `{ base: 24, md: 56 }` for
+   * the Figma spec — 24px on mobile, 56px on tablet and desktop). Stroke width
+   * scales proportionally with the size.
    */
   progressSize?: DashboardInfoCardProgressSize
   className?: string
@@ -129,21 +134,38 @@ export function DashboardInfoCard({
       return <CircularProgress {...common} size={progressSize} strokeWidth={strokeFor(progressSize)} />
     }
 
-    // Responsive: smaller ring below `lg`, larger from `lg` up.
+    // Responsive: `base` (mobile) plus optional `md` / `lg` overrides. Each ring
+    // is toggled with Tailwind display utilities so only one shows per breakpoint.
+    // NOTE: the class names must stay static string literals — Tailwind's JIT
+    // scanner can't see dynamically-built names (e.g. `${bp}:hidden`).
+    const { base, md, lg } = progressSize
+
+    const rings: Array<{ key: string; size: number; className: string }> = []
+    if (md !== undefined && lg !== undefined) {
+      rings.push({ key: 'base', size: base, className: 'md:hidden' })
+      rings.push({ key: 'md', size: md, className: 'hidden md:block lg:hidden' })
+      rings.push({ key: 'lg', size: lg, className: 'hidden lg:block' })
+    } else if (md !== undefined) {
+      rings.push({ key: 'base', size: base, className: 'md:hidden' })
+      rings.push({ key: 'md', size: md, className: 'hidden md:block' })
+    } else if (lg !== undefined) {
+      rings.push({ key: 'base', size: base, className: 'lg:hidden' })
+      rings.push({ key: 'lg', size: lg, className: 'hidden lg:block' })
+    } else {
+      rings.push({ key: 'base', size: base, className: '' })
+    }
+
     return (
       <>
-        <CircularProgress
-          {...common}
-          size={progressSize.base}
-          strokeWidth={strokeFor(progressSize.base)}
-          className="lg:hidden"
-        />
-        <CircularProgress
-          {...common}
-          size={progressSize.lg}
-          strokeWidth={strokeFor(progressSize.lg)}
-          className="hidden lg:block"
-        />
+        {rings.map(ring => (
+          <CircularProgress
+            key={ring.key}
+            {...common}
+            size={ring.size}
+            strokeWidth={strokeFor(ring.size)}
+            className={ring.className}
+          />
+        ))}
       </>
     )
   }

--- a/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
     },
     progressSize: {
       control: { type: 'number' },
-      description: 'Ring diameter in px (number), or `{ base, lg }` for a responsive ring. Default 56.',
+      description: 'Ring diameter in px (number), or `{ base, md?, lg? }` for a responsive ring. Default 56.',
     },
     href: { control: 'text', description: 'Navigation URL — renders as a Next.js Link with pointer cursor' },
     tooltip: { control: 'text', description: 'Tooltip content for the question-mark icon' },
@@ -276,7 +276,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="success"
         percentageDisplay="plain"
-        progressSize={{ base: 24, lg: 56 }}
+        progressSize={{ base: 24, md: 56 }}
       />
       <DashboardInfoCard
         title="Offline Devices"
@@ -285,7 +285,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="error"
         percentageDisplay="plain"
-        progressSize={{ base: 24, lg: 56 }}
+        progressSize={{ base: 24, md: 56 }}
       />
       <DashboardInfoCard
         title="Pending Devices"
@@ -294,7 +294,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="warning"
         percentageDisplay="plain"
-        progressSize={{ base: 24, lg: 56 }}
+        progressSize={{ base: 24, md: 56 }}
       />
       <DashboardInfoCard
         title="Archived Devices"
@@ -303,7 +303,7 @@ export const DeviceStatusesOverview: Story = {
         showProgress
         progressVariant="info"
         percentageDisplay="plain"
-        progressSize={{ base: 24, lg: 56 }}
+        progressSize={{ base: 24, md: 56 }}
       />
     </div>
   ),
@@ -311,7 +311,7 @@ export const DeviceStatusesOverview: Story = {
     docs: {
       description: {
         story:
-          'Matches the Figma "Devices Overview" — green/red/amber/grey rings with neutral percentages via `percentageDisplay="plain"`, and a responsive ring (`progressSize={{ base: 24, lg: 56 }}`) that is 24px on mobile and 56px from the `lg` breakpoint up.',
+          'Matches the Figma "Devices Overview" — green/red/amber/grey rings with neutral percentages via `percentageDisplay="plain"`, and a responsive ring (`progressSize={{ base: 24, md: 56 }}`) that is 24px on mobile and 56px on tablet and desktop (from the `md` breakpoint up).',
       },
     },
   },
@@ -320,7 +320,7 @@ export const DeviceStatusesOverview: Story = {
 /**
  * `progressSize` controls the ring diameter (stroke scales with it). Left: the
  * 24px mobile spec. Right: the 56px desktop default. In production pass
- * `progressSize={{ base: 24, lg: 56 }}` for the responsive switch.
+ * `progressSize={{ base: 24, md: 56 }}` for the responsive switch.
  */
 export const ProgressSizeComparison: Story = {
   render: () => (


### PR DESCRIPTION
## Description

DashboardInfoCard progressSize now accepts `{ base, md?, lg? }` so the ring can switch at the Tailwind `md` (768px) breakpoint, not only `lg`. This matches the Figma spec (24px on mobile, 56px on tablet AND desktop) via `{ base: 24, md: 56 }`.

Each ring is toggled with static Tailwind display utilities so the JIT scanner can see them — fixes a bug where a dynamically-built class name (`${bp}:hidden`) was never generated, leaving both rings visible.

Backward compatible: a plain number and `{ base, lg }` behave as before. Storybook DeviceStatusesOverview/controls updated to the md form.

## Task

[Dashboard — Device Statuses update](https://app.clickup.com/t/9013925967/86ahyn0fg)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard info cards now support more flexible responsive progress-ring sizes, including separate settings for medium and large breakpoints.
  * Story examples and usage guidance now reflect the updated responsive sizing behavior.

* **Documentation**
  * Updated component and Storybook guidance to explain the new breakpoint-based progress size options more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->