### PR TITLE
refactor(embeds): default OG endpoint to /api/og-scraper

### DIFF
--- a/openframe-frontend-core/src/components/embeds/og-link-preview.tsx
+++ b/openframe-frontend-core/src/components/embeds/og-link-preview.tsx
@@ -8,7 +8,7 @@ import { useImageEdgeColor } from '../../hooks'
  * Open-Graph metadata returned by the consumer's scrape endpoint.
  *
  * The shape MUST match the JSON the OG endpoint serves at `ogEndpointPath`.
- * The hub's `/api/blog/og-scraper` returns exactly these fields — embedders
+ * The hub's `/api/og-scraper` returns exactly these fields — embedders
  * with a different endpoint must return the same shape (or adapt at the
  * route boundary). Keeps the consumer surface trivial: one URL → one card.
  */
@@ -90,7 +90,7 @@ export interface OGLinkPreviewProps {
    *  one configuration knob. */
   apiBaseUrl?: string
   /** Path of the OG endpoint on the configured base. Default
-   *  `'/api/blog/og-scraper'` matches the hub's route. Override if the
+   *  `'/api/og-scraper'` matches the hub's route. Override if the
    *  embedder serves the same `OGData` shape from a different path. */
   ogEndpointPath?: string
   /** Optional placeholder-builder. Omit to disable the placeholder image
@@ -158,7 +158,7 @@ const Favicon = ({ src, size = 'w-6 h-6' }: { src: string; size?: string }) => (
 export const OGLinkPreview: React.FC<OGLinkPreviewProps> = ({
   url,
   apiBaseUrl,
-  ogEndpointPath = '/api/blog/og-scraper',
+  ogEndpointPath = '/api/og-scraper',
   buildPlaceholderUrl,
   fallbackTitle,
   fallbackDescription,

--- a/openframe-frontend-core/src/components/embeds/rich-markdown-runtime.tsx
+++ b/openframe-frontend-core/src/components/embeds/rich-markdown-runtime.tsx
@@ -34,7 +34,7 @@ export interface RichMarkdownRuntime {
 const DEFAULT_RUNTIME: RichMarkdownRuntime = {
   redditProxyUrl: '/api/blog/reddit-proxy',
   twitterProxyUrl: '/api/blog/twitter-proxy',
-  ogScraperUrl: '/api/blog/og-scraper',
+  ogScraperUrl: '/api/og-scraper',
   transformImageSrc: () => null,
 }
 

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -64,7 +64,7 @@ export const EP = {
   // Hub serves these from /api/blog/*, so the proxied paths are /content/api/blog/*.
   redditProxy: `${CONTENT}/blog/reddit-proxy`,
   twitterProxy: `${CONTENT}/blog/twitter-proxy`,
-  ogScraper: `${CONTENT}/blog/og-scraper`,
+  ogScraper: `${CONTENT}/og-scraper`,
 } as const
 
 /** Public hub origin for new-tab "open the full content" links (embed mode). */


### PR DESCRIPTION
The hub's OG scraper moved from `/api/blog/og-scraper` to `/api/og-scraper` (multi-platform-hub #787) — it serves every markdown/link-preview surface (chat cards, KB docs, tickets, embeds), not just blog. This updates the lib defaults to the new canonical path:

- `og-link-preview.tsx`: `ogEndpointPath` default + doc comments
- `rich-markdown-runtime.tsx`: `ogScraperUrl` default
- `react-embedding-example/src/config/endpoints.ts`: example endpoint

**Ordering**: safe to merge/release in any order relative to the hub PR — the hub keeps a back-compat alias at `/api/blog/og-scraper` until all deployments run a lib version with these defaults, and the new `/api/og-scraper` path only requires the hub PR to be deployed first (it is part of the same rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OG link previews and markdown rendering to use the correct OG scraper endpoint.
  * Aligned the example app’s OG scraping URL with the new hub route, helping previews load properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->