### PR TITLE
feat(chat): render configurable identity (name + icon) on chat empty state

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -1026,6 +1026,24 @@ function EmbeddableChatInner({
   const effectiveSuggestedQueries = emptyStateUrl
     ? emptyStateConfig.suggestedQueries
     : suggestedQueries
+  // Structured quick actions (WITH icons) — the primary empty-state chip source
+  // both endpoints emit. Only meaningful in embed mode (`emptyStateUrl` set); in
+  // host mode chips arrive via the `guideWelcome.quickActions` prop instead.
+  const effectiveQuickActions = emptyStateUrl ? emptyStateConfig.quickActions : []
+  // Chat identity (name + icon) — surfaced on the empty state for BOTH agents
+  // (`/api/ai-agents/:slug` → agent's `openframe_ai_agents` identity) AND
+  // platform-driven chats (`/api/docs/empty-state` → `chat_admin_personas`
+  // identity). Null (admin configured none, or a host that omits it) → the
+  // built-in default (Mingo mark + "Mingo Guide"). Host-mode (no
+  // `emptyStateUrl`) still gets identity via the `guideWelcome` prop below.
+  const effectiveAssistantName = emptyStateConfig.name
+  const effectiveAssistantIcon = emptyStateConfig.icon
+  // The panel header needs a plain string. Host-mode passes the name via
+  // `guideWelcome.title` (any ReactNode) rather than the fetch, so fall back to
+  // it when it's a string. Null → header keeps the built-in "Mingo Guide".
+  const headerAssistantName =
+    effectiveAssistantName ??
+    (typeof guideWelcome?.title === 'string' ? guideWelcome.title : null)
 
   const {
     messages: rawMessages,
@@ -1401,13 +1419,28 @@ function EmbeddableChatInner({
   // via the GuideWelcome `onQuickAction` → `handleSend` at the render site (no
   // pre-fill) — restoring the original behavior + the admin "sends" copy.
   const guideSuggestedActions = useMemo(
-    () =>
-      (effectiveSuggestedQueries ?? []).map((q, i) => ({
+    () => {
+      // Prefer the structured quick actions (label + prompt + icon) so embed
+      // chips render icons identically to the host SSR path. Only fall back to
+      // the legacy string-only `suggestedQueries` when no structured chips came
+      // back (older backend, or an admin who configured none).
+      if (effectiveQuickActions.length > 0) {
+        return effectiveQuickActions.map((qa) => ({
+          id: qa.id,
+          label: qa.label,
+          prompt: qa.prompt,
+          iconName: qa.iconName,
+          iconUrl: qa.iconUrl,
+          iconProps: qa.iconProps,
+        }))
+      }
+      return (effectiveSuggestedQueries ?? []).map((q, i) => ({
         id: `suggested-${i}`,
         label: q,
         prompt: q,
-      })),
-    [effectiveSuggestedQueries],
+      }))
+    },
+    [effectiveQuickActions, effectiveSuggestedQueries],
   )
 
   // Dialog-history concerns (archive page, read-only archived conversation,
@@ -1619,7 +1652,7 @@ function EmbeddableChatInner({
                   hasConversation
                     ? activeDialog?.title || 'New Chat'
                     : isGuideEmpty
-                      ? 'Mingo Guide'
+                      ? (headerAssistantName ?? 'Mingo Guide')
                       : 'Current Chats'
                 }
                 backAriaLabel={
@@ -1799,6 +1832,13 @@ function EmbeddableChatInner({
                     // subtitle skeleton instead of flashing empty → text.
                     subtitleLoading={emptyStateLoading}
                     {...guideWelcome}
+                    // Agent identity (name → title, icon → empty-state glyph)
+                    // wins over the host `guideWelcome` spread + built-in
+                    // defaults; falls back to the host value when no agent is
+                    // active. Placed after the spread so resolution is
+                    // deterministic.
+                    title={effectiveAssistantName ?? guideWelcome?.title}
+                    icon={effectiveAssistantIcon ?? guideWelcome?.icon}
                     // Admin "try-asking chips" → Guide quick-action chips. A
                     // host-provided `guideWelcome.quickActions` wins (preserved
                     // via the `??` fallback); placed after the spread so the

--- a/openframe-frontend-core/src/components/chat/guide-welcome.tsx
+++ b/openframe-frontend-core/src/components/chat/guide-welcome.tsx
@@ -37,6 +37,10 @@ function renderQuickActionIcon(a: GuideQuickAction): React.ReactNode {
 export interface GuideWelcomeProps {
   /** Greeting heading. Defaults to "Guide Mode Chat". */
   title?: React.ReactNode
+  /** Optional identity icon (agent mode) — replaces the built-in Mingo mark as
+   *  the empty-state glyph. `{ name | url | props }` resolved via <EntityIcon>.
+   *  Omitted/empty → the default Mingo mark renders. */
+  icon?: { name?: string | null; url?: string | null; props?: Record<string, unknown> | null } | null
   /** Greeting sub-line. No built-in default — when omitted/empty the sub-line
    *  is not rendered, so the empty state shows only the title. Set via the
    *  admin `emptyStateGreeting` (or a host override). */
@@ -87,6 +91,7 @@ const DEFAULT_TITLE = 'Guide Mode Chat'
  */
 export function GuideWelcome({
   title = DEFAULT_TITLE,
+  icon,
   subtitle,
   subtitleLoading = false,
   quickActions = [],
@@ -162,12 +167,18 @@ export function GuideWelcome({
               scroll-viewport-top position regardless of the list height
               beneath them. */}
           <div className="flex flex-1 flex-col items-center gap-[var(--spacing-system-l)] px-[var(--spacing-system-l)] py-[var(--spacing-system-xxl)] text-center">
-            <MingoIcon
-              className="h-12 w-12"
-              color="white"
-              eyesColor="var(--ods-flamingo-cyan-base)"
-              cornerColor="var(--ods-flamingo-cyan-base)"
-            />
+            {icon && (icon.name || icon.url) ? (
+              // Agent-mode identity glyph (chat-config Identity tab). Sized to
+              // match the default Mingo mark (48px).
+              <EntityIcon icon={{ name: icon.name, url: icon.url, props: icon.props }} size={48} />
+            ) : (
+              <MingoIcon
+                className="h-12 w-12"
+                color="white"
+                eyesColor="var(--ods-flamingo-cyan-base)"
+                cornerColor="var(--ods-flamingo-cyan-base)"
+              />
+            )}
             <div className="flex w-full flex-col gap-1">
               <p className="text-h4 text-ods-text-primary">{title}</p>
               {/* Sub-line: while the greeting is still being fetched show a

--- a/openframe-frontend-core/src/components/chat/hooks/use-empty-state-config.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-empty-state-config.ts
@@ -16,21 +16,59 @@
 import { useQuery } from "@tanstack/react-query";
 import { embedAuthedFetch } from "../../../utils/embed-authed-fetch";
 
-/** Wire shape of `GET /api/docs/empty-state`. */
+/** A structured empty-state quick-action chip — `{ id, label, prompt }` plus an
+ *  optional icon (library-glyph name, uploaded URL, or icon props). Mirrors the
+ *  hub's `AiAgentQuickActionChip` / the SSR `guideWelcome.quickActions` shape so
+ *  the fetched (embed) and prop-injected (host) paths render identically. */
+export interface EmptyStateQuickAction {
+  id: string;
+  label: string;
+  prompt: string;
+  iconName?: string | null;
+  iconUrl?: string | null;
+  iconProps?: Record<string, unknown> | null;
+}
+
+/** An identity icon (agent mode) — library-glyph name, uploaded URL, or icon
+ *  props. Resolved via `<EntityIcon>` as the empty-state glyph. */
+export interface EmptyStateIcon {
+  name?: string | null;
+  url?: string | null;
+  props?: Record<string, unknown> | null;
+}
+
+/** Wire shape of `GET /api/docs/empty-state` (and the FLAT agent config from
+ *  `GET /api/ai-agents/[slug]`, a superset). */
 export interface EmptyStateConfig {
+  /** Agent DISPLAY NAME — shown as the empty-state title + panel header. ONLY
+   *  the agent public config (`/api/ai-agents/:slug`) emits this; the platform
+   *  empty-state endpoint does NOT, so a non-agent Guide chat keeps its built-in
+   *  "Guide Mode Chat" / "Mingo Guide" copy. */
+  name: string | null;
+  /** Agent identity ICON — the configurable glyph shown on the empty state.
+   *  Same agent-only provenance as `name`. Null → built-in Mingo mark. */
+  icon: EmptyStateIcon | null;
   /** Admin-edited greeting (`chat_admin_personas.empty_state_greeting`).
    *  Null → caller falls back to the explicit prop / in-code default. */
   greeting: string | null;
   /** Override-aware enabled RAG-table ids — the chip-catalog filter. */
   enabledRagTableIds: string[];
-  /** Admin-curated starter prompts ("Try-asking chips" →
-   *  empty-state quick actions). Empty array when none. */
+  /** Admin-curated quick actions — the empty-state chips WITH icons. This is the
+   *  primary field both endpoints emit; the chat prefers it over
+   *  `suggestedQueries` so embed chips carry icons (matches the host SSR path). */
+  quickActions: EmptyStateQuickAction[];
+  /** Legacy string-only starter prompts (= `quickActions.map(q => q.prompt)` on
+   *  the agent endpoint; absent on the empty-state endpoint). Kept as a fallback
+   *  for older backends that emit only strings. */
   suggestedQueries: string[];
 }
 
 const EMPTY_STATE_FALLBACK: EmptyStateConfig = {
+  name: null,
+  icon: null,
   greeting: null,
   enabledRagTableIds: [],
+  quickActions: [],
   suggestedQueries: [],
 };
 
@@ -66,8 +104,11 @@ export async function fetchEmptyStateConfig(
     }
     const data = (await res.json()) as Partial<EmptyStateConfig> | null;
     return {
+      name: data?.name ?? null,
+      icon: data?.icon ?? null,
       greeting: data?.greeting ?? null,
       enabledRagTableIds: data?.enabledRagTableIds ?? [],
+      quickActions: data?.quickActions ?? [],
       suggestedQueries: data?.suggestedQueries ?? [],
     };
   } catch (err) {

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -11,6 +11,11 @@ export const EP = {
   // chat
   chatStream: `${CONTENT}/docs/chat`,
   commands: `${CONTENT}/docs/commands`,
+  // Guide-mode empty-state config (greeting + enabled RAG tables + quick-action
+  // chips WITH icons). The host injects these at SSR; a cross-origin embedder has
+  // no server hop, so EmbeddableChat fetches them here via
+  // runtime.endpoints.emptyStateUrl. Without this, Guide mode shows no quick actions.
+  emptyState: `${CONTENT}/docs/empty-state`,
   // OpenFrame AI agents (Fae/Mingo) — public per-agent display config. Drives
   // EmbeddableChat "agent mode" via runtime.endpoints.aiAgentConfigUrl.
   aiAgent: (slug: string) => `${CONTENT}/ai-agents/${slug}`,

--- a/react-embedding-example/src/providers/content-runtime.ts
+++ b/react-embedding-example/src/providers/content-runtime.ts
@@ -27,6 +27,10 @@ export function buildChatRuntime(): Omit<ChatRuntime, 'source'> {
       chatStreamUrl: EP.chatStream,
       approvalToolUrl: EP.approval,
       commandsUrl: EP.commands,
+      // Guide-mode empty-state config (greeting + enabled RAG tables + quick-action
+      // chips WITH icons). Injected at SSR in the host; the embedder fetches it here
+      // (see EP.emptyState). Without this, Guide mode renders no quick actions.
+      emptyStateUrl: EP.emptyState,
       // OpenFrame agent-mode: EmbeddableChat fetches the per-agent display config
       // (greeting + suggested prompts + source chips) from here when an
       // `activeAgentSlug` is set. See ask-ai.tsx's agent chooser.


### PR DESCRIPTION
## Render configurable chat identity (name + icon) on the empty state

Companion to hub PR **flamingo-stack/multi-platform-hub#721**. Makes `EmbeddableChat` show the admin-configured assistant **name** (empty-state title + panel header) and **icon** (empty-state glyph) for **both AI agents and platform-driven chats**, falling back to the built-in Mingo default when unconfigured.

### `openframe-frontend-core`
- `EmptyStateConfig` now carries `name` + `icon` + structured `quickActions` (with icons). `guideSuggestedActions` prefers the icon-bearing `quickActions` over the legacy string `suggestedQueries`, so embed chips render icons identically to the host SSR path.
- `GuideWelcome` accepts an identity `icon` prop that replaces the built-in Mingo mark.
- `embeddable-chat` threads name/icon into the title, panel header, and glyph — resolved from the empty-state/agent fetch (embed) or the `guideWelcome` props (host SSR). No `activeAgentSlug` gate, so platform chats get identity too.

### `react-embedding-example`
- Wire `emptyStateUrl` → `/content/api/docs/empty-state` so Guide mode fetches identity + quick actions (previously unwired — Guide mode showed no quick actions at all).

### Notes for reviewers
- The identity/quick-action fields degrade gracefully: any non-2xx or missing field falls back to the built-in defaults.
- Requires the hub PR deployed for the new `name`/`icon` fields to be returned by `/api/docs/empty-state` and `/api/ai-agents/[slug]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced embedded chat empty states with a customizable assistant name, icon, and quick-action chips.
  * Guide mode now shows richer “try asking” suggestions with prompts and icons, when available.

* **Bug Fixes**
  * Improved fallback behavior so the chat header and welcome screen display sensible defaults if custom assistant details are missing.
  * Guide mode now continues to show suggestions reliably even when newer empty-state data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->