### PR TITLE
Frontend-core): elevator draggable scrollbar styles platform-wide

### DIFF
--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -1,14 +1,39 @@
 /* Global resets */
 * {
   @apply border-border;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
 }
 
+/* Elevator scrollbar, Firefox fallback. Scoped via @supports because
+   scrollbar-width/color would disable ::-webkit-scrollbar styling in Chrome */
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ods-system-greys-grey) var(--ods-system-greys-soft-grey);
+  }
+}
+
+/* Elevator scrollbar (ODS): 8px track + draggable rounded thumb */
 *::-webkit-scrollbar {
-  width: 0px !important;
-  height: 0px !important;
-  display: none !important;
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: var(--ods-system-greys-soft-grey);
+  border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--ods-system-greys-grey);
+  border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--ods-system-greys-grey-hover);
+}
+
+*::-webkit-scrollbar-corner {
+  background-color: transparent;
 }
 
 body {
@@ -132,18 +157,6 @@ body {
     transform-origin: left top;
     transform: scale(1);
   }
-}
-
-/* Global scrollbar suppression */
-*::-webkit-scrollbar-thumb {
-  background-color: transparent;
-}
-*::-webkit-scrollbar-track {
-  background-color: transparent;
-}
-
-* {
-  scrollbar-color: transparent transparent;
 }
 
 /* Shadcn/ui HSL CSS variables for Tailwind compatibility */


### PR DESCRIPTION
## Description
Replace global scrollbar suppression with ODS elevator scrollbar: 8px track (soft-grey) and draggable rounded thumb (grey) per design. .scrollbar-hide utility stays as opt-out.

## Task
[Add elevator draggable scroll support across entire OpenFrame platform](https://app.clickup.com/t/9013925967/86ajdbzr4)