### PR TITLE
chore(deps-fleetmdm-agent): Skip device-token check in OpenFrame mode

### DIFF
--- a/openframe-management-service-core/src/main/resources/agent-configurations/fleetmdm-agent.json
+++ b/openframe-management-service-core/src/main/resources/agent-configurations/fleetmdm-agent.json
@@ -1,7 +1,7 @@
 {
   "id": "fleetmdm-agent",
   "toolId": "fleetmdm-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "status": "ENABLED",
   "sessionType": "SERVICE",
   "runCommandArgs": [


### PR DESCRIPTION
## Summary by CodeRabbit

* **Chores**
  * Updated the agent configuration version to **0.2.2**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->