### PR TITLE
feat(notifications): dismiss a notification for all recipients on lifecycle resolve

### DIFF
--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
@@ -32,6 +32,15 @@ public interface NotificationReadStateRepository
     @Update("{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
     long markAllAsRead(String recipientId, RecipientType recipientType);
 
+    /**
+     * Flips every recipient's UNREAD row for the given notification to READ in one bulk update.
+     * Used to dismiss a notification from the active list for ALL recipients at once on a
+     * lifecycle-resolve event, while it remains in history. Already-READ/DELETED rows are untouched.
+     */
+    @Query("{ 'notificationId': ?0, 'status': 'UNREAD' }")
+    @Update("{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
+    long markAllRecipientsRead(String notificationId);
+
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': { '$ne': 'DELETED' } }")
     @Update("{ '$set': { 'status': 'DELETED' } }")
     long softDelete(String recipientId, RecipientType recipientType, String notificationId);

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
@@ -68,6 +68,18 @@ public class NotificationReadStateService {
         return repository.markAllAsRead(recipientId, recipientType);
     }
 
+    /**
+     * Moves a notification out of the active list into history for EVERY recipient at once by
+     * flipping their UNREAD rows to READ. Intended for lifecycle-resolve events (e.g. an approval
+     * request resolved by one admin) so the notification stops being actionable for all recipients
+     * while remaining visible in history. Rows already READ or DELETED are left untouched.
+     *
+     * @return number of recipient rows moved from UNREAD to READ
+     */
+    public long dismissForAllRecipients(@NotBlank String notificationId) {
+        return repository.markAllRecipientsRead(notificationId);
+    }
+
     public boolean deleteNotification(@NotBlank String recipientId,
                                       @NotNull RecipientType recipientType,
                                       @NotBlank String notificationId) {

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
@@ -105,6 +105,40 @@ class NotificationReadStateServiceIT extends BaseMongoIntegrationTest {
     }
 
     @Test
+    @DisplayName("Given a notification with UNREAD rows for several recipients, when dismissForAllRecipients is called, then every recipient's row flips to READ so it leaves the active list for all — used on lifecycle-resolve (e.g. an approval resolved by one admin)")
+    void dismiss_for_all_recipients_marks_every_recipient_read() {
+        service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
+        assertThat(service.hasUnread(ALICE, U)).isTrue();
+        assertThat(service.hasUnread(BOB, U)).isTrue();
+
+        assertThat(service.dismissForAllRecipients("notif-1")).isEqualTo(2L);
+
+        assertThat(service.hasUnread(ALICE, U)).isFalse();
+        assertThat(service.hasUnread(BOB, U)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Given one recipient who already deleted their row and one who left it UNREAD, when dismissForAllRecipients is called, then only the UNREAD row moves to READ — already-DELETED rows are left untouched")
+    void dismiss_for_all_recipients_leaves_non_unread_untouched() {
+        service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
+        service.deleteNotification(BOB, U, "notif-1");
+
+        assertThat(service.dismissForAllRecipients("notif-1")).isEqualTo(1L);
+
+        NotificationReadState bobRow = mongoTemplate.findAll(NotificationReadState.class).stream()
+                .filter(r -> r.getRecipientId().equals(BOB)).findFirst().orElseThrow();
+        assertThat(bobRow.getStatus()).isEqualTo(ReadStatus.DELETED);
+        assertThat(service.hasUnread(ALICE, U)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Given a blank/null notificationId, when dismissForAllRecipients is called, then it throws ConstraintViolationException — invalid input is caller's bug")
+    void dismiss_for_all_recipients_blank_throws() {
+        assertThatThrownBy(() -> service.dismissForAllRecipients(null)).isInstanceOf(ConstraintViolationException.class);
+        assertThatThrownBy(() -> service.dismissForAllRecipients("")).isInstanceOf(ConstraintViolationException.class);
+    }
+
+    @Test
     @DisplayName("Given a read_state row for the caller, when deleteNotification is called, then the row is soft-deleted (status=DELETED) — Notification document and other recipients are untouched")
     void delete_notification_soft_deletes() {
         service.createForAudience("n1", CAT_TICKETS, "title", U, Set.of(ALICE));


### PR DESCRIPTION
## Description

Adds a reusable read-state primitive to move a notification **out of the active list into history for every recipient at once**, so a lifecycle-resolve event (e.g. an approval request resolved by one admin) stops the notification being actionable for **all** recipients — not just the one who acted — while it stays visible in history.

Today dismiss/read is strictly per-user (`markRead`, `markAllAsRead`, `softDelete` all act on a single `recipientId`); there was no "for all recipients of a notification" operation. This PR adds it.

**Why `READ` (not a new status):** the drawer shows unread only (`notifications.filter(n => !n.read)`), history shows read. Flipping every recipient's row `UNREAD → READ` drops the card from active and keeps it in history — identical to the existing manual mark-as-read path, so no new frontend rendering logic is required. The "resolved by X / when" detail already lives in `context` (PR #1908), so history stays rich. No schema change, no migration.

## Improvements
- `NotificationReadStateRepository#markAllRecipientsRead(notificationId)` — `@Query`/`@Update` keyed on `notificationId`, mirroring `markAllAsRead`; flips all `UNREAD` rows to `READ` in one bulk update (already-`READ`/`DELETED` rows untouched). Tenant scoping is applied by the tenant-aware repository layer, same as the sibling methods.
- `NotificationReadStateService#dismissForAllRecipients(notificationId)` — validated (`@NotBlank`) wrapper over the repository method.
- Integration tests in `NotificationReadStateServiceIT`: all-recipients dismiss flips every row to READ; a `DELETED` row is left untouched (only the `UNREAD` row moves); blank/null input throws `ConstraintViolationException`.

## Follow-up (separate PR, after this lib is released + version-bumped)
Wire the consumer in `openframe-saas-ai-agent`: `ChatNotificationDispatcher#onApprovalResolved(...)` calls `dismissForAllRecipients(notification.getId())` right after `NotificationBroadcaster#update(...)`. That's a ~1-line change but it can only compile against the released lib, so it ships separately.

Optional FE polish (Oleksandr): on a live `UPDATED` event with `context.resolution != PENDING`, locally mark the card read so it relocates to history instantly. Not required for correctness — on any refetch/reopen the server-filtered active list already excludes it.

## Notes
- The new method is unused within this repo by design — it's a library capability consumed by downstream services (the ai-agent follow-up above).
- Tests are gated by `-Dintegration.tests=true` like the rest of `NotificationReadStateServiceIT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-step action to mark all unread recipients for a notification as read.
  * The change returns how many recipient records were updated.

* **Bug Fixes**
  * Unread recipient entries are now updated in bulk while already read or deleted entries remain unchanged.
  * Added validation so the notification ID must be provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->