### PR TITLE
Frontend Core: Fix Mingo AI drawer overlap and tablet breakpoint desync in core lib

### DIFF
--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -168,7 +168,9 @@ export const AppHeader = React.memo(function AppHeader({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="end"
-            className="w-[280px] p-0 bg-ods-bg border-ods-border rounded-[6px] overflow-hidden"
+            // z-[104] — above the in-layout AppLayoutDrawer panel (z-[103]) so the
+            // user menu stays clickable while the Mingo AI drawer is open
+            className="w-[280px] p-0 bg-ods-bg border-ods-border rounded-[6px] overflow-hidden z-[104]"
           >
             {/* User info header section */}
             <div className="bg-ods-card border-b border-ods-border p-3 flex items-center gap-2">

--- a/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout-drawer.tsx
@@ -433,7 +433,9 @@ export interface AppLayoutDrawerContentProps
   defaultSize?: number
   storageKey?: string
   /** Pixel breakpoint below which `resizable` is disabled and inline size is
-   *  not applied (so the panel can render full-area on mobile). */
+   *  not applied (so the panel can render full-area on mobile). Defaults to
+   *  800 — the library's Tailwind `md` breakpoint, so the JS mobile switch
+   *  and the `md:` panel styles flip together. */
   mobileBreakpoint?: number
   overlayClassName?: string
   resizeAriaLabel?: string
@@ -481,7 +483,7 @@ const AppLayoutDrawerContent = React.forwardRef<
       maxSize = Number.POSITIVE_INFINITY,
       defaultSize,
       storageKey,
-      mobileBreakpoint = 768,
+      mobileBreakpoint = 800,
       overlayClassName,
       resizeAriaLabel,
       className,

--- a/openframe-frontend-core/src/components/ui/drawer.tsx
+++ b/openframe-frontend-core/src/components/ui/drawer.tsx
@@ -347,7 +347,9 @@ interface DrawerContentProps
   /** localStorage key for persisting the size across sessions. */
   storageKey?: string
   /** Pixel breakpoint below which `resizable` is disabled and inline
-   *  size is not applied (so consumer CSS can render full-viewport). */
+   *  size is not applied (so consumer CSS can render full-viewport).
+   *  Defaults to 800 — the library's Tailwind `md` breakpoint, so the JS
+   *  mobile switch and the `md:` panel styles flip together. */
   mobileBreakpoint?: number
   /** Optional className applied to the overlay. */
   overlayClassName?: string
@@ -379,7 +381,7 @@ const DrawerContent = React.forwardRef<
       maxSize = 1280,
       defaultSize,
       storageKey,
-      mobileBreakpoint = 768,
+      mobileBreakpoint = 800,
       overlayClassName,
       resizeAriaLabel,
       className,


### PR DESCRIPTION
## Description
- Header user menu hidden behind Mingo AI drawer. The profile dropdown (Profile Settings / Log Out) rendered at default z-50, while the in-layout AppLayoutDrawer panel sits at z-[103], so the open chat covered the menu. Raised the user menu dropdown to z-[104] in app-header.tsx.
- Drawer mobile breakpoint out of sync with Tailwind md. AppLayoutDrawerContent and DrawerContent defaulted mobileBreakpoint to 768, while the library's Tailwind md breakpoint is 800px. In the 768–799px range the drawer was already in desktop mode (fixed inline width) but the md: card-chrome styles didn't apply yet, so the Mingo chat filled the screen height without filling its width. Aligned both defaults to 800 so the JS mobile switch and md: styles flip together: below 800px the drawer is full-width edge-to-edge, from 800px it's a desktop side panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu layering so the user dropdown reliably appears above in-app drawers and other overlays.
  * Adjusted the drawer’s mobile breakpoint, improving consistency between mobile behavior and responsive panel styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->