### PR TITLE
feat(chat): QuickActionChipSkeleton - unified 1:1 loading chip

### DIFF
--- a/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
+++ b/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
@@ -148,6 +148,46 @@ export interface QuickActionChipButtonProps {
 }
 
 // =============================================================================
+// Skeleton
+// =============================================================================
+
+export interface QuickActionChipSkeletonProps {
+  /** Label placeholder width in `ch` of the chip's own font — vary per item
+   *  for a realistic spread. Default 16. */
+  labelCh?: number
+  /** Reserve the leading-icon slot (default true — most chips carry one). */
+  icon?: boolean
+  /** Reserve the leading lozenge affix slot. */
+  lozenge?: boolean
+  className?: string
+}
+
+/**
+ * Loading placeholder for {@link QuickActionChipButton} — renders the REAL
+ * `Tag` (same height, padding, border, radius, icon box) with pulse bars in
+ * the icon/lozenge/label slots, so a skeleton chip is 1:1 with a loaded chip
+ * by construction. Use anywhere quick actions stream in (chat empty states,
+ * marketing walls, deck panels).
+ */
+export function QuickActionChipSkeleton({ labelCh = 16, icon = true, lozenge = false, className }: QuickActionChipSkeletonProps) {
+  return (
+    <Tag
+      variant="outline"
+      className={cn('animate-pulse', className)}
+      icon={icon ? <span aria-hidden className="size-4 rounded bg-ods-border" /> : undefined}
+      label={
+        <>
+          {lozenge && (
+            <span aria-hidden className="mr-2 inline-block h-[16px] w-[26px] translate-y-[3px] rounded bg-ods-border" />
+          )}
+          <span aria-hidden className="inline-block h-[0.9em] translate-y-[0.08em] rounded bg-ods-border" style={{ width: `${labelCh}ch` }} />
+        </>
+      }
+    />
+  )
+}
+
+// =============================================================================
 // Component
 // =============================================================================
 

--- a/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
+++ b/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
@@ -162,25 +162,31 @@ export interface QuickActionChipSkeletonProps {
   className?: string
 }
 
+/** Pulse bar inside the chip skeleton — the standard `ui/skeleton` treatment
+ *  (`animate-pulse bg-ods-border`), as a SPAN so it stays valid phrasing
+ *  content inside the Tag's label span. */
+function ChipSkelBar({ className, style }: { className?: string; style?: React.CSSProperties }) {
+  return <span aria-hidden className={cn('animate-pulse rounded-md bg-ods-border', className)} style={style} />
+}
+
 /**
  * Loading placeholder for {@link QuickActionChipButton} — renders the REAL
- * `Tag` (same height, padding, border, radius, icon box) with pulse bars in
- * the icon/lozenge/label slots, so a skeleton chip is 1:1 with a loaded chip
- * by construction. Use anywhere quick actions stream in (chat empty states,
+ * `Tag` (same height, padding, border, radius, icon box) with standard
+ * skeleton pulse bars (identical animation + token as `ui/skeleton`) in the
+ * icon/lozenge/label slots, so a skeleton chip is 1:1 with a loaded chip by
+ * construction. Use anywhere quick actions stream in (chat empty states,
  * marketing walls, deck panels).
  */
 export function QuickActionChipSkeleton({ labelCh = 16, icon = true, lozenge = false, className }: QuickActionChipSkeletonProps) {
   return (
     <Tag
       variant="outline"
-      className={cn('animate-pulse', className)}
-      icon={icon ? <span aria-hidden className="size-4 rounded bg-ods-border" /> : undefined}
+      className={className}
+      icon={icon ? <ChipSkelBar className="block size-4" /> : undefined}
       label={
         <>
-          {lozenge && (
-            <span aria-hidden className="mr-2 inline-block h-[16px] w-[26px] translate-y-[3px] rounded bg-ods-border" />
-          )}
-          <span aria-hidden className="inline-block h-[0.9em] translate-y-[0.08em] rounded bg-ods-border" style={{ width: `${labelCh}ch` }} />
+          {lozenge && <ChipSkelBar className="mr-2 inline-block h-[16px] w-[26px] translate-y-[3px]" />}
+          <ChipSkelBar className="inline-block h-[0.9em] translate-y-[0.08em]" style={{ width: `${labelCh}ch` }} />
         </>
       }
     />


### PR DESCRIPTION
## Summary
Follow-up to #1348: adds `QuickActionChipSkeleton` — the unified loading placeholder for `QuickActionChipButton`.

- Renders the REAL `Tag` (same height, padding, border, radius, icon box), so a skeleton chip is 1:1 with a loaded chip by construction.
- Pulse bars in the icon / lozenge / label slots use the standard `ui/skeleton` treatment (`animate-pulse bg-ods-border`) as spans, so they stay valid phrasing content inside the Tag's label and animate in sync with every other skeleton in the app.
- `labelCh` (width in `ch` of the chip's own font), `icon`, and `lozenge` props let hosts mirror their loaded chip spread.

First consumer: multi-platform-hub company-hub deck slide 3 (flamingo-stack/multi-platform-hub#738) — its panels render 24 of these while the deck bundle streams in, with harness-verified zero layout shift when data lands. Reusable by any surface where quick actions load (chat empty states, marketing walls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading skeleton for quick-action chips in chat.
  * The placeholder now mirrors the final chip layout, including optional icon, lozenge, and label sections for a smoother loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->