### PR TITLE
filter-modal: forward fromDate/toDate bounds to the date filter panel

### DIFF
--- a/openframe-frontend-core/src/components/ui/filter-modal.tsx
+++ b/openframe-frontend-core/src/components/ui/filter-modal.tsx
@@ -64,6 +64,10 @@ export interface FilterModalProps {
     defaultSort?: SortDirection
     /** Applied date range. */
     range?: DateRange
+    /** Minimum selectable date. */
+    fromDate?: Date
+    /** Maximum selectable date (e.g. today, to block future dates). */
+    toDate?: Date
     /** Fired on Apply with the drafted values, and on Reset with the defaults. */
     onChange: (result: DateFilterResult) => void
   }
@@ -276,6 +280,8 @@ export function FilterModal({
               onSortChange={setDraftDateSort}
               selected={draftDateRange}
               onSelect={(value) => setDraftDateRange(value as DateRange | undefined)}
+              fromDate={dateFilter.fromDate}
+              toDate={dateFilter.toDate}
               className="gap-[var(--spacing-system-xxs)]"
             />
           </div>


### PR DESCRIPTION
## Description
Lets consumers constrain the selectable calendar range in the mobile Sort and Filter modal — e.g. toDate=today to block future dates on the logs timestamp filter (DateFilterMenu already exposes the same props).

## Task
[Date filter component](https://app.clickup.com/t/9013925967/86agtua90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for minimum and maximum selectable dates in date filters.
  * Date filter configurations can now restrict selections to a defined date range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->