### PR TITLE
Frontend-core: unify overlay backdrops (dim, no blur) and raise in-layout drawer above mobile menu

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -2041,7 +2041,7 @@ function EmbeddableChatInner({
           defaultSize={750}
           storageKey="mingo-chat-width"
           resizeAriaLabel="Resize chat panel"
-          overlayClassName="mingo-chat-overlay md:bg-black/20"
+          overlayClassName="mingo-chat-overlay"
           aria-describedby={undefined}
           className="
             mingo-chat-content !bg-ods-bg shadow-2xl

--- a/openframe-frontend-core/src/components/features/time-tracker/time-tracker-header-button.tsx
+++ b/openframe-frontend-core/src/components/features/time-tracker/time-tracker-header-button.tsx
@@ -4,6 +4,7 @@ import * as PopoverPrimitive from '@radix-ui/react-popover'
 import { cn } from '../../../utils/cn'
 import { ClockHistoryIcon } from '../../icons-v2-generated/date-and-time/clock-history-icon'
 import { HeaderButton } from '../../navigation/header-button'
+import { OVERLAY_BACKDROP_CLASS } from '../../ui/drawer'
 import { TimeTrackerPanel } from './time-tracker-panel'
 import { useOptionalTimeTracker } from './time-tracker-context'
 import { useTrackerClock } from './use-tracker-clock'
@@ -18,7 +19,8 @@ export interface TimeTrackerHeaderButtonProps {
  * Header affordance for the time tracker. Renders nothing unless wrapped in a
  * `<TimeTrackerProvider>`. The trigger is the standard `HeaderButton`; when a
  * session is active it also shows the live elapsed time. The popup is a Radix
- * Popover anchored under the button (not a modal/drawer).
+ * Popover anchored under the button (not a modal/drawer), backed by the same
+ * dim overlay as the Drawer so all panels darken the page identically.
  */
 export function TimeTrackerHeaderButton({ className, disabled }: TimeTrackerHeaderButtonProps) {
   const ctx = useOptionalTimeTracker()
@@ -68,6 +70,21 @@ export function TimeTrackerHeaderButton({ className, disabled }: TimeTrackerHead
           }
         />
       </PopoverPrimitive.Trigger>
+      {/* Popovers have no built-in overlay — portal a dim backdrop behind the
+          panel. Clicks land on it (outside Content), so Radix still closes the
+          popover. Own Portal: Radix's Portal slots a single child. */}
+      <PopoverPrimitive.Portal>
+        <div
+          aria-hidden="true"
+          data-state={isOpen ? 'open' : 'closed'}
+          className={cn(
+            'fixed inset-0 z-[1299]',
+            OVERLAY_BACKDROP_CLASS,
+            'data-[state=open]:animate-in data-[state=open]:fade-in-0',
+            'data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
+          )}
+        />
+      </PopoverPrimitive.Portal>
       <PopoverPrimitive.Portal>
         <PopoverPrimitive.Content
           align="end"

--- a/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
@@ -11,6 +11,7 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
+  OVERLAY_BACKDROP_CLASS,
   type DrawerSide,
 } from "../ui/drawer"
 import { useAppLayoutDrawerContainer } from "./app-layout"
@@ -85,8 +86,12 @@ AppLayoutDrawerRoot.displayName = "AppLayoutDrawer"
 const AppLayoutDrawerTrigger = DialogPrimitive.Trigger
 const AppLayoutDrawerClose = DialogPrimitive.Close
 
+// z-[103] (overlay z-[102]) — above MobileBurgerMenu (backdrop z-[100],
+// panel z-[101]) so an in-layout drawer opened over the mobile menu is not
+// covered by it. The drawer is absolutely positioned inside the main-area
+// container, so header/sidebar are unaffected regardless of z.
 const appLayoutDrawerVariants = cva(
-  "absolute z-[45] flex outline-none focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-300",
+  "absolute z-[103] flex outline-none focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-300",
   {
     variants: {
       side: {
@@ -589,7 +594,8 @@ const AppLayoutDrawerContent = React.forwardRef<
           aria-hidden
           data-state={open ? "open" : "closed"}
           className={cn(
-            "absolute inset-0 z-[40] bg-[color-mix(in_srgb,var(--ods-system-greys-background)_50%,transparent)] outline-none data-[state=open]:pointer-events-auto data-[state=closed]:pointer-events-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "absolute inset-0 z-[102] outline-none data-[state=open]:pointer-events-auto data-[state=closed]:pointer-events-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            OVERLAY_BACKDROP_CLASS,
             // Persist mode only: hold the fade-out's final (transparent) frame
             // so the backdrop doesn't snap back to opacity 1 and dim the whole
             // content area while the drawer is "closed" (see PERSIST_CLOSED_HOLD).

--- a/openframe-frontend-core/src/components/navigation/mobile-burger-menu.tsx
+++ b/openframe-frontend-core/src/components/navigation/mobile-burger-menu.tsx
@@ -5,6 +5,7 @@ import { NavigationSidebarConfig, NavigationSidebarItem } from '../../types/navi
 import { cn } from '../../utils'
 import { Logout02Icon, PenEditIcon, UserSearchIcon } from '../icons-v2-generated'
 import { Button, SquareAvatar } from '../ui'
+import { OVERLAY_BACKDROP_CLASS } from '../ui/drawer'
 
 // Header height constant (h-12 = 48px)
 const HEADER_HEIGHT = 48
@@ -154,11 +155,11 @@ export const MobileBurgerMenu = React.memo(function MobileBurgerMenu({
 
   return (
     <>
-      {/* Blur backdrop - positioned below header */}
+      {/* Dim backdrop (no blur, unified with Drawer) - positioned below header */}
       <div
         className={cn(
           "fixed inset-0 z-[100] md:hidden",
-          "backdrop-blur-sm bg-ods-bg-overlay",
+          OVERLAY_BACKDROP_CLASS,
           "transition-all duration-300",
           isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
         )}

--- a/openframe-frontend-core/src/components/ui/drawer.tsx
+++ b/openframe-frontend-core/src/components/ui/drawer.tsx
@@ -8,6 +8,11 @@ import { X } from "lucide-react"
 import { cn } from "../../utils/cn"
 import { useHeaderHeight } from "../../hooks/ui/use-header-height"
 
+/** Unified overlay backdrop — dimmed, no blur. Single source of truth for
+ *  every full-screen backdrop (Drawer, AppLayoutDrawer, MobileBurgerMenu,
+ *  TimeTracker popover) so all panels dim the page identically. */
+const OVERLAY_BACKDROP_CLASS = "bg-black/50"
+
 const Drawer = DialogPrimitive.Root
 
 const DrawerTrigger = DialogPrimitive.Trigger
@@ -23,7 +28,8 @@ const DrawerOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9997] bg-black/50 outline-none focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[9997] outline-none focus:outline-none focus-visible:outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      OVERLAY_BACKDROP_CLASS,
       className
     )}
     {...props}
@@ -543,6 +549,7 @@ const DrawerFooter = ({
 DrawerFooter.displayName = "DrawerFooter"
 
 export {
+  OVERLAY_BACKDROP_CLASS,
   Drawer,
   DrawerTrigger,
   DrawerClose,


### PR DESCRIPTION
## Improvements
- shared OVERLAY_BACKDROP_CLASS (bg-black/50) exported from ui/drawer
- MobileBurgerMenu: drop backdrop-blur, use unified dim backdrop
- EmbeddableChat: drop lighter md:bg-black/20 overlay override
- TimeTracker popover: add dim backdrop behind the panel
- AppLayoutDrawer: z-[45]/[40] -> z-[103]/[102] so chat opens above MobileBurgerMenu (z-[100]/[101])