### PR TITLE
Update PinotClientDeviceRepository: fix limit issue, add query for active devices to exclude archived from count

### DIFF
--- a/openframe-data-pinot/src/main/java/com/openframe/data/pinot/repository/PinotClientDeviceRepository.java
+++ b/openframe-data-pinot/src/main/java/com/openframe/data/pinot/repository/PinotClientDeviceRepository.java
@@ -8,8 +8,11 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static com.openframe.data.document.device.DeviceStatus.DELETED;
+import static com.openframe.data.document.device.DeviceStatus.OFFLINE;
+import static com.openframe.data.document.device.DeviceStatus.ONLINE;
 
 @Slf4j
 @Repository
@@ -21,6 +24,22 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
     private static final String ORGANIZATION_ID = "organizationId";
     private static final String TAGS = "tags";
     private static final String TAG_KEY_VALUES = "tagKeyValues";
+
+    /**
+     * Statuses considered "active" for the organization device counts facet
+     * ({@link #getOrganizationFilterOptions}). That facet counts only ONLINE and OFFLINE
+     * devices; every other facet and the filtered device count keep the default behaviour
+     * of excluding only DELETED devices.
+     */
+    private static final List<String> ACTIVE_STATUSES = List.of(ONLINE.name(), OFFLINE.name());
+
+    /**
+     * Explicit upper bound for faceted GROUP BY queries. Without an explicit LIMIT,
+     * Pinot caps GROUP BY results at its default of 10 groups, which silently drops
+     * low-count buckets (e.g. an organization with a single device). 10000 is the
+     * builder's max and is comfortably above the number of distinct filter values.
+     */
+    private static final int MAX_FILTER_OPTIONS = 10000;
 
     @Value("${pinot.tables.devices.name:devices}")
     private String devicesTable;
@@ -74,7 +93,8 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
             List<String> organizationIds,
             List<String> tagKeys,
             List<String> tagKeyValues) {
-        return executeFacetQuery(ORGANIZATION_ID, tenantId, statuses, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, ORGANIZATION_ID);
+        // Organization device counts only include active devices (ONLINE / OFFLINE).
+        return executeActiveFacetQuery(ORGANIZATION_ID, tenantId, statuses, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, ORGANIZATION_ID);
     }
 
     @Override
@@ -105,8 +125,9 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
     }
 
     /**
-     * Executes a faceted filter-option query:
-     * SELECT {facetField}, COUNT(*) as count FROM devices WHERE <filters excluding facetField> GROUP BY {facetField} ORDER BY count DESC
+     * Executes a faceted filter-option query, counting every device except DELETED:
+     * SELECT {facetField}, COUNT(*) as count FROM devices WHERE <filters excluding facetField> GROUP BY {facetField} ORDER BY count DESC LIMIT {MAX_FILTER_OPTIONS}
+     * The explicit LIMIT overrides Pinot's default GROUP BY cap of 10 groups so every bucket is returned.
      */
     private Map<String, Integer> executeFacetQuery(String facetField,
                                                     String tenantId,
@@ -117,17 +138,40 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
                                                     List<String> tagKeys,
                                                     List<String> tagKeyValues,
                                                     String excludeField) {
-        PinotQueryBuilder queryBuilder = new PinotQueryBuilder(devicesTable, tenantId)
-                .select(facetField)
-                .selectCount()
-                .groupBy(facetField)
-                .orderByCountDesc();
+        PinotQueryBuilder queryBuilder = newFacetQueryBuilder(facetField, tenantId);
         applyDeviceFilters(queryBuilder, statuses, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
         return executeKeyCountQuery(queryBuilder.build());
     }
 
     /**
-     * Applies the shared device filter set to a builder. Always excludes DELETED devices.
+     * Same as {@link #executeFacetQuery} but counts only active devices (status ONLINE or OFFLINE).
+     * Used by the organization device counts facet.
+     */
+    private Map<String, Integer> executeActiveFacetQuery(String facetField,
+                                                         String tenantId,
+                                                         List<String> statuses,
+                                                         List<String> deviceTypes,
+                                                         List<String> osTypes,
+                                                         List<String> organizationIds,
+                                                         List<String> tagKeys,
+                                                         List<String> tagKeyValues,
+                                                         String excludeField) {
+        PinotQueryBuilder queryBuilder = newFacetQueryBuilder(facetField, tenantId);
+        applyActiveDeviceFilters(queryBuilder, statuses, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
+        return executeKeyCountQuery(queryBuilder.build());
+    }
+
+    private PinotQueryBuilder newFacetQueryBuilder(String facetField, String tenantId) {
+        return new PinotQueryBuilder(devicesTable, tenantId)
+                .select(facetField)
+                .selectCount()
+                .groupBy(facetField)
+                .orderByCountDesc()
+                .limit(MAX_FILTER_OPTIONS);
+    }
+
+    /**
+     * Applies the shared device filter set to a builder, excluding only DELETED devices.
      * If {@code excludeField} matches a filter's field, that filter is skipped (used for faceted filter-option queries).
      */
     private void applyDeviceFilters(PinotQueryBuilder queryBuilder,
@@ -139,17 +183,55 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
                                     List<String> tagKeyValues,
                                     String excludeField) {
         queryBuilder.whereNotEquals(STATUS, DELETED.name());
+        applyStatusFilter(queryBuilder, statuses, excludeField, status -> !DELETED.name().equals(status));
+        applyNonStatusFilters(queryBuilder, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
+    }
 
-        if (!STATUS.equals(excludeField) && statuses != null) {
-            List<String> filteredStatuses = statuses.stream()
-                    .filter(status -> status != null && !status.isBlank())
-                    .filter(status -> !DELETED.name().equals(status))
-                    .toList();
-            if (!filteredStatuses.isEmpty()) {
-                queryBuilder.whereOr(STATUS, filteredStatuses);
-            }
+    /**
+     * Applies the shared device filter set to a builder, restricting the counted universe to
+     * active devices (status ONLINE or OFFLINE) instead of the default exclude-only-DELETED rule.
+     * If {@code excludeField} matches a filter's field, that filter is skipped.
+     */
+    private void applyActiveDeviceFilters(PinotQueryBuilder queryBuilder,
+                                          List<String> statuses,
+                                          List<String> deviceTypes,
+                                          List<String> osTypes,
+                                          List<String> organizationIds,
+                                          List<String> tagKeys,
+                                          List<String> tagKeyValues,
+                                          String excludeField) {
+        queryBuilder.whereIn(STATUS, ACTIVE_STATUSES);
+        applyStatusFilter(queryBuilder, statuses, excludeField, ACTIVE_STATUSES::contains);
+        applyNonStatusFilters(queryBuilder, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
+    }
+
+    /**
+     * Applies the caller-supplied status filter, keeping only the statuses accepted by {@code keep}
+     * (so it never contradicts the base status restriction). Skipped when status is the faceted field.
+     */
+    private void applyStatusFilter(PinotQueryBuilder queryBuilder,
+                                   List<String> statuses,
+                                   String excludeField,
+                                   Predicate<String> keep) {
+        if (STATUS.equals(excludeField) || statuses == null) {
+            return;
         }
+        List<String> filteredStatuses = statuses.stream()
+                .filter(status -> status != null && !status.isBlank())
+                .filter(keep)
+                .toList();
+        if (!filteredStatuses.isEmpty()) {
+            queryBuilder.whereOr(STATUS, filteredStatuses);
+        }
+    }
 
+    private void applyNonStatusFilters(PinotQueryBuilder queryBuilder,
+                                       List<String> deviceTypes,
+                                       List<String> osTypes,
+                                       List<String> organizationIds,
+                                       List<String> tagKeys,
+                                       List<String> tagKeyValues,
+                                       String excludeField) {
         if (!DEVICE_TYPE.equals(excludeField) && deviceTypes != null && !deviceTypes.isEmpty()) {
             queryBuilder.whereOr(DEVICE_TYPE, deviceTypes);
         }

--- a/openframe-data-pinot/src/main/java/com/openframe/data/pinot/repository/PinotClientDeviceRepository.java
+++ b/openframe-data-pinot/src/main/java/com/openframe/data/pinot/repository/PinotClientDeviceRepository.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static com.openframe.data.document.device.DeviceStatus.DELETED;
 import static com.openframe.data.document.device.DeviceStatus.OFFLINE;
@@ -183,7 +182,7 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
                                     List<String> tagKeyValues,
                                     String excludeField) {
         queryBuilder.whereNotEquals(STATUS, DELETED.name());
-        applyStatusFilter(queryBuilder, statuses, excludeField, status -> !DELETED.name().equals(status));
+        applyStatusFilter(queryBuilder, statuses, excludeField);
         applyNonStatusFilters(queryBuilder, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
     }
 
@@ -201,27 +200,27 @@ public class PinotClientDeviceRepository extends AbstractPinotRepository impleme
                                           List<String> tagKeyValues,
                                           String excludeField) {
         queryBuilder.whereIn(STATUS, ACTIVE_STATUSES);
-        applyStatusFilter(queryBuilder, statuses, excludeField, ACTIVE_STATUSES::contains);
+        applyStatusFilter(queryBuilder, statuses, excludeField);
         applyNonStatusFilters(queryBuilder, deviceTypes, osTypes, organizationIds, tagKeys, tagKeyValues, excludeField);
     }
 
     /**
-     * Applies the caller-supplied status filter, keeping only the statuses accepted by {@code keep}
-     * (so it never contradicts the base status restriction). Skipped when status is the faceted field.
+     * Applies the caller-supplied status filter verbatim (blank values dropped). The base status
+     * restriction is applied separately by the caller, so a selection with no overlap with the allowed
+     * universe becomes a contradiction that correctly yields zero rows rather than broadening the query.
+     * Skipped when status is the faceted field.
      */
     private void applyStatusFilter(PinotQueryBuilder queryBuilder,
                                    List<String> statuses,
-                                   String excludeField,
-                                   Predicate<String> keep) {
+                                   String excludeField) {
         if (STATUS.equals(excludeField) || statuses == null) {
             return;
         }
-        List<String> filteredStatuses = statuses.stream()
+        List<String> requestedStatuses = statuses.stream()
                 .filter(status -> status != null && !status.isBlank())
-                .filter(keep)
                 .toList();
-        if (!filteredStatuses.isEmpty()) {
-            queryBuilder.whereOr(STATUS, filteredStatuses);
+        if (!requestedStatuses.isEmpty()) {
+            queryBuilder.whereOr(STATUS, requestedStatuses);
         }
     }
 

--- a/openframe-data-pinot/src/test/java/com/openframe/data/pinot/repository/PinotClientDeviceRepositoryTest.java
+++ b/openframe-data-pinot/src/test/java/com/openframe/data/pinot/repository/PinotClientDeviceRepositoryTest.java
@@ -158,17 +158,31 @@ class PinotClientDeviceRepositoryTest {
         }
 
         @Test
-        @DisplayName("filtered DELETED values are removed from user status filter")
-        void statusFilterRemovesDeletedValue() {
+        @DisplayName("user-selected statuses are applied verbatim; the base guard neutralizes DELETED")
+        void statusFilterNeutralizesDeleted() {
             whenQueryReturnsEmptyRows();
             repository.getDeviceTypeFilterOptions(TENANT_ID, List.of("ACTIVE", "DELETED"),
                     List.of(), List.of(), List.of(), List.of(), List.of());
             String query = captureQuery();
-            assertTrue(query.contains("status = 'ACTIVE'"));
-            // DELETED should be filtered out (only the "!= DELETED" remains)
-            int deletedOccurrences = query.split("status = 'DELETED'", -1).length - 1;
-            assertEquals(0, deletedOccurrences,
-                    "status = 'DELETED' should not appear as a positive filter: " + query);
+            // The user's selection is applied verbatim (no status is silently dropped)...
+            assertTrue(query.contains("status = 'ACTIVE'"), "was: " + query);
+            // ...but the always-present base guard ensures DELETED devices can never match,
+            // so including DELETED in the selection neither broadens nor returns DELETED rows.
+            assertTrue(query.contains("status != 'DELETED'"), "was: " + query);
+        }
+
+        @Test
+        @DisplayName("a selection with no overlap with the allowed universe is preserved as an empty intersection")
+        void statusFilterPreservesEmptyIntersection() {
+            whenQueryReturnsEmptyRows();
+            // Only DELETED selected: base guard excludes it, so the query must contradict (return nothing)
+            // rather than dropping the status filter and broadening to all non-deleted devices.
+            repository.getDeviceTypeFilterOptions(TENANT_ID, List.of("DELETED"),
+                    List.of(), List.of(), List.of(), List.of(), List.of());
+            String query = captureQuery();
+            assertTrue(query.contains("status != 'DELETED'"), "was: " + query);
+            assertTrue(query.contains("status = 'DELETED'"),
+                    "selected DELETED must still be applied so the intersection is empty, not broadened: " + query);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization facet counts now include active devices, improving filter results for device-related views.
  * Faceted filter options now have a higher, explicit cap to return more complete results.

* **Bug Fixes**
  * Improved status-based filtering so counts better match the selected filters.
  * Reduced the chance of incomplete facet results when large numbers of options are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->