### PR TITLE
Frontend Core: Auth - optional emailReadOnly for OpenFrameSsoSignUpForm

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/auth-benefits-panel.tsx
+++ b/openframe-frontend-core/src/components/features/auth/auth-benefits-panel.tsx
@@ -26,7 +26,7 @@ export interface AuthBenefitsPanelProps {
 const DEFAULT_TITLE = 'The All-in-One Open Platform for MSPs'
 
 const DEFAULT_DESCRIPTION =
-  'All your core ops in one place - built for MSPs who are done duct-taping tools together. Open-source, AI-ready, no vendor tax. Just solid software that lets you run lean and fast.'
+  'All your core ops in one place - built for MSPs who are done duct-taping tools together. Unified stack, AI-ready, no vendor tax. Just solid software that lets you run lean and fast.'
 
 const DEFAULT_BENEFITS: AuthBenefit[] = [
   { icon: <CreditCardXmarkIcon />, label: 'No card required' },

--- a/openframe-frontend-core/src/components/features/auth/login-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/login-form.tsx
@@ -13,8 +13,11 @@ export interface LoginFormProps {
   onEmailChange: (value: string) => void
   /** Primary submit ("Continue") */
   onSubmit: () => void
+  /** When set, renders a "Forgot Password?" button next to Continue. */
+  onForgotPassword?: () => void
   emailPlaceholder?: string
   submitLabel?: string
+  forgotPasswordLabel?: string
   /** Disables just the primary submit (field stays editable). */
   submitDisabled?: boolean
   loading?: boolean
@@ -42,8 +45,10 @@ export function LoginForm({
   email,
   onEmailChange,
   onSubmit,
+  onForgotPassword,
   emailPlaceholder = 'username@mail.com',
   submitLabel = 'Continue',
+  forgotPasswordLabel = 'Forgot Password?',
   submitDisabled = false,
   loading = false,
   disabled = false,
@@ -97,13 +102,26 @@ export function LoginForm({
         />
       ) : (
         <div className="flex items-center gap-[var(--spacing-system-l)]">
-          {/* Spacer keeps the button on the right half, matching the design */}
-          <div className="hidden flex-1 md:block" />
+          {onForgotPassword ? (
+            <Button
+              type="button"
+              variant="transparent"
+              fullWidth
+              className="flex-1"
+              disabled={disabled || loading}
+              onClick={onForgotPassword}
+            >
+              {forgotPasswordLabel}
+            </Button>
+          ) : (
+            // Spacer keeps the button on the right half, matching the design
+            <div className="hidden flex-1 md:block" />
+          )}
           <Button
             type="button"
             variant="accent"
             fullWidth
-            className="md:flex-1"
+            className={onForgotPassword ? 'flex-1' : 'md:flex-1'}
             loading={loading}
             disabled={disabled || submitDisabled}
             onClick={onSubmit}

--- a/openframe-frontend-core/src/components/features/auth/openframe-sso-login-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/openframe-sso-login-form.tsx
@@ -102,13 +102,16 @@ export function OpenFrameSsoLoginForm({
 
       {/* Forgot password + Continue */}
       <div className="flex items-center gap-[var(--spacing-system-l)]">
-        <button
+        <Button
           type="button"
+          variant="transparent"
+          fullWidth
+          className="flex-1"
+          disabled={fieldsDisabled}
           onClick={onForgotPassword}
-          className="flex-1 text-left text-h4 text-ods-text-secondary"
         >
           {forgotPasswordLabel}
-        </button>
+        </Button>
         <Button
           type="button"
           variant="accent"

--- a/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
@@ -98,7 +98,6 @@ export function OpenFrameSsoSignUpForm({
         value={email}
         error={errors?.email}
         disabled={fieldsDisabled || emailReadOnly}
-        readOnly={emailReadOnly}
         onChange={(event) => onEmailChange(event.target.value)}
         onKeyDown={handleKeyDown}
       />

--- a/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
@@ -179,13 +179,16 @@ export function OpenFrameSsoSignUpForm({
 
       {/* Forgot password + Continue */}
       <div className="flex items-center gap-[var(--spacing-system-l)]">
-        <button
+        <Button
           type="button"
+          variant="transparent"
+          fullWidth
+          className="flex-1"
+          disabled={fieldsDisabled}
           onClick={onForgotPassword}
-          className="flex-1 text-left text-h4 text-ods-text-secondary"
         >
           {forgotPasswordLabel}
-        </button>
+        </Button>
         <Button
           type="button"
           variant="accent"

--- a/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
@@ -3,10 +3,8 @@
 import type * as React from 'react'
 import { cn } from '../../../utils/cn'
 import { Button } from '../../ui/button'
-import { CheckboxBlock } from '../../ui/checkbox-block'
 import { Input } from '../../ui/input'
 import { PasswordInput } from '../../ui/password-input'
-import { TermsAgreementLabel } from './terms-agreement-label'
 
 export interface OpenFrameSsoSignUpFormProps {
   /** Controlled field values */
@@ -15,13 +13,11 @@ export interface OpenFrameSsoSignUpFormProps {
   lastName: string
   password: string
   confirmPassword: string
-  agreedToTerms: boolean
   onEmailChange: (value: string) => void
   onFirstNameChange: (value: string) => void
   onLastNameChange: (value: string) => void
   onPasswordChange: (value: string) => void
   onConfirmPasswordChange: (value: string) => void
-  onAgreedToTermsChange: (checked: boolean) => void
   /** Primary submit ("Continue") */
   onSubmit: () => void
   onForgotPassword: () => void
@@ -36,10 +32,7 @@ export interface OpenFrameSsoSignUpFormProps {
     lastName?: string
     password?: string
     confirmPassword?: string
-    terms?: string
   }
-  termsUrl?: string
-  privacyPolicyUrl?: string
   title?: string
   subtitle?: string
   emailLabel?: string
@@ -50,7 +43,7 @@ export interface OpenFrameSsoSignUpFormProps {
 
 /**
  * OpenFrame SSO sign-up form. Presentational + controlled — create OpenFrame SSO
- * credentials (email, name, password) with a Terms gate. Rendered inside SsoAuthShell.
+ * credentials (email, name, password).
  */
 export function OpenFrameSsoSignUpForm({
   email,
@@ -58,13 +51,11 @@ export function OpenFrameSsoSignUpForm({
   lastName,
   password,
   confirmPassword,
-  agreedToTerms,
   onEmailChange,
   onFirstNameChange,
   onLastNameChange,
   onPasswordChange,
   onConfirmPasswordChange,
-  onAgreedToTermsChange,
   onSubmit,
   onForgotPassword,
   emailReadOnly = false,
@@ -72,8 +63,6 @@ export function OpenFrameSsoSignUpForm({
   loading = false,
   disabled = false,
   errors,
-  termsUrl = '#',
-  privacyPolicyUrl = '#',
   title = 'OpenFrame Single Sign-On',
   subtitle = 'Enter your email and password to access your organization.',
   emailLabel = 'Email',
@@ -165,17 +154,6 @@ export function OpenFrameSsoSignUpForm({
           />
         </div>
       </div>
-
-      {/* Terms & Privacy gate */}
-      <CheckboxBlock
-        id="sso-signup-terms"
-        label={<TermsAgreementLabel termsUrl={termsUrl} privacyPolicyUrl={privacyPolicyUrl} />}
-        truncateLabel
-        checked={agreedToTerms}
-        disabled={fieldsDisabled}
-        error={errors?.terms}
-        onCheckedChange={onAgreedToTermsChange}
-      />
 
       {/* Forgot password + Continue */}
       <div className="flex items-center gap-[var(--spacing-system-l)]">

--- a/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/openframe-sso-signup-form.tsx
@@ -25,6 +25,8 @@ export interface OpenFrameSsoSignUpFormProps {
   /** Primary submit ("Continue") */
   onSubmit: () => void
   onForgotPassword: () => void
+  /** Locks the email field, e.g. when it was verified on a previous step. */
+  emailReadOnly?: boolean
   submitDisabled?: boolean
   loading?: boolean
   disabled?: boolean
@@ -65,6 +67,7 @@ export function OpenFrameSsoSignUpForm({
   onAgreedToTermsChange,
   onSubmit,
   onForgotPassword,
+  emailReadOnly = false,
   submitDisabled = false,
   loading = false,
   disabled = false,
@@ -105,7 +108,8 @@ export function OpenFrameSsoSignUpForm({
         placeholder="username@mail.com"
         value={email}
         error={errors?.email}
-        disabled={fieldsDisabled}
+        disabled={fieldsDisabled || emailReadOnly}
+        readOnly={emailReadOnly}
         onChange={(event) => onEmailChange(event.target.value)}
         onKeyDown={handleKeyDown}
       />

--- a/openframe-frontend-core/src/stories/auth/Login.stories.tsx
+++ b/openframe-frontend-core/src/stories/auth/Login.stories.tsx
@@ -57,6 +57,7 @@ function LoginPage(initial: Partial<LoginFormProps>) {
           onEmailChange={setEmail}
           submitDisabled={!isValid}
           onSubmit={() => {}}
+          onForgotPassword={() => {}}
         />
       ) : (
         <div className="flex min-h-[240px] items-center justify-center rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-xl)] text-h4 text-ods-text-secondary">

--- a/openframe-frontend-core/src/stories/auth/OpenFrameSso.stories.tsx
+++ b/openframe-frontend-core/src/stories/auth/OpenFrameSso.stories.tsx
@@ -46,15 +46,13 @@ function SsoSignUpPage({ filled = false }: { filled?: boolean }) {
   const [lastName, setLastName] = useState(filled ? 'Lovelace' : '')
   const [password, setPassword] = useState(filled ? 'SuperSecretPassphrase2024!' : '')
   const [confirmPassword, setConfirmPassword] = useState(filled ? 'SuperSecretPassphrase2024!' : '')
-  const [agreedToTerms, setAgreedToTerms] = useState(filled)
 
   const isValid =
     !!email.trim() &&
     !!firstName.trim() &&
     !!lastName.trim() &&
     password.length >= 8 &&
-    password === confirmPassword &&
-    agreedToTerms
+    password === confirmPassword
 
   return (
     <SsoAuthShell>
@@ -64,18 +62,14 @@ function SsoSignUpPage({ filled = false }: { filled?: boolean }) {
         lastName={lastName}
         password={password}
         confirmPassword={confirmPassword}
-        agreedToTerms={agreedToTerms}
         onEmailChange={setEmail}
         onFirstNameChange={setFirstName}
         onLastNameChange={setLastName}
         onPasswordChange={setPassword}
         onConfirmPasswordChange={setConfirmPassword}
-        onAgreedToTermsChange={setAgreedToTerms}
         onSubmit={() => {}}
         onForgotPassword={() => {}}
         submitDisabled={!isValid}
-        termsUrl="#terms"
-        privacyPolicyUrl="#privacy"
       />
     </SsoAuthShell>
   )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to keep the email field read-only during SSO sign-up.
  * Login now supports an optional “Forgot Password?” action with a customizable label.
* **UI Changes**
  * “Forgot password” controls for SSO login/sign-up now use the shared button styling and respect the disabled state.
  * Removed the Terms & Privacy acceptance gate and related links/validation from SSO sign-up.
* **Chores**
  * Updated the default marketing panel description copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->