### PR TITLE
EmbeddableChat: host-rendered Mingo-mode context banner slot

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -298,6 +298,14 @@ export interface EmbeddableChatProps {
    * the host can clear its queued prompt (which re-arms the one-shot).
    */
   onGuidePromptConsumed?: () => void
+  /**
+   * Host-rendered banner shown as a full-bleed row directly under the panel
+   * header in MINGO mode only (Figma 192:51006) — e.g. a "current page context"
+   * tag naming the entity whose detail page the user is viewing. The host owns
+   * the data + click; pass `null`/return `null` to render nothing. Mirrors the
+   * built-in `GuideModeBanner`, which fills the same slot in Guide mode.
+   */
+  mingoContextBanner?: React.ReactNode
 }
 
 // =============================================================================
@@ -721,6 +729,7 @@ function EmbeddableChatInner({
   renderContextItem,
   guidePendingPrompt,
   onGuidePromptConsumed,
+  mingoContextBanner,
 }: EmbeddableChatProps) {
   // `shell === 'none'` means the consumer hosts us inside their own panel
   // (e.g. AppLayoutDrawer in openframe-frontend). Several drawer-shell
@@ -1597,6 +1606,14 @@ function EmbeddableChatInner({
               {activeMode === 'guide' && hasMingoMode && (
                 <GuideModeBanner className="animate-in fade-in-0 duration-200" />
               )}
+
+              {/* Mingo-mode current-page context banner (Figma 192:51006) —
+                  full-bleed row under the header naming the entity whose detail
+                  page the user is currently viewing, so they can ask Mingo to
+                  recall it. Host-rendered (it reads the host's navigation-context
+                  store) and host-gated to "has an open view"; this slot just
+                  places it, mirroring `GuideModeBanner` above. */}
+              {activeMode === 'mingo' && mingoContextBanner}
 
               {/* Chat-panel row. The dialog history is rendered inline in the
                   Mingo empty state (`<MingoChatHistory>`), so there's no


### PR DESCRIPTION
## Summary
Adds an optional, default-preserving prop to `EmbeddableChat`:

- **`mingoContextBanner?: React.ReactNode`** — a host-rendered, full-bleed row shown directly under the panel header in **MINGO mode only** (Figma 192:51006). For example, a "current page context" tag naming the entity whose detail page the user is viewing, so they can ask Mingo to recall it.

The slot mirrors the built-in `GuideModeBanner`, which fills the same position in Guide mode. The host owns the data and click handling and gates visibility ("has an open view"); this slot just places it. Pass `null` to render nothing.

## Notes
- Additive + default-preserving: omit the prop and every existing caller is unchanged.
- `npm run type-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional banner slot for the embedded chat experience.
  * The banner can now appear directly under the chat header when the chat is in Mingo mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->