### PR TITLE
TitleBlock loading skeleton + titleAdornment; InfoCard header/body grouping

### DIFF
--- a/openframe-frontend-core/src/components/layout/page-layout.tsx
+++ b/openframe-frontend-core/src/components/layout/page-layout.tsx
@@ -58,6 +58,11 @@ export interface PageLayoutProps {
   /** Title typography size, forwarded to `TitleBlock`. Default `'h2'` (frozen
    *  baseline). Pass `'h1'` for the unified Help Center pages. */
   titleSize?: 'h1' | 'h2'
+  /** Optional node rendered inline next to the title (e.g. a status `Tag`), forwarded to `TitleBlock`. */
+  titleAdornment?: React.ReactNode
+  /** When true, the title/subtitle render as line-box-accurate skeleton bars (forwarded to
+   *  `TitleBlock`). Header height stays identical to the loaded state — for page skeletons. */
+  loading?: boolean
 }
 
 /**
@@ -80,10 +85,12 @@ export function PageLayout({
   contentClassName,
   showHeader = true,
   titleSize,
+  titleAdornment,
+  loading,
 }: PageLayoutProps) {
   const hasActions = actions && actions.length > 0
   const needsBottomPadding = hasActions && actionsVariant === 'primary-buttons'
-  const hasHeader = showHeader && (title || subtitle || image || backButton || hasActions || selector)
+  const hasHeader = showHeader && (title || subtitle || image || backButton || hasActions || selector || loading)
 
   return (
     <div className={cn('flex flex-col w-full', className)}>
@@ -99,6 +106,8 @@ export function PageLayout({
           selector={selector}
           variant={headerVariant}
           titleSize={titleSize}
+          titleAdornment={titleAdornment}
+          loading={loading}
         />
       )}
 

--- a/openframe-frontend-core/src/components/layout/title-block.tsx
+++ b/openframe-frontend-core/src/components/layout/title-block.tsx
@@ -163,14 +163,14 @@ export function TitleBlock({
               {(loading || title) && (
                 titleAdornment ? (
                   <div className="flex items-center gap-[var(--spacing-system-m)] min-w-0 w-full">
-                    <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{loading ? <TitleTextSkeleton widthClass="w-48 md:w-72" heightClass="h-4 md:h-6" /> : title}</h1>
+                    <h1 className={cn(titleClass, 'text-ods-text-primary truncate min-w-0')} title={title}>{loading ? <TitleTextSkeleton widthClass="w-48 md:w-72" heightClass="h-4 md:h-6" /> : title}</h1>
                     <span className="shrink-0">{titleAdornment}</span>
                   </div>
                 ) : (
                   <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{loading ? <TitleTextSkeleton widthClass="w-48 md:w-72" heightClass="h-4 md:h-6" /> : title}</h1>
                 )
               )}
-              {(loading || subtitle) && (
+              {subtitle && (
                 <p className="text-h6 text-ods-text-secondary truncate" title={subtitle}>{loading ? <TitleTextSkeleton widthClass="w-28 md:w-36" heightClass="h-2.5 md:h-3" /> : subtitle}</p>
               )}
             </div>
@@ -179,7 +179,7 @@ export function TitleBlock({
           title && (
             titleAdornment ? (
               <div className="flex items-center gap-[var(--spacing-system-m)] min-w-0 w-full">
-                <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{title}</h1>
+                <h1 className={cn(titleClass, 'text-ods-text-primary truncate min-w-0')} title={title}>{title}</h1>
                 <span className="shrink-0">{titleAdornment}</span>
               </div>
             ) : (

--- a/openframe-frontend-core/src/components/layout/title-block.tsx
+++ b/openframe-frontend-core/src/components/layout/title-block.tsx
@@ -29,6 +29,15 @@
  * opt the title typography up to `text-h1` (used by the unified Help Center
  * pages). This is additive and default-preserving; do NOT change the default or
  * touch anything else here.
+ *
+ * SANCTIONED EXCEPTION (2026-06, explicit human sign-off): the OPTIONAL
+ * `titleAdornment` and `loading` props. `titleAdornment` renders a node inline
+ * after the title (e.g. a status `Tag`). `loading` swaps ONLY the title/subtitle
+ * TEXT for line-box-accurate skeleton bars (the surrounding `h1`/`p` and their
+ * typography are untouched, so a loading header is pixel-identical in height to
+ * the loaded one — used by page skeletons that render through `PageLayout`).
+ * Both are additive + default-preserving: omit them and every existing caller is
+ * byte-identical. Do NOT change defaults or touch anything else here.
  * ========================================================================== */
 
 import React from 'react'
@@ -70,6 +79,30 @@ export interface TitleBlockProps {
    *  opt the title up to `text-h1` (the unified Help Center pages). Subtitle stays
    *  `text-h6` either way. */
   titleSize?: 'h1' | 'h2'
+  /** Optional node rendered inline, immediately after the title (e.g. a status `Tag`).
+   *  Additive + default-preserving: omit it and every existing caller is byte-identical. */
+  titleAdornment?: React.ReactNode
+  /** When true, the title/subtitle TEXT is replaced by line-box-accurate skeleton bars
+   *  (typography + surrounding markup unchanged, so header height is identical to loaded).
+   *  Additive + default-preserving: omit it and every existing caller is byte-identical. */
+  loading?: boolean
+}
+
+/**
+ * Inline text skeleton — used only in `loading` mode, placed directly inside the real
+ * `h1`/`p`. It is a single `inline-block` bar whose height is intentionally SHORTER than the
+ * typography line-height, and it uses the default baseline alignment. That way the element's
+ * own line-box STRUT (text-h2 → 40px, text-h6 → 20px) sets the height exactly as it would for
+ * real text — the bar fits within the ascent and never inflates the line. So a loading header
+ * is pixel-identical in height to the loaded one. Phrasing-valid (`span` only).
+ */
+function TitleTextSkeleton({ widthClass, heightClass }: { widthClass: string; heightClass: string }) {
+  return (
+    <span
+      aria-hidden
+      className={cn('inline-block max-w-full rounded-md bg-ods-border animate-pulse', widthClass, heightClass)}
+    />
+  )
 }
 
 export function TitleBlock({
@@ -84,6 +117,8 @@ export function TitleBlock({
   variant = 'plain',
   className,
   titleSize = 'h2',
+  titleAdornment,
+  loading,
 }: TitleBlockProps) {
   const hasActions = actions && actions.length > 0
   const hasMenuActions = !!menuActions && menuActions.some(g => g.items.length > 0)
@@ -115,7 +150,7 @@ export function TitleBlock({
             className="hidden md:inline-flex"
           />
         )}
-        {(image || subtitle) ? (
+        {(image || subtitle || loading) ? (
           <div className="flex items-center gap-[var(--spacing-system-m)] min-w-0 w-full">
             {image && (
               <EntityImage
@@ -125,16 +160,32 @@ export function TitleBlock({
               />
             )}
             <div className="flex flex-col justify-center min-w-0 flex-1">
-              {title && (
-                <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{title}</h1>
+              {(loading || title) && (
+                titleAdornment ? (
+                  <div className="flex items-center gap-[var(--spacing-system-m)] min-w-0 w-full">
+                    <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{loading ? <TitleTextSkeleton widthClass="w-48 md:w-72" heightClass="h-4 md:h-6" /> : title}</h1>
+                    <span className="shrink-0">{titleAdornment}</span>
+                  </div>
+                ) : (
+                  <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{loading ? <TitleTextSkeleton widthClass="w-48 md:w-72" heightClass="h-4 md:h-6" /> : title}</h1>
+                )
               )}
-              {subtitle && (
-                <p className="text-h6 text-ods-text-secondary truncate" title={subtitle}>{subtitle}</p>
+              {(loading || subtitle) && (
+                <p className="text-h6 text-ods-text-secondary truncate" title={subtitle}>{loading ? <TitleTextSkeleton widthClass="w-28 md:w-36" heightClass="h-2.5 md:h-3" /> : subtitle}</p>
               )}
             </div>
           </div>
         ) : (
-          title && <h1 className={cn(titleClass, 'text-ods-text-primary')}>{title}</h1>
+          title && (
+            titleAdornment ? (
+              <div className="flex items-center gap-[var(--spacing-system-m)] min-w-0 w-full">
+                <h1 className={cn(titleClass, 'text-ods-text-primary truncate')} title={title}>{title}</h1>
+                <span className="shrink-0">{titleAdornment}</span>
+              </div>
+            ) : (
+              <h1 className={cn(titleClass, 'text-ods-text-primary')}>{title}</h1>
+            )
+          )
         )}
       </div>
 

--- a/openframe-frontend-core/src/components/ui/info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/info-card.tsx
@@ -62,16 +62,21 @@ export function InfoCard({ data, className = '' }: InfoCardProps) {
         {(data.title || data.subtitle) && (
           <div className="flex flex-col items-start self-stretch w-full">
             {data.title && (
-              <div className="flex items-center gap-[var(--spacing-system-xsf)] self-stretch h-6">
-                <span className="text-h4 text-ods-text-primary truncate" title={data.title}>
+              <div className="flex items-center gap-[var(--spacing-system-xsf)] self-stretch">
+                <span className="text-h4 text-ods-text-primary truncate min-w-0" title={data.title}>
                   {data.title}
                 </span>
                 {data.icon}
               </div>
             )}
             {data.subtitle && (
-              <div className="text-h4 text-ods-text-secondary truncate self-stretch h-6" title={data.subtitle}>
-                {data.subtitle}
+              <div className="flex items-center gap-[var(--spacing-system-xsf)] self-stretch">
+                <span className="text-h4 text-ods-text-secondary truncate min-w-0" title={data.subtitle}>
+                  {data.subtitle}
+                </span>
+                {/* Icon lives with the title when present; otherwise it falls to the subtitle so
+                    subtitle-only cards still render it. */}
+                {!data.title && data.icon}
               </div>
             )}
           </div>

--- a/openframe-frontend-core/src/components/ui/info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/info-card.tsx
@@ -55,52 +55,61 @@ export function InfoCard({ data, className = '' }: InfoCardProps) {
         className,
       )}
     >
-      <div className="p-[var(--spacing-system-m)] flex flex-col gap-[var(--spacing-system-s)] items-start w-full">
-        {data.title && (
-          <div className="flex items-center gap-[var(--spacing-system-xsf)] self-stretch h-6">
-            <span className="text-h4 text-ods-text-primary truncate" title={data.title}>
-              {data.title}
-            </span>
-            {data.icon}
+      {/* Header (title + subtitle) and body (rows + progress) are two groups separated by
+          `gap-l`; the title/subtitle stack tightly and the rows use `gap-xs` — matching the ODS
+          "Info-card" design. With no title/subtitle, the body is the only group. */}
+      <div className="p-[var(--spacing-system-m)] flex flex-col gap-[var(--spacing-system-l)] items-start w-full">
+        {(data.title || data.subtitle) && (
+          <div className="flex flex-col items-start self-stretch w-full">
+            {data.title && (
+              <div className="flex items-center gap-[var(--spacing-system-xsf)] self-stretch h-6">
+                <span className="text-h4 text-ods-text-primary truncate" title={data.title}>
+                  {data.title}
+                </span>
+                {data.icon}
+              </div>
+            )}
+            {data.subtitle && (
+              <div className="text-h4 text-ods-text-secondary truncate self-stretch h-6" title={data.subtitle}>
+                {data.subtitle}
+              </div>
+            )}
           </div>
         )}
 
-        {/* Subtitle */}
-        {data.subtitle && (
-          <div className="text-h4 text-ods-text-secondary truncate self-stretch" title={data.subtitle}>
-            {data.subtitle}
+        {(data.items.length > 0 || data.progress) && (
+          <div className="flex flex-col gap-[var(--spacing-system-xs)] items-start self-stretch w-full">
+            {/* Info items */}
+            {data.items.map((item, index) => {
+              const values = Array.isArray(item.value) ? item.value : [item.value]
+
+              return (
+                <React.Fragment key={index}>
+                  {values.map((val, valIndex) => (
+                    <InfoCardValueRow
+                      key={`${index}-${valIndex}`}
+                      label={item.label}
+                      value={val}
+                      showLabel={valIndex === 0}
+                      copyable={item.copyable}
+                      icon={valIndex === 0 ? item.icon : undefined}
+                      copyAriaLabel={`Copy ${item.label ?? 'value'} ${valIndex + 1}`}
+                    />
+                  ))}
+                </React.Fragment>
+              )
+            })}
+
+            {/* Progress bar */}
+            {data.progress && (
+              <ProgressBar
+                progress={data.progress.value}
+                warningThreshold={data.progress.warningThreshold}
+                criticalThreshold={data.progress.criticalThreshold}
+                inverted={data.progress.inverted}
+              />
+            )}
           </div>
-        )}
-
-        {/* Info items */}
-        {data.items.map((item, index) => {
-          const values = Array.isArray(item.value) ? item.value : [item.value]
-
-          return (
-            <React.Fragment key={index}>
-              {values.map((val, valIndex) => (
-                <InfoCardValueRow
-                  key={`${index}-${valIndex}`}
-                  label={item.label}
-                  value={val}
-                  showLabel={valIndex === 0}
-                  copyable={item.copyable}
-                  icon={valIndex === 0 ? item.icon : undefined}
-                  copyAriaLabel={`Copy ${item.label ?? 'value'} ${valIndex + 1}`}
-                />
-              ))}
-            </React.Fragment>
-          )
-        })}
-
-        {/* Progress bar */}
-        {data.progress && (
-          <ProgressBar
-            progress={data.progress.value}
-            warningThreshold={data.progress.warningThreshold}
-            criticalThreshold={data.progress.criticalThreshold}
-            inverted={data.progress.inverted}
-          />
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- **PageLayout / TitleBlock**: add two additive, default-preserving props (documented inline as a sanctioned 2026-06 exception to the frozen chrome):
  - `loading` — swaps title/subtitle text for line-box-accurate skeleton bars while keeping header height pixel-identical to the loaded state (for page skeletons rendered through `PageLayout`).
  - `titleAdornment` — renders a node (e.g. a status `Tag`) inline immediately after the title.
- **InfoCard**: group the header (title/subtitle) and body (info rows / progress) into two blocks with correct ODS spacing (`gap-l` between groups, `gap-xs` within the body), matching the ODS Info-card design.

Both TitleBlock props are byte-identical for existing callers when omitted.

## Notes
- ODS tokens only; no hardcoded colors/spacing.
- Skeleton bars use `bg-ods-border` + `animate-pulse`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page headers can now show an inline title adornment and display a loading state with skeleton text.
  * Info cards now have clearer separation between header content and value/progress content.

* **UI Improvements**
  * Header and title layouts were refined to keep spacing consistent when content is loading.
  * Info cards now render only the sections that have content, reducing unnecessary empty space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->