### PR TITLE
fix organization test comparison to ignore lastActivityAt

### DIFF
--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/OrganizationsTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/OrganizationsTest.java
@@ -38,7 +38,7 @@ public class OrganizationsTest extends BaseTest {
         assertThat(organization).as("Created organization should match request")
                 .usingRecursiveComparison()
                 .ignoringFields("id", "organizationId", "isDefault", "createdAt",
-                        "updatedAt", "status", "statusChangedAt", "contactInformation.mailingAddress")
+                        "updatedAt", "lastActivityAt", "status", "statusChangedAt", "contactInformation.mailingAddress")
                 .isEqualTo(request);
     }
 
@@ -89,7 +89,7 @@ public class OrganizationsTest extends BaseTest {
         assertThat(organization).as("Updated organization should match request")
                 .usingRecursiveComparison()
                 .ignoringFields("id", "organizationId", "isDefault", "createdAt",
-                        "updatedAt", "status", "statusChangedAt")
+                        "updatedAt", "lastActivityAt", "status", "statusChangedAt")
                 .isEqualTo(request);
     }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear, concise description of what this PR changes -->

## Improvements
- <!-- Step by step improvements -->
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated organization-related test assertions to account for a changing activity timestamp, reducing false failures while keeping the existing test coverage intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->