### PR TITLE
fix(notifications): read-state readAt persisted literal "$$NOW" instead of a timestamp

### DIFF
--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.mongodb.repository.Update;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -26,12 +25,12 @@ public interface NotificationReadStateRepository
     List<NotificationReadState> findByNotificationId(String notificationId);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': ?3 } }")
-    long markAsRead(String recipientId, RecipientType recipientType, String notificationId, Instant readAt);
+    @Update(pipeline = "{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
+    long markAsRead(String recipientId, RecipientType recipientType, String notificationId);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': ?2 } }")
-    long markAllAsRead(String recipientId, RecipientType recipientType, Instant readAt);
+    @Update(pipeline = "{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
+    long markAllAsRead(String recipientId, RecipientType recipientType);
 
     /**
      * Flips every recipient's UNREAD row for the given notification to READ in one bulk update.
@@ -39,8 +38,8 @@ public interface NotificationReadStateRepository
      * lifecycle-resolve event, while it remains in history. Already-READ/DELETED rows are untouched.
      */
     @Query("{ 'notificationId': ?0, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': ?1 } }")
-    long markAllRecipientsRead(String notificationId, Instant readAt);
+    @Update(pipeline = "{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
+    long markAllRecipientsRead(String notificationId);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': { '$ne': 'DELETED' } }")
     @Update("{ '$set': { 'status': 'DELETED' } }")

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.repository.Update;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 
 @Repository
@@ -25,12 +26,12 @@ public interface NotificationReadStateRepository
     List<NotificationReadState> findByNotificationId(String notificationId);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
-    long markAsRead(String recipientId, RecipientType recipientType, String notificationId);
+    @Update("{ '$set': { 'status': 'READ', 'readAt': ?3 } }")
+    long markAsRead(String recipientId, RecipientType recipientType, String notificationId, Instant readAt);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
-    long markAllAsRead(String recipientId, RecipientType recipientType);
+    @Update("{ '$set': { 'status': 'READ', 'readAt': ?2 } }")
+    long markAllAsRead(String recipientId, RecipientType recipientType, Instant readAt);
 
     /**
      * Flips every recipient's UNREAD row for the given notification to READ in one bulk update.
@@ -38,8 +39,8 @@ public interface NotificationReadStateRepository
      * lifecycle-resolve event, while it remains in history. Already-READ/DELETED rows are untouched.
      */
     @Query("{ 'notificationId': ?0, 'status': 'UNREAD' }")
-    @Update("{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
-    long markAllRecipientsRead(String notificationId);
+    @Update("{ '$set': { 'status': 'READ', 'readAt': ?1 } }")
+    long markAllRecipientsRead(String notificationId, Instant readAt);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': { '$ne': 'DELETED' } }")
     @Update("{ '$set': { 'status': 'DELETED' } }")

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -62,11 +61,11 @@ public class NotificationReadStateService {
     public boolean markRead(@NotBlank String recipientId,
                             @NotNull RecipientType recipientType,
                             @NotBlank String notificationId) {
-        return repository.markAsRead(recipientId, recipientType, notificationId, Instant.now()) > 0;
+        return repository.markAsRead(recipientId, recipientType, notificationId) > 0;
     }
 
     public long markAllAsRead(@NotBlank String recipientId, @NotNull RecipientType recipientType) {
-        return repository.markAllAsRead(recipientId, recipientType, Instant.now());
+        return repository.markAllAsRead(recipientId, recipientType);
     }
 
     /**
@@ -78,7 +77,7 @@ public class NotificationReadStateService {
      * @return number of recipient rows moved from UNREAD to READ
      */
     public long dismissForAllRecipients(@NotBlank String notificationId) {
-        return repository.markAllRecipientsRead(notificationId, Instant.now());
+        return repository.markAllRecipientsRead(notificationId);
     }
 
     public boolean deleteNotification(@NotBlank String recipientId,

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -61,11 +62,11 @@ public class NotificationReadStateService {
     public boolean markRead(@NotBlank String recipientId,
                             @NotNull RecipientType recipientType,
                             @NotBlank String notificationId) {
-        return repository.markAsRead(recipientId, recipientType, notificationId) > 0;
+        return repository.markAsRead(recipientId, recipientType, notificationId, Instant.now()) > 0;
     }
 
     public long markAllAsRead(@NotBlank String recipientId, @NotNull RecipientType recipientType) {
-        return repository.markAllAsRead(recipientId, recipientType);
+        return repository.markAllAsRead(recipientId, recipientType, Instant.now());
     }
 
     /**
@@ -77,7 +78,7 @@ public class NotificationReadStateService {
      * @return number of recipient rows moved from UNREAD to READ
      */
     public long dismissForAllRecipients(@NotBlank String notificationId) {
-        return repository.markAllRecipientsRead(notificationId);
+        return repository.markAllRecipientsRead(notificationId, Instant.now());
     }
 
     public boolean deleteNotification(@NotBlank String recipientId,

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
@@ -18,6 +18,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -115,6 +117,24 @@ class NotificationReadStateServiceIT extends BaseMongoIntegrationTest {
 
         assertThat(service.hasUnread(ALICE, U)).isFalse();
         assertThat(service.hasUnread(BOB, U)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Given rows flipped to READ, when they are read back as entities, then readAt is a real Instant — regression: $$NOW must be a server/param timestamp, never the literal string '$$NOW' (which fails Instant conversion on read)")
+    void read_at_is_a_real_instant_not_literal_now() {
+        Instant before = Instant.now();
+        service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
+        service.dismissForAllRecipients("notif-1");
+
+        // If readAt were persisted as the literal string "$$NOW", deserializing NotificationReadState
+        // (Instant readAt) below would throw DateTimeParseException.
+        List<NotificationReadState> rows = mongoTemplate.findAll(NotificationReadState.class);
+        assertThat(rows).hasSize(2);
+        assertThat(rows).allSatisfy(r -> {
+            assertThat(r.getStatus()).isEqualTo(ReadStatus.READ);
+            assertThat(r.getReadAt()).isNotNull().isInstanceOf(Instant.class);
+            assertThat(r.getReadAt()).isAfterOrEqualTo(before.minusSeconds(5));
+        });
     }
 
     @Test


### PR DESCRIPTION
## Description

The read-state read-marking updates used `@Update("{ '$set': { 'readAt': '$$NOW' } }")`. In a **classic (document-form) update**, MongoDB does **not** evaluate the `$$NOW` aggregation variable — it stores the literal string `"$$NOW"` in `readAt`. Reading such a row back into `NotificationReadState` (which has an `Instant readAt`) then throws:

```
java.time.format.DateTimeParseException: Text '$$NOW' could not be parsed at index 0
  ... StringToInstantConverter ... MappingMongoConverter.getPotentiallyConvertedSimpleRead ...
```

This surfaced in `NotificationBroadcaster.update()` → `findRecipients()` → `findByNotificationId()` (which deserializes the entities) as swallowed **"Approval-resolved notification update failed"** errors.

**Pre-existing** in `markAsRead` / `markAllAsRead`. `markAllRecipientsRead` (added in #1407) inherited the same pattern and wired it into the approval-resolve hot path (`ChatNotificationDispatcher.onApprovalResolved` → `dismissForAllRecipients`), so every approval resolution would have written bad `readAt` for all recipients.

## Fix
Bind a real `Instant` parameter instead of `$$NOW`, for all three read-marking methods (`markAsRead`, `markAllAsRead`, `markAllRecipientsRead`). This is guaranteed correct through the tenant-aware repository layer (a normal bound-parameter update, no reliance on pipeline-update support). The service passes `Instant.now()`. `softDelete`/`softDeleteAllRead` set only `status` and are unchanged.

## Test
Adds a regression test that flips rows to READ and then **reads them back as entities**, asserting `readAt` is a real `Instant` — this deserialization is exactly what throws under the old literal-`"$$NOW"` bug. (The gap before: the existing tests only asserted counts/`hasUnread`, never deserialized `readAt`; and the integration tests are gated by `-Dintegration.tests=true` so they don't run in normal CI.)

## Follow-ups
- **Data cleanup:** rows already persisted with `readAt="$$NOW"` (any env) stay unreadable until fixed — a one-off `updateMany({readAt:"$$NOW"}, {$unset:{readAt:""}})` per tenant DB. Not included here.
- Consumers pick this up after release + `openframe.oss.libs.version` bump (currently 6.15.3 in the tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification read timestamps being stored as the literal `$$NOW` value instead of an actual timestamp.
  * Notification read and dismissal actions now record the correct time consistently.

* **Tests**
  * Added coverage verifying that notification read states contain valid timestamps after dismissal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->