### PR TITLE
fix(gateway): use unpooled connection for WebSocket upstreams

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/.NettySocketConfig.md
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/.NettySocketConfig.md
@@ -7,11 +7,13 @@ Configures Netty socket options for the OpenFrame API Gateway, applying low-late
 |------|------|---------|
 | `nettyServerCustomizer` | `WebServerFactoryCustomizer` | Applies socket options to the embedded Netty server for inbound connections |
 | `gatewayHttpClientCustomizer` | `HttpClientCustomizer` | Applies socket options to the Spring Cloud Gateway outbound HTTP client |
-| `reactorNettyWebSocketClient` | `WebSocketClient` | Creates a `ReactorNettyWebSocketClient` with the same TCP tuning for WebSocket proxying |
+| `reactorNettyWebSocketClient` | `WebSocketClient` | Creates a `ReactorNettyWebSocketClient` over an **unpooled** `HttpClient` (fresh connection per handshake), with `TCP_NODELAY` but **without** `SO_LINGER=0`, for WebSocket proxying |
 
-**Socket options applied across all three beans:**
-- `SO_LINGER = 0` — Immediately resets connections on close, avoiding `TIME_WAIT` buildup
-- `TCP_NODELAY = true` — Disables Nagle's algorithm for lower latency on small packets
+**Socket options:**
+- `TCP_NODELAY = true` — Disables Nagle's algorithm for lower latency on small packets (all three beans)
+- `SO_LINGER = 0` — Immediately resets connections on close, avoiding `TIME_WAIT` buildup (`nettyServerCustomizer` and `gatewayHttpClientCustomizer` only)
+
+The `reactorNettyWebSocketClient` intentionally differs: it uses an unpooled provider (`ConnectionProvider.newConnection()`) and omits `SO_LINGER=0`. WebSocket upstreams (MeshCentral, NATS) are long-lived and dedicated per session, so pooling only risks handing out an idle connection the upstream already closed (`AbortedException: Connection has been closed BEFORE send operation`); a fresh connection per handshake plus a graceful FIN close avoids that.
 
 ## Usage Example
 
@@ -43,4 +45,4 @@ public class CustomNettySocketConfig extends NettySocketConfig {
 }
 ```
 
-> **Note:** `SO_LINGER = 0` is intentional for gateway workloads — it prevents file-descriptor exhaustion under high connection churn. Adjust only if upstream services require graceful FIN-based teardown.
+> **Note:** `SO_LINGER = 0` on the inbound server and outbound HTTP client beans is intentional for gateway workloads — it prevents file-descriptor exhaustion under high connection churn. The WebSocket client bean deliberately omits it (and connection pooling) because its upstreams require graceful FIN-based teardown and must never reuse a stale pooled connection.

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/NettySocketConfig.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/NettySocketConfig.java
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
 import org.springframework.web.reactive.socket.client.WebSocketClient;
 import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 @Slf4j
 @Configuration
@@ -33,8 +34,8 @@ public class NettySocketConfig {
 
     @Bean("reactorNettyWebSocketClient")
     public WebSocketClient reactorNettyWebSocketClient() {
-        HttpClient httpClient = HttpClient.create()
-                .option(ChannelOption.SO_LINGER, 0)
+        // Unpooled + graceful close: WS upstreams are long-lived per session; a pooled, non-evicted idle connection can be handed out already closed (AbortedException before send), and SO_LINGER=0 would RST it.
+        HttpClient httpClient = HttpClient.create(ConnectionProvider.newConnection())
                 .option(ChannelOption.TCP_NODELAY, true);
         return new ReactorNettyWebSocketClient(httpClient);
     }


### PR DESCRIPTION
> **Draft** — posting for review of the approach + the `SO_LINGER` question. Not urgent to merge; CI needs to validate the build.

## Problem

Agents (MeshCentral meshagent) and NATS clients across multiple tenants are stuck in a WebSocket reconnect loop. Client logs show `Connection FAILED: No HTTP response` / `Network timeout` at ~once/minute for hours; REST auth on the same clients succeeds (`agent_auth_service: Successfully authenticated using refresh token`), so it is **WebSocket-specific**, not connectivity or credentials.

Gateway logs (12h, tenant `tenant-010-15`) show the WS upstream bridge failing:
- **2094×** `Debug ws upstream connection FAILED url=ws://meshcentral…:8383/…/agent.ashx : reactor.netty.channel.AbortedException: Connection has been closed BEFORE send operation`
- **231×** the same to `ws://nats…`
- **859×** `Cannot enable websocket if headers have already been sent`

MeshCentral received 4882 upgrades but only 2746 delivered a first frame — connections upgrade then die immediately.

## Root cause (confirmed in config)

`NettySocketConfig.reactorNettyWebSocketClient()` built the WS upstream client with:

```java
HttpClient httpClient = HttpClient.create()          // shared pool, NO idle eviction
        .option(ChannelOption.SO_LINGER, 0)          // abortive close = RST
        .option(ChannelOption.TCP_NODELAY, true);
```

- `HttpClient.create()` uses Reactor Netty's default pool with **`maxIdleTime` / `maxLifeTime` / `evictInBackground` all unset** → idle connections are never evicted. MeshCentral (`agentidletimeout` ≈ 150s) and NATS close idle connections server-side, so the pool hands out a socket the upstream already closed → **`AbortedException: Connection has been closed BEFORE send operation`** on the first relayed frame.
- It also bypasses the `spring.cloud.gateway.httpclient` tuning (that only applies to the SCG-managed client), so the WS path can't be fixed via yaml.
- `SO_LINGER=0` makes every close an abortive **RST**, which the agent surfaces as `No HTTP response` (reset, no HTTP reply) rather than a clean close.

REST survives the same pool because WebClient/Reactor Netty retry idempotent requests on a reset; the WS retry (`FluxRetryWhen`) instead re-runs after the client upgrade has started → `Cannot enable websocket if headers have already been sent`.

## Fix

```java
HttpClient httpClient = HttpClient.create(ConnectionProvider.newConnection())  // fresh connection per handshake
        .option(ChannelOption.TCP_NODELAY, true);
```

WebSocket upstreams are long-lived and dedicated per session — pooling gives no benefit and is the sole source of the staleness. A fresh connection per handshake eliminates the stale-reuse `AbortedException`. Dropping `SO_LINGER=0` lets the upstream close gracefully (FIN) instead of RST.

### Alternative considered
Keep pooling but add a dedicated `ConnectionProvider` with `maxIdleTime` (< MeshCentral's ~150s) + `evictInBackground`. Rejected as more complex for zero pooling benefit on WS — happy to switch if preferred.

## Open question for reviewers (the `SO_LINGER` review)
This PR only removes `SO_LINGER=0` from the **WS client**. The same option is also set on the inbound server child channel (`nettyServerCustomizer`) and the REST client customizer (`gatewayHttpClientCustomizer`). Removing it from the inbound server side would make agent-facing closes graceful FINs instead of RSTs — arguably cleaner, but broader blast radius, so I left those untouched here. Let me know if we want a follow-up.

## Testing
- No local JVM/Maven in my env — relying on CI to build.
- Recommended validation: watch gateway logs for `AbortedException: Connection has been closed BEFORE send operation` (should drop to ~0) and MeshCentral `first-frame / upgrade` ratio (should approach 1.0) for tenant `tenant-010-15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling for more reliable, graceful disconnects.
  * Kept low-latency socket settings in place while updating the underlying connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->