### PR TITLE
fix(chat): optically center quick-action chip lozenge for all-caps labels

### DIFF
--- a/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
+++ b/openframe-frontend-core/src/components/chat/quick-action-chip.tsx
@@ -114,7 +114,12 @@ function composeChipLabel(
     <>
       <span
         className={cn(
-          'mr-2 inline-flex items-center rounded px-[5px] py-[3px] align-middle text-[10px] font-bold uppercase leading-none tracking-[0.08em]',
+          // -translate-y-[1px]: align-middle centers on x-height, but the chip
+          // labels are uppercase (no descenders), so the lozenge reads ~1px low
+          // against the caps' optical center (measured 9.1px above / 6.9px
+          // below in the 32px Tag). Keep QuickActionChipSkeleton's lozenge bar
+          // offset in lockstep.
+          'mr-2 inline-flex items-center rounded px-[5px] py-[3px] align-middle -translate-y-[1px] text-[10px] font-bold uppercase leading-none tracking-[0.08em]',
           lozenge.className,
         )}
         style={{ background: 'color-mix(in srgb, currentColor 14%, transparent)' }}
@@ -185,7 +190,7 @@ export function QuickActionChipSkeleton({ labelCh = 16, icon = true, lozenge = f
       icon={icon ? <ChipSkelBar className="block size-4" /> : undefined}
       label={
         <>
-          {lozenge && <ChipSkelBar className="mr-2 inline-block h-[16px] w-[26px] translate-y-[3px]" />}
+          {lozenge && <ChipSkelBar className="mr-2 inline-block h-[16px] w-[26px] translate-y-[2px]" />}
           <ChipSkelBar className="inline-block h-[0.9em] translate-y-[0.08em]" style={{ width: `${labelCh}ch` }} />
         </>
       }


### PR DESCRIPTION
## Summary
The IT/SEC lozenge inside `QuickActionChipButton` rides ~1px low: `align-middle` centers the box on the parent's x-height, but chip labels are all-caps (no descenders), so against the caps' optical center the lozenge measured **9.1px above / 6.9px below** inside the 32px Tag (headless-measured on the company-hub deck, slide 3).

- Nudge the lozenge up 1px (`-translate-y-[1px]`) → measures 8.1 / 7.9 after the fix.
- Keep `QuickActionChipSkeleton`'s lozenge bar in lockstep (`translate-y-[3px]` → `[2px]`) so skeleton chips stay 1:1 with loaded chips.

Companion hub PR unifies the deck's chip panels into one `ChipPanel` component (multi-platform-hub, same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical alignment of the quick-action chip lozenge so it sits more naturally with the chip text.
  * Kept the loading skeleton’s lozenge placeholder visually consistent with the final chip appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->