### PR TITLE
feat(chat): preview quick-action prompt in composer on hover/focus

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-quick-action-row.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-quick-action-row.tsx
@@ -21,6 +21,11 @@ export interface QuickActionChip {
   /** `'primary'` = accent (yellow) chip, `'outline'` = bordered chip (default). */
   variant?: 'primary' | 'outline'
   onSelect?: () => void
+  /** Pointer/keyboard focus enters the chip — e.g. preview the full prompt in
+   *  the composer. */
+  onHoverStart?: () => void
+  /** Pointer/keyboard focus leaves the chip — e.g. restore the composer. */
+  onHoverEnd?: () => void
 }
 
 export interface ChatQuickActionRowProps {
@@ -42,6 +47,10 @@ function ChipButton({ chip }: { chip: QuickActionChip }) {
     <button
       type="button"
       onClick={chip.onSelect}
+      onMouseEnter={chip.onHoverStart}
+      onMouseLeave={chip.onHoverEnd}
+      onFocus={chip.onHoverStart}
+      onBlur={chip.onHoverEnd}
       className="shrink-0 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-ods-accent"
     >
       <Tag variant={chip.variant ?? 'outline'} icon={chip.icon} label={chip.label} />

--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -790,6 +790,10 @@ function EmbeddableChatInner({
 
   // Imperative handle to the chat input.
   const chatInputRef = useRef<ChatInputRef | null>(null)
+  // Saved composer draft while a quick-action chip is hovered/focused (its full
+  // prompt is previewed in the composer); restored on hover-end. `null` = not
+  // currently previewing.
+  const quickActionDraftRef = useRef<string | null>(null)
 
   // The slash-command registry (Guide onboarding cards) is loaded via
   // react-query below, after `activeMode` is resolved — gated on Guide mode and
@@ -1685,11 +1689,28 @@ function EmbeddableChatInner({
                     quickActions={
                       guideWelcome?.quickActions ?? guideSuggestedActions
                     }
-                    // Quick-action chips SEND the prompt immediately rather
-                    // than pre-filling the composer (restores the original
-                    // EmbeddableChat behavior + matches the admin "sends" copy).
+                    // Quick-action chips SEND the prompt immediately on click.
                     onQuickAction={(action) => {
+                      // Clear any hover-preview text first so nothing lingers
+                      // in the composer after the message is sent.
+                      quickActionDraftRef.current = null
+                      chatInputRef.current?.setValue('')
                       handleSend(action.prompt ?? action.label)
+                    }}
+                    // Hover/focus PREVIEWS the action's full prompt in the
+                    // composer (the label chip is short; this reveals what will
+                    // be sent). Leaving restores whatever the user had typed.
+                    onQuickActionHover={(action) => {
+                      if (quickActionDraftRef.current === null) {
+                        quickActionDraftRef.current = chatInputRef.current?.getValue() ?? ''
+                      }
+                      chatInputRef.current?.setValue(action.prompt ?? action.label)
+                    }}
+                    onQuickActionHoverEnd={() => {
+                      if (quickActionDraftRef.current !== null) {
+                        chatInputRef.current?.setValue(quickActionDraftRef.current)
+                        quickActionDraftRef.current = null
+                      }
                     }}
                   >
                     {/* Figma node 7363:205938 — single-column slash-command

--- a/openframe-frontend-core/src/components/chat/guide-welcome.tsx
+++ b/openframe-frontend-core/src/components/chat/guide-welcome.tsx
@@ -39,6 +39,11 @@ export interface GuideWelcomeProps {
   quickActions?: ReadonlyArray<GuideQuickAction>
   /** Fired when a quick-action chip (inline or menu) is activated. */
   onQuickAction?: (action: GuideQuickAction) => void
+  /** Pointer/keyboard focus enters a quick-action chip — e.g. preview the
+   *  action's full `prompt` in the composer input. */
+  onQuickActionHover?: (action: GuideQuickAction) => void
+  /** Pointer/keyboard focus leaves the chip — e.g. restore the composer. */
+  onQuickActionHoverEnd?: () => void
   /** Slash-command onboarding list — rendered inside the shared scroll region
    *  below the greeting (so greeting + list scroll together, with edge fades). */
   children?: React.ReactNode
@@ -72,6 +77,8 @@ export function GuideWelcome({
   subtitleLoading = false,
   quickActions = [],
   onQuickAction,
+  onQuickActionHover,
+  onQuickActionHoverEnd,
   children,
   className,
 }: GuideWelcomeProps) {
@@ -106,8 +113,10 @@ export function GuideWelcome({
         id: action.id,
         label: action.label,
         onSelect: () => onQuickAction?.(action),
+        onHoverStart: () => onQuickActionHover?.(action),
+        onHoverEnd: () => onQuickActionHoverEnd?.(),
       })),
-    [quickActions, onQuickAction],
+    [quickActions, onQuickAction, onQuickActionHover, onQuickActionHoverEnd],
   )
 
   return (


### PR DESCRIPTION
## Summary
Guide-mode chat quick-action chips now **preview their full prompt in the composer input on hover/focus**. The chip label is the short title; hovering reveals the longer `prompt` (what will be sent) in the input, and leaving restores whatever the user had typed. Click still sends immediately.

## Changes
- `chat-quick-action-row.tsx` — `QuickActionChip` gains `onHoverStart` / `onHoverEnd`; `ChipButton` wires them to `onMouseEnter`/`onMouseLeave` **and** `onFocus`/`onBlur` (keyboard a11y).
- `guide-welcome.tsx` — `GuideWelcomeProps` gains `onQuickActionHover(action)` / `onQuickActionHoverEnd()`, threaded into the chip items.
- `embeddable-chat.tsx` — wires those to the composer via `chatInputRef.getValue()/setValue()` with a saved-draft ref (preview on hover, restore on leave; click clears the preview before sending).

Inline chips only (the "⋯" overflow-menu items stay click-only). Consumed by the hub's product-hub chat, which already passes `guideWelcome.quickActions` (label + prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick action chips in chat now preview the full prompt in the composer when hovered or focused.
  * Clicking a quick action now sends the selected prompt while restoring any previously typed text afterward.
  * Quick actions now support both mouse and keyboard interactions for the preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->