### PR TITLE
fix(platform-icon): render OpenMSP logo correctly on dark surfaces

### DIFF
--- a/openframe-frontend-core/src/utils/platform-config.tsx
+++ b/openframe-frontend-core/src/utils/platform-config.tsx
@@ -199,7 +199,10 @@ export function getPlatformIconComponent(platformName: string, className: string
     case 'openframe':
       return <OpenFrameLogo className={className} />;
     case 'openmsp':
-      return <OpenmspLogo className={className} color="#f1f1f1" />;
+      // `OpenmspLogo` ignores `color`; it uses the three bubble props. On a dark
+      // surface the default black front-bubble vanishes — use the canonical dark
+      // treatment (matches getPlatformIcon above + every hub call-site).
+      return <OpenmspLogo className={className} frontBubbleColor="#f1f1f1" innerFrontBubbleColor="#000000" backBubbleColor="#FFC008" />;
     case 'flamingo':
     case 'flamingo-teaser':
       return <FlamingoLogo className={`${className} text-white`} />;


### PR DESCRIPTION
## What & why

`getPlatformIconComponent('openmsp')` rendered a generic white blob on dark admin surfaces (e.g. the platform-access Audit Log) instead of the OpenMSP logo.

Root cause: it called `<OpenmspLogo … color="#f1f1f1" />`, but `OpenmspLogo` **ignores `color`** — it draws from `frontBubbleColor` / `innerFrontBubbleColor` / `backBubbleColor` (defaults `#000000` / `#fff` / `#fff`). On a dark surface the default **black** front bubble (the detail that makes it recognizable) vanishes, leaving the white back/inner squares.

Fix: use the canonical dark treatment already used by `getPlatformIcon` (line 172 of this file) and every hub call-site (`publications-management`, `media-management`, `hubspot-oauth-config`, `vendor-detail`, …):

```tsx
<OpenmspLogo className={className} frontBubbleColor="#f1f1f1" innerFrontBubbleColor="#000000" backBubbleColor="#FFC008" />
```

## Scope

One line in `getPlatformIconComponent` (`src/utils/platform-config.tsx`). Fixes the OpenMSP icon in **every** admin table that uses `PlatformCell` → `getPlatformIconComponent`, not just the audit log.

Note: the two `icon-utils` registries still pass the no-op `color="#f1f1f1"` for `'openmsp-logo'`; left untouched since those may render on light surfaces — separate call if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OpenMSP platform icon styling to display correctly with the intended bubble colors in dark and other high-contrast surfaces.
  * Improved consistency in how the platform icon appears across the app, matching the same visual treatment used elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->