### PR TITLE
fix(): table auto height

### DIFF
--- a/openframe-frontend-core/src/components/ui/data-table/data-table-body.tsx
+++ b/openframe-frontend-core/src/components/ui/data-table/data-table-body.tsx
@@ -30,6 +30,11 @@ export interface DataTableBodyProps<T = any> {
   /** Dense row height. */
   compact?: boolean
   /**
+   * Treat the design row height as a minimum so multi-line cell content grows
+   * the row instead of clipping. Default keeps the fixed height.
+   */
+  autoHeight?: boolean
+  /**
    * Click anywhere on a row (except elements with `data-no-row-click`). Prefer
    * `useCallback` to avoid breaking `React.memo` on rows.
    */
@@ -66,6 +71,7 @@ export function DataTableBody<T = any>({
   className,
   rowClassName,
   compact,
+  autoHeight,
   onRowClick,
   rowHref,
   minRows,
@@ -112,6 +118,7 @@ export function DataTableBody<T = any>({
             onClick={onRowClick}
             href={href}
             compact={compact}
+            autoHeight={autoHeight}
             className={cls}
             subRow={renderSubRow?.(item)}
           />

--- a/openframe-frontend-core/src/components/ui/data-table/data-table-row.tsx
+++ b/openframe-frontend-core/src/components/ui/data-table/data-table-row.tsx
@@ -13,6 +13,12 @@ export interface DataTableRowProps<T> {
   href?: string | null
   /** Dense row height. */
   compact?: boolean
+  /**
+   * Treat the design row height as a minimum: a cell rendering multi-line
+   * content (e.g. a line-clamped description) grows the row instead of being
+   * clipped. Default keeps the fixed height.
+   */
+  autoHeight?: boolean
   className?: string
   /** Expandable content rendered below the cells, inside the same card. */
   subRow?: ReactNode
@@ -60,6 +66,7 @@ function DataTableRowImpl<T>({
   onClick,
   href,
   compact,
+  autoHeight,
   className,
   subRow,
 }: DataTableRowProps<T>) {
@@ -100,7 +107,11 @@ function DataTableRowImpl<T>({
     <div
       className={cn(
         'flex items-center gap-[var(--spacing-system-mf)] px-[var(--spacing-system-mf)]',
-        compact ? 'py-[var(--spacing-system-xsf)]' : `py-0 ${ROW_HEIGHT_DESKTOP}`,
+        compact
+          ? 'py-[var(--spacing-system-xsf)]'
+          : autoHeight
+            ? 'py-[var(--spacing-system-sf)] min-h-[68px] md:min-h-[80px]'
+            : `py-0 ${ROW_HEIGHT_DESKTOP}`,
         hasSubRow && 'border-b border-ods-border',
       )}
     >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional auto-height setting for data table rows and bodies.
  * Multi-line cell content can now expand row height instead of being clipped, while the default fixed-height behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->