### PR TITLE
refactor: migrate last smooth window.scrollTo calls to scrollElementIntoView

### DIFF
--- a/openframe-frontend-core/src/components/docs/use-document-tree.ts
+++ b/openframe-frontend-core/src/components/docs/use-document-tree.ts
@@ -18,7 +18,9 @@ function scrollToContent() {
   if (article) {
     scrollElementIntoView(article, { headerOffset: HUB_HEADER_OFFSET_PX })
   } else {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    // Same anchoring-proof tween for the no-article fallback — native smooth
+    // scrollTo is cancelled by scroll anchoring while the new doc renders in.
+    scrollElementIntoView(document.documentElement)
   }
 }
 

--- a/openframe-frontend-core/src/components/unified-filter-logic.tsx
+++ b/openframe-frontend-core/src/components/unified-filter-logic.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams, useRouter } from "../embed-shims/next-navigation"
 import { useTransition } from "react"
+import { scrollElementIntoView } from "../utils/scroll-into-view"
 
 /**
  * Unified AND Filter Logic
@@ -117,10 +118,10 @@ export function useUnifiedFiltering(config: FilterConfig) {
       
       if (preserveScroll) {
         setTimeout(() => {
-          window.scrollTo({
-            top: currentScrollY,
-            behavior: 'smooth'
-          })
+          // Smooth-restore via the shared anchoring-proof tween: the filtered
+          // list re-renders mid-scroll, which cancels a NATIVE smooth scrollTo
+          // (browser scroll anchoring) — the tween re-asserts every frame.
+          scrollElementIntoView(document.body, { adjustTargetY: () => currentScrollY })
         }, 100)
       }
     })


### PR DESCRIPTION
## Migrate the lib's last smooth `window.scrollTo` calls to `scrollElementIntoView`

Companion to hub PR [flamingo-stack/multi-platform-hub#728](https://github.com/flamingo-stack/multi-platform-hub/pull/728) (company-hub deck vertical-scroll rebuild + product-wide scroll unification). After this PR, `scrollElementIntoView` (the self-driven rAF tween, immune to browser scroll-anchoring cancellation) is the ONLY smooth vertical-scroll mechanism in the lib as well.

### Changed
- **`unified-filter-logic.tsx`** — the `preserveScroll` restore after `router.push` used a native smooth `window.scrollTo`. This is the exact anchoring-cancellation scenario: the filtered list re-renders mid-animation and the browser aborts the scroll. Now restores via `scrollElementIntoView(document.body, { adjustTargetY: () => currentScrollY })`.
- **`docs/use-document-tree.ts`** — `scrollToContent()`'s no-`<article>` fallback branch used native smooth scroll-to-top while the new doc renders in. Now uses the tween (the main branch already did).

### Audited and deliberately left alone
- `unified-pagination.tsx` — already `behavior: 'instant'` (anchoring only cancels smooth scrolls)
- `tab-navigation.tsx`, `use-horizontal-scrollbar.ts` — horizontal container scrolls (anchoring is a block-axis behavior)
- `markdown-editor.tsx` (`scrollBy` drag-autoscroll), `chat/embeddable-chat.tsx` + `chat/chat-message-list.tsx` (instant restores / instant `scrollIntoView` in an inner container) — all instant
- `tickets/help-center-*` — already migrated (the primitive's original call sites)

tsc clean. No API/exports changes — safe to ride along in the next scheduled release; no urgent release/pin-bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior when content is loading or filters update, helping the page stay anchored more reliably.
  * Restored the previous scroll position more consistently during filter changes.
  * Reduced unwanted jumpiness by using smoother, more stable scrolling in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->