### PR TITLE
Frontend Core: Update Auth screen

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/accept-invitation-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/accept-invitation-form.tsx
@@ -1,27 +1,20 @@
 'use client'
 
 import { cn } from '../../../utils/cn'
-import { CheckboxBlock } from '../../ui/checkbox-block'
 import { Input } from '../../ui/input'
 import { BackToLoginLink } from './back-to-login-link'
 import type { AuthSsoProvider } from './sso-providers'
 import { SsoProviderButtons } from './sso-providers'
-import { TermsAgreementLabel } from './terms-agreement-label'
 
 export interface AcceptInvitationFormProps {
-  /** Invited email — shown read-only. */
+  /** Invited email — shown read-only (prefilled from the invitation link). */
   email: string
-  /** Terms & Privacy gate — SSO buttons stay disabled until checked. */
-  agreedToTerms: boolean
-  onAgreedToTermsChange: (checked: boolean) => void
   /** SSO providers offered to accept the invitation. */
   ssoProviders: AuthSsoProvider[]
   onSsoClick: (provider: AuthSsoProvider) => void
   onBackToLogin: () => void
   /** Verb prefix for provider buttons, e.g. "Sign Up with". Ignored for "openframe". */
   ssoActionLabel?: string
-  termsUrl?: string
-  privacyPolicyUrl?: string
   emailLabel?: string
   title?: string
   subtitle?: string
@@ -32,19 +25,14 @@ export interface AcceptInvitationFormProps {
 
 /**
  * Accept Invitation form. Presentational + controlled — the invited email is
- * read-only; the user agrees to terms and picks an SSO provider to join the
- * organization. SSO buttons are gated behind the terms checkbox.
+ * read-only; the user picks an SSO provider to join the organization.
  */
 export function AcceptInvitationForm({
   email,
-  agreedToTerms,
-  onAgreedToTermsChange,
   ssoProviders,
   onSsoClick,
   onBackToLogin,
   ssoActionLabel = 'Sign Up with',
-  termsUrl = '#',
-  privacyPolicyUrl = '#',
   emailLabel = 'Email',
   title = 'Accept Invitation',
   subtitle = 'Complete your registration to join the organization',
@@ -68,22 +56,12 @@ export function AcceptInvitationForm({
       {/* Invited email — read-only */}
       <Input type="email" label={emailLabel} value={email} disabled readOnly />
 
-      {/* Terms & Privacy gate */}
-      <CheckboxBlock
-        id="accept-invite-terms"
-        label={<TermsAgreementLabel termsUrl={termsUrl} privacyPolicyUrl={privacyPolicyUrl} />}
-        truncateLabel
-        checked={agreedToTerms}
-        disabled={disabled || loading}
-        onCheckedChange={onAgreedToTermsChange}
-      />
-
-      {/* SSO providers — disabled until terms accepted */}
+      {/* SSO providers */}
       <SsoProviderButtons
         providers={ssoProviders}
         onSsoClick={onSsoClick}
         actionLabel={ssoActionLabel}
-        disabled={disabled || loading || !agreedToTerms}
+        disabled={disabled || loading}
       />
 
       {/* Back to Login — in-card on tablet/mobile; desktop shows it in the shell footer */}

--- a/openframe-frontend-core/src/components/features/auth/invite-link-invalid-modal.tsx
+++ b/openframe-frontend-core/src/components/features/auth/invite-link-invalid-modal.tsx
@@ -15,8 +15,9 @@ export interface InviteLinkInvalidModalProps {
 }
 
 /**
- * Centered notice shown when an invitation link is expired or invalid. Full-screen
- * dark backdrop with a single card; both the X and the button return to login.
+ * Notice shown when an invitation link is expired or invalid. Full-screen dark
+ * backdrop with a single card — pinned to the bottom on mobile, centered from
+ * tablet up; both the X and the button return to login.
  */
 export function InviteLinkInvalidModal({
   onBackToLogin,
@@ -27,12 +28,13 @@ export function InviteLinkInvalidModal({
   className,
 }: InviteLinkInvalidModalProps) {
   return (
-    <div className={cn('flex min-h-screen w-full items-center justify-center bg-ods-bg p-[var(--spacing-system-l)]', className)}>
+    <div className={cn('flex min-h-screen w-full items-end justify-center bg-ods-bg p-[var(--spacing-system-l)] md:items-center', className)}>
       <div className="flex w-full max-w-[600px] flex-col gap-[var(--spacing-system-l)] rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-xl)]">
         {/* Title + close */}
         <div className="flex items-center gap-[var(--spacing-system-mf)]">
           <h1 className="flex-1 text-h2 text-ods-text-primary tracking-[-0.64px]">{title}</h1>
-          <button type="button" aria-label="Close" onClick={onClose ?? onBackToLogin} className="shrink-0 text-ods-text-primary">
+          {/* Close (X) — desktop/tablet only, per design */}
+          <button type="button" aria-label="Close" onClick={onClose ?? onBackToLogin} className="hidden shrink-0 text-ods-text-primary md:block">
             <XmarkIcon className="h-6 w-6" />
           </button>
         </div>

--- a/openframe-frontend-core/src/components/features/auth/password-reset-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/password-reset-form.tsx
@@ -4,6 +4,7 @@ import type * as React from 'react'
 import { cn } from '../../../utils/cn'
 import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
+import { BackToLoginLink } from './back-to-login-link'
 
 export interface PasswordResetFormProps {
   /** Controlled field values */
@@ -15,6 +16,8 @@ export interface PasswordResetFormProps {
   onSubmit: () => void
   /** Secondary action ("Cancel") */
   onCancel: () => void
+  /** In-card "Back to Login" shown on tablet/mobile; desktop uses the shell footer. */
+  onBackToLogin?: () => void
   /** Disables just the primary submit (fields stay editable). */
   submitDisabled?: boolean
   loading?: boolean
@@ -46,6 +49,7 @@ export function PasswordResetForm({
   onConfirmPasswordChange,
   onSubmit,
   onCancel,
+  onBackToLogin,
   submitDisabled = false,
   loading = false,
   disabled = false,
@@ -129,6 +133,9 @@ export function PasswordResetForm({
           {submitLabel}
         </Button>
       </div>
+
+      {/* Back to Login — in-card on tablet/mobile; desktop shows it in the shell footer */}
+      {onBackToLogin && <BackToLoginLink onClick={onBackToLogin} className="self-start lg:hidden" />}
     </div>
   )
 }

--- a/openframe-frontend-core/src/stories/auth/AcceptInvitation.stories.tsx
+++ b/openframe-frontend-core/src/stories/auth/AcceptInvitation.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
-import { useState } from 'react'
 import {
   AcceptInvitationForm,
   type AuthSsoProvider,
@@ -15,7 +14,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Accept Invitation from the auth redesign. Presentational + controlled: read-only invited email, a Terms gate, and SSO providers to join the org. Shown inside AuthShell without tabs. SSO buttons stay disabled until the Terms checkbox is checked.',
+          'Accept Invitation from the auth redesign. Presentational + controlled: read-only invited email (prefilled from the invitation link) and SSO providers to join the org. Shown inside AuthShell without tabs.',
       },
     },
   },
@@ -28,9 +27,7 @@ type Story = StoryObj<typeof meta>
 const SSO_PROVIDERS: AuthSsoProvider[] = ['openframe', 'google', 'microsoft']
 
 /** Full page: invitation form + marketing panel (no tabs). */
-function AcceptInvitationPage({ initialChecked = false }: { initialChecked?: boolean }) {
-  const [agreedToTerms, setAgreedToTerms] = useState(initialChecked)
-
+function AcceptInvitationPage() {
   return (
     <AuthShell
       mobileTagline={
@@ -43,24 +40,15 @@ function AcceptInvitationPage({ initialChecked = false }: { initialChecked?: boo
     >
       <AcceptInvitationForm
         email="roman@mail.com"
-        agreedToTerms={agreedToTerms}
-        onAgreedToTermsChange={setAgreedToTerms}
         ssoProviders={SSO_PROVIDERS}
         onSsoClick={() => {}}
         onBackToLogin={() => {}}
-        termsUrl="#terms"
-        privacyPolicyUrl="#privacy"
       />
     </AuthShell>
   )
 }
 
-/** Terms unchecked — SSO buttons disabled. */
-export const NoCheck: Story = {
+/** Prefilled invited email, SSO providers ready to pick. */
+export const Default: Story = {
   render: () => <AcceptInvitationPage />,
-}
-
-/** Terms accepted — SSO buttons enabled. */
-export const WithCheck: Story = {
-  render: () => <AcceptInvitationPage initialChecked />,
 }

--- a/openframe-frontend-core/src/stories/auth/PasswordReset.stories.tsx
+++ b/openframe-frontend-core/src/stories/auth/PasswordReset.stories.tsx
@@ -44,6 +44,7 @@ function PasswordResetPage({ initialPassword = '', initialConfirm = '' }: { init
         onConfirmPasswordChange={setConfirmPassword}
         onSubmit={() => {}}
         onCancel={() => {}}
+        onBackToLogin={() => {}}
         submitDisabled={!isValid}
         errors={{
           confirmPassword:


### PR DESCRIPTION
single Accept Invitation screen, bottom-pinned invalid-link card on mobile, in-card Back to Login for Password Reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a back-to-login action inside the password reset form on smaller screens.
  * Updated invitation acceptance screens to use a simpler sign-up flow with SSO options and prefilled invited email.

* **UI/UX Improvements**
  * Improved the invalid-invitation modal layout for mobile and desktop.
  * Removed the terms-acceptance step from the invitation flow, reducing friction.

* **Storybook**
  * Updated demo examples to match the latest authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->