### PR TITLE
fix(chat): quick-action hover preview oscillation + Storybook coverage for PR #1342

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-input.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-input.tsx
@@ -514,13 +514,18 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>((allProps, ref) => {
                   {disabled ? "Connection lost. Waiting to reconnect..." : placeholder}
                 </span>
               )}
-              {/* Ghost preview of a hovered quick-action's prompt. In-flow (drives
-                  the row height so a multi-line prompt grows the composer and
-                  wraps) and muted, so it reads as a preview, not typed text. The
-                  editor is hidden (absolute + transparent) underneath while this
-                  shows; clearing `previewText` restores it. */}
+              {/* Ghost preview of a hovered quick-action's prompt. Overlaid like
+                  the placeholder and CLAMPED to one line (truncate): the row's
+                  height must not change on hover. An in-flow multi-line preview
+                  would grow the composer → shift the chip strip up → move the
+                  hovered chip out from under the cursor → hover-end → shrink →
+                  chip back under the cursor — an infinite grow/shrink
+                  oscillation (smeared flicker); an upward overlay would cover
+                  the chips instead. Muted color reads as a preview, not typed
+                  text; clearing `previewText` restores the (opacity-hidden)
+                  editor. */}
               {showPreview && (
-                <p className="pointer-events-none m-0 select-none whitespace-pre-wrap break-words text-h4 !leading-9 text-ods-text-secondary">
+                <p className="pointer-events-none absolute inset-x-0 top-0 m-0 select-none truncate text-h4 !leading-9 text-ods-text-secondary">
                   {previewText}
                 </p>
               )}
@@ -548,9 +553,11 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>((allProps, ref) => {
                 onBlur={() => setFocused(false)}
                 className={cn(
                   "max-h-[160px] overflow-y-auto whitespace-pre-wrap break-words outline-none",
-                  // While a ghost preview shows, the editor is empty — collapse it
-                  // out of flow + transparent so the in-flow preview drives height.
-                  showPreview && "absolute inset-0 opacity-0",
+                  // While a ghost preview shows, the editor stays IN FLOW (it
+                  // alone drives the row height, which must NOT change on hover —
+                  // see the preview comment above) and is only made transparent;
+                  // the absolutely-positioned single-line preview paints over it.
+                  showPreview && "opacity-0",
                   // `leading-9` (36px) sits just above the 32px chip's line-box need
                   // (~35.5px incl. vertical-align overhead): the LINE drives row
                   // height (deterministic 48px, no overflow) AND the near-zero slack

--- a/openframe-frontend-core/src/components/ui/tab-navigation.tsx
+++ b/openframe-frontend-core/src/components/ui/tab-navigation.tsx
@@ -116,6 +116,7 @@ export function TabNavigation({
 
   const scrollRef = useRef<HTMLDivElement>(null)
   const activeTabRef = useRef<HTMLButtonElement>(null)
+  const isFirstActiveScrollRef = useRef(true)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(false)
 
@@ -174,12 +175,17 @@ export function TabNavigation({
     const el = scrollRef.current
     const active = activeTabRef.current
     if (!el || !active) return
+    // On mount (e.g. a deep link landing on an off-screen tab, such as
+    // `?tab=software` as the last of many), snap instantly instead of visibly
+    // sliding right after first paint — smooth is reserved for later tab changes.
+    const behavior = isFirstActiveScrollRef.current ? 'auto' : 'smooth'
+    isFirstActiveScrollRef.current = false
     const elRect = el.getBoundingClientRect()
     const aRect = active.getBoundingClientRect()
     if (aRect.left < elRect.left) {
-      el.scrollBy({ left: aRect.left - elRect.left, behavior: 'smooth' })
+      el.scrollBy({ left: aRect.left - elRect.left, behavior })
     } else if (aRect.right > elRect.right) {
-      el.scrollBy({ left: aRect.right - elRect.right, behavior: 'smooth' })
+      el.scrollBy({ left: aRect.right - elRect.right, behavior })
     }
   }, [activeTab])
 

--- a/openframe-frontend-core/src/stories/EmbeddableChat.stories.tsx
+++ b/openframe-frontend-core/src/stories/EmbeddableChat.stories.tsx
@@ -28,6 +28,29 @@ import {
 
 const COMMANDS_URL = '/__story__/commands'
 
+// Agent-config endpoint. EmbeddableChat's `DEFAULT_AI_AGENT_CONFIG_URL` resolves
+// `activeAgentSlug` → `/api/ai-agents/<slug>`; the fetch shim below answers any
+// href containing this prefix with a mocked `EmptyStateConfig` so agent-mode
+// quick-action chips render from the fetch (not the host prop).
+const AI_AGENT_CONFIG_PREFIX = '/api/ai-agents/'
+
+// Mocked `/api/ai-agents/fae` response — the `EmptyStateConfig` shape
+// (see use-empty-state-config.ts). `icon: { name: 'fae' }` is the agent
+// identity mark; the chip `iconName`s resolve via the icon library and get the
+// fae→pink accent auto-derived from the slug (no `iconProps.color` set).
+const FAE_AGENT_CONFIG = {
+  name: 'Fae',
+  icon: { name: 'fae' },
+  greeting: "Hi, I'm Fae — ask me about incidents, scripts, or device health.",
+  quickActions: [
+    { id: 'fae-triage', label: 'Triage an alert', prompt: 'Help me triage the latest critical alert.', iconName: 'search' },
+    { id: 'fae-script', label: 'Write a script', prompt: 'Write a PowerShell script to audit local admins.', iconName: 'bracket-curly' },
+    { id: 'fae-health', label: 'Device health', prompt: 'Which devices are unhealthy right now?', iconName: 'rocket' },
+    { id: 'fae-logs', label: 'Summarize logs', prompt: 'Summarize the last 24h of error logs.', iconName: 'newspaper' },
+  ],
+  suggestedQueries: [],
+}
+
 // =============================================================================
 // Shared mocks
 // =============================================================================
@@ -417,6 +440,14 @@ if (
         }),
       )
     }
+    if (href.includes(AI_AGENT_CONFIG_PREFIX)) {
+      return Promise.resolve(
+        new Response(JSON.stringify(FAE_AGENT_CONFIG), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+    }
     return originalFetch(input as RequestInfo, init)
   }) as typeof window.fetch
 }
@@ -698,5 +729,49 @@ export const ArchiveEmpty: Story = {
       name: 'Chat archive',
     })
     await userEvent.click(archiveButton)
+  },
+}
+
+// =============================================================================
+// 9. Agent-mode quick actions (fetched chips — PR #1342)
+// =============================================================================
+
+/**
+ * Agent-mode empty state. `activeAgentSlug="fae"` makes EmbeddableChat resolve
+ * `/api/ai-agents/fae` and fetch that agent's `EmptyStateConfig` (mocked by the
+ * fetch shim → `FAE_AGENT_CONFIG`). The Guide-mode chip row renders the agent's
+ * fetched `quickActions` — pink-tinted because the fae→pink accent is
+ * auto-derived from the slug — with Fae's identity (name + mark) on the
+ * greeting. No host `guideWelcome.quickActions` here, so the fetched chips are
+ * the only source.
+ */
+export const AgentModeQuickActions: Story = {
+  args: {
+    defaultOpen: true,
+    showInternalTrigger: false,
+    activeAgentSlug: 'fae',
+  },
+}
+
+/**
+ * The PR #1342 precedence fix. BOTH sources are configured: the host passes its
+ * own `guideWelcome.quickActions` (platform defaults) AND an agent is active
+ * with fetched chips. The agent's chips WIN — previously the host array always
+ * won, so agent chips never rendered. You should see Fae's "Triage an alert /
+ * Write a script / Device health / Summarize logs" chips, NOT the host's
+ * "Host default …" chips.
+ */
+export const AgentChipsWinOverHost: Story = {
+  args: {
+    defaultOpen: true,
+    showInternalTrigger: false,
+    activeAgentSlug: 'fae',
+    guideWelcome: {
+      quickActions: [
+        { id: 'host-a', label: 'Host default A', prompt: 'host prompt A' },
+        { id: 'host-b', label: 'Host default B', prompt: 'host prompt B' },
+        { id: 'host-c', label: 'Host default C', prompt: 'host prompt C' },
+      ],
+    },
   },
 }

--- a/openframe-frontend-core/src/stories/QuickActionChip.stories.tsx
+++ b/openframe-frontend-core/src/stories/QuickActionChip.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import {
+  QuickActionChipButton,
+  type QuickActionIconSpec,
+} from '../components/chat/quick-action-chip'
+
+const meta: Meta<typeof QuickActionChipButton> = {
+  title: 'Chat/QuickActionChip',
+  component: QuickActionChipButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The unified quick-action chip (`QuickActionChipButton`) used by every chat empty state (guide / mingo / ai-agent), the marketing marquee strips, and the ROI table task cells. Icon resolution is owned entirely by `<EntityIcon>` in two `QuickActionIconSpec` formats: the **agent format** (`{ name: \'fae\' | \'mingo\' }`) renders the packaged agent mark, and the **config format** (`{ name, url, props, accent }`) renders an admin-configured glyph tinted via `accent` (`pink` → flamingo-pink, `cyan` → flamingo-cyan, or any CSS color). An explicit `props.color` wins over `accent`.',
+      },
+    },
+  },
+  argTypes: {
+    label: { control: 'text' },
+    variant: { control: 'inline-radio', options: ['outline', 'primary'] },
+    interactive: { control: 'boolean' },
+    icon: { control: false },
+    onSelect: { control: false },
+    onHoverStart: { control: false },
+    onHoverEnd: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center bg-ods-bg p-8">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof QuickActionChipButton>
+
+// Config-format icon specs — resolved by <EntityIcon> against the icons-v2
+// library, tinted by `accent`.
+const SEARCH_ICON: QuickActionIconSpec = { name: 'search', accent: 'pink' }
+const BUG_ICON: QuickActionIconSpec = { name: 'bug', accent: 'cyan' }
+
+/** Default bordered (`outline`) chip with a config glyph tinted flamingo-pink. */
+export const Default: Story = {
+  args: {
+    label: 'How to start',
+    icon: SEARCH_ICON,
+    variant: 'outline',
+    onSelect: () => console.log('select'),
+  },
+}
+
+/** Accent (`primary`, yellow) chip variant. */
+export const Primary: Story = {
+  args: {
+    label: 'Run scripts',
+    icon: { name: 'rocket' },
+    variant: 'primary',
+    onSelect: () => console.log('select'),
+  },
+}
+
+/** Config glyphs tinted via `accent` — `pink` and `cyan` brand tokens. */
+export const AccentTints: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <QuickActionChipButton label="Search docs" icon={SEARCH_ICON} onSelect={() => {}} />
+      <QuickActionChipButton label="Report a bug" icon={BUG_ICON} onSelect={() => {}} />
+      <QuickActionChipButton
+        label="Custom color"
+        icon={{ name: 'compass', accent: '#8b5cf6' }}
+        onSelect={() => {}}
+      />
+    </div>
+  ),
+}
+
+/**
+ * Agent-format icons — `{ name: 'fae' }` / `{ name: 'mingo' }` render the
+ * packaged agent marks (they carry their own colors; `accent` is ignored).
+ */
+export const AgentMarks: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <QuickActionChipButton label="Ask fae" icon={{ name: 'fae' }} onSelect={() => {}} />
+      <QuickActionChipButton label="Ask mingo" icon={{ name: 'mingo' }} onSelect={() => {}} />
+    </div>
+  ),
+}
+
+/** No icon — label only. */
+export const NoIcon: Story = {
+  args: {
+    label: 'Find device',
+    onSelect: () => console.log('select'),
+  },
+}
+
+/**
+ * `interactive={false}` renders a plain, non-focusable `<Tag>` (decorative use:
+ * marquee strips, ROI table cells) — no button, no hover callbacks.
+ */
+export const NonInteractive: Story = {
+  args: {
+    label: 'Decorative',
+    icon: SEARCH_ICON,
+    interactive: false,
+  },
+}
+
+/**
+ * `onHoverStart` / `onHoverEnd` fire on pointer AND keyboard focus — used to
+ * preview the full prompt in the composer, then restore it. Hover or tab the
+ * chip and watch the Actions/console panel.
+ */
+export const HoverCallbacks: Story = {
+  args: {
+    label: 'Preview prompt',
+    icon: { name: 'fae' },
+    onSelect: () => console.log('select'),
+    onHoverStart: () => console.log('hover start → preview prompt'),
+    onHoverEnd: () => console.log('hover end → restore composer'),
+  },
+}
+
+/** All variants side by side. */
+export const Gallery: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <QuickActionChipButton label="Outline" icon={SEARCH_ICON} onSelect={() => {}} />
+        <QuickActionChipButton
+          label="Primary"
+          icon={{ name: 'rocket' }}
+          variant="primary"
+          onSelect={() => {}}
+        />
+        <QuickActionChipButton label="No icon" onSelect={() => {}} />
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <QuickActionChipButton label="fae" icon={{ name: 'fae' }} onSelect={() => {}} />
+        <QuickActionChipButton label="mingo" icon={{ name: 'mingo' }} onSelect={() => {}} />
+        <QuickActionChipButton label="Decorative" icon={BUG_ICON} interactive={false} />
+      </div>
+    </div>
+  ),
+}

--- a/openframe-frontend-core/src/stories/QuickActionMarquee.stories.tsx
+++ b/openframe-frontend-core/src/stories/QuickActionMarquee.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import {
+  QuickActionMarquee,
+  type QuickActionMarqueeItem,
+} from '../components/chat/quick-action-marquee'
+
+// fae-row items (config glyphs tinted pink) and mingo-row items (tinted cyan) —
+// mirrors the Figma fae/mingo marquee rows.
+const FAE_ITEMS: ReadonlyArray<QuickActionMarqueeItem> = [
+  { id: 'how-to-start', label: 'How to start', icon: { name: 'fae' } },
+  { id: 'connect-device', label: 'Connect device', icon: { name: 'search', accent: 'pink' } },
+  { id: 'find-device', label: 'Find device', icon: { name: 'compass', accent: 'pink' } },
+  { id: 'remote-connection', label: 'Remote connection', icon: { name: 'rocket', accent: 'pink' } },
+  { id: 'run-scripts', label: 'Run scripts', icon: { name: 'bracket-curly', accent: 'pink' } },
+  { id: 'device-software', label: 'Device software', icon: { name: 'package', accent: 'pink' } },
+]
+
+const MINGO_ITEMS: ReadonlyArray<QuickActionMarqueeItem> = [
+  { id: 'roi', label: 'Calculate ROI', icon: { name: 'mingo' } },
+  { id: 'ticket', label: 'Open ticket', icon: { name: 'ticket', accent: 'cyan' } },
+  { id: 'report-bug', label: 'Report a bug', icon: { name: 'bug', accent: 'cyan' } },
+  { id: 'docs', label: 'Read docs', icon: { name: 'book', accent: 'cyan' } },
+  { id: 'chat', label: 'Start a chat', icon: { name: 'chats', accent: 'cyan' } },
+  { id: 'news', label: "What's new", icon: { name: 'newspaper', accent: 'cyan' } },
+]
+
+const meta: Meta<typeof QuickActionMarquee> = {
+  title: 'Chat/QuickActionMarquee',
+  component: QuickActionMarquee,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Endless horizontally-scrolling strip of quick-action chips (Figma fae/mingo marquee rows). The item list is padded to ≥6 chips and rendered twice so the `qa-marquee` keyframe’s `translateX(-50%)` loops seamlessly; the duplicate half is `aria-hidden` and never focusable. Pauses on hover (`pauseOnHover`, default on) and always under `prefers-reduced-motion`. Pass `onSelect` to make chips interactive buttons; omit it for a purely decorative strip.',
+      },
+    },
+  },
+  argTypes: {
+    items: { control: false },
+    direction: { control: 'inline-radio', options: ['left', 'right'] },
+    duration: { control: { type: 'number', min: 5, max: 120, step: 5 } },
+    pauseOnHover: { control: 'boolean' },
+    onSelect: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-ods-bg py-8">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof QuickActionMarquee>
+
+/** Single fae row scrolling left, interactive chips. */
+export const Default: Story = {
+  args: {
+    items: FAE_ITEMS,
+    onSelect: (item) => console.log('select', item.id),
+  },
+}
+
+/** The two Figma rows: fae (left) over mingo (right, reversed). */
+export const TwoRows: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <QuickActionMarquee items={FAE_ITEMS} direction="left" onSelect={(i) => console.log(i.id)} />
+      <QuickActionMarquee items={MINGO_ITEMS} direction="right" onSelect={(i) => console.log(i.id)} />
+    </div>
+  ),
+}
+
+/** Reversed scroll direction. */
+export const ScrollRight: Story = {
+  args: {
+    items: MINGO_ITEMS,
+    direction: 'right',
+    onSelect: (item) => console.log('select', item.id),
+  },
+}
+
+/**
+ * No `onSelect` → chips render as plain, non-focusable tags (decorative
+ * marketing strip). Nothing is clickable or tabbable.
+ */
+export const Decorative: Story = {
+  args: {
+    items: FAE_ITEMS,
+  },
+}
+
+/**
+ * Fewer than 6 items — the track is auto-repeated up to the `MIN_TRACK_ITEMS`
+ * heuristic so the halved loop still fills the viewport with no visible gap.
+ */
+export const FewItems: Story = {
+  args: {
+    items: FAE_ITEMS.slice(0, 2),
+    onSelect: (item) => console.log('select', item.id),
+  },
+}
+
+/** Faster loop (`duration={15}`) and hover-pause disabled. */
+export const FastNoPause: Story = {
+  args: {
+    items: FAE_ITEMS,
+    duration: 15,
+    pauseOnHover: false,
+    onSelect: (item) => console.log('select', item.id),
+  },
+}


### PR DESCRIPTION
## What

### Fix: hover-preview feedback loop in the composer (`chat-input.tsx`)

The ghost preview of a hovered quick-action prompt rendered **in-flow**, so a prompt wrapping to 2+ lines grew the composer → shifted the chip strip up → moved the hovered chip out from under the cursor → hover-end cleared the preview → composer shrank → chip returned under the cursor → hover again. An infinite grow/shrink oscillation at frame rate — visible as smeared, doubled chips.

The preview is now an absolutely-positioned **single-line overlay** (`truncate`) in the placeholder's spot:
- row height never changes on hover — the in-flow (opacity-hidden) editor alone drives it, so the chip strip never moves;
- nothing is covered — the preview lives strictly inside the existing composer line (an upward-growing overlay variant was tried and rejected: it covered the chip rows).

Trade-off: prompts longer than one composer line are ellipsized in the preview. Follow-up option: surface the full prompt via the chip's native `title` (currently duplicates the label via `Tag`).

### Storybook coverage for the PR #1342 quick-action surface

- **`QuickActionChip.stories.tsx`** — outline/primary variants, config-glyph accent tints (pink/cyan/custom CSS color), fae/mingo agent marks, no-icon, non-interactive (decorative `Tag`), hover callbacks, gallery.
- **`QuickActionMarquee.stories.tsx`** — fae/mingo rows (Figma), direction, decorative (no `onSelect`), auto-repeat with few items, speed/pause.
- **`EmbeddableChat.stories.tsx`** — fetch shim now answers `/api/ai-agents/*` with a mocked `EmptyStateConfig`; new `AgentModeQuickActions` (fetched agent chips, slug-derived pink accent, Fae identity) and `AgentChipsWinOverHost` (host `guideWelcome.quickActions` AND an active agent set — the agent's fetched chips win, demonstrating the #1342 precedence fix).

## Verified

- Playwright (system Chrome) against live Storybook at 380/480/900px: hovered the 2-line-prompt chip, sampled its position 24× — `chip y` identical in every sample before/during/after hover; editor height constant at 36px; preview text shown; hover state stable (no flicker).
- `npm run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the chat composer’s quick-action preview so it stays on one line and no longer changes the input row height on hover.
  * Added new component showcase examples for chat quick actions, including agent-mode behavior and different chip/marquee variations.

* **Bug Fixes**
  * Kept the chat editor layout stable while quick-action previews are shown, preventing the composer from collapsing or shifting unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Fix: tab strip snaps (not slides) to the active tab on first render (`tab-navigation.tsx`)

Deep-linking to an off-screen tab (e.g. `?tab=software` as the last of many) visibly slid the strip right after first paint. The first active-tab scroll now uses `behavior: 'auto'`; smooth scrolling is reserved for subsequent tab changes.
