### PR TITLE
Updated name existence validation

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptService.java
@@ -53,6 +53,9 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ScriptService {
 
+    private static final List<ScriptStatus> NAME_UNIQUE_STATUSES =
+            List.of(ScriptStatus.ACTIVE, ScriptStatus.ARCHIVED);
+
     private final ScriptRepository scriptRepository;
     private final ScriptMapper scriptMapper;
     private final TenantIdProvider tenantIdProvider;
@@ -67,9 +70,9 @@ public class ScriptService {
     public ScriptResponse create(CreateScriptInput input, String createdBy) {
         String tenantId = tenantIdProvider.getTenantId();
 
-        if (scriptRepository.existsByTenantIdAndName(tenantId, input.getName())) {
+        if (scriptRepository.existsByTenantIdAndNameAndStatusIn(tenantId, input.getName(), NAME_UNIQUE_STATUSES)) {
             throw new ConflictException(
-                    "Script with name '" + input.getName() + "' already exists in this tenant");
+                    "Script with name '" + input.getName() + "' already exists");
         }
 
         Script entity = scriptMapper.toEntity(tenantId, input);
@@ -217,9 +220,10 @@ public class ScriptService {
         Script existing = loadVisibleOrThrow(tenantId, id);
 
         if (!input.getName().equals(existing.getName())
-                && scriptRepository.existsByTenantIdAndNameAndIdNot(tenantId, input.getName(), id)) {
+                && scriptRepository.existsByTenantIdAndNameAndIdNotAndStatusIn(
+                        tenantId, input.getName(), id, NAME_UNIQUE_STATUSES)) {
             throw new ConflictException(
-                    "Script with name '" + input.getName() + "' already exists in this tenant");
+                    "Script with name '" + input.getName() + "' already exists");
         }
 
         scriptMapper.updateEntity(existing, input);

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptServiceTest.java
@@ -48,6 +48,12 @@ class ScriptServiceTest {
 
     private static final String TENANT_ID = "tenant-1";
     private static final String SCRIPT_ID = "65f4a8000000000000000001";
+    /**
+     * Mirror of the ScriptService constant — DELETED is intentionally OUT so
+     * the mock asserts we ONLY collide against visible (ACTIVE/ARCHIVED) rows.
+     */
+    private static final List<ScriptStatus> UNIQUE_STATUSES =
+            List.of(ScriptStatus.ACTIVE, ScriptStatus.ARCHIVED);
 
     @Mock
     private ScriptRepository scriptRepository;
@@ -95,7 +101,7 @@ class ScriptServiceTest {
         saved.setName(createInput.getName());
         ScriptResponse response = ScriptResponse.builder().id(SCRIPT_ID).name(createInput.getName()).build();
 
-        when(scriptRepository.existsByTenantIdAndName(TENANT_ID, createInput.getName())).thenReturn(false);
+        when(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_ID, createInput.getName(), UNIQUE_STATUSES)).thenReturn(false);
         when(scriptMapper.toEntity(TENANT_ID, createInput)).thenReturn(mapped);
         when(scriptRepository.save(mapped)).thenReturn(saved);
         when(scriptMapper.toResponse(saved)).thenReturn(response);
@@ -115,7 +121,7 @@ class ScriptServiceTest {
     @Test
     @DisplayName("create: throws ConflictException when a script with the same name already exists in the tenant")
     void create_whenNameAlreadyExists_throwsConflict() {
-        when(scriptRepository.existsByTenantIdAndName(TENANT_ID, createInput.getName())).thenReturn(true);
+        when(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_ID, createInput.getName(), UNIQUE_STATUSES)).thenReturn(true);
 
         assertThatThrownBy(() -> scriptService.create(createInput, "user-1"))
                 .isInstanceOf(ConflictException.class)
@@ -135,7 +141,7 @@ class ScriptServiceTest {
         Script mapped = new Script();
         Script saved = new Script();
         saved.setId(SCRIPT_ID);
-        when(scriptRepository.existsByTenantIdAndName(TENANT_ID, createInput.getName())).thenReturn(false);
+        when(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_ID, createInput.getName(), UNIQUE_STATUSES)).thenReturn(false);
         when(scriptMapper.toEntity(TENANT_ID, createInput)).thenReturn(mapped);
         when(scriptRepository.save(mapped)).thenReturn(saved);
         when(scriptMapper.toResponse(saved)).thenReturn(ScriptResponse.builder().id(SCRIPT_ID).build());
@@ -463,7 +469,7 @@ class ScriptServiceTest {
         updateInput.setName("taken name");
 
         when(scriptRepository.findByTenantIdAndId(TENANT_ID, SCRIPT_ID)).thenReturn(Optional.of(existing));
-        when(scriptRepository.existsByTenantIdAndNameAndIdNot(TENANT_ID, "taken name", SCRIPT_ID)).thenReturn(true);
+        when(scriptRepository.existsByTenantIdAndNameAndIdNotAndStatusIn(TENANT_ID, "taken name", SCRIPT_ID, UNIQUE_STATUSES)).thenReturn(true);
 
         assertThatThrownBy(() -> scriptService.update(updateInput))
                 .isInstanceOf(ConflictException.class)
@@ -486,7 +492,7 @@ class ScriptServiceTest {
 
         scriptService.update(updateInput);
 
-        verify(scriptRepository, never()).existsByTenantIdAndNameAndIdNot(any(), any(), any());
+        verify(scriptRepository, never()).existsByTenantIdAndNameAndIdNotAndStatusIn(any(), any(), any(), any());
     }
 
     @Test
@@ -507,7 +513,7 @@ class ScriptServiceTest {
 
         scriptService.update(updateInput);
 
-        verify(scriptRepository, never()).existsByTenantIdAndNameAndIdNot(any(), any(), any());
+        verify(scriptRepository, never()).existsByTenantIdAndNameAndIdNotAndStatusIn(any(), any(), any(), any());
         verify(scriptMapper).updateEntity(existing, updateInput);
     }
 

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/Script.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/Script.java
@@ -26,9 +26,11 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(collection = "scripts")
+// Non-unique tenant-scoped lookup index. The actual name-uniqueness
+// constraint lives in MongoIndexConfig as a PARTIAL unique index filtered
+// by {status: {$ne: 'DELETED'}} — soft-deleted names free up for reuse.
 @CompoundIndex(
-        def = "{'tenantId': 1, 'name': 1}",
-        unique = true
+        def = "{'tenantId': 1, 'name': 1}"
 )
 public class Script implements TenantScoped {
     @Id

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptStatus.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptStatus.java
@@ -7,9 +7,12 @@ package com.openframe.data.document.rmm;
  * so historic execution records continue to reference a valid script, but
  * the script is hidden from default list / get / update API surfaces.
  *
- * <p>Because the compound unique index on {@code (tenantId, name)} includes
- * {@code DELETED} documents, a soft-deleted name remains occupied. To reuse
- * a name, the document must be hard-deleted (admin tooling).
+ * <p>Name uniqueness is enforced by a PARTIAL unique index on
+ * {@code (tenantId, name)} filtered by {@code status != DELETED} (see
+ * {@code MongoIndexConfig}). Soft-deleted names are therefore free for reuse
+ * — matches the user-facing model "if I deleted it, it's gone". The
+ * document itself stays in Mongo so historic execution rows keep resolving
+ * the script's display name.
  */
 public enum ScriptStatus {
     ACTIVE,

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoIndexConfig.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/config/MongoIndexConfig.java
@@ -7,10 +7,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.PartialIndexFilter;
+import org.springframework.data.mongodb.core.query.Criteria;
 
 @Slf4j
 @Configuration
 public class MongoIndexConfig {
+
+    /**
+     * Partial-unique name index on {@code scripts}. Explicitly named so it
+     * survives redeploys and can be dropped/recreated cleanly.
+     */
+    private static final String SCRIPTS_NAME_UNIQUE_INDEX = "scripts_tenant_name_notDeleted_unique";
 
     @Autowired
     private MongoTemplate mongoTemplate;
@@ -32,6 +40,19 @@ public class MongoIndexConfig {
         // enforced by {key, entityType} via 'key_entity_idx'.
         dropStaleIndex("tags", "key_org_idx");
         dropStaleIndex("tags", "key_org_entity_idx");
+
+        // Scripts: name uniqueness IGNORES soft-deleted rows so a user can
+        // reuse the name of a script they previously deleted. The legacy
+        // {tenantId, name} unique index (auto-named "tenantId_1_name_1") did
+        // not filter status — drop it and recreate as a PARTIAL unique index
+        // over {status: {$ne: 'DELETED'}}.
+        dropStaleIndex("scripts", "tenantId_1_name_1");
+        mongoTemplate.indexOps("scripts").ensureIndex(
+                new Index().on("tenantId", Sort.Direction.ASC)
+                        .on("name", Sort.Direction.ASC)
+                        .unique()
+                        .named(SCRIPTS_NAME_UNIQUE_INDEX)
+                        .partial(PartialIndexFilter.of(Criteria.where("status").ne("DELETED"))));
     }
 
     private void dropStaleIndex(String collection, String indexName) {

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/ScriptRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/ScriptRepository.java
@@ -1,6 +1,7 @@
 package com.openframe.data.repository.rmm;
 
 import com.openframe.data.document.rmm.Script;
+import com.openframe.data.document.rmm.ScriptStatus;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -33,14 +34,25 @@ public interface ScriptRepository extends MongoRepository<Script, String>, Custo
     List<Script> findByTenantIdAndIdIn(String tenantId, Collection<String> ids);
 
     /**
-     * Find a single script by name within the given tenant. The compound index
-     * {@code (tenantId, name)} guarantees uniqueness.
+     * Find a single script by name within the given tenant. Uniqueness under
+     * {@code (tenantId, name)} is only enforced for non-{@code DELETED} rows,
+     * so this may return a soft-deleted document; callers filter as needed.
      */
     Optional<Script> findByTenantIdAndName(String tenantId, String name);
 
-    boolean existsByTenantIdAndName(String tenantId, String name);
+    /**
+     * Duplicate-name check for {@code create}. Ignores {@code DELETED} rows —
+     * a soft-deleted script frees its name for reuse. Pass
+     * {@code List.of(ACTIVE, ARCHIVED)} to restrict to the visible surface.
+     */
+    boolean existsByTenantIdAndNameAndStatusIn(String tenantId, String name, Collection<ScriptStatus> statuses);
 
-    boolean existsByTenantIdAndNameAndIdNot(String tenantId, String name, String excludeId);
+    /**
+     * Rename-collision check for {@code update} — excludes the row being
+     * edited from the comparison. Same {@code DELETED}-ignoring semantics as
+     * {@link #existsByTenantIdAndNameAndStatusIn}.
+     */
+    boolean existsByTenantIdAndNameAndIdNotAndStatusIn(String tenantId, String name, String excludeId, Collection<ScriptStatus> statuses);
 
     /**
      * Hard-delete a script by id within the given tenant. Returns the number of

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/repository/rmm/ScriptRepositoryIT.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/repository/rmm/ScriptRepositoryIT.java
@@ -204,34 +204,73 @@ class ScriptRepositoryIT extends BaseMongoIntegrationTest {
         assertThat(page.get(0).getId()).isEqualTo(seeded.get(2).getId());
     }
 
+    private static final List<ScriptStatus> UNIQUE_STATUSES =
+            List.of(ScriptStatus.ACTIVE, ScriptStatus.ARCHIVED);
+
     @Test
-    @DisplayName("Given a script with name X in tenant A, when existsByTenantIdAndName is called in tenant B with the same name, then false is returned")
-    void existsByTenantIdAndName_isolatesByTenant() {
+    @DisplayName("existsByTenantIdAndNameAndStatusIn: tenant-isolated — the same name in a different tenant does NOT collide")
+    void existsByTenantIdAndNameAndStatusIn_isolatesByTenant() {
         scriptRepository.save(newScript(TENANT_A, "shared"));
 
-        assertThat(scriptRepository.existsByTenantIdAndName(TENANT_A, "shared")).isTrue();
-        assertThat(scriptRepository.existsByTenantIdAndName(TENANT_B, "shared")).isFalse();
+        assertThat(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_A, "shared", UNIQUE_STATUSES)).isTrue();
+        assertThat(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_B, "shared", UNIQUE_STATUSES)).isFalse();
     }
 
     @Test
-    @DisplayName("Given a script being edited (its own name), when existsByTenantIdAndNameAndIdNot checks against the same name, then false is returned — the document does not collide with itself")
-    void existsByTenantIdAndNameAndIdNot_excludesEditedDocument() {
+    @DisplayName("existsByTenantIdAndNameAndStatusIn: a soft-deleted script does NOT reserve its name — user can create a new script with the same name")
+    void existsByTenantIdAndNameAndStatusIn_ignoresDeletedRows() {
+        Script gone = newScript(TENANT_A, "Dir");
+        gone.setStatus(ScriptStatus.DELETED);
+        scriptRepository.save(gone);
+
+        assertThat(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_A, "Dir", UNIQUE_STATUSES)).isFalse();
+    }
+
+    @Test
+    @DisplayName("existsByTenantIdAndNameAndStatusIn: an ARCHIVED script DOES reserve its name — visible in list, so name stays taken")
+    void existsByTenantIdAndNameAndStatusIn_countsArchivedRows() {
+        Script archived = newScript(TENANT_A, "old-runner");
+        archived.setStatus(ScriptStatus.ARCHIVED);
+        scriptRepository.save(archived);
+
+        assertThat(scriptRepository.existsByTenantIdAndNameAndStatusIn(TENANT_A, "old-runner", UNIQUE_STATUSES)).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByTenantIdAndNameAndIdNotAndStatusIn: the document being edited does NOT collide with itself")
+    void existsByTenantIdAndNameAndIdNotAndStatusIn_excludesEditedDocument() {
         Script saved = scriptRepository.save(newScript(TENANT_A, "X"));
 
-        boolean collides = scriptRepository.existsByTenantIdAndNameAndIdNot(TENANT_A, "X", saved.getId());
+        boolean collides = scriptRepository.existsByTenantIdAndNameAndIdNotAndStatusIn(
+                TENANT_A, "X", saved.getId(), UNIQUE_STATUSES);
 
         assertThat(collides).isFalse();
     }
 
     @Test
-    @DisplayName("Given two scripts in the same tenant, when existsByTenantIdAndNameAndIdNot checks the other script's name while editing one of them, then true is returned (real collision)")
-    void existsByTenantIdAndNameAndIdNot_detectsRealCollision() {
+    @DisplayName("existsByTenantIdAndNameAndIdNotAndStatusIn: renaming to a sibling's name detects a real collision")
+    void existsByTenantIdAndNameAndIdNotAndStatusIn_detectsRealCollision() {
         Script keep = scriptRepository.save(newScript(TENANT_A, "keep"));
         Script editing = scriptRepository.save(newScript(TENANT_A, "editing"));
 
-        boolean collides = scriptRepository.existsByTenantIdAndNameAndIdNot(TENANT_A, keep.getName(), editing.getId());
+        boolean collides = scriptRepository.existsByTenantIdAndNameAndIdNotAndStatusIn(
+                TENANT_A, keep.getName(), editing.getId(), UNIQUE_STATUSES);
 
         assertThat(collides).isTrue();
+    }
+
+    @Test
+    @DisplayName("existsByTenantIdAndNameAndIdNotAndStatusIn: renaming to a soft-deleted sibling's name is ALLOWED — soft-delete freed the name")
+    void existsByTenantIdAndNameAndIdNotAndStatusIn_ignoresDeletedSibling() {
+        Script gone = newScript(TENANT_A, "old-name");
+        gone.setStatus(ScriptStatus.DELETED);
+        scriptRepository.save(gone);
+        Script editing = scriptRepository.save(newScript(TENANT_A, "current-name"));
+
+        boolean collides = scriptRepository.existsByTenantIdAndNameAndIdNotAndStatusIn(
+                TENANT_A, "old-name", editing.getId(), UNIQUE_STATUSES);
+
+        assertThat(collides).isFalse();
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Script names can now be reused after a script is soft-deleted.
  * Name conflicts are now checked more accurately, preventing false collisions when editing or creating scripts.
  * Archived and active scripts still reserve their names within the same tenant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->