### PR TITLE
Frontend-core: MSP organization section in ChatHeader

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-container.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-container.tsx
@@ -7,6 +7,8 @@ import { XmarkIcon } from "../icons-v2-generated/signs-and-symbols/xmark-icon"
 import { Chevron02LeftIcon } from "../icons-v2-generated"
 import { TicketStatusTag, resolveStatusTagProps } from "../ui/ticket-status-tag"
 import { Skeleton } from "../ui/skeleton"
+import { MspOrganizationCard } from "./msp-organization-card"
+import { MspOrganizationCardSkeleton } from "./msp-organization-card-skeleton"
 import type { ConnectionIndicatorProps, ChatContainerProps, ChatHeaderProps } from "./types"
 
 const ConnectionIndicator: React.FC<ConnectionIndicatorProps> = ({ status }) => {
@@ -61,7 +63,7 @@ const ChatContainer = React.forwardRef<HTMLDivElement, ChatContainerProps>(
 ChatContainer.displayName = "ChatContainer"
 
 const ChatHeader = React.forwardRef<HTMLDivElement, ChatHeaderProps>(
-  ({ className, userName = 'Grace "Fae" Meadows', userTitle = "Your Personal Assistant", userAvatar, userIcon, onSettingsClick, onNewChat, onClose, onBack, showNewChat = false, connectionStatus = 'disconnected', serverUrl = null, headerActions, ticketInfo, fullWidth = false, bare = false, isLoading = false, ...props }, ref) => {
+  ({ className, userName = 'Grace "Fae" Meadows', userTitle = "Your Personal Assistant", userAvatar, userIcon, onSettingsClick, onNewChat, onClose, onBack, showNewChat = false, connectionStatus = 'disconnected', serverUrl = null, headerActions, ticketInfo, mspOrganization, isMspLoading = false, fullWidth = false, bare = false, isLoading = false, ...props }, ref) => {
     const cardClasses = bare
       ? ""
       : "rounded-md bg-ods-card border border-ods-border"
@@ -159,6 +161,23 @@ const ChatHeader = React.forwardRef<HTMLDivElement, ChatHeaderProps>(
               {headerActions}
             </div>
           </div>
+          {/* MSP branding slot — home-screen only; `ticketInfo` (open chat)
+              claims this space, so it wins when both are provided. The card
+              already draws the chrome: strip the section's own ring and keep
+              only the bottom rounding so its bg fits the card corners. */}
+          {!ticketInfo && (isMspLoading || mspOrganization) && (
+            <>
+              <div className="h-px bg-ods-border" />
+              {isMspLoading || !mspOrganization ? (
+                <MspOrganizationCardSkeleton className={cn("ring-0 rounded-none", !bare && "rounded-b-md")} />
+              ) : (
+                <MspOrganizationCard
+                  {...mspOrganization}
+                  className={cn("ring-0 rounded-none", !bare && "rounded-b-md", mspOrganization.className)}
+                />
+              )}
+            </>
+          )}
           {ticketInfo && (
             <>
               <div className="h-px bg-ods-border" />

--- a/openframe-frontend-core/src/components/chat/types/component.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/component.types.ts
@@ -7,6 +7,7 @@ import type { AssistantType, AuthorType, ChatApprovalStatus, ConnectionStatus } 
 import type { ApprovalRequestData, Message, MessageSegment, ToolExecutionData } from './message.types'
 import type { ChatRef } from '../chat-ref.types'
 import type { ChatContextItem } from './context-item.types'
+import type { MspOrganizationCardProps } from '../msp-organization-card'
 
 /**
  * Anchor component supplied by the host (or the lib's
@@ -89,6 +90,19 @@ export interface ChatHeaderProps extends HTMLAttributes<HTMLDivElement> {
    * Default `false` — renders the resolved identity row.
    */
   isLoading?: boolean
+  /**
+   * MSP organization branding section (logo + "Your IT is managed by {name}"
+   * + website link) rendered beneath the identity row, inside the header
+   * card. Intended for the home chat screen; `ticketInfo` takes precedence
+   * over it — on open-chat screens that slot shows the ticket details row.
+   */
+  mspOrganization?: MspOrganizationCardProps
+  /**
+   * Render a skeleton in the MSP organization slot while the host is still
+   * resolving tenant info, so the header doesn't shift when the section
+   * appears. Like `mspOrganization`, ignored when `ticketInfo` is set.
+   */
+  isMspLoading?: boolean
 }
 
 // ========== Connection Indicator Props ==========

--- a/openframe-frontend-core/src/stories/ChatContainer.stories.tsx
+++ b/openframe-frontend-core/src/stories/ChatContainer.stories.tsx
@@ -70,11 +70,15 @@ const FAE_MESSAGES: Message[] = [
 
 function FaeChatShell({
   withTicketInfo = false,
+  withMspOrganization = false,
+  mspLoading = false,
   bare = false,
   fullWidth = false,
   modelLoading = false,
 }: {
   withTicketInfo?: boolean
+  withMspOrganization?: boolean
+  mspLoading?: boolean
   bare?: boolean
   fullWidth?: boolean
   modelLoading?: boolean
@@ -121,6 +125,16 @@ function FaeChatShell({
               }
             : undefined
         }
+        mspOrganization={
+          withMspOrganization
+            ? {
+                name: 'TechFlow Solutions',
+                website: 'www.techflow.com',
+                href: 'https://www.techflow.com',
+              }
+            : undefined
+        }
+        isMspLoading={mspLoading}
       />
       <ChatContent>
         <ChatMessageList
@@ -202,6 +216,28 @@ export const Fae: Story = {
  */
 export const FaeWithTicket: Story = {
   render: () => <FaeChatShell withTicketInfo />,
+}
+
+/**
+ * Client chat home-screen header with the MSP organization branding bar —
+ * logo, "Your IT is managed by {name}" and the website link rendered inside
+ * the header card beneath the assistant identity row. This is the state of
+ * the main AI Assistant screen (with the chats list); once a chat/ticket is
+ * open, `ticketInfo` takes over the slot (see `FaeWithTicket`). The block
+ * renders only when the host has MSP info — absent it, the header stays a
+ * single identity row.
+ */
+export const ClientChatWithMspOrganization: Story = {
+  render: () => <FaeChatShell withMspOrganization />,
+}
+
+/**
+ * Client chat MSP organization slot in its loading state —
+ * `MspOrganizationCardSkeleton` holds the space while tenant info resolves,
+ * so the header doesn't shift when the branding bar swaps in.
+ */
+export const ClientChatMspOrganizationLoading: Story = {
+  render: () => <FaeChatShell mspLoading />,
 }
 
 /**


### PR DESCRIPTION
## Improvements
Add mspOrganization / isMspLoading props to ChatHeader: reuse MspOrganizationCard (and its skeleton) beneath the identity row for the AI Assistant home screen. ticketInfo keeps precedence over the slot on open-chat screens. Figma: openframe — fae-chat, node 1:5833.

## Task
[Always display MSP image and name bar on AI Assistant chat](https://app.clickup.com/t/9013925967/86ajbpbjf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MSP branding in the chat header on home-screen-only views.
  * Shows either a loading skeleton or an organization card while MSP info is being resolved.
  * The branding section is hidden when ticket details are present.

* **Documentation**
  * Added Storybook examples for the MSP branding and loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->