### PR TITLE
test(client): ignore privileged/interactive tests that fail or hang in headless CI

### DIFF
--- a/clients/openframe-client/src/platform/directories.rs
+++ b/clients/openframe-client/src/platform/directories.rs
@@ -901,6 +901,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        not(windows),
+        ignore = "requires root-owned secured dir; not applicable to non-root unix runs"
+    )]
     fn test_directory_permissions() {
         let temp_dir = tempdir().unwrap();
         let logs_dir = temp_dir.path().join("logs");
@@ -1015,6 +1019,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        not(windows),
+        ignore = "requires root-owned secured dir; not applicable to non-root unix runs"
+    )]
     fn test_health_check() {
         let temp_dir = tempdir().unwrap();
         let logs_dir = temp_dir.path().join("logs");

--- a/clients/openframe-client/src/platform/permissions.rs
+++ b/clients/openframe-client/src/platform/permissions.rs
@@ -600,6 +600,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "triggers an interactive macOS osascript / Windows UAC admin prompt; hangs in headless CI"]
     fn test_ensure_admin() {
         // This should return Ok if already admin, or attempt to get privileges
         let result = PermissionUtils::ensure_admin();


### PR DESCRIPTION
## What & why

`make -C clients/openframe-client test` (added to the Rust CI in `test.yml`) surfaced three tests that assume a **root-capable or interactive** environment. On the headless CI runner they fail — and one **hangs**, canceling the job:

| Test | Needs | Headless CI |
|---|---|---|
| `platform::directories::tests::test_directory_permissions` | secured dir owned by root (`chown` to root) | FAIL (`Operation not permitted`) |
| `platform::directories::tests::test_health_check` | same | FAIL |
| `platform::permissions::tests::test_ensure_admin` | interactive admin auth prompt | **HANG** → job canceled |

- The directory tests build a `DirectoryManager` via `with_custom_dirs()` (not development mode); on macOS the secured-dir check requires `uid == 0`, which can't hold for a non-root `cargo test`.
- `ensure_admin()` runs `osascript … "with administrator privileges"` (macOS) / a UAC `runas` prompt (Windows) when the caller isn't already admin. A headless runner has no session to answer it, so it blocks until timeout. (It passes locally only because a dev's account is already an admin, short-circuiting the prompt.)

## Change

Mark all three `#[ignore = "…"]` with a reason, matching the existing `executor::unix::run_as_user::tests::user_privilege_drops_privilege` precedent. No production code changes.

## Verification

`cargo test` → **81 passed, 0 failed, 4 ignored**, no hang. Run the full set on an interactive/root machine with `sudo cargo test -- --ignored`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Several environment-dependent tests are now skipped by default in CI.
  * This prevents failures or hangs when secured directory ownership expectations aren’t met (non-Windows by default) and when tests would otherwise trigger interactive admin elevation prompts that are unsuitable for headless execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->