### PR TITLE
[MONGO] Set UTC timezone by default

### DIFF
--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/LocalDateUtcMongoConverters.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/LocalDateUtcMongoConverters.java
@@ -1,0 +1,52 @@
+package com.openframe.data.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * UTC {@link LocalDate} &lt;-&gt; Mongo {@code Date} converters, shared by every config that builds a
+ * {@code MongoCustomConversions}.
+ * <p>
+ * Spring's default JSR-310 converters use {@code ZoneId.systemDefault()}, so the same {@code LocalDate}
+ * is persisted at a different instant by pods in different timezones (UTC stores midnight as
+ * {@code 00:00Z}, CEST as the previous day's {@code 22:00Z} — 2h apart). That made
+ * {@code product_usage_periods} exact-date dedup miss the existing doc and insert duplicate/overlapping
+ * period docs. Pinning to UTC makes every pod encode the same logical date identically.
+ */
+public final class LocalDateUtcMongoConverters {
+
+    private LocalDateUtcMongoConverters() {
+    }
+
+    /** The UTC LocalDate converters, to be added to any {@code MongoCustomConversions}. */
+    public static List<Object> converters() {
+        return List.of(LocalDateToUtcDateConverter.INSTANCE, UtcDateToLocalDateConverter.INSTANCE);
+    }
+
+    @WritingConverter
+    public enum LocalDateToUtcDateConverter implements Converter<LocalDate, Date> {
+        INSTANCE;
+
+        @Override
+        public Date convert(LocalDate source) {
+            return Date.from(source.atStartOfDay(ZoneOffset.UTC).toInstant());
+        }
+    }
+
+    @ReadingConverter
+    public enum UtcDateToLocalDateConverter implements Converter<Date, LocalDate> {
+        INSTANCE;
+
+        @Override
+        public LocalDate convert(Date source) {
+            return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC).toLocalDate();
+        }
+    }
+}

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoInfraConfig.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoInfraConfig.java
@@ -1,8 +1,14 @@
 package com.openframe.data.config;
 
+import com.openframe.data.repository.notification.NotificationContextReadConverter;
+import com.openframe.data.repository.notification.NotificationContextWriteConverter;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
@@ -11,10 +17,37 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
 @Configuration
 @ConditionalOnProperty(name = "spring.data.mongodb.enabled", havingValue = "true", matchIfMissing = false)
 @EnableMongoAuditing
 public class MongoInfraConfig {
+
+    /**
+     * Single source of truth for Mongo custom converters. Always registers UTC {@link LocalDate} &lt;-&gt;
+     * {@code Date} conversion so the same LocalDate is persisted/read identically regardless of the
+     * JVM/container timezone (Spring's default JSR-310 converters use {@code ZoneId.systemDefault()},
+     * which made pods in different zones store the same date 2h apart and produce duplicate
+     * {@code product_usage_periods} docs). Notification-context converters are aggregated here too when
+     * present, replacing the previous standalone MongoCustomConversions.
+     */
+    @Bean
+    public MongoCustomConversions mongoCustomConversions(
+            ObjectProvider<NotificationContextReadConverter> notificationReadConverter,
+            ObjectProvider<NotificationContextWriteConverter> notificationWriteConverter) {
+        List<Object> converters = new ArrayList<>();
+        converters.add(LocalDateToUtcDateConverter.INSTANCE);
+        converters.add(UtcDateToLocalDateConverter.INSTANCE);
+        notificationReadConverter.ifAvailable(converters::add);
+        notificationWriteConverter.ifAvailable(converters::add);
+        return new MongoCustomConversions(converters);
+    }
 
     @Bean
     public MappingMongoConverter mappingMongoConverter(MongoDatabaseFactory factory,
@@ -25,5 +58,25 @@ public class MongoInfraConfig {
         converter.setCustomConversions(conversions);
         converter.setMapKeyDotReplacement("__dot__");
         return converter;
+    }
+
+    @WritingConverter
+    enum LocalDateToUtcDateConverter implements Converter<LocalDate, Date> {
+        INSTANCE;
+
+        @Override
+        public Date convert(LocalDate source) {
+            return Date.from(source.atStartOfDay(ZoneOffset.UTC).toInstant());
+        }
+    }
+
+    @ReadingConverter
+    enum UtcDateToLocalDateConverter implements Converter<Date, LocalDate> {
+        INSTANCE;
+
+        @Override
+        public LocalDate convert(Date source) {
+            return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC).toLocalDate();
+        }
     }
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoInfraConfig.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoInfraConfig.java
@@ -1,14 +1,11 @@
 package com.openframe.data.config;
 
-import com.openframe.data.repository.notification.NotificationContextReadConverter;
-import com.openframe.data.repository.notification.NotificationContextWriteConverter;
-import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.ReadingConverter;
-import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
@@ -17,36 +14,23 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 @Configuration
 @ConditionalOnProperty(name = "spring.data.mongodb.enabled", havingValue = "true", matchIfMissing = false)
+@AutoConfigureBefore(MongoDataAutoConfiguration.class)
 @EnableMongoAuditing
 public class MongoInfraConfig {
 
     /**
-     * Single source of truth for Mongo custom converters. Always registers UTC {@link LocalDate} &lt;-&gt;
-     * {@code Date} conversion so the same LocalDate is persisted/read identically regardless of the
-     * JVM/container timezone (Spring's default JSR-310 converters use {@code ZoneId.systemDefault()},
-     * which made pods in different zones store the same date 2h apart and produce duplicate
-     * {@code product_usage_periods} docs). Notification-context converters are aggregated here too when
-     * present, replacing the previous standalone MongoCustomConversions.
+     * Fallback {@link MongoCustomConversions} that pins UTC {@link java.time.LocalDate} &lt;-&gt; {@code Date}
+     * conversion (see {@link LocalDateUtcMongoConverters}) so dates are stored/read identically regardless
+     * of the JVM/container timezone. Backs off when another config already provides a conversions bean
+     * (e.g. {@code NotificationContextMongoConfig}, which adds the same UTC converters alongside its own),
+     * so there is never a duplicate {@code MongoCustomConversions} bean.
      */
     @Bean
-    public MongoCustomConversions mongoCustomConversions(
-            ObjectProvider<NotificationContextReadConverter> notificationReadConverter,
-            ObjectProvider<NotificationContextWriteConverter> notificationWriteConverter) {
-        List<Object> converters = new ArrayList<>();
-        converters.add(LocalDateToUtcDateConverter.INSTANCE);
-        converters.add(UtcDateToLocalDateConverter.INSTANCE);
-        notificationReadConverter.ifAvailable(converters::add);
-        notificationWriteConverter.ifAvailable(converters::add);
-        return new MongoCustomConversions(converters);
+    @ConditionalOnMissingBean(MongoCustomConversions.class)
+    public MongoCustomConversions mongoCustomConversions() {
+        return new MongoCustomConversions(LocalDateUtcMongoConverters.converters());
     }
 
     @Bean
@@ -58,25 +42,5 @@ public class MongoInfraConfig {
         converter.setCustomConversions(conversions);
         converter.setMapKeyDotReplacement("__dot__");
         return converter;
-    }
-
-    @WritingConverter
-    enum LocalDateToUtcDateConverter implements Converter<LocalDate, Date> {
-        INSTANCE;
-
-        @Override
-        public Date convert(LocalDate source) {
-            return Date.from(source.atStartOfDay(ZoneOffset.UTC).toInstant());
-        }
-    }
-
-    @ReadingConverter
-    enum UtcDateToLocalDateConverter implements Converter<Date, LocalDate> {
-        INSTANCE;
-
-        @Override
-        public LocalDate convert(Date source) {
-            return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC).toLocalDate();
-        }
     }
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/NotificationContextMongoConfig.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/NotificationContextMongoConfig.java
@@ -6,9 +6,6 @@ import com.openframe.data.repository.notification.NotificationContextWriteConver
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
-
-import java.util.List;
 
 @Configuration
 @Import(NotificationContextJacksonConfig.class)
@@ -24,10 +21,6 @@ public class NotificationContextMongoConfig {
         return new NotificationContextWriteConverter(objectMapper);
     }
 
-    @Bean
-    public MongoCustomConversions notificationContextCustomConversions(
-            NotificationContextReadConverter readConverter,
-            NotificationContextWriteConverter writeConverter) {
-        return new MongoCustomConversions(List.of(readConverter, writeConverter));
-    }
+    // The MongoCustomConversions bean is aggregated centrally in MongoInfraConfig (which also adds the
+    // UTC LocalDate converters), so these converters are exposed as plain beans and collected there.
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/NotificationContextMongoConfig.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/NotificationContextMongoConfig.java
@@ -6,6 +6,9 @@ import com.openframe.data.repository.notification.NotificationContextWriteConver
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+
+import java.util.List;
 
 @Configuration
 @Import(NotificationContextJacksonConfig.class)
@@ -21,6 +24,21 @@ public class NotificationContextMongoConfig {
         return new NotificationContextWriteConverter(objectMapper);
     }
 
-    // The MongoCustomConversions bean is aggregated centrally in MongoInfraConfig (which also adds the
-    // UTC LocalDate converters), so these converters are exposed as plain beans and collected there.
+    /**
+     * The {@link MongoCustomConversions} for contexts that import this config standalone (e.g. the
+     * notification integration tests, which don't bring in {@link MongoInfraConfig}). Includes the
+     * notification context converters plus the shared UTC {@link java.time.LocalDate} converters.
+     * In full application contexts this is the single conversions bean; {@code MongoInfraConfig}'s
+     * fallback is {@code @ConditionalOnMissingBean} so the two never collide.
+     */
+    @Bean
+    public MongoCustomConversions notificationContextCustomConversions(
+            NotificationContextReadConverter readConverter,
+            NotificationContextWriteConverter writeConverter) {
+        return new MongoCustomConversions(List.of(
+                readConverter,
+                writeConverter,
+                LocalDateUtcMongoConverters.LocalDateToUtcDateConverter.INSTANCE,
+                LocalDateUtcMongoConverters.UtcDateToLocalDateConverter.INSTANCE));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date handling so calendar values are stored and read consistently in UTC.
  * Consolidated Mongo conversion setup to ensure notification-related data continues to work reliably with the shared configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->