### PR TITLE
revert(notifications): dismiss-for-all back to mark-read (not soft-delete to history)

### DIFF
--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/notification/NotificationReadStateRepository.java
@@ -33,15 +33,13 @@ public interface NotificationReadStateRepository
     long markAllAsRead(String recipientId, RecipientType recipientType);
 
     /**
-     * Flips every recipient's non-DELETED row for the given notification to DELETED in one bulk
-     * update — moving it out of the active list into history for ALL recipients at once. Used on a
-     * shared lifecycle-resolve event (e.g. an approval resolved by one admin completes it for
-     * everyone). DELETED is what actually removes it from the active list: that list filters
-     * {@code status != DELETED}, so a READ row would still show. Already-DELETED rows are untouched.
+     * Flips every recipient's UNREAD row for the given notification to READ in one bulk update.
+     * Used to dismiss a notification from the active list for ALL recipients at once on a
+     * lifecycle-resolve event, while it remains in history. Already-READ/DELETED rows are untouched.
      */
-    @Query("{ 'notificationId': ?0, 'status': { '$ne': 'DELETED' } }")
-    @Update("{ '$set': { 'status': 'DELETED' } }")
-    long softDeleteAllRecipients(String notificationId);
+    @Query("{ 'notificationId': ?0, 'status': 'UNREAD' }")
+    @Update(pipeline = "{ '$set': { 'status': 'READ', 'readAt': '$$NOW' } }")
+    long markAllRecipientsRead(String notificationId);
 
     @Query("{ 'recipientId': ?0, 'recipientType': ?1, 'notificationId': ?2, 'status': { '$ne': 'DELETED' } }")
     @Update("{ '$set': { 'status': 'DELETED' } }")

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/notification/NotificationReadStateService.java
@@ -69,17 +69,15 @@ public class NotificationReadStateService {
     }
 
     /**
-     * Completes a notification for EVERY recipient at once by soft-deleting their rows
-     * (status → DELETED), moving it out of the active list into history. Intended for shared
-     * lifecycle-resolve events (e.g. an approval request resolved by one admin) so it stops
-     * showing in "New Notifications" for all recipients. Marking READ would NOT do this — the
-     * active list filters {@code status != DELETED}, so READ rows still appear there. Rows already
-     * DELETED are left untouched.
+     * Moves a notification out of the active list into history for EVERY recipient at once by
+     * flipping their UNREAD rows to READ. Intended for lifecycle-resolve events (e.g. an approval
+     * request resolved by one admin) so the notification stops being actionable for all recipients
+     * while remaining visible in history. Rows already READ or DELETED are left untouched.
      *
-     * @return number of recipient rows moved to DELETED
+     * @return number of recipient rows moved from UNREAD to READ
      */
     public long dismissForAllRecipients(@NotBlank String notificationId) {
-        return repository.softDeleteAllRecipients(notificationId);
+        return repository.markAllRecipientsRead(notificationId);
     }
 
     public boolean deleteNotification(@NotBlank String recipientId,

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/integration/service/notification/NotificationReadStateServiceIT.java
@@ -107,28 +107,24 @@ class NotificationReadStateServiceIT extends BaseMongoIntegrationTest {
     }
 
     @Test
-    @DisplayName("Given a notification with active rows for several recipients, when dismissForAllRecipients is called, then every recipient's row is soft-deleted (status=DELETED) so it leaves the active list into history for all — used on a shared lifecycle-resolve (e.g. an approval resolved by one admin)")
-    void dismiss_for_all_recipients_soft_deletes_every_recipient() {
+    @DisplayName("Given a notification with UNREAD rows for several recipients, when dismissForAllRecipients is called, then every recipient's row flips to READ so it leaves the active list for all — used on lifecycle-resolve (e.g. an approval resolved by one admin)")
+    void dismiss_for_all_recipients_marks_every_recipient_read() {
         service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
         assertThat(service.hasUnread(ALICE, U)).isTrue();
         assertThat(service.hasUnread(BOB, U)).isTrue();
 
         assertThat(service.dismissForAllRecipients("notif-1")).isEqualTo(2L);
 
-        List<NotificationReadState> rows = mongoTemplate.findAll(NotificationReadState.class);
-        assertThat(rows).hasSize(2);
-        assertThat(rows).allSatisfy(r -> assertThat(r.getStatus()).isEqualTo(ReadStatus.DELETED));
         assertThat(service.hasUnread(ALICE, U)).isFalse();
         assertThat(service.hasUnread(BOB, U)).isFalse();
     }
 
     @Test
-    @DisplayName("Given rows flipped to READ via markAllAsRead, when they are read back as entities, then readAt is a real Instant — regression: $$NOW must be a server/param timestamp, never the literal string '$$NOW' (which fails Instant conversion on read)")
+    @DisplayName("Given rows flipped to READ, when they are read back as entities, then readAt is a real Instant — regression: $$NOW must be a server/param timestamp, never the literal string '$$NOW' (which fails Instant conversion on read)")
     void read_at_is_a_real_instant_not_literal_now() {
         Instant before = Instant.now();
         service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
-        service.markAllAsRead(ALICE, U);
-        service.markAllAsRead(BOB, U);
+        service.dismissForAllRecipients("notif-1");
 
         // If readAt were persisted as the literal string "$$NOW", deserializing NotificationReadState
         // (Instant readAt) below would throw DateTimeParseException.
@@ -142,15 +138,16 @@ class NotificationReadStateServiceIT extends BaseMongoIntegrationTest {
     }
 
     @Test
-    @DisplayName("Given one recipient who already deleted their row and one still active, when dismissForAllRecipients is called, then only the active row moves to DELETED (returns 1) — already-DELETED rows are left untouched")
-    void dismiss_for_all_recipients_leaves_already_deleted_untouched() {
+    @DisplayName("Given one recipient who already deleted their row and one who left it UNREAD, when dismissForAllRecipients is called, then only the UNREAD row moves to READ — already-DELETED rows are left untouched")
+    void dismiss_for_all_recipients_leaves_non_unread_untouched() {
         service.createForAudience("notif-1", CAT_TICKETS, "title", U, Set.of(ALICE, BOB));
         service.deleteNotification(BOB, U, "notif-1");
 
         assertThat(service.dismissForAllRecipients("notif-1")).isEqualTo(1L);
 
-        List<NotificationReadState> rows = mongoTemplate.findAll(NotificationReadState.class);
-        assertThat(rows).allSatisfy(r -> assertThat(r.getStatus()).isEqualTo(ReadStatus.DELETED));
+        NotificationReadState bobRow = mongoTemplate.findAll(NotificationReadState.class).stream()
+                .filter(r -> r.getRecipientId().equals(BOB)).findFirst().orElseThrow();
+        assertThat(bobRow.getStatus()).isEqualTo(ReadStatus.DELETED);
         assertThat(service.hasUnread(ALICE, U)).isFalse();
     }
 


### PR DESCRIPTION
Reverts the dismiss-for-all behavior from soft-delete (→ DELETED / history, shipped in 6.15.6) **back to mark-read** (UNREAD → READ). Moving resolved shared approvals into history turned out to be the wrong UX — real-time removal will be handled by a separate FE push-event later.

- `dismissForAllRecipients` → `markAllRecipientsRead` again.
- Restores the READ-based IT expectations.
- **Context-aware category change from #1415 is kept untouched.**

Will ship as oss-libs 6.15.7; tenant bumps to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dismissing a notification for all recipients now marks unread notifications as read instead of deleting their read-state records.
  * Existing deleted records remain unchanged.
  * Read timestamps are recorded when notifications are marked as read.

* **Tests**
  * Updated coverage to verify bulk dismissal, partial dismissal, and timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->