### PR TITLE
fix(theme): map ods-attention-* named colors in the Tailwind preset

### DIFF
--- a/openframe-frontend-core/src/components/features/array-entry-manager.tsx
+++ b/openframe-frontend-core/src/components/features/array-entry-manager.tsx
@@ -176,7 +176,7 @@ export function ArrayEntryManager<T extends { [key: string]: any }>({
             variant="transparent"
             size="icon"
             onClick={() => removeItem(index)}
-            className="text-ods-attention-red-error hover:bg-ods-attention-red-error/10"
+            className="text-ods-attention-red-error hover:bg-ods-attention-red-error-secondary"
           >
             <Trash2 className="h-4 w-4" />
           </Button>

--- a/openframe-frontend-core/src/components/features/push-button-selector.tsx
+++ b/openframe-frontend-core/src/components/features/push-button-selector.tsx
@@ -79,7 +79,7 @@ function PushButtonSelectorError({ message, title }: { message: string; title?: 
           {title}
         </h3>
       )}
-      <div className="p-4 bg-ods-attention-red-error-secondary border border-ods-attention-red-error/30 rounded-lg">
+      <div className="p-4 bg-ods-attention-red-error-secondary border border-ods-attention-red-error rounded-lg">
         <div className="font-['DM_Sans'] text-[14px] text-ods-attention-red-error">
           ⚠️ {message}
         </div>
@@ -299,7 +299,7 @@ export function PushButtonSelector({
 
       {/* Selection Summary */}
       {selectionSummary && validSelectedIds.length > 0 && (
-        <div className="p-4 bg-ods-attention-green-success-secondary border border-ods-attention-green-success/30 rounded-lg">
+        <div className="p-4 bg-ods-attention-green-success-secondary border border-ods-attention-green-success rounded-lg">
           <div className="flex items-center gap-2 mb-2">
             <div className="w-2 h-2 bg-ods-attention-green-success rounded-full"></div>
             <span className="font-['DM_Sans'] text-[14px] text-ods-attention-green-success font-medium">
@@ -329,7 +329,7 @@ export function PushButtonSelector({
 
       {/* Empty State Warning */}
       {validSelectedIds.length === 0 && title && !optional && (
-        <div className="p-3 bg-ods-attention-red-error-secondary border border-ods-attention-red-error/30 rounded-lg">
+        <div className="p-3 bg-ods-attention-red-error-secondary border border-ods-attention-red-error rounded-lg">
           <div className="font-['DM_Sans'] text-[12px] text-ods-attention-red-error">
             ⚠️ Please select at least one option
           </div>

--- a/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
@@ -588,7 +588,7 @@ function ReplyFailureBanner({
         variant="transparent"
         onClick={onDismiss}
         aria-label="Dismiss reply failure"
-        className="ml-auto px-2 py-0.5 text-xs font-medium uppercase tracking-wider text-ods-attention-red-error hover:bg-ods-attention-red-error/10 border-transparent"
+        className="ml-auto px-2 py-0.5 text-xs font-medium uppercase tracking-wider text-ods-attention-red-error hover:bg-ods-attention-red-error-secondary border-transparent"
       >
         Dismiss
       </Button>

--- a/openframe-frontend-core/src/components/ui/error-state.tsx
+++ b/openframe-frontend-core/src/components/ui/error-state.tsx
@@ -34,14 +34,17 @@ export function ErrorState({
     switch (variant) {
       case 'error':
         return {
-          bg: 'bg-ods-attention-red-error/20',
+          // -secondary tokens, NOT `/20` alpha modifiers: the ods colors are
+          // hex CSS vars, and Tailwind 3.x can't inject alpha into those —
+          // the modifier silently produced no background at all.
+          bg: 'bg-ods-attention-red-error-secondary',
           border: 'border-ods-attention-red-error',
           text: 'text-ods-attention-red-error',
           icon: 'text-ods-attention-red-error'
         }
       case 'warning':
         return {
-          bg: 'bg-ods-attention-yellow-warning/20',
+          bg: 'bg-ods-attention-yellow-warning-secondary',
           border: 'border-ods-attention-yellow-warning',
           text: 'text-ods-attention-yellow-warning',
           icon: 'text-ods-attention-yellow-warning'

--- a/openframe-frontend-core/tailwind.config.ts
+++ b/openframe-frontend-core/tailwind.config.ts
@@ -201,6 +201,31 @@ const config: Config = {
           },
           "open-yellow": "var(--ods-open-yellow-base)",
 
+          // Attention tokens (ods-colors.css). Components reference these BY
+          // NAME (error-state.tsx: `border-ods-attention-red-error` etc.) —
+          // without these mappings Tailwind silently generates NOTHING for
+          // the class and the component renders colorless in every consumer.
+          attention: {
+            "red-error": "var(--ods-attention-red-error)",
+            "red-error-hover": "var(--ods-attention-red-error-hover)",
+            "red-error-action": "var(--ods-attention-red-error-action)",
+            "red-error-secondary": "var(--ods-attention-red-error-secondary)",
+            "red-error-secondary-hover": "var(--ods-attention-red-error-secondary-hover)",
+            "red-error-secondary-action": "var(--ods-attention-red-error-secondary-action)",
+            "yellow-warning": "var(--ods-attention-yellow-warning)",
+            "yellow-warning-hover": "var(--ods-attention-yellow-warning-hover)",
+            "yellow-warning-action": "var(--ods-attention-yellow-warning-action)",
+            "yellow-warning-secondary": "var(--ods-attention-yellow-warning-secondary)",
+            "yellow-warning-secondary-hover": "var(--ods-attention-yellow-warning-secondary-hover)",
+            "yellow-warning-secondary-action": "var(--ods-attention-yellow-warning-secondary-action)",
+            "green-success": "var(--ods-attention-green-success)",
+            "green-success-hover": "var(--ods-attention-green-success-hover)",
+            "green-success-action": "var(--ods-attention-green-success-action)",
+            "green-success-secondary": "var(--ods-attention-green-success-secondary)",
+            "green-success-secondary-hover": "var(--ods-attention-green-success-secondary-hover)",
+            "green-success-secondary-action": "var(--ods-attention-green-success-secondary-action)",
+          },
+
           // Adaptive platform color
           current: "var(--ods-current)",
         },


### PR DESCRIPTION
## What

The Tailwind preset never defined named colors for the ODS attention tokens, yet lib components reference them BY NAME — `error-state.tsx` (`border-ods-attention-red-error`…), `alert.tsx`, `tag.tsx`, `status-badge.tsx`, `ticket-status-tag.tsx`, `phone-input.tsx`, `simple-markdown-renderer.tsx`, `utils/platform-config.tsx`. Tailwind silently generates NOTHING for unknown color names, so all of these rendered colorless (default border, inherited text) in every consumer app.

## Changes

1. **`tailwind.config.ts`**: adds the full `ods.attention` family (red-error / yellow-warning / green-success + hover/action/secondary/secondary-hover/secondary-action) mapped to the existing `ods-colors.css` variables → generates `bg/text/border-ods-attention-*` utilities everywhere the preset is used.
2. **`error-state.tsx`**: replaces `bg-…/20` alpha modifiers with the `-secondary` background tokens. The ods colors are hex CSS vars — Tailwind 3.x can't inject alpha into those, so the `/20` classes produced no background at all.

## Context

Found while building the auth revamp (multi-platform-hub PR #777): the access-denied screen's `ErrorState` rendered white. The hub added a temporary consumer-side mapping (`multi-platform-hub` commit `fdec5584`) — once this ships in a release and the hub's pin is bumped, that hub-side `theme.extend.colors` block should be removed.

## Not in scope

Other `/NN` alpha modifiers on ods var colors (`bg-ods-accent/10`, `bg-ods-error/5`, etc. in `file-upload.tsx`, `hover-dropdown.tsx`, `input.tsx`…) have the same silent no-op behavior — pre-existing, mostly subtle hover tints, worth a separate sweep (fix = channel-format vars + `<alpha-value>`, or dedicated tint tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error and warning state backgrounds so they now display correctly in the UI.
  * Improved visual consistency for attention-related colors, including error, warning, and success states.
* **New Features**
  * Added support for additional attention color styles, enabling more reliable use of these UI tokens across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->