### PR TITLE
feat(gateway-service-core): observability for WebSocket session teardown

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClient.java
@@ -1,6 +1,9 @@
 package com.openframe.gateway.config.ws;
 
 import com.openframe.gateway.tenant.TenantRoutingHeaders;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -13,6 +16,7 @@ import reactor.core.publisher.Mono;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -27,32 +31,111 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
 
     @Override
     public Mono<Void> execute(URI url, WebSocketHandler handler) {
-        return decorateConnection(url, null, delegate.execute(url, wrapHandler(url, handler)));
+        AtomicBoolean relayStarted = new AtomicBoolean(false);
+        return decorateConnection(url, null, subFrom(url, null), relayStarted,
+                delegate.execute(url, wrapHandler(url, handler, relayStarted)));
     }
 
     @Override
     public Mono<Void> execute(URI url, HttpHeaders headers, WebSocketHandler handler) {
+        AtomicBoolean relayStarted = new AtomicBoolean(false);
         String tenant = headers != null ? headers.getFirst(TenantRoutingHeaders.TENANT_ID_HEADER) : null;
-        return decorateConnection(url, tenant, delegate.execute(url, headers, wrapHandler(url, handler)));
+        String sub = subFrom(url, headers);
+        return decorateConnection(url, tenant, sub, relayStarted,
+                delegate.execute(url, headers, wrapHandler(url, handler, relayStarted)));
     }
 
     // Upstream connect/finish/failure logging. Gated by the global frame-logging switch rather than a
     // path prefix: this runs at the WebSocketClient level where the URL is the rewritten upstream
     // address, so per-path scoping is not meaningful here (frame logging itself is scoped on the
-    // original request path in WebSocketServiceSecurityDecorator).
-    private Mono<Void> decorateConnection(URI url, String tenant, Mono<Void> connection) {
+    // original request path in WebSocketServiceSecurityDecorator). `sub` (agent machine id) is included
+    // so an abort/relay line can be joined by agent to the client-side "session closed code=…" line.
+    // `relayStarted` flips true once the upstream WS is established (handler.handle invoked): only then is
+    // a peer-closed abort the expected teardown race (DEBUG). The same error BEFORE relay starts is a
+    // genuine connect/handshake failure and must stay WARN.
+    private Mono<Void> decorateConnection(URI url, String tenant, String sub,
+                                          AtomicBoolean relayStarted, Mono<Void> connection) {
         if (!loggingProperties.isFramePayloadLoggingEnabled()) {
             return connection;
         }
         String tnt = tenant == null ? "-" : tenant;
+        String sb = sub == null ? "-" : sub;
         return connection
-                .doOnSubscribe(s -> log.debug("Debug ws upstream connecting url={} tenant={}", url, tnt))
-                .doOnError(e -> log.warn("Debug ws upstream connection FAILED url={} tenant={} : {}",
-                        url, tnt, e.toString(), e))
-                .doOnSuccess(v -> log.debug("Debug ws upstream relay finished url={} tenant={}", url, tnt));
+                .doOnSubscribe(s -> log.debug("Debug ws upstream connecting url={} tenant={} sub={}", url, tnt, sb))
+                .doOnError(e -> {
+                    if (relayStarted.get() && isPeerClosed(e)) {
+                        // Expected teardown race: the upstream WS was relaying, then the peer (agent/tool)
+                        // closed and an in-flight frame could not be delivered. Not a connect failure -> DEBUG.
+                        log.debug("Debug ws upstream relay ended (peer closed) url={} tenant={} sub={} : {}",
+                                url, tnt, sb, e.toString());
+                    } else {
+                        // Pre-relay (connect/handshake) failure, or an unexpected error -> real problem.
+                        log.warn("Debug ws upstream connection FAILED url={} tenant={} sub={} : {}",
+                                url, tnt, sb, e.toString(), e);
+                    }
+                })
+                .doOnSuccess(v -> log.debug("Debug ws upstream relay finished url={} tenant={} sub={}", url, tnt, sb));
     }
 
-    private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler) {
+    /** True when the throwable looks like the peer having already closed the connection. Only decisive
+     *  once relay has started (see {@link #decorateConnection}); the same signature before relay starts is
+     *  treated as a genuine connect/handshake failure and logged at WARN. */
+    static boolean isPeerClosed(Throwable e) {
+        String m = String.valueOf(e);
+        return m.contains("AbortedException")
+                || m.contains("Connection has been closed")
+                || m.contains("Connection reset")
+                || m.contains("prematurely closed");
+    }
+
+    /** Best-effort agent id (JWT {@code sub}) from the forwarded Authorization header, falling back to
+     *  the {@code authorization} query param some tool routes carry. Claims are read WITHOUT verifying
+     *  the signature — for logging/correlation only. Returns null if unavailable. */
+    static String subFrom(URI url, HttpHeaders headers) {
+        String token = bearerToken(headers);
+        if (token == null) {
+            token = queryAuthToken(url);
+        }
+        if (token == null) {
+            return null;
+        }
+        try {
+            String unsigned = token.substring(0, token.lastIndexOf('.') + 1);
+            return claimSub(Jwts.parserBuilder().build().parseClaimsJwt(unsigned).getBody());
+        } catch (ExpiredJwtException ex) {
+            return claimSub(ex.getClaims());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String claimSub(Claims claims) {
+        Object sub = claims == null ? null : claims.get("sub");
+        return sub == null ? null : String.valueOf(sub);
+    }
+
+    private static String bearerToken(HttpHeaders headers) {
+        if (headers == null) {
+            return null;
+        }
+        String auth = headers.getFirst(HttpHeaders.AUTHORIZATION);
+        return (auth != null && auth.startsWith("Bearer ")) ? auth.substring(7) : null;
+    }
+
+    private static String queryAuthToken(URI url) {
+        String query = url == null ? null : url.getRawQuery();
+        if (query == null) {
+            return null;
+        }
+        for (String kv : query.split("&")) {
+            if (kv.startsWith("authorization=")) {
+                return kv.substring("authorization=".length());
+            }
+        }
+        return null;
+    }
+
+    private WebSocketHandler wrapHandler(URI targetUrl, WebSocketHandler handler, AtomicBoolean relayStarted) {
         String target = targetUrl.getPath();
         boolean debugPath = loggingProperties.isDebugPath(target);
 
@@ -64,6 +147,9 @@ public class ProxySessionCleanupWebSocketClient implements WebSocketClient {
 
             @Override
             public Mono<Void> handle(WebSocketSession proxySession) {
+                // Upstream WS established: relay is starting. From here a peer-closed abort is the
+                // expected teardown race (DEBUG), not a connect/handshake failure (WARN).
+                relayStarted.set(true);
                 String sessionId = proxySession.getId();
                 if (debugPath) {
                     log.debug(LOG_PREFIX + "downstream proxy session opened", sessionId, target);

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecorator.java
@@ -126,6 +126,7 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
                                     : -1;
                             String logSub = info != null ? info.sub() : sub;
                             gatewayTrafficMetrics.webSocketClosed(sessionId, path, logSub);
+                            gatewayTrafficMetrics.recordSessionClosed(toolFromPath(path), status.getCode(), lifetimeSec);
                             if (loggingProperties.isDebugPath(path)) {
                                 log.debug(LOG_PREFIX + "session closed code={} reason={} lifetime={}",
                                         sessionId, path, logSub, status.getCode(), status.getReason(), formatLifetime(lifetimeSec));
@@ -143,6 +144,27 @@ public class WebSocketServiceSecurityDecorator implements WebSocketService {
                             disposable.dispose();
                         }
                 );
+    }
+
+    /** Low-cardinality tool label for metrics: meshcentral-server / tactical-rmm / nats / nats-api / other. */
+    static String toolFromPath(String path) {
+        if (path == null) {
+            return "unknown";
+        }
+        String[] p = path.split("/");
+        if (path.startsWith(TOOLS_AGENT_WS_ENDPOINT_PREFIX + "/") && p.length > 4) {
+            return p[4];   // /ws/tools/agent/{tool}/...
+        }
+        if (path.startsWith(TOOLS_API_WS_ENDPOINT_PREFIX + "/") && p.length > 3) {
+            return p[3];   // /ws/tools/{tool}/...
+        }
+        if (path.startsWith(NATS_API_WS_ENDPOINT_PATH)) {
+            return "nats-api";
+        }
+        if (path.startsWith(NATS_WS_ENDPOINT_PATH)) {
+            return "nats";
+        }
+        return "other";
     }
 
     private static String formatLifetime(long totalSeconds) {

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/metrics/GatewayTrafficMetrics.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/metrics/GatewayTrafficMetrics.java
@@ -13,11 +13,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class GatewayTrafficMetrics {
 
     private static final String LOG_PREFIX = "sessionId={} path={} sub={} | ";
+    private static final String CLOSED_COUNTER = "openframe.tenant.gateway.websocket.sessions.closed";
 
     @Getter
     private final AtomicInteger activeWebSocketConnections = new AtomicInteger(0);
 
+    private final MeterRegistry registry;
+
     public GatewayTrafficMetrics(MeterRegistry registry) {
+        this.registry = registry;
         Gauge.builder("openframe.tenant.gateway.websocket.connections.active", activeWebSocketConnections, AtomicInteger::get)
                 .description("Number of active websocket connections on the gateway")
                 .register(registry);
@@ -31,6 +35,38 @@ public class GatewayTrafficMetrics {
     public void webSocketClosed(String sessionId, String path, String sub) {
         int count = activeWebSocketConnections.updateAndGet(v -> v > 0 ? v - 1 : 0);
         log.debug(LOG_PREFIX + "WebSocket closed, active={}", sessionId, path, sub, count);
+    }
+
+    /**
+     * Counts a closed WebSocket session, tagged by tool, WS close code and a coarse lifetime bucket.
+     * Tags are intentionally low-cardinality (no tenant/sub) so this is safe as a time-series metric on
+     * the shared multi-tenant gateway — it surfaces trends like "0s meshcentral flaps rising"; per-tenant
+     * / per-agent drill-down stays in the logs (which carry tenant + sub).
+     */
+    public void recordSessionClosed(String tool, int closeCode, long lifetimeSeconds) {
+        registry.counter(CLOSED_COUNTER,
+                "tool", tool,
+                "code", String.valueOf(closeCode),
+                "lifetime", lifetimeBucket(lifetimeSeconds)).increment();
+    }
+
+    static String lifetimeBucket(long seconds) {
+        if (seconds < 0) {
+            return "unknown";
+        }
+        if (seconds == 0) {
+            return "0s";
+        }
+        if (seconds < 60) {
+            return "<1m";
+        }
+        if (seconds < 600) {
+            return "<10m";
+        }
+        if (seconds < 3600) {
+            return "<1h";
+        }
+        return ">=1h";
     }
 
 }

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClientTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/ProxySessionCleanupWebSocketClientTest.java
@@ -1,0 +1,135 @@
+package com.openframe.gateway.config.ws;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ProxySessionCleanupWebSocketClientTest {
+
+    @Test
+    void isPeerClosed_trueForTeardownRaces() {
+        assertThat(ProxySessionCleanupWebSocketClient.isPeerClosed(new RuntimeException(
+                "reactor.netty.channel.AbortedException: Connection has been closed BEFORE send operation"))).isTrue();
+        assertThat(ProxySessionCleanupWebSocketClient.isPeerClosed(
+                new java.io.IOException("Connection reset by peer"))).isTrue();
+    }
+
+    @Test
+    void isPeerClosed_falseForRealConnectFailure() {
+        assertThat(ProxySessionCleanupWebSocketClient.isPeerClosed(
+                new java.net.ConnectException("Connection refused"))).isFalse();
+    }
+
+    @Test
+    void subFrom_readsBearerHeader() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + unsignedJwt("agent_x"));
+
+        assertThat(ProxySessionCleanupWebSocketClient.subFrom(URI.create("ws://h/agent.ashx"), headers))
+                .isEqualTo("agent_x");
+    }
+
+    @Test
+    void subFrom_fallsBackToQueryParam() {
+        URI url = URI.create("ws://h/natsws?authorization=" + unsignedJwt("agent_q"));
+
+        assertThat(ProxySessionCleanupWebSocketClient.subFrom(url, new HttpHeaders())).isEqualTo("agent_q");
+    }
+
+    @Test
+    void subFrom_nullWhenAbsent() {
+        assertThat(ProxySessionCleanupWebSocketClient.subFrom(URI.create("ws://h/x"), new HttpHeaders())).isNull();
+    }
+
+    // --- relayStarted gating: a peer-closed error is only the expected teardown race (DEBUG) once the
+    //     upstream WS is relaying; the same error during connect/handshake is a real failure (WARN). ---
+
+    private static final URI MESH_URL = URI.create("ws://mesh/tenant-x/agent.ashx");
+    private static final String PEER_ABORT =
+            "reactor.netty.channel.AbortedException: Connection has been closed BEFORE send operation";
+
+    private Logger clientLogger;
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void attachAppender() {
+        clientLogger = (Logger) LoggerFactory.getLogger(ProxySessionCleanupWebSocketClient.class);
+        clientLogger.setLevel(Level.DEBUG);
+        appender = new ListAppender<>();
+        appender.start();
+        clientLogger.addAppender(appender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        clientLogger.detachAppender(appender);
+    }
+
+    @Test
+    void peerClosedBeforeRelayStarts_logsWarn() {
+        // Delegate fails during connect/handshake: the wrapped handler is never invoked -> relayStarted stays false.
+        WebSocketClient delegate = mock(WebSocketClient.class);
+        when(delegate.execute(any(), any(HttpHeaders.class), any()))
+                .thenReturn(Mono.error(new RuntimeException(PEER_ABORT)));
+
+        client(delegate).execute(MESH_URL, new HttpHeaders(), session -> Mono.empty())
+                .onErrorResume(e -> Mono.empty()).block();
+
+        assertThat(levelOf("connection FAILED")).isEqualTo(Level.WARN);
+    }
+
+    @Test
+    void peerClosedAfterRelayStarts_logsDebug() {
+        // Delegate starts the relay (invokes the wrapped handler) and then the peer aborts mid-relay.
+        WebSocketSession upstream = mock(WebSocketSession.class);
+        when(upstream.getId()).thenReturn("up-1");
+        WebSocketClient delegate = mock(WebSocketClient.class);
+        when(delegate.execute(any(), any(HttpHeaders.class), any())).thenAnswer(invocation -> {
+            WebSocketHandler wrapped = invocation.getArgument(2);
+            return wrapped.handle(upstream).then(Mono.error(new RuntimeException(PEER_ABORT)));
+        });
+
+        client(delegate).execute(MESH_URL, new HttpHeaders(), session -> Mono.empty())
+                .onErrorResume(e -> Mono.empty()).block();
+
+        assertThat(levelOf("relay ended (peer closed)")).isEqualTo(Level.DEBUG);
+    }
+
+    private static ProxySessionCleanupWebSocketClient client(WebSocketClient delegate) {
+        WebSocketLoggingProperties props = new WebSocketLoggingProperties();
+        props.setFramePayloadLoggingEnabled(true);
+        return new ProxySessionCleanupWebSocketClient(delegate, props, false);
+    }
+
+    private Level levelOf(String messageSubstring) {
+        return appender.list.stream()
+                .filter(e -> e.getFormattedMessage().contains(messageSubstring))
+                .map(ILoggingEvent::getLevel)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no log line containing \"" + messageSubstring + "\" — saw: " + appender.list));
+    }
+
+    // Unsecured JWT (alg=none) — subFrom reads claims without verifying the signature.
+    private static String unsignedJwt(String sub) {
+        return Jwts.builder().setSubject(sub).compact();
+    }
+}

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecoratorTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/config/ws/WebSocketServiceSecurityDecoratorTest.java
@@ -55,6 +55,16 @@ class WebSocketServiceSecurityDecoratorTest {
         assertThat(proxied).isNotInstanceOf(LoggingWebSocketSessionDecorator.class);
     }
 
+    @Test
+    void toolFromPath_extractsLowCardinalityToolLabel() {
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/tools/agent/meshcentral-server/agent.ashx")).isEqualTo("meshcentral-server");
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/tools/agent/tactical-rmm/natsws")).isEqualTo("tactical-rmm");
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/tools/meshcentral-server/meshrelay.ashx")).isEqualTo("meshcentral-server");
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/nats-api")).isEqualTo("nats-api");
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/nats")).isEqualTo("nats");
+        assertThat(WebSocketServiceSecurityDecorator.toolFromPath("/ws/other")).isEqualTo("other");
+    }
+
     private WebSocketSession handleAndCaptureProxiedSession(WebSocketLoggingProperties props, String requestPath) {
         WebSocketService defaultService = mock(WebSocketService.class);
         RequestJwtClaimsReader jwtReader = mock(RequestJwtClaimsReader.class);

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/metrics/GatewayTrafficMetricsTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/metrics/GatewayTrafficMetricsTest.java
@@ -1,0 +1,36 @@
+package com.openframe.gateway.metrics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GatewayTrafficMetricsTest {
+
+    @Test
+    void lifetimeBucketBoundaries() {
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(-1)).isEqualTo("unknown");
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(0)).isEqualTo("0s");     // the flap bucket
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(59)).isEqualTo("<1m");
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(60)).isEqualTo("<10m");
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(599)).isEqualTo("<10m");
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(3599)).isEqualTo("<1h");
+        assertThat(GatewayTrafficMetrics.lifetimeBucket(3600)).isEqualTo(">=1h");
+    }
+
+    @Test
+    void recordSessionClosedIncrementsTaggedCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        GatewayTrafficMetrics metrics = new GatewayTrafficMetrics(registry);
+
+        metrics.recordSessionClosed("meshcentral-server", 1002, 0);
+        metrics.recordSessionClosed("meshcentral-server", 1002, 0);
+
+        double count = registry.get("openframe.tenant.gateway.websocket.sessions.closed")
+                .tag("tool", "meshcentral-server")
+                .tag("code", "1002")
+                .tag("lifetime", "0s")
+                .counter().count();
+        assertThat(count).isEqualTo(2.0);
+    }
+}


### PR DESCRIPTION
## Description

Follow-up observability for the WebSocket relay, from the 12h gateway log analysis (one tenant's MeshCentral agents were flapping with 0-second sessions, and it was hard to see **which** agents and **why**). Makes teardown diagnosable and cuts misleading noise. No behavior change to the relay itself.

## Improvements

- **Agent id in relay/abort logs.** Add `sub` (machine id, parsed best-effort from the forwarded `Authorization` header / `?authorization=` query) to the upstream connect / relay-ended / failed lines, so they can be joined **by agent** to the client-side `session closed code=…` line.
- **Right level for teardown races.** Classify `AbortedException` / connection reset / "connection has been closed" as **DEBUG** `relay ended (peer closed)`; keep genuine upstream connect failures at **WARN** with stack. Removes the misleading "connection FAILED" WARN spam (2k+/12h in the sample).
- **Close-session metric.** New counter `openframe.tenant.gateway.websocket.sessions.closed` tagged by `tool` / `code` / `lifetime` bucket (`0s` / `<1m` / `<10m` / `<1h` / `>=1h`), recorded from `WebSocketServiceSecurityDecorator` on close. Deliberately **low-cardinality** (no tenant/sub) so it's safe as a time series on the shared multi-tenant gateway — the `0s` bucket is the flap signal; per-tenant/agent drill-down stays in the logs.
- **Tests:** lifetime buckets + tagged counter, `isPeerClosed` classification, `sub` extraction (header / query / absent), `toolFromPath` labelling. 29 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket session-closure metrics, including close code and coarse lifetime buckets.
  * Enhanced WebSocket connection logs with additional identity context derived from authorization data.
  * Improved low-cardinality tool labeling based on request paths.
* **Bug Fixes**
  * Reduced noisy upstream error logging for expected peer-closure race conditions.
* **Tests**
  * Added unit tests for identity extraction, tool labeling, session-closed metrics, and lifetime bucketing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->