### PR TITLE
feat(ui-table): opt-in animateRowReorder FLIP prop

### DIFF
--- a/openframe-frontend-core/src/components/ui/table/table-row.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table-row.tsx
@@ -2,6 +2,7 @@
 
 import Link from '../../../embed-shims/next-link'
 import React from 'react'
+import { motion } from 'framer-motion'
 import { cn } from '../../../utils/cn'
 import { Checkbox } from '../checkbox'
 import { TableCell } from './table-cell'
@@ -20,9 +21,17 @@ export function TableRow<T = any>({
   compact,
   selectable,
   selected,
-  onSelect
+  onSelect,
+  animateRowReorder
 }: TableRowProps<T>) {
   const isLinkMode = Boolean(href) && !onClick
+  // Opt-in FLIP: the outer row becomes a `motion.div` that animates only its
+  // position (`layout="position"`) so reordering doesn't distort inner cell
+  // content (CircularProgress / ProgressBar). Plain `<div>` when off — zero cost.
+  const Row: any = animateRowReorder ? motion.div : 'div'
+  const motionProps = animateRowReorder
+    ? { layout: 'position' as const, transition: { layout: { duration: 0.35, ease: [0.22, 1, 0.36, 1] as const } } }
+    : {}
 
   const handleRowClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement
@@ -67,7 +76,8 @@ export function TableRow<T = any>({
   }
 
   return (
-    <div
+    <Row
+      {...motionProps}
       className={cn(
         'relative rounded-[6px] bg-ods-card border border-ods-border overflow-hidden',
         (onClick || isLinkMode) && 'cursor-pointer hover:bg-ods-bg-active transition-colors',
@@ -112,6 +122,6 @@ export function TableRow<T = any>({
           </TableCell>
         ))}
       </div>
-    </div>
+    </Row>
   )
 }

--- a/openframe-frontend-core/src/components/ui/table/table-row.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table-row.tsx
@@ -2,7 +2,6 @@
 
 import Link from '../../../embed-shims/next-link'
 import React from 'react'
-import { motion } from 'framer-motion'
 import { cn } from '../../../utils/cn'
 import { Checkbox } from '../checkbox'
 import { TableCell } from './table-cell'
@@ -22,14 +21,18 @@ export function TableRow<T = any>({
   selectable,
   selected,
   onSelect,
-  animateRowReorder
+  animateRowReorder,
+  motionDiv
 }: TableRowProps<T>) {
   const isLinkMode = Boolean(href) && !onClick
-  // Opt-in FLIP: the outer row becomes a `motion.div` that animates only its
-  // position (`layout="position"`) so reordering doesn't distort inner cell
-  // content (CircularProgress / ProgressBar). Plain `<div>` when off — zero cost.
-  const Row: any = animateRowReorder ? motion.div : 'div'
-  const motionProps = animateRowReorder
+  // Opt-in FLIP: the outer row becomes a `motion.div` (passed down lazily from
+  // Table, so framer-motion stays out of the default bundle) that animates only
+  // its position (`layout="position"`) so reordering doesn't distort inner cell
+  // content (CircularProgress / ProgressBar). Plain `<div>` when off, or until
+  // framer-motion has loaded — zero cost on the default path.
+  const animate = Boolean(animateRowReorder && motionDiv)
+  const Row: any = animate ? motionDiv : 'div'
+  const motionProps = animate
     ? { layout: 'position' as const, transition: { layout: { duration: 0.35, ease: [0.22, 1, 0.36, 1] as const } } }
     : {}
 

--- a/openframe-frontend-core/src/components/ui/table/table.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { type ReactNode, useEffect, useRef } from 'react'
-import { LayoutGroup } from 'framer-motion'
 import { cn } from '../../../utils/cn'
 import { Chevron02RightIcon } from '../../icons-v2-generated'
 import { Pagination } from '../../pagination'
@@ -11,6 +10,7 @@ import { TableEmptyState } from './table-empty-state'
 import { TableHeader } from './table-header'
 import { TableRow } from './table-row'
 import { ROW_HEIGHT_DESKTOP, ROW_HEIGHT_MOBILE, TableCardSkeleton } from './table-skeleton'
+import { useTableMotion } from './use-table-motion'
 import type { RowAction, TableColumn, TableProps } from './types'
 
 /**
@@ -121,6 +121,9 @@ export function Table<T = any>({
   stickyHeaderOffset,
   animateRowReorder,
 }: TableProps<T>) {
+  // Opt-in row-reorder animation: framer-motion is loaded lazily (its own chunk)
+  // ONLY when `animateRowReorder` is set, so the default table stays motion-free.
+  const tableMotion = useTableMotion(Boolean(animateRowReorder))
   const columnsWithActions = injectSyntheticColumns(columns, rowActions, renderRowActions, rowHref)
   const getRowHref = (item: T): string | undefined => {
     if (onRowClick || !rowHref) return undefined
@@ -275,9 +278,13 @@ export function Table<T = any>({
                   selected={isRowSelected(item)}
                   onSelect={handleSelectRow}
                   animateRowReorder={animateRowReorder}
+                  motionDiv={tableMotion?.motionDiv}
                 />
               ))
-              return animateRowReorder ? <LayoutGroup>{rows}</LayoutGroup> : rows
+              // LayoutGroup only once framer-motion has lazily resolved; until
+              // then (and when off) rows render as plain `<div>`s.
+              const LayoutGroup = tableMotion?.LayoutGroup
+              return animateRowReorder && LayoutGroup ? <LayoutGroup>{rows}</LayoutGroup> : rows
             })()}
             {/* Infinite scroll: skeleton rows */}
             {infiniteScroll?.isFetchingNextPage && (

--- a/openframe-frontend-core/src/components/ui/table/table.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { type ReactNode, useEffect, useRef } from 'react'
+import { LayoutGroup } from 'framer-motion'
 import { cn } from '../../../utils/cn'
 import { Chevron02RightIcon } from '../../icons-v2-generated'
 import { Pagination } from '../../pagination'
@@ -118,6 +119,7 @@ export function Table<T = any>({
   infiniteScroll,
   stickyHeader,
   stickyHeaderOffset,
+  animateRowReorder,
 }: TableProps<T>) {
   const columnsWithActions = injectSyntheticColumns(columns, rowActions, renderRowActions, rowHref)
   const getRowHref = (item: T): string | undefined => {
@@ -252,21 +254,31 @@ export function Table<T = any>({
           <TableEmptyState message={emptyMessage} />
         ) : (
           <>
-            {data.map((item, index) => (
-              <TableRow
-                key={getRowKey(item, index)}
-                item={item}
-                columns={columnsWithActions}
-                onClick={onRowClick}
-                href={getRowHref(item)}
-                className={getRowClassName(item, index)}
-                index={index}
-                compact={compact}
-                selectable={selectable}
-                selected={isRowSelected(item)}
-                onSelect={handleSelectRow}
-              />
-            ))}
+            {/* Real data rows. When `animateRowReorder` is on, wrap ONLY these
+                in a `LayoutGroup` so a reorder (same key, new order) animates via
+                FLIP — the invisible placeholder rows below are intentionally left
+                outside it. `AnimatePresence` is not needed here: the row set is
+                stable across a reorder (no enter/exit); add it if a future task
+                animates rows being added/removed. */}
+            {(() => {
+              const rows = data.map((item, index) => (
+                <TableRow
+                  key={getRowKey(item, index)}
+                  item={item}
+                  columns={columnsWithActions}
+                  onClick={onRowClick}
+                  href={getRowHref(item)}
+                  className={getRowClassName(item, index)}
+                  index={index}
+                  compact={compact}
+                  selectable={selectable}
+                  selected={isRowSelected(item)}
+                  onSelect={handleSelectRow}
+                  animateRowReorder={animateRowReorder}
+                />
+              ))
+              return animateRowReorder ? <LayoutGroup>{rows}</LayoutGroup> : rows
+            })()}
             {/* Infinite scroll: skeleton rows */}
             {infiniteScroll?.isFetchingNextPage && (
               <TableCardSkeleton

--- a/openframe-frontend-core/src/components/ui/table/types.ts
+++ b/openframe-frontend-core/src/components/ui/table/types.ts
@@ -151,6 +151,15 @@ export interface TableProps<T = any> {
   stickyHeader?: boolean
   /** Tailwind top class for sticky header offset, e.g. "top-[72px]" */
   stickyHeaderOffset?: string
+
+  /**
+   * Opt-in: render body rows as `motion.div` with `layout="position"` so a data
+   * reorder (same `rowKey`, new order) animates via FLIP. Off by default — all
+   * existing usages are unaffected. Honor `prefers-reduced-motion` at the call
+   * site (pass `false` when reduced motion is requested) so the lib prop stays
+   * purely mechanical and adds zero motion runtime when off.
+   */
+  animateRowReorder?: boolean
 }
 
 /** @deprecated Use types from `data-table` instead. */
@@ -209,6 +218,8 @@ export interface TableRowProps<T = any> {
   selectable?: boolean
   selected?: boolean
   onSelect?: (item: T) => void
+  /** Opt-in FLIP reorder — see `TableProps.animateRowReorder`. Forwarded by `Table`. */
+  animateRowReorder?: boolean
 }
 
 /** @deprecated Use types from `data-table` instead. */

--- a/openframe-frontend-core/src/components/ui/table/types.ts
+++ b/openframe-frontend-core/src/components/ui/table/types.ts
@@ -220,6 +220,12 @@ export interface TableRowProps<T = any> {
   onSelect?: (item: T) => void
   /** Opt-in FLIP reorder — see `TableProps.animateRowReorder`. Forwarded by `Table`. */
   animateRowReorder?: boolean
+  /**
+   * Internal: the lazily-resolved framer-motion `motion.div`, injected by `Table`
+   * so framer-motion stays out of the default bundle. `any` so this module never
+   * statically references framer-motion. Plain `<div>` is used until it's set.
+   */
+  motionDiv?: any
 }
 
 /** @deprecated Use types from `data-table` instead. */

--- a/openframe-frontend-core/src/components/ui/table/use-table-motion.ts
+++ b/openframe-frontend-core/src/components/ui/table/use-table-motion.ts
@@ -30,9 +30,15 @@ export function useTableMotion(enabled: boolean): TableMotionRuntime | null {
   useEffect(() => {
     if (!enabled || runtime) return
     let active = true
-    import('framer-motion').then((m) => {
-      if (active) setRuntime({ motionDiv: m.motion.div, LayoutGroup: m.LayoutGroup })
-    })
+    import('framer-motion')
+      .then((m) => {
+        if (active) setRuntime({ motionDiv: m.motion.div, LayoutGroup: m.LayoutGroup })
+      })
+      .catch(() => {
+        // Chunk-load failure → keep `runtime` null so the table degrades to
+        // plain (non-animated) rows, instead of surfacing an unhandled
+        // promise rejection / global chunk-load error.
+      })
     return () => {
       active = false
     }

--- a/openframe-frontend-core/src/components/ui/table/use-table-motion.ts
+++ b/openframe-frontend-core/src/components/ui/table/use-table-motion.ts
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Framer Motion runtime resolved lazily for the opt-in row-reorder animation.
+ * `motionDiv` is `motion.div`; `LayoutGroup` coordinates the FLIP.
+ */
+export interface TableMotionRuntime {
+  // framer-motion component types are intentionally `any` here so the base table
+  // never has to statically reference framer-motion (keeping it out of the
+  // default bundle).
+  motionDiv: any
+  LayoutGroup: any
+}
+
+/**
+ * Lazily loads `framer-motion` — via a dynamic `import()` so it lands in its own
+ * chunk — ONLY when row-reorder animation is enabled. Consumers that never set
+ * `animateRowReorder` never pull framer-motion into their bundle (the default
+ * `Table`/`TableRow` path stays motion-free).
+ *
+ * Returns `null` until the module resolves (and always when `enabled` is false);
+ * callers render plain DOM in the meantime, so the first paint is non-animated
+ * and the FLIP kicks in once the chunk has loaded.
+ */
+export function useTableMotion(enabled: boolean): TableMotionRuntime | null {
+  const [runtime, setRuntime] = useState<TableMotionRuntime | null>(null)
+
+  useEffect(() => {
+    if (!enabled || runtime) return
+    let active = true
+    import('framer-motion').then((m) => {
+      if (active) setRuntime({ motionDiv: m.motion.div, LayoutGroup: m.LayoutGroup })
+    })
+    return () => {
+      active = false
+    }
+  }, [enabled, runtime])
+
+  return enabled ? runtime : null
+}


### PR DESCRIPTION
## What

Adds an **opt-in, default-off** `animateRowReorder` prop to the (deprecated) `Table` component. When `true`, body rows render as `motion.div` with `layout="position"` inside a `LayoutGroup`, so a data reorder (same `rowKey`, new order) animates via FLIP.

## Why

The People Hub Team screen ([multi-platform-hub] hub#TBD, ClickUp 86aj995vj) loads the employee roster instantly, then merges performance scores in the background and re-sorts by overall score. This prop lets that re-sort animate smoothly instead of snapping.

## Safety

- **Backward compatible**: the prop defaults off; every existing `Table`/`DataTable` usage renders byte-identically (plain `<div>` rows, zero motion runtime).
- **Reduced motion** is honored at the call site (callers pass `false`), keeping the lib prop purely mechanical.
- `layout="position"` animates translation only, so inner cell content (CircularProgress/ProgressBar) isn't distorted.

## Files

- `src/components/ui/table/types.ts` — add `animateRowReorder?: boolean` to `TableProps` + `TableRowProps`
- `src/components/ui/table/table.tsx` — thread the prop, wrap real-data rows in `LayoutGroup`
- `src/components/ui/table/table-row.tsx` — render the outer row as `motion.div` when opted in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in FLIP-style row reorder animation for tables to make row order changes feel smoother.
  * Exposed new table props to enable animated row reordering (with motion support loaded only when needed).

* **Bug Fixes**
  * Improved row movement behavior when rows with the same key reorder.
  * Ensured row checkbox selection wiring remains consistent when interacting with table rows.

* **Documentation**
  * Updated public table and row prop types with new animation-related options and usage notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->