### PR TITLE
Frontend-core: mutually exclude mobile burger menu and in-layout drawer

### DIFF
--- a/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
@@ -14,7 +14,7 @@ import {
   OVERLAY_BACKDROP_CLASS,
   type DrawerSide,
 } from "../ui/drawer"
-import { useAppLayoutDrawerContainer } from "./app-layout"
+import { useAppLayoutDrawerContainer, useAppLayoutDrawerCoordination } from "./app-layout"
 
 /**
  * AppLayoutDrawer is a Drawer variant that renders **inside** AppLayout's main
@@ -67,6 +67,28 @@ const AppLayoutDrawerRoot = ({
     },
     [isControlled, onOpenChange],
   )
+
+  // Coordinate with AppLayout's mobile burger menu (the drawer covers it):
+  // opening the drawer closes the menu, and opening the menu closes the
+  // drawer via the registered close handle. Refs keep the registration
+  // effect independent of render-to-render identity changes.
+  const coordination = useAppLayoutDrawerCoordination()
+  const openRef = React.useRef(open)
+  openRef.current = open
+  const handleOpenChangeRef = React.useRef(handleOpenChange)
+  handleOpenChangeRef.current = handleOpenChange
+
+  React.useEffect(() => {
+    if (open) coordination?.notifyDrawerDidOpen()
+  }, [open, coordination])
+
+  React.useEffect(() => {
+    return coordination?.registerDrawer({
+      close: () => {
+        if (openRef.current) handleOpenChangeRef.current(false)
+      },
+    })
+  }, [coordination])
 
   return (
     <DrawerOpenContext.Provider value={open}>

--- a/openframe-frontend-core/src/components/navigation/app-layout.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, Suspense, useCallback, useContext, useState } from 'react'
+import { createContext, Suspense, useCallback, useContext, useMemo, useRef, useState } from 'react'
 import { NavigationSidebarConfig } from '../../types/navigation'
 import { cn } from '../../utils'
 import { NotificationDrawer } from '../features/notifications/notification-drawer'
@@ -18,6 +18,32 @@ const AppLayoutDrawerContainerContext = createContext<HTMLElement | null>(null)
 
 export function useAppLayoutDrawerContainer(): HTMLElement | null {
   return useContext(AppLayoutDrawerContainerContext)
+}
+
+/**
+ * Two-way coordination between AppLayout's mobile burger menu and in-layout
+ * drawers (`AppLayoutDrawer`), which render above the menu (z-[103] vs
+ * z-[101]) — the two must never be open at the same time:
+ *   - a drawer that opens calls `notifyDrawerDidOpen` so the layout closes
+ *     the menu (otherwise it would resurface once the drawer closes);
+ *   - each drawer registers a close handle so opening the menu via the
+ *     burger button closes any open drawer instead of hiding the menu
+ *     underneath it. Null outside of AppLayout.
+ */
+export interface AppLayoutDrawerHandle {
+  close: () => void
+}
+
+interface AppLayoutDrawerCoordination {
+  notifyDrawerDidOpen: () => void
+  /** Returns an unregister cleanup. */
+  registerDrawer: (handle: AppLayoutDrawerHandle) => () => void
+}
+
+const AppLayoutDrawerCoordinationContext = createContext<AppLayoutDrawerCoordination | null>(null)
+
+export function useAppLayoutDrawerCoordination(): AppLayoutDrawerCoordination | null {
+  return useContext(AppLayoutDrawerCoordinationContext)
 }
 
 export interface AppLayoutProps {
@@ -57,16 +83,37 @@ export function AppLayout({
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [drawerContainer, setDrawerContainer] = useState<HTMLDivElement | null>(null)
 
+  // Mirrors `mobileMenuOpen` so the toggle callback can stay identity-stable.
+  const mobileMenuOpenRef = useRef(mobileMenuOpen)
+  mobileMenuOpenRef.current = mobileMenuOpen
+
+  const drawerHandlesRef = useRef(new Set<AppLayoutDrawerHandle>())
+
   const handleToggleMobileMenu = useCallback(() => {
-    setMobileMenuOpen(prev => !prev)
+    const opening = !mobileMenuOpenRef.current
+    // Opening the menu closes any open in-layout drawer — otherwise the menu
+    // would open invisibly underneath it (the drawer renders above the menu).
+    if (opening) {
+      for (const handle of drawerHandlesRef.current) handle.close()
+    }
+    setMobileMenuOpen(opening)
   }, [])
 
   const handleCloseMobileMenu = useCallback(() => {
     setMobileMenuOpen(false)
   }, [])
 
+  const drawerCoordination = useMemo<AppLayoutDrawerCoordination>(() => ({
+    notifyDrawerDidOpen: () => setMobileMenuOpen(false),
+    registerDrawer: (handle) => {
+      drawerHandlesRef.current.add(handle)
+      return () => drawerHandlesRef.current.delete(handle)
+    },
+  }), [])
+
   return (
     <AppLayoutDrawerContainerContext.Provider value={drawerContainer}>
+      <AppLayoutDrawerCoordinationContext.Provider value={drawerCoordination}>
       <div className={cn("flex h-screen bg-ods-bg", className)}>
         <NavigationSidebar config={sidebarConfig} disabled={disabled} />
         {/* Mobile Burger Menu - opens below header */}
@@ -112,6 +159,7 @@ export function AppLayout({
           </div>
         </div>
       </div>
+      </AppLayoutDrawerCoordinationContext.Provider>
     </AppLayoutDrawerContainerContext.Provider>
   )
 }


### PR DESCRIPTION
## Description
Opening an AppLayoutDrawer (Mingo chat) closes the mobile menu, and opening the mobile menu via the burger button closes any open in-layout drawer — the drawer renders above the menu, so the menu must never open underneath it.