### PR TITLE
Fix: Status Propagation | Relay Format for initiatorIds and authorIds.

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/ScriptDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/ScriptDataFetcher.java
@@ -77,9 +77,10 @@ public class ScriptDataFetcher {
             @InputArgument Integer last,
             @InputArgument String before) {
 
-        // tagIds arrive as Tag global ids — decode to raw before filtering.
+        // tagIds / authorIds arrive as Relay global ids (Tag / User) — decode to raw before filtering.
         if (filter != null) {
             filter.setTagIds(decodeIds(filter.getTagIds()));
+            filter.setAuthorIds(decodeIds(filter.getAuthorIds()));
         }
         ConnectionArgs args = ConnectionArgs.builder()
                 .first(first).after(after).last(last).before(before)
@@ -94,6 +95,7 @@ public class ScriptDataFetcher {
     public ScriptFilters scriptFilters(@InputArgument @Valid ScriptFilterInput filter) {
         if (filter != null) {
             filter.setTagIds(decodeIds(filter.getTagIds()));
+            filter.setAuthorIds(decodeIds(filter.getAuthorIds()));
         }
         return scriptFilterService.getScriptFilters(filter);
     }

--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcher.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.dataloader.DataLoader;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -72,6 +73,10 @@ public class ScriptExecutionDataFetcher {
             @InputArgument Integer last,
             @InputArgument String before) {
 
+        // initiatorIds arrive as User Relay global ids — decode to raw before filtering.
+        if (filter != null) {
+            filter.setInitiatorIds(decodeIds(filter.getInitiatorIds()));
+        }
         ConnectionArgs args = ConnectionArgs.builder()
                 .first(first).after(after).last(last).before(before)
                 .build();
@@ -86,11 +91,19 @@ public class ScriptExecutionDataFetcher {
             @InputArgument @NotBlank String scriptId,
             @InputArgument ScriptExecutionFilterInput filter,
             @InputArgument String search) {
+        // initiatorIds arrive as User Relay global ids — decode to raw before filtering.
+        if (filter != null) {
+            filter.setInitiatorIds(decodeIds(filter.getInitiatorIds()));
+        }
         return scriptExecutionFilterService.getExecutionFilters(decodeId(scriptId), filter, search);
     }
 
     private static String decodeId(String globalId) {
         return globalId == null ? null : RELAY.fromGlobalId(globalId).getId();
+    }
+
+    private static List<String> decodeIds(List<String> globalIds) {
+        return globalIds == null ? null : globalIds.stream().map(ScriptExecutionDataFetcher::decodeId).toList();
     }
 
     @DgsData(parentType = "ScriptExecution", field = "initiator")

--- a/openframe-api-service-core/src/main/resources/schema/script-execution.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/script-execution.graphqls
@@ -36,7 +36,7 @@ enum ScriptExecutionStatus {
 input ScriptExecutionFilterInput {
     statuses: [ScriptExecutionStatus!]
     initiatorIds: [ID!]
-    machineIds: [ID!]
+    machineIds: [String!]
 }
 
 type ScriptExecution implements Node {

--- a/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptDataFetcherTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptDataFetcherTest.java
@@ -135,11 +135,11 @@ class ScriptDataFetcherTest {
     }
 
     @Test
-    @DisplayName("scripts: decodes tagIds (Tag global ids) to raw, but leaves authorIds raw (FE sends raw createdBy)")
-    void scripts_decodesTagIdsButNotAuthorIds() {
+    @DisplayName("scripts: decodes tagIds (Tag global ids) AND authorIds (User global ids) to raw before filtering")
+    void scripts_decodesTagIdsAndAuthorIds() {
         ScriptFilterInput filter = ScriptFilterInput.builder()
                 .tagIds(List.of(RELAY.toGlobalId("Tag", "tag-1")))
-                .authorIds(List.of("user-7"))
+                .authorIds(List.of(RELAY.toGlobalId("User", "user-7")))
                 .build();
         CountedGenericQueryResult<ScriptResponse> result = CountedGenericQueryResult.<ScriptResponse>builder().build();
         CountedGenericConnection<GenericEdge<ScriptResponse>> connection =
@@ -152,22 +152,22 @@ class ScriptDataFetcherTest {
         dataFetcher.scripts(filter, null, null, null, null, null, null);
 
         assertThat(filter.getTagIds()).containsExactly("tag-1");       // Tag global id → decoded
-        assertThat(filter.getAuthorIds()).containsExactly("user-7");   // raw createdBy → untouched
+        assertThat(filter.getAuthorIds()).containsExactly("user-7");   // User global id → decoded
     }
 
     @Test
-    @DisplayName("scriptFilters: decodes tagIds (Tag global ids) to raw, leaves authorIds raw, and delegates to ScriptFilterService")
+    @DisplayName("scriptFilters: decodes tagIds (Tag global ids) AND authorIds (User global ids) to raw, and delegates to ScriptFilterService")
     void scriptFilters() {
         ScriptFilters filters = ScriptFilters.builder().filteredCount(7).build();
         ScriptFilterInput input = ScriptFilterInput.builder()
                 .tagIds(List.of(RELAY.toGlobalId("Tag", "tag-1")))
-                .authorIds(List.of("user-7"))
+                .authorIds(List.of(RELAY.toGlobalId("User", "user-7")))
                 .build();
         when(scriptFilterService.getScriptFilters(input)).thenReturn(filters);
 
         assertThat(dataFetcher.scriptFilters(input)).isSameAs(filters);
         assertThat(input.getTagIds()).containsExactly("tag-1");       // Tag global id → decoded
-        assertThat(input.getAuthorIds()).containsExactly("user-7");   // raw createdBy → untouched
+        assertThat(input.getAuthorIds()).containsExactly("user-7");   // User global id → decoded
         verify(scriptFilterService).getScriptFilters(input);
     }
 

--- a/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcherTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcherTest.java
@@ -77,16 +77,17 @@ class ScriptExecutionDataFetcherTest {
     }
 
     @Test
-    @DisplayName("scriptExecutionFilters: forwards scriptId/filter/search to ScriptExecutionFilterService and returns the result")
+    @DisplayName("scriptExecutionFilters: decodes scriptId AND initiatorIds (User global ids) to raw, then forwards to ScriptExecutionFilterService")
     void scriptExecutionFilters() {
         ScriptExecutionFilters filters = ScriptExecutionFilters.builder().filteredCount(3).build();
         ScriptExecutionFilterInput input = ScriptExecutionFilterInput.builder()
-                .initiatorIds(java.util.List.of("u-1")).build();
+                .initiatorIds(java.util.List.of(new Relay().toGlobalId("User", "u-1"))).build();
         when(scriptExecutionFilterService.getExecutionFilters("script-1", input, "alice")).thenReturn(filters);
 
-        // Relay global id in → raw Script id forwarded to the filter service.
+        // Relay global ids in → raw Script id + raw initiatorIds forwarded to the filter service.
         String globalScriptId = new Relay().toGlobalId("Script", "script-1");
         assertThat(dataFetcher.scriptExecutionFilters(globalScriptId, input, "alice")).isSameAs(filters);
+        assertThat(input.getInitiatorIds()).containsExactly("u-1");   // User global id → decoded
         verify(scriptExecutionFilterService).getExecutionFilters("script-1", input, "alice");
     }
 

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/ScriptExecutionRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/ScriptExecutionRepository.java
@@ -24,6 +24,8 @@ public interface ScriptExecutionRepository
 
     Optional<ScriptExecution> findByTenantIdAndExecutionIdAndMachineId(String tenantId, String executionId, String machineId);
 
+    Optional<ScriptExecution> findByMachineIdAndExecutionId(String machineId, String executionId);
+
     Optional<ScriptExecution> findFirstByTenantIdAndExecutionId(String tenantId, String executionId);
 
     List<ScriptExecution> findByStatusAndDispatchedAtBefore(ExecutionStatus status, Instant dispatchedAtBefore);

--- a/openframe-stream-service-core/src/main/java/com/openframe/stream/handler/ScriptExecutionStatusUpdateHandler.java
+++ b/openframe-stream-service-core/src/main/java/com/openframe/stream/handler/ScriptExecutionStatusUpdateHandler.java
@@ -80,17 +80,12 @@ public class ScriptExecutionStatusUpdateHandler
             log.warn("RMM result has no machineId — cannot update Execution row (executionId={})", executionId);
             return;
         }
-        String tenantId = message.getTenantId();
-        if (tenantId == null || tenantId.isBlank()) {
-            log.warn("RMM result has no tenantId (enrichment did not set it) — cannot update Execution row");
-            return;
-        }
 
-        scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(tenantId, executionId, machineId)
+        scriptExecutionRepository.findByMachineIdAndExecutionId(machineId, executionId)
                 .ifPresentOrElse(
                         row -> applyResult(row, after),
-                        () -> log.warn("No Execution row for tenantId={} executionId={} machineId={} — result arrived before dispatch persisted OR row was never created",
-                                tenantId, executionId, machineId));
+                        () -> log.warn("No Execution row for executionId={} machineId={} — result arrived before dispatch persisted OR row was never created",
+                                executionId, machineId));
     }
 
     private void applyResult(ScriptExecution row, JsonNode after) {

--- a/openframe-stream-service-core/src/test/java/com/openframe/stream/handler/ScriptExecutionStatusUpdateHandlerTest.java
+++ b/openframe-stream-service-core/src/test/java/com/openframe/stream/handler/ScriptExecutionStatusUpdateHandlerTest.java
@@ -59,7 +59,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @DisplayName("handle: RUNNING row + exit 0 + no timeout + no error → transitions to SUCCESS; result fields copied verbatim, finishedAt + statusChangedAt set")
     void handle_success_transitionsRowToSuccess() {
         ScriptExecution row = runningRow(EXECUTION_ID);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         handler.handle(messageWith(EXECUTION_ID, 0, false, null, 42L, "ok\n", ""), new IntegratedToolEnrichedData());
@@ -81,7 +81,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @DisplayName("handle: non-zero exitCode → FAILED")
     void handle_nonZeroExit_transitionsRowToFailing() {
         ScriptExecution row = runningRow(EXECUTION_ID);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         handler.handle(messageWith(EXECUTION_ID, 1, false, null, null, null, null), new IntegratedToolEnrichedData());
@@ -95,7 +95,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @DisplayName("handle: timedOut=true → FAILED even with null/zero exitCode")
     void handle_timedOut_transitionsRowToFailing() {
         ScriptExecution row = runningRow(EXECUTION_ID);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         handler.handle(messageWith(EXECUTION_ID, null, true, null, null, null, null), new IntegratedToolEnrichedData());
@@ -110,7 +110,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @DisplayName("handle: agent-level error set → FAILED (even with exitCode=0)")
     void handle_agentError_transitionsRowToFailing() {
         ScriptExecution row = runningRow(EXECUTION_ID);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         handler.handle(messageWith(EXECUTION_ID, 0, false, "SHELL_UNAVAILABLE", null, null, null), new IntegratedToolEnrichedData());
@@ -126,7 +126,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     void handle_alreadyTerminal_doesNotOverwrite() {
         ScriptExecution row = runningRow(EXECUTION_ID);
         row.setStatus(ExecutionStatus.FAILED);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         handler.handle(messageWith(EXECUTION_ID, 0, false, null, null, null, null), new IntegratedToolEnrichedData());
@@ -137,7 +137,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @Test
     @DisplayName("handle: no Execution row found → save NOT called, no exception (Kafka consumer keeps moving)")
     void handle_rowMissing_skipsSaveQuietly() {
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.empty());
 
         handler.handle(messageWith(EXECUTION_ID, 0, false, null, null, null, null), new IntegratedToolEnrichedData());
@@ -149,7 +149,7 @@ class ScriptExecutionStatusUpdateHandlerTest {
     @DisplayName("handle: stdout/stderr exceeding MAX_OUTPUT_BYTES are truncated; *Truncated flags set true")
     void handle_truncatesLargeStdoutAndStderr() {
         ScriptExecution row = runningRow(EXECUTION_ID);
-        when(scriptExecutionRepository.findByTenantIdAndExecutionIdAndMachineId(TENANT_ID, EXECUTION_ID, MACHINE_ID))
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
                 .thenReturn(Optional.of(row));
 
         String huge = "x".repeat(ScriptExecution.MAX_OUTPUT_BYTES + 1024);
@@ -182,20 +182,27 @@ class ScriptExecutionStatusUpdateHandlerTest {
     }
 
     @Test
-    @DisplayName("handle: missing tenantId (enrichment never ran) → repo NOT touched")
-    void handle_missingTenantId_skipsQuietly() {
+    @DisplayName("handle: NO tenantId (stream enrichment can't resolve it) → row still matched by (machineId, executionId) and transitioned — the fix that stops watchdog false-FAILEDs")
+    void handle_noTenantId_stillMatchesAndTransitions() {
+        ScriptExecution row = runningRow(EXECUTION_ID);
+        when(scriptExecutionRepository.findByMachineIdAndExecutionId(MACHINE_ID, EXECUTION_ID))
+                .thenReturn(Optional.of(row));
+
         DeserializedDebeziumMessage message = new DeserializedDebeziumMessage();
         ObjectNode after = mapper.createObjectNode()
                 .put("executionId", EXECUTION_ID)
-                .put("machineId", MACHINE_ID);
+                .put("machineId", MACHINE_ID)
+                .put("exitCode", 0);
         DebeziumMessage.Payload<com.fasterxml.jackson.databind.JsonNode> payload = new DebeziumMessage.Payload<>();
         payload.setAfter(after);
         message.setPayload(payload);
-        // tenantId not set
+        // tenantId intentionally NOT set — mirrors the stream consumer context.
 
         handler.handle(message, new IntegratedToolEnrichedData());
 
-        verifyNoInteractions(scriptExecutionRepository);
+        ArgumentCaptor<ScriptExecution> captor = ArgumentCaptor.forClass(ScriptExecution.class);
+        verify(scriptExecutionRepository).save(captor.capture());
+        assertThat(captor.getValue().getStatus()).isEqualTo(ExecutionStatus.SUCCESS);
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Script execution status updates now match records using machine and execution identifiers, improving reliability when tenant information is missing.
  * Filtering now correctly decodes user author/initiator Relay global IDs into raw IDs before applying script and execution filters.
* **API Changes**
  * Updated `ScriptExecutionFilterInput.machineIds` GraphQL type from `[ID!]` to `[String!]`.
* **Tests**
  * Adjusted unit tests to reflect the new identifier matching and decoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->