### PR TITLE
Frontend Core: success/muted status variants for Input

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/create-organization-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/create-organization-form.tsx
@@ -38,6 +38,8 @@ export interface CreateOrganizationFormProps {
     domain?: string
     terms?: string
   }
+  /** Informational status under the email field (e.g. live availability). `errors.email` wins. */
+  emailStatus?: { message: string; variant: 'error' | 'warning' | 'success' | 'muted' }
   /**
    * SSO providers to offer. When non-empty the form switches to SSO mode:
    * fields and the terms checkbox are disabled and the primary submit is
@@ -74,6 +76,7 @@ export function CreateOrganizationForm({
   loading = false,
   disabled = false,
   errors,
+  emailStatus,
   ssoProviders,
   onSsoClick,
   ssoActionLabel = 'Sign Up with',
@@ -109,7 +112,8 @@ export function CreateOrganizationForm({
             label="Email"
             placeholder="username@mail.com"
             value={email}
-            error={errors?.email}
+            error={errors?.email ?? emailStatus?.message}
+            errorVariant={errors?.email ? 'error' : emailStatus?.variant}
             disabled={fieldsDisabled}
             onChange={(event) => onEmailChange(event.target.value)}
             onKeyDown={handleKeyDown}

--- a/openframe-frontend-core/src/components/ui/field-wrapper.tsx
+++ b/openframe-frontend-core/src/components/ui/field-wrapper.tsx
@@ -6,10 +6,10 @@ import { cn } from "../../utils/cn"
 export interface FieldWrapperProps {
   /** Label text displayed above the field */
   label?: string
-  /** Error message displayed below the field. Space is always reserved to prevent layout shifts. */
+  /** Status message displayed below the field. Space is always reserved to prevent layout shifts. */
   error?: string
-  /** Color variant for the error message: "error" (red) or "warning" (yellow) */
-  errorVariant?: "error" | "warning"
+  /** Color variant for the message: "error" (red), "warning" (yellow), "success" (green) or "muted" (grey) */
+  errorVariant?: "error" | "warning" | "success" | "muted"
   /** Additional className for the outer wrapper */
   className?: string
   children: React.ReactNode
@@ -18,6 +18,8 @@ export interface FieldWrapperProps {
 const errorVariantClasses = {
   error: "text-ods-error",
   warning: "text-[var(--ods-attention-yellow-warning)]",
+  success: "text-ods-success",
+  muted: "text-ods-text-secondary",
 } as const
 
 const FieldWrapper = React.forwardRef<HTMLDivElement, FieldWrapperProps>(

--- a/openframe-frontend-core/src/components/ui/input.tsx
+++ b/openframe-frontend-core/src/components/ui/input.tsx
@@ -15,10 +15,11 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   endAdornment?: React.ReactNode;
   /** Label text displayed above the input */
   label?: string;
-  /** Error message displayed below the input */
+  /** Status message displayed below the input */
   error?: string;
-  /** Color variant for error state: "error" (red) or "warning" (yellow) */
-  errorVariant?: "error" | "warning";
+  /** Color variant for the message: "error" (red), "warning" (yellow), "success" (green) or "muted" (grey).
+      Only "error" and "warning" mark the field invalid (colored border). */
+  errorVariant?: "error" | "warning" | "success" | "muted";
   /** When true, shows a loading spinner as end adornment */
   loading?: boolean;
 }
@@ -30,7 +31,9 @@ const invalidBorderClasses = {
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, invalid = false, startAdornment, endAdornment, label, error, errorVariant = "error", loading = false, ...props }, ref) => {
-    const isInvalid = invalid || !!error
+    // success/muted are informational — they never paint the invalid border
+    const variantIsInvalid = errorVariant === "error" || errorVariant === "warning"
+    const isInvalid = invalid || (!!error && variantIsInvalid)
 
     // Range inputs get a clean slider rendering — no label wrapper, borders, or adornments
     if (type === 'range') {
@@ -83,7 +86,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           // Disabled
           props.disabled && "!cursor-not-allowed bg-ods-bg",
           // Invalid
-          isInvalid && invalidBorderClasses[errorVariant],
+          isInvalid && invalidBorderClasses[variantIsInvalid ? (errorVariant as "error" | "warning") : "error"],
           className
         )}
       >


### PR DESCRIPTION
email status on CreateOrganizationForm

Widen FieldWrapper/Input errorVariant with informational "success" (green) and "muted" (grey) variants — they color the message only and never paint the invalid border. Add an emailStatus prop to CreateOrganizationForm to surface live email availability (checking/taken/available) under the email field; errors.email wins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization signup and form fields can now display additional message types, including success and muted states.
  * Email status messages can appear even when there isn’t a validation error.

* **Bug Fixes**
  * Improved form styling so informational messages no longer trigger invalid/error styling.
  * Expanded field and input display behavior to better match the message type being shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->