### PR TITLE
Chat: split approval blocks into admin/client variants

### DIFF
--- a/openframe-frontend-core/src/components/chat/approval-batch-message.tsx
+++ b/openframe-frontend-core/src/components/chat/approval-batch-message.tsx
@@ -9,8 +9,9 @@ import { ToolIcon } from "../tool-icon"
 import { CheckCircleIcon, DotsLoaderIcon, XmarkCircleIcon, XmarkIcon } from "../icons-v2-generated"
 import { ExpandChevron } from "./expand-chevron"
 import { useCollapsible } from "./hooks/use-collapsible"
-import { ArgRow, CommandBlock, ResultBlock } from "./tool-call-blocks"
+import { ArgRow, ResultBlock } from "./tool-call-blocks"
 import type {
+  ApprovalBlockVariant,
   AssistantType,
   ApprovalBatchExecutionState,
   ApprovalBatchSegment,
@@ -18,7 +19,6 @@ import type {
 } from "./types"
 import {
   COMMAND_BODY_ARG_KEYS,
-  getCommandBody,
   getCommandText,
 } from "./utils/tool-call-helpers"
 
@@ -42,11 +42,20 @@ export interface ApprovalBatchMessageProps extends React.HTMLAttributes<HTMLDivE
    */
   showExecutionStatus?: boolean
   /**
-   * Chat identity, which drives the styling variant. `'fae'` = client
-   * (frameless outer, bordered command box, no tool icon, no divider,
-   * full-text status pill); `'mingo'`/undefined = admin (original layout).
+   * Chat identity. Kept for prop parity with the message renderers; does NOT
+   * drive the styling anymore — use `variant` instead. An admin can be
+   * looking at a Fae dialog (tickets dialog client tab) and must still see
+   * the full admin block.
    */
   assistantType?: AssistantType
+  /**
+   * Viewer variant. `'admin'` (default) = full block with command preview,
+   * expandable args/result and tool icon. `'client'` = end-client (Fae
+   * desktop app) card that shows ONLY the BE-generated title(s) plus the
+   * Approve/Reject buttons or the full-text resolved pill ("Approved by
+   * {name}") — commands and scripts are never rendered.
+   */
+  variant?: ApprovalBlockVariant
   /**
    * Render the footer Approve/Reject buttons (or the resolved-status tag).
    * Turn off when the host owns the actions row — e.g. the approval
@@ -119,45 +128,29 @@ interface ToolCallRowProps {
   batchStatus: ApprovalBatchSegment["status"]
   execution: ApprovalBatchExecutionState | undefined
   showExecutionStatus: boolean
-  isClient: boolean
 }
 
-function ToolCallRow({ call, expanded, onToggle, batchStatus, execution, showExecutionStatus, isClient }: ToolCallRowProps) {
+// ADMIN-only row: command preview header, expandable args/result. The client
+// variant never renders tool calls — see the `variant === 'client'` branch of
+// `<ApprovalBatchMessage>`.
+function ToolCallRow({ call, expanded, onToggle, batchStatus, execution, showExecutionStatus }: ToolCallRowProps) {
   const command = getCommandText(call)
   const args = getArgEntries(call)
   const toolType = (call.toolType as ToolType) || ("OPENFRAME" as ToolType)
   const { innerRef, containerStyle } = useCollapsible({ expanded })
   const result = execution?.status === "done" ? execution.result : undefined
-  // CLIENT (Fae): the collapsed line shows the human-readable `toolExplanation`
-  // and the raw command moves into the expanded body (Figma 1972-6100). Falls
-  // back to the command when no explanation is present. ADMIN is unchanged.
-  const explanation = call.toolExplanation?.trim()
-  const headerText = isClient && explanation ? explanation : command
-  const commandBody = isClient ? getCommandBody(call.toolCallArguments) : undefined
-  const hasExpandableBody = !!commandBody || args.length > 0 || (typeof result === "string" && result.length > 0)
+  const hasExpandableBody = args.length > 0 || (typeof result === "string" && result.length > 0)
 
   return (
-    <div
-      className={cn(
-        "bg-ods-card flex flex-col items-start w-full",
-        // ADMIN: rows share one outer card, separated by a bottom border.
-        // CLIENT (Fae): each command is its own self-contained bordered box
-        // (Figma 1092-2804 / 1972-7925) — the outer component is frameless.
-        isClient
-          ? "border border-ods-border rounded-[6px] overflow-hidden"
-          : "border-b border-ods-border last:border-b-0",
-      )}
-    >
+    <div className="bg-ods-card flex flex-col items-start w-full border-b border-ods-border last:border-b-0">
       <button
         type="button"
         onClick={onToggle}
         className="flex gap-[var(--spacing-system-xsf)] items-start w-full p-[var(--spacing-system-sf)] cursor-pointer text-left"
       >
-        {!isClient && (
-          <div className="flex items-center justify-center shrink-0 w-5 h-5">
-            <ToolIcon toolType={toolType} size={16} />
-          </div>
-        )}
+        <div className="flex items-center justify-center shrink-0 w-5 h-5">
+          <ToolIcon toolType={toolType} size={16} />
+        </div>
         <div
           className={cn(
             "flex-1 min-w-0 text-h6",
@@ -166,7 +159,7 @@ function ToolCallRow({ call, expanded, onToggle, batchStatus, execution, showExe
               : "text-ods-text-secondary line-clamp-2 max-h-10 break-all",
           )}
         >
-          {headerText}
+          {command}
         </div>
         {showExecutionStatus && (
           <div className="flex items-center justify-center shrink-0 w-5 h-5">
@@ -182,12 +175,6 @@ function ToolCallRow({ call, expanded, onToggle, batchStatus, execution, showExe
         <div ref={innerRef}>
           {hasExpandableBody && (
             <div className="flex flex-col gap-0 items-start w-full text-h6 px-[var(--spacing-system-sf)] pb-[var(--spacing-system-sf)] bg-ods-card">
-              {commandBody && (
-                <CommandBlock
-                  command={commandBody}
-                  className={args.length > 0 || result ? "mb-[var(--spacing-system-xsf)]" : undefined}
-                />
-              )}
               {args.map(([key, value]) => (
                 <ArgRow key={key} argKey={key} value={value} />
               ))}
@@ -206,17 +193,14 @@ function ToolCallRow({ call, expanded, onToggle, batchStatus, execution, showExe
 }
 
 const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProps>(
-  ({ className, data, onApprove, onReject, status = "pending", maxBodyHeight, resolvedByName, showExecutionStatus = true, assistantType, showFooterActions = true, ...props }, ref) => {
+  ({ className, data, onApprove, onReject, status = "pending", maxBodyHeight, resolvedByName, showExecutionStatus = true, assistantType: _assistantType, variant = "admin", showFooterActions = true, ...props }, ref) => {
     const [expandedId, setExpandedId] = useState<string | null>(null)
     const [isProcessing, setIsProcessing] = useState(false)
-    const isClient = assistantType === "fae"
+    const isClient = variant === "client"
 
-    // CLIENT (Fae) promotes each tool's `toolExplanation` to the command row's
-    // header, so the footer must NOT repeat it as bullets. ADMIN keeps the
-    // explanation bullets in the footer.
-    const explanations = isClient
-      ? []
-      : data.toolCalls.map((c) => c.toolExplanation?.trim()).filter((s): s is string => !!s)
+    const explanations = data.toolCalls
+      .map((c) => c.toolExplanation?.trim())
+      .filter((s): s is string => !!s)
 
     const handleApprove = async () => {
       setIsProcessing(true)
@@ -236,6 +220,76 @@ const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProp
       }
     }
 
+    const actionButtons = (
+      <>
+        <Button
+          size="small-legacy"
+          variant="accent"
+          onClick={handleApprove}
+          disabled={isProcessing}
+          className={cn(
+            "bg-ods-accent hover:bg-ods-accent/90",
+            "text-h5 text-ods-bg",
+            "px-[var(--spacing-system-xsf)] h-8",
+          )}
+        >
+          Approve
+        </Button>
+        <Button
+          size="small-legacy"
+          variant="outline"
+          onClick={handleReject}
+          disabled={isProcessing}
+          className={cn(
+            "bg-ods-card border-ods-border",
+            "text-h5 text-ods-text-primary",
+            "hover:bg-ods-bg px-[var(--spacing-system-xsf)] h-8",
+          )}
+        >
+          Reject
+        </Button>
+      </>
+    )
+
+    // CLIENT (Fae end-user) card — Figma 203-11947 "fae-approval-block".
+    // One bordered card: BE-generated title(s) + Approve/Reject buttons or the
+    // full-text resolved pill ("Approved by {name}"). No commands, scripts,
+    // expansion or execution icons — the end client must not see them.
+    if (isClient) {
+      const titles = data.toolCalls
+        .map((c) => c.toolExplanation?.trim() || c.toolTitle?.trim())
+        .filter((s): s is string => !!s)
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            "bg-ods-card border border-ods-border rounded-md p-[var(--spacing-system-mf)] mb-[var(--spacing-system-xsf)] flex flex-col gap-[var(--spacing-system-mf)]",
+            className,
+          )}
+          {...props}
+        >
+          {titles.length > 0 ? (
+            titles.map((title, i) => (
+              <p key={i} className="text-h4 text-ods-text-primary whitespace-pre-line break-words w-full">
+                {title}
+              </p>
+            ))
+          ) : (
+            <p className="text-h4 text-ods-text-primary w-full">Approval required</p>
+          )}
+          {showFooterActions && (status === "pending" ? (
+            <div className="flex gap-[var(--spacing-system-mf)] items-center w-full">
+              {actionButtons}
+            </div>
+          ) : (
+            <div className="flex w-full">
+              <ApprovalStatusTag status={status} resolvedByName={resolvedByName} inlineResolver />
+            </div>
+          ))}
+        </div>
+      )
+    }
+
     const showFooterBlock = explanations.length > 0 || showFooterActions
 
     return (
@@ -243,11 +297,7 @@ const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProp
         ref={ref}
         className={cn(
           "flex flex-col mb-[var(--spacing-system-xsf)]",
-          // ADMIN: one framed card. CLIENT (Fae): frameless container — the
-          // bordered command box(es) + button/status row stacked 16px apart.
-          isClient
-            ? "gap-[var(--spacing-system-mf)]"
-            : "bg-ods-card border border-ods-border rounded-md overflow-hidden",
+          "bg-ods-card border border-ods-border rounded-md overflow-hidden",
           className,
         )}
         {...props}
@@ -255,7 +305,6 @@ const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProp
         <div
           className={cn(
             "flex flex-col",
-            isClient && "gap-[var(--spacing-system-mf)]",
             maxBodyHeight != null && "overflow-y-auto overscroll-contain",
           )}
           style={maxBodyHeight != null ? { maxHeight: maxBodyHeight } : undefined}
@@ -273,20 +322,12 @@ const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProp
               batchStatus={status}
               execution={data.executions?.[call.toolExecutionRequestId]}
               showExecutionStatus={showExecutionStatus}
-              isClient={isClient}
             />
           ))}
         </div>
 
         {showFooterBlock && (
-          <div
-            className={cn(
-              "flex flex-col gap-[var(--spacing-system-xsf)] items-start justify-center",
-              // ADMIN: padded footer inside the card, divided from the list.
-              // CLIENT (Fae): buttons/status sit flush outside the box.
-              !isClient && "bg-ods-card border-t border-ods-border p-[var(--spacing-system-sf)]",
-            )}
-          >
+          <div className="flex flex-col gap-[var(--spacing-system-xsf)] items-start justify-center bg-ods-card border-t border-ods-border p-[var(--spacing-system-sf)]">
             {explanations.length > 0 && (
               <ul className="list-disc pl-5 text-h6 text-ods-text-primary w-full">
                 {explanations.map((expl, i) => (
@@ -297,37 +338,12 @@ const ApprovalBatchMessage = forwardRef<HTMLDivElement, ApprovalBatchMessageProp
 
             {showFooterActions && (status === "pending" ? (
               <div className="flex gap-[var(--spacing-system-xsf)] items-center">
-                <Button
-                  size="small-legacy"
-                  variant="accent"
-                  onClick={handleApprove}
-                  disabled={isProcessing}
-                  className={cn(
-                    "bg-ods-accent hover:bg-ods-accent/90",
-                    "text-h5 text-ods-bg",
-                    "px-[var(--spacing-system-xsf)] h-8",
-                  )}
-                >
-                  Approve
-                </Button>
-                <Button
-                  size="small-legacy"
-                  variant="outline"
-                  onClick={handleReject}
-                  disabled={isProcessing}
-                  className={cn(
-                    "bg-ods-card border-ods-border",
-                    "text-h5 text-ods-text-primary",
-                    "hover:bg-ods-bg px-[var(--spacing-system-xsf)] h-8",
-                  )}
-                >
-                  Reject
-                </Button>
+                {actionButtons}
               </div>
             ) : (
               <div className="flex items-center gap-[var(--spacing-system-xsf)]">
-                <ApprovalStatusTag status={status} resolvedByName={resolvedByName} inlineResolver={isClient} />
-                {!isClient && resolvedByName && (
+                <ApprovalStatusTag status={status} resolvedByName={resolvedByName} />
+                {resolvedByName && (
                   <span className="text-h6 text-ods-text-secondary">by {resolvedByName}</span>
                 )}
               </div>

--- a/openframe-frontend-core/src/components/chat/approval-request-message.tsx
+++ b/openframe-frontend-core/src/components/chat/approval-request-message.tsx
@@ -5,6 +5,7 @@ import { cn } from "../../utils/cn"
 import { Button } from "../ui/button"
 import { Tag } from "../ui/tag"
 import { Ban, CheckCircle, XCircle } from "lucide-react"
+import { ApprovalStatusTag } from "./approval-batch-message"
 import type { ApprovalRequestMessageProps } from "./types"
 import type { ApprovalRequestField } from "./types/message.types"
 
@@ -78,9 +79,8 @@ function ApprovalCardBody({
 
 const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessageProps>(
   // `assistantType` is accepted for prop-parity with the batch card (so hosts
-  // can forward it uniformly); the legacy single-command card has no
-  // icon/divider to vary, so it renders identically for admin and client today.
-  ({ className, data, onApprove, onReject, status = 'pending', assistantType: _assistantType, ...props }, ref) => {
+  // can forward it uniformly); the viewer variant is driven by `variant`.
+  ({ className, data, onApprove, onReject, status = 'pending', assistantType: _assistantType, variant = 'admin', resolvedByName, ...props }, ref) => {
     const [isProcessing, setIsProcessing] = useState(false)
 
     const handleApprove = async () => {
@@ -99,6 +99,60 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
       } finally {
         setIsProcessing(false)
       }
+    }
+
+    // CLIENT (Fae end-user) card — Figma 203-11947 "fae-approval-block".
+    // Shows ONLY the BE-generated title (`explanation`) plus the actions row
+    // or the full-text resolved pill; the raw command is never rendered.
+    if (variant === 'client') {
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            "bg-ods-card border border-ods-border rounded-md p-[var(--spacing-system-mf)] mb-[var(--spacing-system-xsf)] flex flex-col gap-[var(--spacing-system-mf)]",
+            className
+          )}
+          {...props}
+        >
+          <p className="text-h4 text-ods-text-primary whitespace-pre-line break-words w-full">
+            {data.explanation?.trim() || "Approval required"}
+          </p>
+          {status === 'pending' ? (
+            <div className="flex gap-[var(--spacing-system-mf)] items-center w-full">
+              <Button
+                size="small-legacy"
+                variant="accent"
+                onClick={handleApprove}
+                disabled={isProcessing}
+                className={cn(
+                  "bg-ods-accent hover:bg-ods-accent/90",
+                  "text-h5 text-ods-bg",
+                  "px-[var(--spacing-system-xsf)] h-8"
+                )}
+              >
+                Approve
+              </Button>
+              <Button
+                size="small-legacy"
+                variant="outline"
+                onClick={handleReject}
+                disabled={isProcessing}
+                className={cn(
+                  "bg-ods-card border-ods-border",
+                  "text-h5 text-ods-text-primary",
+                  "hover:bg-ods-bg px-[var(--spacing-system-xsf)] h-8"
+                )}
+              >
+                Reject
+              </Button>
+            </div>
+          ) : (
+            <div className="flex w-full">
+              <ApprovalStatusTag status={status} resolvedByName={resolvedByName} inlineResolver />
+            </div>
+          )}
+        </div>
+      )
     }
 
     return (

--- a/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
@@ -43,7 +43,7 @@ function normalizeContent(content: MessageContent): MessageSegment[] {
 }
 
 const ChatMessageEnhanced = forwardRef<HTMLDivElement, ChatMessageEnhancedProps>(
-  ({ className, role, content, name, avatar, isTyping = false, timestamp, showAvatar = true, assistantType, authorType: authorTypeProp, assistantIcon, chatRefs, contextItems, resolveContextIcon, renderContextItem, renderMention, renderEntityCard, NavLinkAnchor, ...props }, ref) => {
+  ({ className, role, content, name, avatar, isTyping = false, timestamp, showAvatar = true, assistantType, approvalVariant, authorType: authorTypeProp, assistantIcon, chatRefs, contextItems, resolveContextIcon, renderContextItem, renderMention, renderEntityCard, NavLinkAnchor, ...props }, ref) => {
     const isUser = role === 'user'
     const isError = role === 'error'
     const authorType = authorTypeProp ?? (isUser ? 'user' : assistantType === 'mingo' ? 'mingo' : 'fae')
@@ -546,9 +546,11 @@ const ChatMessageEnhanced = forwardRef<HTMLDivElement, ChatMessageEnhancedProps>
                       key={index}
                       data={segment.data}
                       status={segment.status}
+                      resolvedByName={segment.resolvedByName}
                       onApprove={segment.onApprove}
                       onReject={segment.onReject}
                       assistantType={assistantType}
+                      variant={approvalVariant}
                     />
                   )
                 } else if (segment.type === 'approval_batch') {
@@ -561,6 +563,7 @@ const ChatMessageEnhanced = forwardRef<HTMLDivElement, ChatMessageEnhancedProps>
                       onApprove={segment.onApprove}
                       onReject={segment.onReject}
                       assistantType={assistantType}
+                      variant={approvalVariant}
                     />
                   )
                 } else if (segment.type === 'error') {
@@ -620,6 +623,7 @@ const MemoizedChatMessageEnhanced = memo(ChatMessageEnhanced, (prevProps, nextPr
     prevProps.timestamp?.getTime() === nextProps.timestamp?.getTime() &&
     prevProps.showAvatar === nextProps.showAvatar &&
     prevProps.assistantType === nextProps.assistantType &&
+    prevProps.approvalVariant === nextProps.approvalVariant &&
     prevProps.authorType === nextProps.authorType &&
     prevProps.assistantIcon === nextProps.assistantIcon &&
     prevProps.className === nextProps.className &&

--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -100,6 +100,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       fullWidth = false,
       contentClassName,
       assistantType,
+      approvalVariant,
       assistantIcon,
       pendingApprovals,
       hasNextPage,
@@ -535,6 +536,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
                   avatar={showAvatars ? message.avatar : null}
                   showAvatar={showAvatars}
                   assistantType={message.assistantType || assistantType}
+                  approvalVariant={approvalVariant}
                   authorType={message.authorType}
                   assistantIcon={message.role !== 'user' ? assistantIcon : undefined}
                   chatRefs={message.chatRefs}
@@ -590,6 +592,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
               timestamp={new Date()}
               showAvatar={showAvatars}
               assistantType={assistantType}
+              approvalVariant={approvalVariant}
               assistantIcon={assistantIcon}
               NavLinkAnchor={NavLinkAnchor}
               className="py-3"

--- a/openframe-frontend-core/src/components/chat/types/chat.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/chat.types.ts
@@ -64,6 +64,23 @@ export const APPROVAL_STATUS = {
 
 export type ChatApprovalStatus = typeof APPROVAL_STATUS[keyof typeof APPROVAL_STATUS]
 
+// ========== Approval Block Variant Definitions ==========
+
+/**
+ * Who is LOOKING at an approval block — not which assistant produced it.
+ * `admin` (default) shows the full block: command/script preview, expandable
+ * args/result, tool icon. `client` (end-user Fae desktop app) shows only the
+ * BE-generated title plus Approve/Reject or the resolved-status pill — raw
+ * commands and scripts must never reach the end client. Admin surfaces that
+ * render a Fae dialog (tickets dialog client tab) keep the admin variant.
+ */
+export const APPROVAL_BLOCK_VARIANT = {
+  ADMIN: 'admin',
+  CLIENT: 'client',
+} as const
+
+export type ApprovalBlockVariant = typeof APPROVAL_BLOCK_VARIANT[keyof typeof APPROVAL_BLOCK_VARIANT]
+
 // ========== Connection Status Definitions ==========
 
 export const CONNECTION_STATUS = {

--- a/openframe-frontend-core/src/components/chat/types/component.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/component.types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ComponentType, HTMLAttributes, ReactNode, TextareaHTMLAttributes } from 'react'
-import type { AssistantType, AuthorType, ChatApprovalStatus, ConnectionStatus } from './chat.types'
+import type { ApprovalBlockVariant, AssistantType, AuthorType, ChatApprovalStatus, ConnectionStatus } from './chat.types'
 import type { ApprovalRequestData, Message, MessageSegment, ToolExecutionData } from './message.types'
 import type { ChatRef } from '../chat-ref.types'
 import type { ChatContextItem } from './context-item.types'
@@ -119,6 +119,11 @@ export interface ChatMessageEnhancedProps extends Omit<HTMLAttributes<HTMLDivEle
   name?: string
   assistantType?: AssistantType
   authorType?: AuthorType
+  /** Viewer variant for approval blocks in this message's segments.
+   *  `'admin'` (default) = full command block; `'client'` = end-client
+   *  (Fae desktop app) title-only card. Forwarded to
+   *  ApprovalRequestMessage / ApprovalBatchMessage. */
+  approvalVariant?: ApprovalBlockVariant
   assistantIcon?: React.ReactNode
   avatar?: string | null
   timestamp?: Date
@@ -229,6 +234,12 @@ export interface ChatMessageListProps extends HTMLAttributes<HTMLDivElement> {
    *  override (custom max-w value, etc.). */
   contentClassName?: string
   assistantType?: AssistantType
+  /** Viewer variant for approval blocks in every rendered message (incl. the
+   *  sticky pending-approvals footer). `'admin'` (default) = full command
+   *  block; `'client'` = end-client (Fae desktop app) title-only card. Set to
+   *  `'client'` ONLY on true end-client surfaces — admin views of a Fae
+   *  dialog (tickets dialog client tab) keep the default. */
+  approvalVariant?: ApprovalBlockVariant
   assistantIcon?: React.ReactNode
   pendingApprovals?: MessageSegment[]
   onApprove?: (requestId?: string) => void | Promise<void>
@@ -488,9 +499,16 @@ export interface ApprovalRequestMessageProps extends HTMLAttributes<HTMLDivEleme
   onReject?: (requestId?: string) => void | Promise<void>
   status?: ChatApprovalStatus
   disabled?: boolean
-  /** Chat identity; drives the CLIENT (Fae) styling. Accepted for parity with
-   *  the batch card. `'fae'` = client, `'mingo'`/undefined = admin. */
+  /** Chat identity. Accepted for parity with the batch card; does NOT drive
+   *  the styling — use `variant`. */
   assistantType?: AssistantType
+  /** Viewer variant. `'admin'` (default) = full card with the raw command;
+   *  `'client'` = end-client (Fae desktop app) card with only the
+   *  BE-generated title (`explanation`) + actions/status pill. */
+  variant?: ApprovalBlockVariant
+  /** Display name of the user who resolved the request; baked into the
+   *  client variant's full-text status pill ("Approved by {name}"). */
+  resolvedByName?: string | null
 }
 
 // ========== Error Message Display Props ==========

--- a/openframe-frontend-core/src/components/chat/types/message.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/message.types.ts
@@ -171,6 +171,9 @@ export type ApprovalRequestSegment = {
   type: 'approval_request'
   data: ApprovalRequestData & { approvalType?: string }
   status?: ChatApprovalStatus
+  /** Display name of the user who resolved the request; baked into the client
+   *  variant's full-text status pill ("Approved by {name}"). */
+  resolvedByName?: string | null
   onApprove?: (requestId?: string) => void | Promise<void>
   onReject?: (requestId?: string) => void | Promise<void>
 }

--- a/openframe-frontend-core/src/stories/ApprovalBatchMessageClient.stories.tsx
+++ b/openframe-frontend-core/src/stories/ApprovalBatchMessageClient.stories.tsx
@@ -4,25 +4,23 @@ import type React from "react";
 import { ApprovalBatchMessage } from "../components/chat/approval-batch-message";
 import type {
 	ApprovalBatchData,
-	ApprovalBatchExecutionState,
 	PendingToolCallData,
 } from "../components/chat/types";
 
 /**
- * CLIENT (Fae) variant of the Command Block — Figma node 1092-2807.
+ * CLIENT (end-user Fae desktop app) variant of the approval block — Figma
+ * node 203-11947 ("fae-approval-block").
  *
- * Same component and props as the Admin card, driven by `assistantType="fae"`.
- * Differences vs Admin: no tool icon next to the command, no footer divider,
- * and a single full-text status pill ("Approved by Michael Johnson") instead
- * of a compact tag + separate "by {name}".
+ * Same component and props as the Admin card, driven by `variant="client"`.
+ * The end client sees ONLY the BE-generated title plus the Approve/Reject
+ * buttons, or the full-text resolved pill ("Approved by Michael Johnson").
+ * Commands, scripts, expandable args/results and execution icons are never
+ * rendered in this variant.
  */
 
 const LONG_COMMAND = `Get-CimInstance Win32_Process |
   Select-Object ProcessId, Name, Path, CommandLine |
   Where-Object { $_.Path -like 'C:\\Users\\Public\\*' }`;
-
-const RESULT = `pid  | name           | path                          | cmdline
-4821 | suspicious.exe | C:\\Users\\Public\\suspicious.exe | suspicious.exe --hidden --connect 185.220.101.45`;
 
 const REQUEST_ID = "req-1";
 
@@ -30,8 +28,7 @@ const toolCall: PendingToolCallData = {
 	toolExecutionRequestId: REQUEST_ID,
 	toolName: "run_script",
 	toolTitle: "Run Script",
-	// Human-readable description shown as the collapsed row header (CLIENT);
-	// the raw command moves into the expanded body (Figma 1972-6100).
+	// BE-generated human-readable title — the ONLY content the client sees.
 	toolExplanation:
 		"Collects today's system, application, and security event logs and exports them to a CSV file.",
 	toolType: "OPENFRAME_RMM",
@@ -44,38 +41,11 @@ const toolCall: PendingToolCallData = {
 	},
 };
 
-const makeData = (
-	executions?: Record<string, ApprovalBatchExecutionState>,
-): ApprovalBatchData => ({
+const makeData = (): ApprovalBatchData => ({
 	approvalRequestId: "batch-1",
 	approvalType: "CLIENT",
 	toolCalls: [toolCall],
-	executions,
 });
-
-const executingData = makeData({ [REQUEST_ID]: { status: "executing" } });
-const doneData = makeData({
-	[REQUEST_ID]: { status: "done", result: RESULT, success: true },
-});
-
-/**
- * The assistant's message text that precedes the command block in the real
- * chat (Figma "Command description text."). It is NOT part of the component —
- * shown here only so the story matches the Figma frame.
- */
-const CommandHeading = () => (
-	<p className="text-h4 text-ods-text-primary mb-[var(--spacing-system-xxs)]">
-		Command description text.
-	</p>
-);
-
-const constrainedDecorator =
-	(width?: number) => (Story: React.ComponentType) => (
-		<div style={{ maxWidth: width ?? 400, background: "var(--color-bg)" }}>
-			<CommandHeading />
-			<Story />
-		</div>
-	);
 
 const plainDecorator =
 	(width?: number) => (Story: React.ComponentType) => (
@@ -88,22 +58,22 @@ const meta = {
 	title: "Chat/Client/ApprovalBatchMessage",
 	component: ApprovalBatchMessage,
 	tags: ["autodocs"],
-	args: { assistantType: "fae" },
+	args: { variant: "client" },
 	parameters: {
 		docs: {
 			description: {
 				component:
-					"CLIENT (Fae) Command Block — no tool icon, no divider, full-text status pill. Same component/props as Admin, gated by assistantType='fae' (Figma 1092-2807).",
+					"CLIENT (Fae end-user) approval block — title-only card with Approve/Reject or a full-text status pill. Commands/scripts are never shown. Gated by variant='client' (Figma 203-11947).",
 			},
 		},
 	},
-	decorators: [constrainedDecorator()],
+	decorators: [plainDecorator()],
 } satisfies Meta<typeof ApprovalBatchMessage>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-/** Pending — Approve / Reject buttons. Click the row to expand args. */
+/** Pending — title + Approve / Reject buttons. No expandable command. */
 export const Pending: Story = {
 	args: {
 		data: makeData(),
@@ -113,19 +83,10 @@ export const Pending: Story = {
 	},
 };
 
-/** Approved and still executing — grey loader on the row, no result yet. */
-export const ApprovedExecuting: Story = {
+/** Approved — full-text green status pill. */
+export const Approved: Story = {
 	args: {
-		data: executingData,
-		status: "approved",
-		resolvedByName: "Michael Johnson",
-	},
-};
-
-/** Approved and finished — green check + expandable Result block. */
-export const ApprovedDone: Story = {
-	args: {
-		data: doneData,
+		data: makeData(),
 		status: "approved",
 		resolvedByName: "Michael Johnson",
 	},
@@ -150,25 +111,22 @@ export const Cancelled: Story = {
 };
 
 /**
- * All states side by side — mirrors the Figma CLIENT "Command Blocks" board.
+ * All states side by side — mirrors the Figma CLIENT approval-block frames
+ * (1-6575 / 1-6621 / 1-6637 / 1-6653).
  */
 export const AllStates: Story = {
 	decorators: [plainDecorator(420)],
 	render: () => {
 		const states = [
 			{ data: makeData(), status: "pending" as const, onApprove: () => {}, onReject: () => {} },
-			{ data: executingData, status: "approved" as const, resolvedByName: "Michael Johnson" },
-			{ data: doneData, status: "approved" as const, resolvedByName: "Michael Johnson" },
+			{ data: makeData(), status: "approved" as const, resolvedByName: "Michael Johnson" },
 			{ data: makeData(), status: "rejected" as const, resolvedByName: "Michael Johnson" },
 			{ data: makeData(), status: "cancelled" as const, resolvedByName: "Michael Johnson" },
 		];
 		return (
 			<div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
 				{states.map((s, i) => (
-					<div key={i}>
-						<CommandHeading />
-						<ApprovalBatchMessage assistantType="fae" {...s} />
-					</div>
+					<ApprovalBatchMessage key={i} variant="client" {...s} />
 				))}
 			</div>
 		);


### PR DESCRIPTION
## Description
Client (Fae end-user) variant shows only the BE-generated title with Approve/Reject or a full-text resolved pill — commands, scripts, args and execution icons are never rendered. Admin variant (default) keeps the full command block; assistantType no longer drives approval block styling, the new approvalVariant/variant prop does.

## Task
[Fae — Approval Blocks Redesign](https://app.clickup.com/t/9013925967/86ajd5jmx)
