### PR TITLE
Chat: show date on timestamps of older messages

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
@@ -2,6 +2,7 @@
 
 import React, { forwardRef, memo, useMemo, useRef } from "react"
 import { cn } from "../../utils/cn"
+import { isToday } from "../../utils/date-utils"
 import { SquareAvatar } from "../ui/square-avatar"
 import { ToolExecutionDisplay } from "./tool-execution-display"
 import { ApprovalRequestMessage } from "./approval-request-message"
@@ -34,6 +35,15 @@ const MENTION_MARKER_REGEX = /(^|[^\w@])@[a-z]+:([A-Za-z0-9_.+/=-]*[A-Za-z0-9_+/
  * both files must update.
  */
 const CARD_MARKER_REGEX = /\[card:\/\/([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)[\])]/g
+
+/** Timestamp label: today's messages show time only ("2:47 PM"),
+ *  older messages prepend the date ("05/05/2026 2:47 PM"). */
+function formatMessageTimestamp(timestamp: Date): string {
+  const time = timestamp.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+  if (isToday(timestamp)) return time
+  const date = timestamp.toLocaleDateString('en-US', { month: '2-digit', day: '2-digit', year: 'numeric' })
+  return `${date} ${time}`
+}
 
 function normalizeContent(content: MessageContent): MessageSegment[] {
   if (typeof content === 'string') {
@@ -469,7 +479,7 @@ const ChatMessageEnhanced = forwardRef<HTMLDivElement, ChatMessageEnhancedProps>
             </span>
             {timestamp && (
               <span className="font-sans text-heading-5 font-medium text-ods-text-secondary shrink-0 whitespace-nowrap">
-                {timestamp.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+                {formatMessageTimestamp(timestamp)}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Description
Messages from a previous day render MM/DD/YYYY before the time; today's messages keep time only. Applies to both Mingo and Fae via the shared ChatMessageEnhanced component.

## Task
[Fae and Mingo - Show Date on Older Messages](https://app.clickup.com/t/9013925967/86ajee10m)