### PR TITLE
Update meshagent version 0.0.22

### DIFF
--- a/openframe-management-service-core/src/main/resources/agent-configurations/meshcentral-agent.json
+++ b/openframe-management-service-core/src/main/resources/agent-configurations/meshcentral-agent.json
@@ -2,7 +2,7 @@
   "id": "meshcentral-agent",
   "toolId": "meshcentral-server",
   "releaseVersion": false,
-  "version": "0.0.21",
+  "version": "0.0.22",
   "status": "ENABLED",
   "sessionType": "CONSOLE",
   "installationCommandArgs": [


### PR DESCRIPTION
## Description
Bump the deployed meshcentral-agent version to 0.0.22 (same shape as #1307).

## Improvements
- 0.0.22 includes the control-channel reconnect fixes from the mesh-offline investigation: single-flight dial guard (flamingo-stack/meshagent#58) and stale-pooled-connection eviction before each dial (flamingo-stack/meshagent#60).

🤖 Generated with [Claude Code](https://claude.com/claude-code)