### PR TITLE
feat(faq): align FaqAccordion with Figma flat-list design

### DIFF
--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useRef, useState, useEffect, useCallback } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { Chevron02DownIcon } from './icons-v2-generated/arrows/chevron-02-down-icon'
 import { cn } from "../utils/cn"
 import { faqItemAnchor } from "../utils/faq-anchor"
 
@@ -81,15 +81,16 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
                 }
               }}
               aria-expanded={isOpen}
-              className="flex w-full items-center gap-6 md:gap-10 px-6 py-4 text-left focus:outline-none transition-colors cursor-pointer"
+              className="flex w-full items-center gap-6 md:gap-10 px-6 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ods-focus transition-colors cursor-pointer"
             >
               <h3 className="flex-1 min-w-0 break-words">
                 {item.question}
               </h3>
-              <ChevronDown
+              <Chevron02DownIcon
                 aria-hidden="true"
+                size={24}
                 className={cn(
-                  'size-6 shrink-0 text-ods-text-primary transition-transform duration-300',
+                  'shrink-0 text-ods-text-primary transition-transform duration-300',
                   isOpen && 'rotate-180',
                 )}
               />

--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useRef, useState, useEffect, useCallback } from 'react'
-import { ChevronButton } from './ui/chevron-button'
+import { ChevronDown } from 'lucide-react'
 import { cn } from "../utils/cn"
 import { faqItemAnchor } from "../utils/faq-anchor"
 
@@ -53,7 +53,7 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
   }
 
   return (
-    <div className="rounded-3xl border border-ods-border divide-y divide-ods-border bg-ods-card overflow-hidden">
+    <div className="rounded-md border border-ods-border divide-y divide-ods-border bg-ods-bg overflow-hidden">
       {items.map(item => {
         const isOpen = openSet.has(item.id)
         const { ref, maxHeight } = useMeasuredHeight(isOpen)
@@ -67,7 +67,7 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
             // sticky nav offset (matches `<section>`'s scroll-margin for
             // category anchors).
             id={faqItemAnchor(item.id)}
-            className={cn('group scroll-mt-24 transition-colors hover:bg-[#1E1E1E]', isOpen ? 'bg-ods-bg' : 'bg-transparent')}
+            className="scroll-mt-24 transition-colors hover:bg-ods-bg-hover"
           >
             {/* Header */}
             <div
@@ -81,33 +81,29 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
                 }
               }}
               aria-expanded={isOpen}
-              className="flex w-full items-center justify-between px-6 md:px-8 py-6 text-left focus:outline-none transition-colors cursor-pointer"
+              className="flex w-full items-center gap-6 md:gap-10 px-6 py-4 text-left focus:outline-none transition-colors cursor-pointer"
             >
-              <div className="min-w-0 pr-4">
-                <h3>
-                  {item.question}
-                </h3>
-              </div>
-              <div className="flex-shrink-0">
-                <ChevronButton
-                  aria-label={isOpen ? 'Collapse question' : 'Expand question'}
-                  size="md"
-                  isExpanded={isOpen}
-                  backgroundColor="transparent"
-                  borderColor="#3A3A3A"
-                />
-              </div>
+              <h3 className="flex-1 min-w-0 break-words">
+                {item.question}
+              </h3>
+              <ChevronDown
+                aria-hidden="true"
+                className={cn(
+                  'size-6 shrink-0 text-ods-text-primary transition-transform duration-300',
+                  isOpen && 'rotate-180',
+                )}
+              />
             </div>
             {/* Content wrapper with max-height animation */}
             <div
               style={{ maxHeight, transition: 'max-height 0.35s ease-in-out, opacity 0.35s ease-in-out', opacity: isOpen ? 1 : 0 }}
-              className="overflow-hidden group-hover:bg-[#1E1E1E]/30"
+              className="overflow-hidden"
             >
               {/* break-words: FAQ answers render as plain text, so a long URL or
                   token has no wrap opportunity — and the parent is overflow-hidden,
                   which would CLIP it past the viewport on mobile. Mirrors the
                   markdown-renderer overflow-wrap fix. */}
-              <div ref={ref} className="px-6 md:px-8 pb-6 text-ods-text-primary text-h4 break-words">
+              <div ref={ref} className="px-6 pb-4 text-ods-text-primary text-h4 break-words">
                 {item.answer}
               </div>
             </div>

--- a/openframe-frontend-core/src/components/faq-accordion.tsx
+++ b/openframe-frontend-core/src/components/faq-accordion.tsx
@@ -53,7 +53,7 @@ export function FaqAccordion({ items, defaultOpenIds = [] }: FaqAccordionProps) 
   }
 
   return (
-    <div className="rounded-md border border-ods-border divide-y divide-ods-border bg-ods-bg overflow-hidden">
+    <div className="rounded-md border border-ods-border divide-y divide-ods-border bg-transparent overflow-hidden">
       {items.map(item => {
         const isOpen = openSet.has(item.id)
         const { ref, maxHeight } = useMeasuredHeight(isOpen)

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -316,7 +316,7 @@ function FaqSkeleton() {
   return (
     <div className="space-y-8 animate-pulse">
       <div className="h-12 md:h-14 w-2/3 rounded bg-ods-border" />
-      <div className="rounded-md border border-ods-border overflow-hidden bg-ods-bg divide-y divide-ods-border w-full">
+      <div className="rounded-md border border-ods-border overflow-hidden bg-transparent divide-y divide-ods-border w-full">
         {Array.from({ length: 8 }).map((_, idx) => (
           <div key={idx} className="flex items-center justify-between gap-6 md:gap-10 px-6 py-4">
             <div className="h-6 w-5/6 rounded bg-ods-border" />

--- a/openframe-frontend-core/src/components/faq/faq-section.tsx
+++ b/openframe-frontend-core/src/components/faq/faq-section.tsx
@@ -316,11 +316,11 @@ function FaqSkeleton() {
   return (
     <div className="space-y-8 animate-pulse">
       <div className="h-12 md:h-14 w-2/3 rounded bg-ods-border" />
-      <div className="rounded-3xl border border-ods-border overflow-hidden bg-ods-card divide-y divide-ods-border w-full">
+      <div className="rounded-md border border-ods-border overflow-hidden bg-ods-bg divide-y divide-ods-border w-full">
         {Array.from({ length: 8 }).map((_, idx) => (
-          <div key={idx} className="flex items-center justify-between px-6 md:px-8 py-6">
+          <div key={idx} className="flex items-center justify-between gap-6 md:gap-10 px-6 py-4">
             <div className="h-6 w-5/6 rounded bg-ods-border" />
-            <div className="h-10 w-10 rounded-md bg-ods-border" />
+            <div className="size-6 rounded bg-ods-border" />
           </div>
         ))}
       </div>


### PR DESCRIPTION
Aligns the shared Q&A accordion (used by `FaqSection` on every platform surface — /faqs, the global nested-page FAQ block, entity embeds) with the Figma spec ([node 4033:88658](https://www.figma.com/design/etEsOUsmdzjqnIbSH4kULB/Flamingo-Website?node-id=4033-88658)).

Per request, section title and category badges/pills are untouched.

**FaqAccordion**
- Container: `rounded-3xl bg-ods-card` → `rounded-md bg-ods-bg` (6px radius, #161616), keeping the 1px `ods-border` frame + row dividers.
- Rows: `px-6 py-4` with `gap-6 md:gap-10` (Figma: 24/16px padding, 40px gap → 56px rows) instead of `px-6 md:px-8 py-6`.
- Chevron: bordered `ChevronButton` replaced with a plain 24px lucide `ChevronDown` that rotates 180° when open, per design.
- Hover: hardcoded `#1E1E1E` replaced with the `hover:bg-ods-bg-hover` token; removed the now-redundant open-state `bg-ods-bg` toggle and the answer-area `group-hover` tint.
- Question stays a bare `<h3>` — global `text-h3` already matches the design's 18px/24px DM Sans bold style.

**FaqSection**
- Loading skeleton updated to the same geometry (rounded-md, bg-ods-bg, compact rows, 24px chevron placeholder).

Verified locally on openframe (`/faqs` and the global block on `/contact`): collapsed and expanded states, chevron rotation, category heading + default title unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the FAQ accordion appearance with updated borders, spacing, hover states, icon sizing, and expanded-content layout.
  * Updated FAQ loading placeholders with a more compact layout and refreshed styling.
  * Improved consistency between FAQ content and its loading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->