### PR TITLE
refactor(video): center play/unmute glyphs use the icon system, no inline SVG paths

### DIFF
--- a/openframe-frontend-core/src/components/features/video-center-badge.tsx
+++ b/openframe-frontend-core/src/components/features/video-center-badge.tsx
@@ -9,8 +9,10 @@
  * mux-player controls get the same via `::part(button):hover` in
  * styles/app-globals.css).
  *
- * Glyphs come from THE icon system (icons-v2-generated) — never inline SVG
- * paths here: PlayIcon (media-playback) and VolumeOffIcon (audio-and-visual).
+ * Glyphs come from THE icon system — never inline SVG paths here:
+ * PlayFilledIcon / VolumeOffFilledIcon (components/icons — the FILLED
+ * media-chrome-matching glyphs, so custom affordances are pixel-identical to
+ * MuxPlayer's native center button on real players).
  *
  * Consumers:
  *   - <VideoBiteCard> resting/paused posters (md)
@@ -22,8 +24,8 @@
  */
 
 import React from 'react'
-import { PlayIcon } from '../icons-v2-generated/media-playback/play-icon'
-import { VolumeOffIcon } from '../icons-v2-generated/audio-and-visual/volume-off-icon'
+import { PlayFilledIcon } from '../icons/play-filled-icon'
+import { VolumeOffFilledIcon } from '../icons/volume-off-filled-icon'
 import { cn } from '../../utils/cn'
 
 export type VideoCenterBadgeSize = 'sm' | 'md' | 'lg'
@@ -50,7 +52,7 @@ export function VideoPlayBadge({ size = 'md', className }: VideoPlayBadgeProps):
       className={cn('pointer-events-none flex items-center justify-center text-ods-text-primary transition-colors', className)}
       style={{ filter: GLYPH_SHADOW }}
     >
-      <PlayIcon size={SIZES[size]} color="currentColor" />
+      <PlayFilledIcon size={SIZES[size]} color="currentColor" />
     </div>
   )
 }
@@ -60,12 +62,12 @@ export interface VideoUnmuteGlyphProps {
   className?: string
 }
 
-/** Bare muted-volume glyph (the icon system's VolumeOffIcon). Rendered by
- *  FilePlayer's unmute button; exported here so play + unmute share one
+/** Bare muted-volume glyph (the icon system's VolumeOffFilledIcon). Rendered
+ *  by FilePlayer's unmute button; exported here so play + unmute share one
  *  identity. */
 export function VideoUnmuteGlyph({ size = 'md', className }: VideoUnmuteGlyphProps): React.ReactElement {
   return (
-    <VolumeOffIcon
+    <VolumeOffFilledIcon
       size={SIZES[size]}
       color="currentColor"
       className={className}

--- a/openframe-frontend-core/src/components/features/video-center-badge.tsx
+++ b/openframe-frontend-core/src/components/features/video-center-badge.tsx
@@ -4,7 +4,13 @@
  * THE center media glyphs — the single visual identity for every play/unmute
  * affordance over video, across the whole project: a SOLID WHITE GLYPH
  * (`text-ods-text-primary`), NO background disc, with a soft drop-shadow for
- * legibility over arbitrary frames.
+ * legibility over arbitrary frames. Accent color appears ONLY while the
+ * icon's own control is hovered (hosts pass `group-hover:text-ods-accent`;
+ * mux-player controls get the same via `::part(button):hover` in
+ * styles/app-globals.css).
+ *
+ * Glyphs come from THE icon system (icons-v2-generated) — never inline SVG
+ * paths here: PlayIcon (media-playback) and VolumeOffIcon (audio-and-visual).
  *
  * Consumers:
  *   - <VideoBiteCard> resting/paused posters (md)
@@ -12,14 +18,12 @@
  *   - <MediaCarousel> video thumbnails (sm)
  *   - <FilePlayer>'s unmute chip (VideoUnmuteGlyph, md)
  *   - MuxPlayer's native center pre-play button is stripped to the same bare
- *     white glyph via CSS (`mux-player::part(center play button)` in
- *     styles/app-globals.css) so full players match too.
- *
- * Glyph paths are media-chrome's own (filled triangle / filled volume-off) so
- * the replica and the real player chrome stay pixel-consistent.
+ *     glyph language via CSS (see styles/app-globals.css).
  */
 
 import React from 'react'
+import { PlayIcon } from '../icons-v2-generated/media-playback/play-icon'
+import { VolumeOffIcon } from '../icons-v2-generated/audio-and-visual/volume-off-icon'
 import { cn } from '../../utils/cn'
 
 export type VideoCenterBadgeSize = 'sm' | 'md' | 'lg'
@@ -38,7 +42,7 @@ export interface VideoPlayBadgeProps {
   className?: string
 }
 
-/** Bare white play glyph (media-chrome's filled triangle). Decorative
+/** Bare play glyph (the icon system's PlayIcon). Decorative
  *  (`pointer-events-none`) — the host surface owns activation. */
 export function VideoPlayBadge({ size = 'md', className }: VideoPlayBadgeProps): React.ReactElement {
   return (
@@ -46,9 +50,7 @@ export function VideoPlayBadge({ size = 'md', className }: VideoPlayBadgeProps):
       className={cn('pointer-events-none flex items-center justify-center text-ods-text-primary transition-colors', className)}
       style={{ filter: GLYPH_SHADOW }}
     >
-      <svg aria-hidden viewBox="0 0 24 24" fill="currentColor" style={{ width: SIZES[size], height: SIZES[size] }}>
-        <path d="m6 21 15-9L6 3v18Z" />
-      </svg>
+      <PlayIcon size={SIZES[size]} color="currentColor" />
     </div>
   )
 }
@@ -58,19 +60,16 @@ export interface VideoUnmuteGlyphProps {
   className?: string
 }
 
-/** Bare white muted-volume glyph (filled, material volume_off — the same
- *  family as media-chrome's mute icon). Rendered by FilePlayer's unmute
- *  button; exported here so play + unmute share one identity. */
+/** Bare muted-volume glyph (the icon system's VolumeOffIcon). Rendered by
+ *  FilePlayer's unmute button; exported here so play + unmute share one
+ *  identity. */
 export function VideoUnmuteGlyph({ size = 'md', className }: VideoUnmuteGlyphProps): React.ReactElement {
   return (
-    <svg
-      aria-hidden
-      viewBox="0 0 24 24"
-      fill="currentColor"
+    <VolumeOffIcon
+      size={SIZES[size]}
+      color="currentColor"
       className={className}
-      style={{ width: SIZES[size], height: SIZES[size], filter: GLYPH_SHADOW }}
-    >
-      <path d="M16.5 12A4.5 4.5 0 0 0 14 7.97v2.21l2.45 2.45c.03-.2.05-.41.05-.63Zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51A8.796 8.796 0 0 0 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71ZM4.27 3 3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06a8.99 8.99 0 0 0 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3ZM12 4 9.91 6.09 12 8.18V4Z" />
-    </svg>
+      style={{ filter: GLYPH_SHADOW }}
+    />
   )
 }

--- a/openframe-frontend-core/src/components/features/video.tsx
+++ b/openframe-frontend-core/src/components/features/video.tsx
@@ -249,9 +249,6 @@ interface VideoFileProps extends VideoCommonProps {
    *  true → start hover playback, false → pause. When provided, the internal
    *  pointer handlers are disabled. */
   playWhenHovered?: boolean;
-  /** Hide the bottom control bar, keep only the CENTER play/pause control
-   *  (bite-strip cards per Figma). */
-  centerControlsOnly?: boolean;
   /** Render ONLY a lightweight first-frame preview — a metadata-only element
    *  seeked to `#t=0.1` (media-fragment trick; paints on iOS Safari where a
    *  fragmentless metadata load stays blank). No chrome, no playback, no
@@ -277,7 +274,6 @@ interface VideoAutoProps extends VideoCommonProps {
   chromeless?: boolean;
   playOnHover?: boolean;
   playWhenHovered?: boolean;
-  centerControlsOnly?: boolean;
   firstFrameOnly?: boolean;
 }
 
@@ -317,7 +313,6 @@ export function Video(props: VideoProps): React.ReactElement | null {
         chromeless={'chromeless' in props ? props.chromeless : undefined}
         playOnHover={'playOnHover' in props ? props.playOnHover : undefined}
         playWhenHovered={'playWhenHovered' in props ? props.playWhenHovered : undefined}
-        centerControlsOnly={'centerControlsOnly' in props ? props.centerControlsOnly : undefined}
         className={props.className}
       />
     );
@@ -425,7 +420,6 @@ interface FilePlayerProps {
   chromeless?: boolean;
   playOnHover?: boolean;
   playWhenHovered?: boolean;
-  centerControlsOnly?: boolean;
   /** Media preload hint — the firstFrameOnly facade passes 'metadata'. */
   preload?: 'none' | 'metadata' | 'auto';
   className?: string;
@@ -442,13 +436,9 @@ function FilePlayer({
   chromeless,
   playOnHover,
   playWhenHovered,
-  centerControlsOnly,
   preload,
   className,
 }: FilePlayerProps): React.ReactElement {
-  // centerControlsOnly: the center play button shows at REST only — while
-  // playing, ALL chrome hides (no pause sign over the hover-preview).
-  const [isPlaying, setIsPlaying] = useState(false);
   // True while hover playback is running MUTED because the browser's autoplay
   // policy blocked sound (no user activation yet). Drives the center unmute
   // control — the industry pattern (muted autoplay + explicit unmute button)
@@ -586,8 +576,6 @@ function FilePlayer({
   const player = (
     <MuxPlayer
       ref={hoverPlayerRef as React.Ref<never>}
-      onPlay={centerControlsOnly ? () => setIsPlaying(true) : undefined}
-      onPause={centerControlsOnly ? () => setIsPlaying(false) : undefined}
       src={url}
       poster={poster || undefined}
       streamType="on-demand"
@@ -622,15 +610,6 @@ function FilePlayer({
         width: '100%',
         height: '100%',
         ...(chromeless ? ({ '--controls': 'none' } as React.CSSProperties) : {}),
-        ...(centerControlsOnly && !chromeless
-          ? ({
-              '--bottom-controls': 'none',
-              '--top-controls': 'none',
-              // While playing, hide the center control too — no pause sign
-              // over the hover-preview; it reappears when playback pauses.
-              ...(isPlaying ? { '--center-controls': 'none' } : {}),
-            } as React.CSSProperties)
-          : {}),
       }}
     >
       {captionsUrl ? (

--- a/openframe-frontend-core/src/components/icons/index.ts
+++ b/openframe-frontend-core/src/components/icons/index.ts
@@ -35,6 +35,8 @@ export { VendorDirectoryIcon } from './vendor-directory-icon';
 export { OpenSourceIcon } from './open-source-icon';
 export { CommunityHubIcon } from './community-hub-icon';
 export { AboutIcon } from './about-icon';
+export { PlayFilledIcon } from './play-filled-icon';
+export { VolumeOffFilledIcon } from './volume-off-filled-icon';
 export { UserIcon } from './user-icon';
 export { HamburgerIcon } from './hamburger-icon';
 export { MenuIcon } from './menu-icon';

--- a/openframe-frontend-core/src/components/icons/play-filled-icon.tsx
+++ b/openframe-frontend-core/src/components/icons/play-filled-icon.tsx
@@ -1,0 +1,36 @@
+import type { SVGProps } from "react";
+
+export interface PlayFilledIconProps
+  extends Omit<SVGProps<SVGSVGElement>, "width" | "height"> {
+  className?: string;
+  size?: number;
+  color?: string;
+}
+
+/**
+ * Solid play triangle — the SAME glyph media-chrome/MuxPlayer renders in its
+ * native center play button, so custom video affordances (strip cards,
+ * facades, carousels) stay pixel-consistent with real player chrome.
+ * Hand-maintained (not in the Figma-generated set, which has only the
+ * outline `PlayIcon`).
+ */
+export function PlayFilledIcon({
+  className = "",
+  size = 24,
+  color = "currentColor",
+  ...props
+}: PlayFilledIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      fill="none"
+      viewBox="0 0 24 24"
+      className={className}
+      {...props}
+    >
+      <path fill={color} d="m6 21 15-9L6 3v18Z" />
+    </svg>
+  );
+}

--- a/openframe-frontend-core/src/components/icons/volume-off-filled-icon.tsx
+++ b/openframe-frontend-core/src/components/icons/volume-off-filled-icon.tsx
@@ -1,0 +1,38 @@
+import type { SVGProps } from "react";
+
+export interface VolumeOffFilledIconProps
+  extends Omit<SVGProps<SVGSVGElement>, "width" | "height"> {
+  className?: string;
+  size?: number;
+  color?: string;
+}
+
+/**
+ * Solid muted-volume glyph (speaker + slash) — the filled companion to
+ * `PlayFilledIcon`, matching media-chrome's icon family so video unmute
+ * affordances read identically to real player chrome. Hand-maintained (the
+ * Figma-generated set has only outline volume icons).
+ */
+export function VolumeOffFilledIcon({
+  className = "",
+  size = 24,
+  color = "currentColor",
+  ...props
+}: VolumeOffFilledIconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      fill="none"
+      viewBox="0 0 24 24"
+      className={className}
+      {...props}
+    >
+      <path
+        fill={color}
+        d="M16.5 12A4.5 4.5 0 0 0 14 7.97v2.21l2.45 2.45c.03-.2.05-.41.05-.63Zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51A8.796 8.796 0 0 0 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71ZM4.27 3 3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06a8.99 8.99 0 0 0 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3ZM12 4 9.91 6.09 12 8.18V4Z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What

Follow-up to #1410 (review feedback): the video center glyphs are now proper icon-system components and the glyph is the FILLED triangle in every case — pixel-identical between custom affordances and MuxPlayer's native center button.

- **New icons** in `components/icons/` (the hand-maintained set — the Figma-generated folder is `rm -rf`'d on regeneration, and it only carries outline variants): **`PlayFilledIcon`** (media-chrome's exact play path) and **`VolumeOffFilledIcon`**. Exported from the icons barrel; `video-center-badge.tsx` carries zero inline SVG paths.
- **Parity restored**: strip cards / facades / carousels render the same filled triangle the real player shows (the interim swap to the outline `PlayIcon` broke that).
- **Dead code deleted**: `centerControlsOnly` (prop on `Video`/`FilePlayer`, the `isPlaying` state and its style block) — zero consumers remained after the bite card went chromeless.

Verified live: strip cards and the podcast full player show the identical filled glyph; white at rest, accent on icon-hover; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)