### PR TITLE
feat(vendor-tag): add api/data/k8s/secured platform-capability types

### DIFF
--- a/openframe-frontend-core/src/components/vendor-tag.tsx
+++ b/openframe-frontend-core/src/components/vendor-tag.tsx
@@ -3,10 +3,10 @@
 import { OpenSourceIcon, CoinsIcon } from "./icons-stub"
 import { OpenFrameLogo } from "./openframe-logo"
 import { cn } from "../utils/cn"
-import { Hand, Sparkles } from "lucide-react"
+import { Boxes, Database, Hand, Plug, ShieldCheck, Sparkles } from "lucide-react"
 
 export interface VendorTagProps {
-  type: 'open-source' | 'commercial' | 'free' | 'freemium' | 'paid' | 'enterprise' | 'recommended' | 'classification' | 'ai' | 'manual' | 'openframe_selected' | 'placeholder'
+  type: 'open-source' | 'commercial' | 'free' | 'freemium' | 'paid' | 'enterprise' | 'recommended' | 'classification' | 'ai' | 'manual' | 'openframe_selected' | 'placeholder' | 'api' | 'data' | 'k8s' | 'secured'
   text?: string
   className?: string
   size?: 'sm' | 'md'
@@ -80,6 +80,43 @@ export function VendorTag({
           icon: (
             <div className="w-4 h-4 bg-ods-border rounded-sm flex items-center justify-center flex-shrink-0">
               <CoinsIcon width={10} height={10} className="text-ods-text-secondary" />
+            </div>
+          )
+        }
+      // platform-capability tags — same neutral icon-box chrome as 'commercial'
+      case 'api':
+        return {
+          text: text || "API",
+          icon: (
+            <div className="w-4 h-4 bg-ods-border rounded-sm flex items-center justify-center flex-shrink-0">
+              <Plug width={10} height={10} className="text-ods-text-secondary" />
+            </div>
+          )
+        }
+      case 'data':
+        return {
+          text: text || "Data",
+          icon: (
+            <div className="w-4 h-4 bg-ods-border rounded-sm flex items-center justify-center flex-shrink-0">
+              <Database width={10} height={10} className="text-ods-text-secondary" />
+            </div>
+          )
+        }
+      case 'k8s':
+        return {
+          text: text || "K8s",
+          icon: (
+            <div className="w-4 h-4 bg-ods-border rounded-sm flex items-center justify-center flex-shrink-0">
+              <Boxes width={10} height={10} className="text-ods-text-secondary" />
+            </div>
+          )
+        }
+      case 'secured':
+        return {
+          text: text || "Secured",
+          icon: (
+            <div className="w-4 h-4 bg-ods-border rounded-sm flex items-center justify-center flex-shrink-0">
+              <ShieldCheck width={10} height={10} className="text-ods-text-secondary" />
             </div>
           )
         }


### PR DESCRIPTION
## What

Adds four platform-capability types to `VendorTag`: `api` (Plug), `data` (Database), `k8s` (Boxes), `secured` (ShieldCheck) — all on the same neutral icon-box chrome as the existing `commercial` tag. Icons are lucide-react (already a dependency). Default labels: API / Data / K8s / Secured, overridable via the existing `text` prop.

## Why

The company-hub investor deck (slide 7, OpenFrame Core payoff box) needs capability badges next to the product title, using the common openmsp badge component rather than a bespoke deck style. Adding them as first-class VendorTag types makes them reusable product-wide.

## Reviewer notes

- Pure additive change — no existing type's rendering is touched.
- The hub consumes this via its exact-version pin, so after merge this needs a release from main, then a hub pin bump (hub PR referencing this one follows the usual lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tag variants for API, data, Kubernetes, and secured items.
  * These tags now display with matching icons and consistent styling.
  * Default label text is shown when a custom label isn’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->