### PR TITLE
"Admin & Client" chats add quick-action hover previews prompt in composer

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -263,10 +263,15 @@ export interface EmbeddableChatProps {
    * Each field falls back to the built-in OpenFrame defaults, so the kit
    * stays platform-agnostic. `userName`, `onStartGuideChat` and
    * `hasExistingChats` are wired internally and are NOT overridable here.
+   * The quick-action hover-preview callbacks are also wired internally.
    */
   mingoWelcome?: Omit<
     MingoWelcomeProps,
-    'userName' | 'onStartGuideChat' | 'hasExistingChats'
+    | 'userName'
+    | 'onStartGuideChat'
+    | 'hasExistingChats'
+    | 'onQuickActionHover'
+    | 'onQuickActionHoverEnd'
   >
 
   /**
@@ -1536,12 +1541,15 @@ function EmbeddableChatInner({
   // Guide-mode empty state (no open conversation) — drives the "Mingo Guide"
   // header, the guide banner, and the GuideWelcome content branch.
   const isGuideEmpty = !hasConversation && activeMode === 'guide'
-  // Quick-action chips only exist in the guide empty state. If it goes away
-  // (a message is sent, or the mode switches) while a chip is still hovered,
-  // drop the in-flight preview so it can't leak into the next composer state.
+  // Quick-action chips exist in BOTH empty states (Guide onboarding + Mingo
+  // welcome). If the chip row goes away (a message is sent, or the mode
+  // switches) while a chip is still hovered, drop the in-flight preview so it
+  // can't leak into the next composer state.
+  const isQuickActionEmpty =
+    !hasConversation && (activeMode === 'guide' || activeMode === 'mingo')
   useEffect(() => {
-    if (!isGuideEmpty) setQuickActionPreview(null)
-  }, [isGuideEmpty])
+    if (!isQuickActionEmpty) setQuickActionPreview(null)
+  }, [isQuickActionEmpty])
   // The guide-empty back-chevron returns to Mingo — only offer it when Mingo
   // mode actually exists to return to (guide is normally entered from Mingo).
   const guideCanReturnToMingo = isGuideEmpty && hasMingoMode
@@ -1793,6 +1801,15 @@ function EmbeddableChatInner({
                     loadError={dialogsLoadError}
                     onRetry={reloadDialogs}
                     historySearchable={!!mingoCaps.onSearchChange}
+                    // Hover/focus PREVIEWS the action's full prompt as ghost
+                    // text in the empty composer — same behaviour as Guide-mode
+                    // chips (see `quickActionPreview` / `ChatInput.previewText`).
+                    // Wired after the `{...mingoWelcome}` spread so the host
+                    // can't override it.
+                    onQuickActionHover={(action) =>
+                      setQuickActionPreview(action.prompt ?? action.label)
+                    }
+                    onQuickActionHoverEnd={() => setQuickActionPreview(null)}
                     dialogHistory={
                       // Keep the history (and its search bar) mounted during an
                       // active search even at 0 results — otherwise a no-match

--- a/openframe-frontend-core/src/components/chat/mingo-welcome.tsx
+++ b/openframe-frontend-core/src/components/chat/mingo-welcome.tsx
@@ -49,6 +49,10 @@ export interface MingoQuickAction {
   /** `'primary'` = accent (yellow) chip, `'outline'` = bordered chip. */
   variant?: 'primary' | 'outline'
   onClick?: () => void
+  /** Full prompt text previewed as ghost text in the composer on hover/focus.
+   *  The chip `label` is short; this reveals what the action will actually ask.
+   *  Omitted → falls back to `label`. */
+  prompt?: string
 }
 
 export interface MingoWelcomeProps {
@@ -71,6 +75,11 @@ export interface MingoWelcomeProps {
   promoStorage?: 'local' | 'session'
   /** Extra quick-action chips appended after the "Start Guide Chat" chip. */
   quickActions?: ReadonlyArray<MingoQuickAction>
+  /** Pointer/keyboard focus enters a quick-action chip — e.g. preview the
+   *  action's full `prompt` in the composer input. */
+  onQuickActionHover?: (action: MingoQuickAction) => void
+  /** Pointer/keyboard focus leaves the chip — e.g. restore the composer. */
+  onQuickActionHoverEnd?: () => void
   /** Returning-user variation: the user already has chats. Hides the
    *  "New to OpenFrame?" notification entirely and renders the "Start Guide
    *  Chat" chip in the muted `outline` style instead of the accent yellow. */
@@ -169,6 +178,8 @@ export function MingoWelcome({
   promoStorageKey = DEFAULT_PROMO_STORAGE_KEY,
   promoStorage = 'local',
   quickActions,
+  onQuickActionHover,
+  onQuickActionHoverEnd,
   hasExistingChats = false,
   dialogHistory,
   isLoadingHistory = false,
@@ -444,6 +455,8 @@ export function MingoWelcome({
             icon: action.icon,
             variant: action.variant,
             onSelect: action.onClick,
+            onHoverStart: () => onQuickActionHover?.(action),
+            onHoverEnd: () => onQuickActionHoverEnd?.(),
           }))}
         />
       )}


### PR DESCRIPTION
## Description
MingoWelcome quick-action chips now preview their full prompt as ghost text in the composer on hover/focus, matching the Guide-mode behaviour.
## Improvements
- Add `prompt` to MingoQuickAction (previewed text; falls back to label)
- Add onQuickActionHover/onQuickActionHoverEnd to MingoWelcomeProps and wire onHoverStart/onHoverEnd on the chips
- EmbeddableChat drives the composer previewText from Mingo chip hover (mirrors Guide) and clears the in-flight preview when either empty state (Guide or Mingo) goes away

## Task
[Quick Actions Hover Preview Not Working on Fae](https://app.clickup.com/t/9013925967/86ajb92e9)