### PR TITLE
fix(media-gallery): remove maxDisplay cap — release page shows all media

### DIFF
--- a/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
+++ b/openframe-frontend-core/src/components/shared/media-gallery-strip.tsx
@@ -19,8 +19,6 @@ function isGalleryImage(mediaType: string): boolean {
 
 export interface MediaGalleryStripProps {
   items: MediaGalleryStripItem[];
-  /** Optional cap on tiles shown (e.g. product-release shows 5). Default: all. */
-  maxDisplay?: number;
   className?: string;
 }
 
@@ -34,16 +32,13 @@ export interface MediaGalleryStripProps {
  * that was hand-rolled inline in the product-release and "What I Shipped" detail
  * pages (the release copy also had a raw-index lightbox bug this component fixes).
  */
-export function MediaGalleryStrip({ items, maxDisplay, className }: MediaGalleryStripProps) {
+export function MediaGalleryStrip({ items, className }: MediaGalleryStripProps) {
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [galleryIndex, setGalleryIndex] = useState(0);
 
   if (!items || items.length === 0) return null;
 
-  // Explicit numeric check (clamped): `maxDisplay={0}` means "show none", which a
-  // truthy check would wrongly treat as "no cap → show all".
-  const display = typeof maxDisplay === 'number' ? items.slice(0, Math.max(0, maxDisplay)) : items;
-  const galleryImages = display.filter((m) => isGalleryImage(m.media_type)).map((m) => m.media_url);
+  const galleryImages = items.filter((m) => isGalleryImage(m.media_type)).map((m) => m.media_url);
 
   const tileClass =
     'shrink-0 w-[240px] h-[200px] rounded-md overflow-hidden border border-ods-border bg-black transition-opacity';
@@ -51,7 +46,7 @@ export function MediaGalleryStrip({ items, maxDisplay, className }: MediaGallery
   return (
     <>
       <div className={`flex gap-6 overflow-x-auto w-full ${className ?? ''}`}>
-        {display.map((mediaItem, index) => {
+        {items.map((mediaItem, index) => {
           // Image tiles open the lightbox, so they're real <button>s — keyboard
           // focusable + Enter/Space activatable. Clips render in <Video>, which
           // owns its own controls, so their tile stays a plain container.
@@ -64,7 +59,7 @@ export function MediaGalleryStrip({ items, maxDisplay, className }: MediaGallery
                 aria-label={`Open ${mediaItem.title || `media ${index + 1}`} in gallery`}
                 onClick={() => {
                   // Lightbox position = rank among image-only items (clips skipped).
-                  setGalleryIndex(display.slice(0, index).filter((m) => isGalleryImage(m.media_type)).length);
+                  setGalleryIndex(items.slice(0, index).filter((m) => isGalleryImage(m.media_type)).length);
                   setGalleryOpen(true);
                 }}
               >

--- a/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
+++ b/openframe-frontend-core/src/components/shared/product-release/release-detail-page.tsx
@@ -317,7 +317,7 @@ export function ReleaseDetailPage({
         </div>
 
         {/* Image gallery — shared strip + lightbox (images) / inline clips. */}
-        <MediaGalleryStrip items={releaseMedia ?? []} maxDisplay={5} />
+        <MediaGalleryStrip items={releaseMedia ?? []} />
 
         {/* Summary */}
         {releaseSummary && (


### PR DESCRIPTION
## Problem

Releases with more than 5 attached images (e.g. `v0-9-52` with 12) only showed 5 on the release details page, and the lightbox counter maxed at "5 / 5".

## Root cause

The product-release detail page passed `maxDisplay={5}` to `MediaGalleryStrip`. The cap was never a product requirement — the original hand-rolled release-page markup rendered exactly 5 tiles to match the Figma mock, and the `MediaGalleryStrip` extraction (#1179) carried it over as a prop for pixel-parity. Since the lightbox is built from the *displayed* tiles, it silently truncated the gallery too.

## Fix

- Remove the `maxDisplay` prop and its slicing logic from `MediaGalleryStrip` entirely — the strip already scrolls horizontally, so it always renders every item and the lightbox includes all of them.
- Drop `maxDisplay={5}` from the release detail page call site.

## Sweep

`MediaGalleryStrip` is the SSOT for detail-page media strips; its only other consumer (What-I-Shipped detail page in the hub) never passed a cap, so removing the prop is non-breaking. The hub data layer returns all `product_release_media` rows uncapped — the UI was the only truncation point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media galleries now show all available items instead of stopping at a fixed limit.
  * The image viewer opens to the correct item when selecting media from a longer gallery.
  * Release detail pages now display the full set of media thumbnails without an artificial cap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->