### PR TITLE
Fix "Modal-v2": cap panel width to the viewport on narrow screens

### DIFF
--- a/openframe-frontend-core/src/components/ui/modal-v2.tsx
+++ b/openframe-frontend-core/src/components/ui/modal-v2.tsx
@@ -95,7 +95,11 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
           ref={ref}
           data-state={state}
           className={cn(
-            "relative z-10 w-full max-w-md flex flex-col",
+            // min() keeps the desktop cap at 28rem while never letting content
+            // stretch the panel past the viewport (minus the mx-4 margins) on
+            // narrow screens. A single base utility (not md:max-w-md) so consumer
+            // max-w-* overrides via className still win at every breakpoint.
+            "relative z-10 w-full min-w-0 max-w-[min(28rem,calc(100vw-2rem))] flex flex-col",
             "mx-4 mb-4 md:mb-0",
             "max-h-[90vh]",
             "bg-ods-bg md:bg-ods-card",


### PR DESCRIPTION
- The panel's max-w-md (28rem) exceeds narrow viewports, so content with a large min-content (e.g. autocomplete chips) could stretch the modal edge-to-edge past its mx-4 margins. Cap it with max-w-[min(28rem,calc(100vw-2rem))] + min-w-0: identical to max-w-md from 480px up, viewport-minus-margins below. Kept as a single base utility so consumer max-w-* overrides via className still win at every breakpoint (an md:max-w-md variant would clamp e.g. FilterModal's max-w-[600px]).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated modal sizing so the dialog stays within the viewport on smaller screens.
  * Modal panels now cap at a consistent width while avoiding horizontal overflow, improving usability on mobile and narrow windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->