### PR TITLE
Fix archived organization disappearing from TimeEntry/ItemAssignment

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/DeviceDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/DeviceDataFetcher.java
@@ -18,6 +18,7 @@ import com.openframe.api.service.TagService;
 import com.openframe.data.document.device.Machine;
 import com.openframe.data.document.installedagents.InstalledAgent;
 import com.openframe.data.document.organization.Organization;
+import com.openframe.data.document.organization.OrganizationStatus;
 import com.openframe.data.document.tag.Tag;
 import com.openframe.data.document.tool.ToolConnection;
 import jakarta.validation.Valid;
@@ -132,7 +133,8 @@ public class DeviceDataFetcher {
             return CompletableFuture.completedFuture(null);
         }
         
-        return dataLoader.load(organizationId);
+        return dataLoader.load(organizationId)
+                .thenApply(org -> org != null && org.getStatus() == OrganizationStatus.ACTIVE ? org : null);
     }
 
 }

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dataloader/OrganizationDataLoader.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dataloader/OrganizationDataLoader.java
@@ -2,7 +2,6 @@ package com.openframe.api.dataloader;
 
 import com.netflix.graphql.dgs.DgsDataLoader;
 import com.openframe.data.document.organization.Organization;
-import com.openframe.data.document.organization.OrganizationStatus;
 import com.openframe.data.repository.organization.OrganizationRepository;
 import lombok.RequiredArgsConstructor;
 import org.dataloader.BatchLoader;
@@ -36,10 +35,8 @@ public class OrganizationDataLoader implements BatchLoader<String, Organization>
                         .collect(Collectors.toList());
             }
 
-            // Batch load organizations (excluding soft deleted)
             List<Organization> organizations = organizationRepository.findByOrganizationIdIn(nonNullIds);
             Map<String, Organization> orgMap = organizations.stream()
-                    .filter(org -> org.getStatus() == OrganizationStatus.ACTIVE)
                     .collect(Collectors.toMap(Organization::getOrganizationId, org -> org));
 
             // Return in same order as input


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Machines now show an organization only when it exists and is active.
  * Inactive organizations are hidden from machine organization details while remaining available for internal data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->