### PR TITLE
fix: shorten OPENFRAME_RMM tool label to RMM

### DIFF
--- a/openframe-frontend-core/src/types/tool.types.ts
+++ b/openframe-frontend-core/src/types/tool.types.ts
@@ -31,7 +31,7 @@ export const toolLabels: Record<ToolType, string> = {
   OPENFRAME: 'OpenFrame',
   OPENFRAME_CHAT: 'OpenFrame Chat',
   OPENFRAME_CLIENT: 'OpenFrame Client',
-  OPENFRAME_RMM: 'OpenFrame RMM',
+  OPENFRAME_RMM: 'RMM',
   OSQUERY: 'Osquery',
   SYSTEM: 'System'
 }


### PR DESCRIPTION
## Summary
Shortens the display label for the `OPENFRAME_RMM` tool type from "OpenFrame RMM" to "RMM".

## Changes
- `src/types/tool.types.ts` — updated `toolLabels.OPENFRAME_RMM` value

## Test plan
- [x] `npm run type-check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated the display label for the RMM tool to show “RMM” instead of “OpenFrame RMM”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->