### PR TITLE
refactor(announcement-bar): SSR-seeded, event-driven, single-line 44px bar with cookie dismissal

### DIFF
--- a/openframe-frontend-core/src/components/.announcement-bar.md
+++ b/openframe-frontend-core/src/components/.announcement-bar.md
@@ -7,14 +7,12 @@ A dismissible platform announcement bar with DUAL MODE support: SSR-seeded (Next
 |----------------|-------------|
 | `AnnouncementBar` | Main component — renders the bar or `null` when there is nothing to show |
 | `initialAnnouncement` prop | SSR mode seed (nullable): server resolved announcement + dismissal cookie; skips the mount fetch |
-| `announcementsUrl` prop | Client-only mode fetch URL for hosts with no SSR and no provider; wins over the EndpointsRuntime value |
-| `platform` prop | Dismissal-cookie namespace for non-Next hosts (defaults to `getAppType()`) |
 | `previewMode` prop | Render-only (admin live preview): no fetch, inert dismiss, no storage side effects |
 
 ## Modes
 
 - **SSR mode** (hub / any Next host): the server passes `initialAnnouncement` (already dismissal-filtered via the cookie helpers in `announcement-storage.ts`). The bar is in the first HTML byte — zero layout shift, no flash for dismissed users, zero mount fetch.
-- **Client-only mode** (Vite/CRA embeds, no SSR): omit `initialAnnouncement`. The bar self-fetches on mount from the `announcementsUrl` prop, or the optional EndpointsRuntime provider. With neither, it renders nothing and never fetches. Appearance animates in (grid `0fr -> 1fr`).
+- **Client-only mode** (Vite/CRA embeds, no SSR — the react-embedding-example structure): mount the bar PROP-LESS inside an EndpointsRuntime provider; `announcementsUrl` is a fixed suffix under the embedder's one content base (`${CONTENT}/announcements/active`). No provider → renders nothing, never fetches. Appearance animates in (grid `0fr -> 1fr`). Deliberately NO per-component URL or platform knobs: the platform is never sent as a parameter — each server returns its own announcement via `currentPlatform()`.
 
 ## Behavior Notes
 
@@ -29,14 +27,16 @@ A dismissible platform announcement bar with DUAL MODE support: SSR-seeded (Next
 // SSR mode (Next server component resolves the seed):
 <AnnouncementBar initialAnnouncement={announcementOrNull} />
 
-// Client-only mode (bare React app, no SSR, no provider):
-<AnnouncementBar
-  announcementsUrl="https://flamingo.run/api/announcements/active"
-  platform="openframe"
-/>
+// Client-only mode (react-embedding-example structure): one content base,
+// endpoints built once, bar mounted prop-less inside the provider.
+const endpointsRuntime: EndpointsRuntime = {
+  announcementsUrl: `${CONTENT}/announcements/active`,
+  accessCode: { validateUrl: `${CONTENT}/validate-access-code`, consumeUrl: `${CONTENT}/consume-access-code` },
+  contactUrl: `${CONTENT}/contact`,
+}
 
-// Client-only via the EndpointsRuntime provider (embedded app shells):
-<EndpointsRuntimeContext.Provider value={{ announcementsUrl: '/api/mingo-guide/announcements/active', ... }}>
-  <AnnouncementBar platform="openframe" />
+<EndpointsRuntimeContext.Provider value={endpointsRuntime}>
+  <AnnouncementBar />
+  <main>{/* app content */}</main>
 </EndpointsRuntimeContext.Provider>
 ```

--- a/openframe-frontend-core/src/components/.announcement-bar.md
+++ b/openframe-frontend-core/src/components/.announcement-bar.md
@@ -1,40 +1,42 @@
-<!-- source-hash: cbe120bea34edef14f05fff077b0b285 -->
-A client-side React component that renders a dismissible announcement banner, fetching active announcements from a configured API endpoint with localStorage-based caching and per-announcement dismissal persistence.
+<!-- source-hash: pending-regeneration -->
+A dismissible platform announcement bar with DUAL MODE support: SSR-seeded (Next hosts) and client-only (bare React apps without SSR). Single-line 44px strip, contrast handled by scoping content with the ODS theme classes, event-driven freshness (no polling).
 
 ## Key Components
 
 | Export/Function | Description |
 |----------------|-------------|
-| `AnnouncementBar` | Main component — renders the announcement banner or `null` if hidden/dismissed |
-| `fetchActiveAnnouncement` | Fetches the active announcement from `announcementsUrl`, updates state and localStorage cache |
-| `handleDismiss` | Marks the current announcement as dismissed in localStorage and hides the bar |
-| `handleCtaClick` | Navigates to the CTA URL, respecting `_blank` target for new-tab behavior |
-| `renderIcon` | Renders either a PNG `<Image>` or an SVG icon based on `announcement.icon_type` |
-| `getSvgIcon` | Thin wrapper around `renderSvgIcon` applying size-appropriate Tailwind classes |
+| `AnnouncementBar` | Main component — renders the bar or `null` when there is nothing to show |
+| `initialAnnouncement` prop | SSR mode seed (nullable): server resolved announcement + dismissal cookie; skips the mount fetch |
+| `announcementsUrl` prop | Client-only mode fetch URL for hosts with no SSR and no provider; wins over the EndpointsRuntime value |
+| `platform` prop | Dismissal-cookie namespace for non-Next hosts (defaults to `getAppType()`) |
+| `previewMode` prop | Render-only (admin live preview): no fetch, inert dismiss, no storage side effects |
+
+## Modes
+
+- **SSR mode** (hub / any Next host): the server passes `initialAnnouncement` (already dismissal-filtered via the cookie helpers in `announcement-storage.ts`). The bar is in the first HTML byte — zero layout shift, no flash for dismissed users, zero mount fetch.
+- **Client-only mode** (Vite/CRA embeds, no SSR): omit `initialAnnouncement`. The bar self-fetches on mount from the `announcementsUrl` prop, or the optional EndpointsRuntime provider. With neither, it renders nothing and never fetches. Appearance animates in (grid `0fr -> 1fr`).
 
 ## Behavior Notes
 
-- **Instant paint**: On mount, the cached announcement from localStorage is applied synchronously before the API response arrives.
-- **Polling**: Refreshes every 5 minutes via `setInterval`; interval restarts if `announcementsUrl` changes.
-- **No provider fallback**: When `useEndpointsRuntime` returns no URL, polling is skipped entirely — cached data still renders.
-- **Platform-scoped keys**: localStorage keys are prefixed with the platform type (via `getAppType()`) to prevent key collisions across apps.
-- **Responsive CTA**: The CTA button is desktop-only; on mobile, tapping the content area triggers `handleCtaClick` directly.
+- **No polling**: freshness is visibility-driven — `useSelfFetch`'s `revalidateOnVisibleAfterMs` refetches on tab refocus when held data is older than 60s. Idle tabs make zero requests.
+- **Dismissal**: cookie is the SSOT (`<platform>-announcement-dismissed=<id>`, id-match); localStorage is read-only legacy. Storage reads happen only in effects (hydration safety).
+- **Contrast**: the admin background's tone selects `.theme-light`/`.theme-dark` around the content; all colors resolve from the active ODS theme's Tier-1 primitives.
+- **Responsive**: single truncating line (description hidden < sm); CTA is desktop-only, the whole bar is the tap target on mobile.
 
-## Usage Example
+## Usage Examples
 
-```typescript
-// Wrap your app with the endpoints provider, then drop in the bar:
-import { AnnouncementBar } from './announcement-bar';
-import { EndpointsRuntimeProvider } from '../contexts/endpoints-runtime-context';
+```tsx
+// SSR mode (Next server component resolves the seed):
+<AnnouncementBar initialAnnouncement={announcementOrNull} />
 
-function AppShell() {
-  return (
-    <EndpointsRuntimeProvider announcementsUrl="/api/announcements/active">
-      <AnnouncementBar />
-      <main>{/* app content */}</main>
-    </EndpointsRuntimeProvider>
-  );
-}
+// Client-only mode (bare React app, no SSR, no provider):
+<AnnouncementBar
+  announcementsUrl="https://flamingo.run/api/announcements/active"
+  platform="openframe"
+/>
+
+// Client-only via the EndpointsRuntime provider (embedded app shells):
+<EndpointsRuntimeContext.Provider value={{ announcementsUrl: '/api/mingo-guide/announcements/active', ... }}>
+  <AnnouncementBar platform="openframe" />
+</EndpointsRuntimeContext.Provider>
 ```
-
-> **Note:** The component renders nothing (`null`) when no active announcement exists, when the fetch URL is unconfigured, or when the user has previously dismissed the current announcement.

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -140,8 +140,8 @@ export function AnnouncementBar({
         text at 13-14px inside a 44px-tall strip (guides converge on 40-60px
         with a single sentence; two stacked 18px rows blew past that), title +
         description merged inline (description hidden on small screens), ONE
-        compact pill CTA on the right, and a 44x44 dismiss target (WCAG 2.2
-        SC 2.5.8 AA needs >=24px; 44px is the SC 2.5.5 AAA / Apple HIG size).
+        compact CTA on the right, and a ghost-icon dismiss (design-system
+        icon-sm: 32px target, >= the 24px WCAG 2.2 SC 2.5.8 AA floor).
       */}
       <div className="min-h-0 overflow-hidden" style={{ backgroundColor: announcement.background_color }}>
         <div className="flex items-center w-full max-w-full min-h-11" style={{ color: fgColor }}>
@@ -212,20 +212,25 @@ export function AnnouncementBar({
             )}
           </div>
 
-          {/* Dismiss - 44x44 target (WCAG 2.5.5 AAA / Apple HIG), 16px glyph;
-              inert in previewMode */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation(); // Prevent triggering the mobile CTA click
-              handleDismiss();
-            }}
-            className="flex-shrink-0 w-11 h-11 flex items-center justify-center rounded-full hover:opacity-70 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-current mr-1 md:mr-3"
-            aria-label="Dismiss announcement"
-            type="button"
-            tabIndex={expanded ? 0 : -1}
-          >
-            <X className="w-4 h-4" strokeWidth={2} />
-          </button>
+          {/* Dismiss - the design-system Button in its documented ghost-icon
+              treatment (variant="transparent" size="icon-sm": 32px target,
+              >= the 24px WCAG 2.5.8 AA floor, 16px glyph), no overrides.
+              Inert in previewMode. */}
+          <div className="flex-shrink-0 mr-1 md:mr-3">
+            <Button
+              onClick={(e) => {
+                e.stopPropagation(); // Prevent triggering the mobile CTA click
+                handleDismiss();
+              }}
+              variant="transparent"
+              size="icon-sm"
+              aria-label="Dismiss announcement"
+              type="button"
+              tabIndex={expanded ? 0 : -1}
+            >
+              <X strokeWidth={2} />
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -119,10 +119,19 @@ export function AnnouncementBar({
 
   // Contrast-aware foreground: announcement colors are admin-chosen hex
   // (data-driven), so the readable text shade is computed, not hardcoded.
-  const fgColor =
-    pickReadableTextColor(announcement.background_color) === 'dark'
-      ? 'var(--ods-system-greys-black)'
-      : 'var(--ods-system-greys-white)';
+  const tone = pickReadableTextColor(announcement.background_color);
+  const fgColor = tone === 'dark' ? 'var(--ods-system-greys-black)' : 'var(--ods-system-greys-white)';
+
+  // Buttons on the bar keep the common Button component but swap its
+  // dark-surface hover for the bar's own idiom: a translucent tint of the
+  // computed foreground over the admin color (the pre-refactor bar's
+  // hover:bg-[#1A1A1A]/10 treatment). ODS surface tokens assume ODS
+  // backgrounds; on an arbitrary admin color they render dark slabs and the
+  // dark hover surface can swallow a dark computed foreground.
+  const barButtonClasses =
+    tone === 'dark'
+      ? 'text-[color:var(--ods-system-greys-black)] hover:bg-black/10 active:bg-black/20'
+      : 'text-[color:var(--ods-system-greys-white)] hover:bg-white/10 active:bg-white/20';
 
   const hasCta = Boolean(announcement.cta_enabled && announcement.cta_url);
 
@@ -180,20 +189,19 @@ export function AnnouncementBar({
               )}
             </p>
 
-            {/* CTA - the design-system Button, UNMODIFIED: variant + size
-                only, no inline styles and no class overrides. The outline
-                variant brings its own ODS surface (bg-ods-card + ODS border
-                + hover/active/focus tokens), so it is self-contained and
-                legible on any admin-chosen bar color. The admin cta_button_*
-                colors are NOT applied: they were designed for the legacy
-                bespoke treatment and fight the token system (broken hover).
-                Hidden on mobile, where the whole bar is the tap target. */}
+            {/* CTA - the common Button in the bar's quiet treatment: ghost
+                surface, computed-foreground text, translucent fg-tint hover
+                (barButtonClasses) so nothing renders as a dark slab on the
+                admin color. The admin cta_button_* colors are NOT applied:
+                they were designed for the legacy bespoke treatment. Hidden
+                on mobile, where the whole bar is the tap target. */}
             {hasCta && announcement.cta_text && (
               <div className="hidden md:flex flex-shrink-0 ml-1">
                 <Button
                   onClick={handleCtaClick}
-                  variant="outline"
+                  variant="transparent"
                   size="small"
+                  className={barButtonClasses}
                   leftIcon={
                     announcement.cta_show_icon && announcement.cta_icon_name
                       ? (
@@ -212,10 +220,10 @@ export function AnnouncementBar({
             )}
           </div>
 
-          {/* Dismiss - the design-system Button in its documented ghost-icon
-              treatment (variant="transparent" size="icon-sm": 32px target,
-              >= the 24px WCAG 2.5.8 AA floor, 16px glyph), no overrides.
-              Inert in previewMode. */}
+          {/* Dismiss - the common Button in its ghost-icon treatment
+              (size="icon-sm": 32px target, >= the 24px WCAG 2.5.8 AA floor,
+              16px glyph) with the bar's quiet tint hover. Inert in
+              previewMode. */}
           <div className="flex-shrink-0 mr-1 md:mr-3">
             <Button
               onClick={(e) => {
@@ -224,6 +232,7 @@ export function AnnouncementBar({
               }}
               variant="transparent"
               size="icon-sm"
+              className={barButtonClasses}
               aria-label="Dismiss announcement"
               type="button"
               tabIndex={expanded ? 0 : -1}

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -16,38 +16,46 @@ import { useSelfFetch } from '../hooks/use-self-fetch';
 import { pickReadableTextColor } from '../utils/color-analysis';
 
 /**
- * Platform announcement bar.
+ * Platform announcement bar — DUAL MODE, works with or without SSR.
  *
- * Data flow (no polling): the hub SSR-seeds `initialAnnouncement` from the
- * root layout (dismissal cookie already applied server-side → zero layout
- * shift, no flash for dismissed users). Embedded hosts omit the prop and the
- * bar self-fetches via the optional endpoints runtime — no provider → no
- * fetch, silent no-op (cached-free: nothing renders). Freshness is
- * event-driven: `useSelfFetch`'s visibility revalidation re-fetches on tab
- * refocus when the held data is >60s old (matching the server cache TTL by
- * convention); idle tabs make zero requests.
+ * SSR mode (Next hosts, e.g. the hub): the server resolves the announcement
+ * and the dismissal cookie, then passes `initialAnnouncement` (nullable).
+ * The bar renders in the first HTML byte (zero layout shift, no flash for
+ * dismissed users) and skips the mount fetch.
  *
- * Layout: the bar animates its height (grid 0fr↔1fr) for client-side
- * appearance and dismissal, so surrounding content reflows smoothly instead
- * of jumping. The initial expanded state is a pure function of props —
- * SSR-seeded bars render at full height on both server and first client
- * render (hydration-identical), with no entrance animation.
+ * Client-only mode (bare React apps without SSR: Vite/CRA embeds): omit
+ * `initialAnnouncement`. The bar self-fetches on mount from, in order of
+ * precedence, the `announcementsUrl` PROP (no provider needed) or the
+ * optional EndpointsRuntime provider's `announcementsUrl`. With neither, it
+ * renders nothing and never fetches (silent no-op). Appearance animates in
+ * (grid 0fr→1fr) so there is no hard layout jump. Non-Next hosts should
+ * also pass `platform` so dismissal cookies are namespaced correctly
+ * (NEXT_PUBLIC_APP_TYPE is not available at their runtime).
  *
- * Dismissal: cookie is the SSOT (`announcement-storage.ts`); reads happen
- * ONLY in effects (a render-time storage read would desync hydration).
+ * Both modes: freshness is event-driven, no polling — `useSelfFetch`'s
+ * visibility revalidation re-fetches on tab refocus when the held data is
+ * >60s old (matching the server cache TTL by convention); idle tabs make
+ * zero requests. Dismissal cookie is the SSOT (`announcement-storage.ts`);
+ * storage reads happen ONLY in effects (a render-time read would desync
+ * hydration in SSR mode).
  */
 export function AnnouncementBar({
   initialAnnouncement,
+  announcementsUrl,
+  platform: platformProp,
   previewMode = false,
   className,
 }: AnnouncementBarProps = {}) {
-  // Platform for the dismissal cookie/legacy keys (matches the hub's
-  // server-side currentPlatform(), both derive from NEXT_PUBLIC_APP_TYPE).
-  const platform = getAppType();
+  // Platform for the dismissal cookie/legacy keys. SSR hosts derive it from
+  // NEXT_PUBLIC_APP_TYPE (matching the server's currentPlatform()); non-Next
+  // embeds pass the prop (getAppType() is runtime-safe but falls back to
+  // 'openmsp' where the env var does not exist).
+  const platform = platformProp ?? getAppType();
 
-  // Optional endpoint runtime: no provider → no URL → fetching disabled.
+  // Fetch URL: prop wins (client-only mode without a provider), then the
+  // optional endpoints runtime. No provider and no prop → fetching disabled.
   const endpoints = useEndpointsRuntime();
-  const url = previewMode ? null : endpoints?.announcementsUrl ?? null;
+  const url = previewMode ? null : announcementsUrl ?? endpoints?.announcementsUrl ?? null;
 
   // MUST be memoized (the hook re-syncs on [initialData] identity — an inline
   // literal per render would setData-loop) and strict-undefined-mapped:

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -23,14 +23,15 @@ import { pickReadableTextColor } from '../utils/color-analysis';
  * The bar renders in the first HTML byte (zero layout shift, no flash for
  * dismissed users) and skips the mount fetch.
  *
- * Client-only mode (bare React apps without SSR: Vite/CRA embeds): omit
- * `initialAnnouncement`. The bar self-fetches on mount from, in order of
- * precedence, the `announcementsUrl` PROP (no provider needed) or the
- * optional EndpointsRuntime provider's `announcementsUrl`. With neither, it
- * renders nothing and never fetches (silent no-op). Appearance animates in
- * (grid 0fr→1fr) so there is no hard layout jump. Non-Next hosts should
- * also pass `platform` so dismissal cookies are namespaced correctly
- * (NEXT_PUBLIC_APP_TYPE is not available at their runtime).
+ * Client-only mode (bare React apps without SSR: Vite/CRA embeds — see
+ * react-embedding-example): omit `initialAnnouncement` and mount the bar
+ * PROP-LESS inside an EndpointsRuntime provider; it self-fetches from the
+ * provider's `announcementsUrl` (a fixed suffix under the embedder's one
+ * content base). No provider → renders nothing, never fetches (silent
+ * no-op). Appearance animates in (grid 0fr→1fr) so there is no hard layout
+ * jump. Deliberately NO per-component URL or platform knobs: the embedder
+ * is platform-agnostic — each server returns ITS OWN announcement via
+ * currentPlatform(); the platform is never sent as a parameter.
  *
  * Both modes: freshness is event-driven, no polling — `useSelfFetch`'s
  * visibility revalidation re-fetches on tab refocus when the held data is
@@ -41,21 +42,19 @@ import { pickReadableTextColor } from '../utils/color-analysis';
  */
 export function AnnouncementBar({
   initialAnnouncement,
-  announcementsUrl,
-  platform: platformProp,
   previewMode = false,
   className,
 }: AnnouncementBarProps = {}) {
-  // Platform for the dismissal cookie/legacy keys. SSR hosts derive it from
-  // NEXT_PUBLIC_APP_TYPE (matching the server's currentPlatform()); non-Next
-  // embeds pass the prop (getAppType() is runtime-safe but falls back to
-  // 'openmsp' where the env var does not exist).
-  const platform = platformProp ?? getAppType();
+  // Namespace for the dismissal cookie/legacy keys. Next hosts inline
+  // NEXT_PUBLIC_APP_TYPE (matching the server's currentPlatform(), which the
+  // hub layout uses for the SSR cookie read); platform-agnostic embeds get
+  // the fallback — fine, cookies are domain-scoped and an embed domain
+  // serves one platform's announcements.
+  const platform = getAppType();
 
-  // Fetch URL: prop wins (client-only mode without a provider), then the
-  // optional endpoints runtime. No provider and no prop → fetching disabled.
+  // Optional endpoint runtime: no provider → no URL → fetching disabled.
   const endpoints = useEndpointsRuntime();
-  const url = previewMode ? null : announcementsUrl ?? endpoints?.announcementsUrl ?? null;
+  const url = previewMode ? null : endpoints?.announcementsUrl ?? null;
 
   // MUST be memoized (the hook re-syncs on [initialData] identity — an inline
   // literal per render would setData-loop) and strict-undefined-mapped:

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -1,221 +1,232 @@
 "use client";
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { X } from 'lucide-react';
 import { Button } from './ui/button';
 import { EntityIcon } from './icon-display';
 import {
-  setStoredAnnouncement,
-  getStoredAnnouncement,
-  clearStoredAnnouncement,
+  dismissAnnouncement,
+  isAnnouncementDismissed,
+  clearLegacyAnnouncementCache,
 } from '../utils/announcement-storage';
-import { Announcement } from '../types/announcement';
+import type { AnnouncementBarProps, AnnouncementResponse } from '../types/announcement';
 import { getAppType } from '../utils/app-config';
 import { useEndpointsRuntime } from '../contexts/endpoints-runtime-context';
+import { useSelfFetch } from '../hooks/use-self-fetch';
+import { pickReadableTextColor } from '../utils/color-analysis';
 
-export function AnnouncementBar() {
-  const [announcement, setAnnouncement] = useState<Announcement | null>(null);
-  const [isVisible, setIsVisible] = useState<boolean>(false);
-
-  // Get the platform type for platform-specific localStorage keys
+/**
+ * Platform announcement bar.
+ *
+ * Data flow (no polling): the hub SSR-seeds `initialAnnouncement` from the
+ * root layout (dismissal cookie already applied server-side → zero layout
+ * shift, no flash for dismissed users). Embedded hosts omit the prop and the
+ * bar self-fetches via the optional endpoints runtime — no provider → no
+ * fetch, silent no-op (cached-free: nothing renders). Freshness is
+ * event-driven: `useSelfFetch`'s visibility revalidation re-fetches on tab
+ * refocus when the held data is >60s old (matching the server cache TTL by
+ * convention); idle tabs make zero requests.
+ *
+ * Layout: the bar animates its height (grid 0fr↔1fr) for client-side
+ * appearance and dismissal, so surrounding content reflows smoothly instead
+ * of jumping. The initial expanded state is a pure function of props —
+ * SSR-seeded bars render at full height on both server and first client
+ * render (hydration-identical), with no entrance animation.
+ *
+ * Dismissal: cookie is the SSOT (`announcement-storage.ts`); reads happen
+ * ONLY in effects (a render-time storage read would desync hydration).
+ */
+export function AnnouncementBar({
+  initialAnnouncement,
+  previewMode = false,
+  className,
+}: AnnouncementBarProps = {}) {
+  // Platform for the dismissal cookie/legacy keys (matches the hub's
+  // server-side currentPlatform(), both derive from NEXT_PUBLIC_APP_TYPE).
   const platform = getAppType();
 
-  // Optional endpoint runtime: when no provider is mounted (e.g. on a
-  // bare React-tree page that doesn't wrap with HubRuntimeProvider),
-  // the bar silently skips its fetch instead of throwing. Apps that DO
-  // mount the provider get the configured URL — typically
-  // '/api/announcements/active' in the hub, or a proxied path in an
-  // embedded host.
+  // Optional endpoint runtime: no provider → no URL → fetching disabled.
   const endpoints = useEndpointsRuntime();
-  const announcementsUrl = endpoints?.announcementsUrl;
+  const url = previewMode ? null : endpoints?.announcementsUrl ?? null;
 
-  // Helper to determine dismissal key for localStorage
-  const getDismissKey = (id: string) => `${platform}-announcement-${id}-dismissed`;
-  
-  // Helper to get platform-specific cache key
-  const getCacheKey = () => `${platform}-announcement-cache`;
+  // MUST be memoized (the hook re-syncs on [initialData] identity — an inline
+  // literal per render would setData-loop) and strict-undefined-mapped:
+  // `null` (hub: dismissed / no active announcement) still seeds the hook and
+  // skips the mount fetch; only an ABSENT prop (embeds) enables self-fetch.
+  const initialData = useMemo<AnnouncementResponse | undefined>(
+    () => (initialAnnouncement === undefined ? undefined : { announcement: initialAnnouncement }),
+    [initialAnnouncement],
+  );
 
-  // Fetch active announcement from API and update state + LS
-  const fetchActiveAnnouncement = async () => {
-    // No provider mounted → no URL configured → skip fetch silently.
-    // Cached announcement from previous sessions still renders if present.
-    if (!announcementsUrl) return;
-    try {
-      // Server-side platform injection - no URL parameter needed
-      const response = await fetch(announcementsUrl);
-      
-      if (response.ok) {
-        const data = await response.json();
-        if (data.announcement) {
-          setAnnouncement(data.announcement);
+  const { data } = useSelfFetch<AnnouncementResponse>(url, {
+    initialData,
+    revalidateOnVisibleAfterMs: 60_000,
+  });
+  const announcement = data?.announcement ?? null;
 
-          // persist latest announcement for quick future loads with platform-specific key
-          setStoredAnnouncement(getCacheKey(), data.announcement);
+  // Expanded (height) state — initial value is a pure function of props so
+  // the SSR HTML and the hydration render agree for every cohort.
+  const [expandedState, setExpandedState] = useState<boolean>(() => initialAnnouncement != null);
+  // Preview always mirrors the draft directly (effects are disabled there).
+  const expanded = previewMode ? announcement != null : expandedState;
 
-          // Check if this specific announcement was dismissed
-          const isDismissed = localStorage.getItem(getDismissKey(data.announcement.id));
-          setIsVisible(!isDismissed);
-        } else {
-          // No announcement available - clean up localStorage and hide bar
-          setAnnouncement(null);
-          setIsVisible(false);
-          
-          // Use utility function to properly clear platform-specific announcement data
-          clearStoredAnnouncement(getCacheKey());
-        }
-      } else {
-        // Network or other error - hide announcement and clean up
-        console.error(`❌ [${platform.toUpperCase()}] Error fetching announcement: ${response.status}`);
-        setAnnouncement(null);
-        setIsVisible(false);
-        
-        // Clear stale data on network errors too
-        clearStoredAnnouncement(getCacheKey());
-      }
-    } catch (error) {
-      console.error('Error fetching active announcement:', error);
-      setAnnouncement(null);
-      setIsVisible(false);
-      
-      // Clear stale data on exceptions too
-      clearStoredAnnouncement(getCacheKey());
-    }
-  };
-
-  // Initial load: use cached announcement synchronously for instant paint
+  // One-time cleanup of the pre-refactor localStorage announcement cache.
   useEffect(() => {
-    const cached = getStoredAnnouncement(getCacheKey());
-    if (cached) {
-      const isDismissed = localStorage.getItem(getDismissKey(cached.id));
-      setAnnouncement(cached);
-      setIsVisible(!isDismissed);
-    }
-
-    // No provider mounted → no URL → no fetch / no polling. Cached
-    // announcement still painted above. Skip scheduling the 5-min
-    // interval entirely to avoid an idle timer + repeated short-circuit
-    // calls.
-    if (!announcementsUrl) return;
-
-    // Always fetch latest on mount
-    fetchActiveAnnouncement();
-
-    // Schedule refresh every 5 minutes. When announcementsUrl flips
-    // (e.g. provider value swap), the effect re-runs and restarts the
-    // interval against the new URL — no stale captured fetch.
-    const interval = setInterval(fetchActiveAnnouncement, 300_000);
-    return () => clearInterval(interval);
+    if (previewMode) return;
+    clearLegacyAnnouncementCache(platform);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [announcementsUrl]);
+  }, []);
 
-  // helpers
+  // Visibility reconciliation — runs on the seed and after EVERY completed
+  // fetch (keyed on `data` identity, not announcement id, so a refocus
+  // revalidation that returns the same announcement still re-checks the
+  // dismissal store: this is what keeps a bar dismissed seconds earlier in
+  // another tab from resurrecting). Also the legacy-migration point: an
+  // LS-only dismissal (no cookie — server couldn't see it) collapses once,
+  // animated, and backfills the cookie so the next SSR skips the bar.
+  useEffect(() => {
+    if (previewMode) return;
+    if (!announcement) {
+      setExpandedState(false);
+      return;
+    }
+    if (isAnnouncementDismissed(platform, announcement.id)) {
+      dismissAnnouncement(platform, announcement.id); // idempotent cookie backfill
+      setExpandedState(false);
+    } else {
+      setExpandedState(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
+
   const handleDismiss = () => {
-    if (!announcement) return;
-    localStorage.setItem(getDismissKey(announcement.id), 'true');
-    setIsVisible(false);
+    if (previewMode || !announcement) return;
+    dismissAnnouncement(platform, announcement.id);
+    setExpandedState(false);
   };
 
   const handleCtaClick = () => {
-    if (!announcement?.cta_url) return;
+    if (previewMode || !announcement?.cta_url) return;
     announcement.cta_target === '_blank'
       ? window.open(announcement.cta_url, '_blank', 'noopener,noreferrer')
       : (window.location.href = announcement.cta_url);
   };
 
-  const renderIcon = () => {
-    if (!announcement) return null;
-    // ONE unified display path (shared with the chat): uploaded image URL wins,
-    // else a library glyph by name (+ props), via <EntityIcon>.
-    return (
-      <EntityIcon
-        icon={{
-          name: announcement.icon_name || 'openframe-logo',
-          url: announcement.icon_url,
-          props: announcement.icon_props,
-        }}
-        size={32}
-        className="relative shrink-0 w-6 h-6 md:w-8 md:h-8"
-      />
-    );
-  };
+  // Nothing to show (and nothing to animate around): render nothing. The
+  // dismissed/deactivated case keeps the element mounted at 0fr so the
+  // collapse animates.
+  if (!announcement) return null;
 
-  // If no announcement or dismissed => render nothing
-  if (!announcement || !isVisible) return null;
+  // Contrast-aware foreground: announcement colors are admin-chosen hex
+  // (data-driven), so the readable text shade is computed, not hardcoded.
+  const fgColor =
+    pickReadableTextColor(announcement.background_color) === 'dark'
+      ? 'var(--ods-system-greys-black)'
+      : 'var(--ods-system-greys-white)';
+
+  const hasCta = Boolean(announcement.cta_enabled && announcement.cta_url);
 
   return (
     <div
-      className="relative w-full z-50"
-      style={{ backgroundColor: announcement.background_color }}
+      role="region"
+      aria-label="Announcement"
+      aria-hidden={!expanded}
       data-announcement-bar
+      className={`relative w-full z-50 grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${className ?? ''}`}
+      style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
     >
-      <div className="flex items-center w-full max-w-full">
-        {/* Mobile: Clickable content area, Desktop: Regular content */}
-        <div
-          className={`flex flex-row gap-2 md:gap-4 items-center pl-4 md:pl-6 py-1.5 md:py-2 flex-1 min-w-0 ${
-            announcement.cta_enabled && announcement.cta_url ? 'md:cursor-default cursor-pointer' : ''
-          }`}
-          onClick={(e) => {
-            // Only handle click on mobile (< 768px) and if CTA is enabled
-            if (window.innerWidth < 768 && announcement.cta_enabled && announcement.cta_url) {
-              e.preventDefault();
-              handleCtaClick();
-            }
-          }}
-        >
-          {renderIcon()}
+      {/*
+        Bar anatomy follows the announcement-bar industry standard: ONE line of
+        text at 13-14px inside a 44px-tall strip (guides converge on 40-60px
+        with a single sentence; two stacked 18px rows blew past that), title +
+        description merged inline (description hidden on small screens), ONE
+        compact pill CTA on the right, and a 44x44 dismiss target (WCAG 2.2
+        SC 2.5.8 AA needs >=24px; 44px is the SC 2.5.5 AAA / Apple HIG size).
+      */}
+      <div className="min-h-0 overflow-hidden" style={{ backgroundColor: announcement.background_color }}>
+        <div className="flex items-center w-full max-w-full min-h-11" style={{ color: fgColor }}>
+          {/* Mobile: Clickable content area, Desktop: Regular content */}
+          <div
+            className={`flex flex-row gap-2 md:gap-3 items-center pl-4 md:pl-6 py-1.5 flex-1 min-w-0 ${
+              hasCta ? 'md:cursor-default cursor-pointer' : ''
+            }`}
+            onClick={(e) => {
+              // Only handle click on mobile (< 768px) and if CTA is enabled
+              if (window.innerWidth < 768 && hasCta) {
+                e.preventDefault();
+                handleCtaClick();
+              }
+            }}
+          >
+            {/* ONE unified icon path (shared with the chat): uploaded image URL
+                wins, else a library glyph by name (+ props), via <EntityIcon>. */}
+            <EntityIcon
+              icon={{
+                name: announcement.icon_name || 'openframe-logo',
+                url: announcement.icon_url,
+                props: announcement.icon_props,
+              }}
+              size={24}
+              className="relative shrink-0 w-5 h-5 md:w-6 md:h-6"
+            />
 
-          <div className="flex-1 min-w-0 max-w-full">
-            <p className="font-body font-bold text-[14px] md:text-[18px] leading-tight tracking-tight mb-0 text-[#1A1A1A] truncate">
-              {announcement.title}
+            {/* Single-line message: bold title + regular description inline,
+                truncating as one unit. Separator is a middot (house rule: no
+                en/em dashes in copy). */}
+            <p className="font-body flex-1 min-w-0 max-w-full text-[13px] md:text-sm leading-snug truncate mb-0">
+              <span className="font-semibold">{announcement.title}</span>
+              {announcement.description && (
+                <span className="hidden sm:inline opacity-80"> · {announcement.description}</span>
+              )}
             </p>
-            <p className="font-body text-[12px] md:text-[18px] leading-tight hidden md:block text-[#1A1A1A] truncate">
-              {announcement.description}
-            </p>
+
+            {/* CTA - the design-system Button, UNMODIFIED: variant + size
+                only, no inline styles and no class overrides. The outline
+                variant brings its own ODS surface (bg-ods-card + ODS border
+                + hover/active/focus tokens), so it is self-contained and
+                legible on any admin-chosen bar color. The admin cta_button_*
+                colors are NOT applied: they were designed for the legacy
+                bespoke treatment and fight the token system (broken hover).
+                Hidden on mobile, where the whole bar is the tap target. */}
+            {hasCta && announcement.cta_text && (
+              <div className="hidden md:flex flex-shrink-0 ml-1">
+                <Button
+                  onClick={handleCtaClick}
+                  variant="outline"
+                  size="small"
+                  leftIcon={
+                    announcement.cta_show_icon && announcement.cta_icon_name
+                      ? (
+                          <EntityIcon
+                            icon={{ name: announcement.cta_icon_name, props: announcement.cta_icon_props }}
+                            size={14}
+                            className="w-3.5 h-3.5"
+                          />
+                        )
+                      : undefined
+                  }
+                >
+                  {announcement.cta_text}
+                </Button>
+              </div>
+            )}
           </div>
 
-          {/* CTA Button - Hidden on mobile, shown on desktop */}
-          {announcement.cta_enabled && announcement.cta_text && announcement.cta_url && (
-            <div className="hidden md:flex flex-shrink-0 ml-1 md:ml-2">
-              <Button
-                onClick={handleCtaClick}
-                variant="outline"
-                size="small-legacy"
-                leftIcon={
-                  announcement.cta_show_icon && announcement.cta_icon_name
-                    ? (
-                        <EntityIcon
-                          icon={{ name: announcement.cta_icon_name, props: announcement.cta_icon_props }}
-                          size={16}
-                          className="w-3 h-3 md:w-4 md:h-4"
-                        />
-                      )
-                    : undefined
-                }
-                className="transition-opacity hover:opacity-90 text-xs md:text-sm whitespace-nowrap"
-                style={{
-                  backgroundColor: announcement.cta_button_background_color || undefined,
-                  color: announcement.cta_button_text_color || undefined,
-                  borderColor: announcement.cta_button_background_color || undefined,
-                }}
-              >
-                {announcement.cta_text}
-              </Button>
-            </div>
-          )}
+          {/* Dismiss - 44x44 target (WCAG 2.5.5 AAA / Apple HIG), 16px glyph;
+              inert in previewMode */}
+          <button
+            onClick={(e) => {
+              e.stopPropagation(); // Prevent triggering the mobile CTA click
+              handleDismiss();
+            }}
+            className="flex-shrink-0 w-11 h-11 flex items-center justify-center rounded-full hover:opacity-70 transition-opacity focus:outline-none focus-visible:ring-2 focus-visible:ring-current mr-1 md:mr-3"
+            aria-label="Dismiss announcement"
+            type="button"
+            tabIndex={expanded ? 0 : -1}
+          >
+            <X className="w-4 h-4" strokeWidth={2} />
+          </button>
         </div>
-
-        {/* Dismiss button - always visible */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation(); // Prevent triggering the mobile CTA click
-            handleDismiss();
-          }}
-          className="flex-shrink-0 w-8 h-8 md:w-10 md:h-10 flex items-center justify-center hover:bg-[#1A1A1A]/10 focus:outline-none focus:ring-2 focus:ring-[#1A1A1A] mr-2 md:mr-4"
-          aria-label="Dismiss announcement"
-          type="button"
-        >
-          <X className="w-4 h-4 text-[#1A1A1A]" strokeWidth={2} />
-        </button>
       </div>
     </div>
   );

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -117,21 +117,22 @@ export function AnnouncementBar({
   // collapse animates.
   if (!announcement) return null;
 
-  // Contrast-aware foreground: announcement colors are admin-chosen hex
-  // (data-driven), so the readable text shade is computed, not hardcoded.
-  const tone = pickReadableTextColor(announcement.background_color);
-  const fgColor = tone === 'dark' ? 'var(--ods-system-greys-black)' : 'var(--ods-system-greys-white)';
+  // Contrast is solved with the ODS THEME system, not color literals: the
+  // admin background's tone selects which ODS theme scopes the bar's content
+  // (light-toned background needs dark-on-light = the light theme's values;
+  // dark-toned needs the dark theme's). `.theme-light` / `.theme-dark` are
+  // the design system's own scoping classes (ods-colors.css) and flip every
+  // Tier-1 `--ods-*` primitive for descendants.
+  const themeScope = pickReadableTextColor(announcement.background_color) === 'dark' ? 'theme-light' : 'theme-dark';
 
-  // Buttons on the bar keep the common Button component but swap its
-  // dark-surface hover for the bar's own idiom: a translucent tint of the
-  // computed foreground over the admin color (the pre-refactor bar's
-  // hover:bg-[#1A1A1A]/10 treatment). ODS surface tokens assume ODS
-  // backgrounds; on an arbitrary admin color they render dark slabs and the
-  // dark hover surface can swallow a dark computed foreground.
+  // Inside the scope, colors reference Tier-1 theme primitives directly
+  // (Tier-2 `--color-*` aliases resolve once at :root and do NOT re-resolve
+  // in a nested theme scope — verified). `--ods-system-greys-white` is the
+  // theme's primary-text primitive; `--ods-system-greys-black-hover/-action`
+  // are its quiet hover/active surfaces. Every value comes from the active
+  // ODS theme; nothing is hardcoded.
   const barButtonClasses =
-    tone === 'dark'
-      ? 'text-[color:var(--ods-system-greys-black)] hover:bg-black/10 active:bg-black/20'
-      : 'text-[color:var(--ods-system-greys-white)] hover:bg-white/10 active:bg-white/20';
+    'text-[color:var(--ods-system-greys-white)] hover:bg-[var(--ods-system-greys-black-hover)] active:bg-[var(--ods-system-greys-black-action)]';
 
   const hasCta = Boolean(announcement.cta_enabled && announcement.cta_url);
 
@@ -152,8 +153,8 @@ export function AnnouncementBar({
         compact CTA on the right, and a ghost-icon dismiss (design-system
         icon-sm: 32px target, >= the 24px WCAG 2.2 SC 2.5.8 AA floor).
       */}
-      <div className="min-h-0 overflow-hidden" style={{ backgroundColor: announcement.background_color }}>
-        <div className="flex items-center w-full max-w-full min-h-11" style={{ color: fgColor }}>
+      <div className={`min-h-0 overflow-hidden ${themeScope}`} style={{ backgroundColor: announcement.background_color }}>
+        <div className="flex items-center w-full max-w-full min-h-11 text-[color:var(--ods-system-greys-white)]">
           {/* Mobile: Clickable content area, Desktop: Regular content */}
           <div
             className={`flex flex-row gap-2 md:gap-3 items-center pl-4 md:pl-6 py-1.5 flex-1 min-w-0 ${

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -114,9 +114,20 @@ export function AnnouncementBar({
 
   const handleCtaClick = () => {
     if (previewMode || !announcement?.cta_url) return;
+    // Scheme guard: cta_url is admin-entered data — only http(s) (absolute or
+    // relative) may navigate. A `javascript:` value would otherwise execute
+    // via location.href / window.open (stored XSS).
+    let safeUrl: string;
+    try {
+      const parsed = new URL(announcement.cta_url, window.location.origin);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
+      safeUrl = parsed.href;
+    } catch {
+      return;
+    }
     announcement.cta_target === '_blank'
-      ? window.open(announcement.cta_url, '_blank', 'noopener,noreferrer')
-      : (window.location.href = announcement.cta_url);
+      ? window.open(safeUrl, '_blank', 'noopener,noreferrer')
+      : (window.location.href = safeUrl);
   };
 
   // Nothing to show (and nothing to animate around): render nothing. The
@@ -210,6 +221,7 @@ export function AnnouncementBar({
                   variant="transparent"
                   size="small"
                   className={barButtonClasses}
+                  tabIndex={expanded ? 0 : -1}
                   leftIcon={
                     announcement.cta_show_icon && announcement.cta_icon_name
                       ? (

--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva(
       size: {
         default: "py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-10",
         small: "p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8",
-        "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small" to avoid breaking changes in AnnouncementBar's CTA button; will be removed in the future
+        "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small"; AnnouncementBar migrated to size="small" — remaining consumers (cursor-pagination, allowed-domains-input, hub) still to migrate before removal
         icon: "p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6",
         // Quiet 32px icon target with a 16px glyph, fixed across breakpoints
         // (Carbon ghost sm / Primer medium / shadcn icon-sm all pin 32px;

--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -29,7 +29,7 @@ const buttonVariants = cva(
       size: {
         default: "py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-10",
         small: "p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8",
-        "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small"; AnnouncementBar migrated to size="small" — remaining consumers (cursor-pagination, allowed-domains-input, hub) still to migrate before removal
+        "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small" — deprecated; grep size="small-legacy" (lib + hub) and migrate the remaining consumers before removal
         icon: "p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6",
         // Quiet 32px icon target with a 16px glyph, fixed across breakpoints
         // (Carbon ghost sm / Primer medium / shadcn icon-sm all pin 32px;

--- a/openframe-frontend-core/src/hooks/.api-hooks.md
+++ b/openframe-frontend-core/src/hooks/.api-hooks.md
@@ -5,18 +5,16 @@ This file provides stub React hooks for API data fetching, offering consistent i
 
 - **`useCategories()`** - Hook for fetching and managing category data with loading/error states
 - **`useVendors()`** - Hook for fetching and managing vendor data with loading/error states  
-- **`useAnnouncements()`** - Hook for fetching announcement data with loading state
 - **`useSubcategoryCountByCategory()`** - Hook that returns empty subcategory count data
 
 ## Usage Example
 
 ```typescript
-import { useCategories, useVendors, useAnnouncements } from './api-hooks';
+import { useCategories, useVendors } from './api-hooks';
 
 function MyComponent() {
   const { categories, loading: categoriesLoading, error: categoriesError } = useCategories();
   const { vendors, loading: vendorsLoading, error: vendorsError } = useVendors();
-  const { announcements, loading: announcementsLoading } = useAnnouncements();
 
   if (categoriesLoading || vendorsLoading) {
     return <div>Loading...</div>;
@@ -30,7 +28,6 @@ function MyComponent() {
     <div>
       <h2>Categories: {categories.length}</h2>
       <h2>Vendors: {vendors.length}</h2>
-      <h2>Announcements: {announcements.length}</h2>
     </div>
   );
 }

--- a/openframe-frontend-core/src/hooks/api-hooks.ts
+++ b/openframe-frontend-core/src/hooks/api-hooks.ts
@@ -17,13 +17,6 @@ export function useVendors() {
   return { vendors, loading, error };
 }
 
-export function useAnnouncements() {
-  const [announcements, setAnnouncements] = useState([]);
-  const [loading, setLoading] = useState(false);
-
-  return { announcements, loading };
-}
-
 export function useSubcategoryCountByCategory() {
   return { data: {}, loading: false };
 }

--- a/openframe-frontend-core/src/hooks/use-self-fetch.ts
+++ b/openframe-frontend-core/src/hooks/use-self-fetch.ts
@@ -31,19 +31,30 @@ export interface UseSelfFetchResult<T> {
  *   - a `cancelled` guard ensures an in-flight response from a STALE `url`
  *     (e.g. a fast pagination / section toggle) can't overwrite a newer one.
  *   - `reload()` bumps an internal key to retry after an error.
+ *   - `revalidateOnVisibleAfterMs` (opt-in) → re-fetch when the tab becomes
+ *     visible AND the held data is older than the threshold. Event-driven
+ *     freshness with ZERO background requests — the replacement for
+ *     setInterval polling. Data age counts from the last completed fetch, or
+ *     from mount when `initialData` seeded it (an SSR seed is milliseconds
+ *     old — without that, the first refocus would always refire).
  *
  * Re-fetches whenever `url` changes, so callers fold all query params INTO the
  * url string (the url IS the cache key).
  */
 export function useSelfFetch<T>(
   url: string | null,
-  options?: { initialData?: T },
+  options?: { initialData?: T; revalidateOnVisibleAfterMs?: number },
 ): UseSelfFetchResult<T> {
   const initialData = options?.initialData
+  const revalidateOnVisibleAfterMs = options?.revalidateOnVisibleAfterMs
   const [data, setData] = useState<T | null>(initialData ?? null)
   const [isLoading, setIsLoading] = useState(initialData === undefined && url !== null)
   const [error, setError] = useState(false)
   const [reloadKey, setReloadKey] = useState(0)
+  // When the held data was obtained: seeded at mount for SSR-hydrated data,
+  // stamped after each completed fetch. Drives the visibility revalidation age
+  // check. 0 = nothing held yet (first visible event may fetch).
+  const dataAtRef = useRef<number>(initialData !== undefined ? Date.now() : 0)
   // The url whose data we currently hold — seeded from SSR `initialData`, then set after
   // each completed fetch. The effect skips the fetch when this equals `url` (so server-
   // rendered data isn't re-fetched on mount). A VALUE compare (not a one-shot flag) so the
@@ -78,6 +89,7 @@ export function useSelfFetch<T>(
         if (!cancelled) {
           setData(json)
           dataUrlRef.current = url // remember the url we now hold data for
+          dataAtRef.current = Date.now()
         }
       } catch (err) {
         // AbortError on cleanup (unmount / stale-url change / React StrictMode's dev
@@ -99,6 +111,22 @@ export function useSelfFetch<T>(
     }
     // `url` folds in every query param; `reloadKey` drives retry.
   }, [url, reloadKey])
+
+  // Opt-in visibility-driven revalidation. Registered only when the option is
+  // set and fetching is enabled; SSR-safe (effects don't run on the server)
+  // and StrictMode-safe (idempotent listener, cleaned up per mount cycle).
+  useEffect(() => {
+    if (!revalidateOnVisibleAfterMs || url === null) return
+    const onVisible = () => {
+      if (document.visibilityState !== 'visible') return
+      if (Date.now() - dataAtRef.current < revalidateOnVisibleAfterMs) return
+      // Same mechanics as reload(): clear the held-url skip, bump the key.
+      dataUrlRef.current = null
+      setReloadKey((k) => k + 1)
+    }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [url, revalidateOnVisibleAfterMs])
 
   return {
     data,

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -1,36 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import type { Announcement } from '../types/announcement'
 import { AnnouncementBar } from '../components/announcement-bar'
+import { announcementDismissCookieName } from '../utils/announcement-storage'
+import { getAppType } from '../utils/app-config'
 
 /**
- * Mock fetch so the component receives announcement data without a real API.
- * Also seeds localStorage so the bar isn't marked as dismissed.
+ * Stories drive the bar through its real `initialAnnouncement` prop (the hub's
+ * SSR-seed path) — no fetch mock needed; with no EndpointsRuntime provider
+ * mounted the bar never fetches. The decorator clears any dismissal state left
+ * by a previous interaction so every story starts visible.
  */
-function mockAnnouncement(announcement: Announcement | null) {
-  // Clear any previous dismiss flags
-  if (announcement) {
-    Object.keys(localStorage).forEach((key) => {
-      if (key.includes(`announcement-${announcement.id}-dismissed`)) {
-        localStorage.removeItem(key)
-      }
-    })
-  }
-
-  const originalFetch = window.fetch
-  window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === 'string' ? input : input.toString()
-    if (url.includes('/api/announcements/active')) {
-      return new Response(JSON.stringify({ announcement }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
+function clearDismissals() {
+  const platform = getAppType()
+  document.cookie = `${announcementDismissCookieName(platform)}=; path=/; max-age=0`
+  Object.keys(localStorage).forEach((key) => {
+    if (key.includes('-announcement-') && key.endsWith('-dismissed')) {
+      localStorage.removeItem(key)
     }
-    return originalFetch(input, init)
-  }) as typeof window.fetch
-
-  return () => {
-    window.fetch = originalFetch
-  }
+  })
 }
 
 const now = new Date().toISOString()
@@ -41,7 +28,6 @@ const baseAnnouncement: Announcement = {
   description: 'Check out our latest updates and improvements to the platform.',
   background_color: '#FFD951',
   icon_name: 'rocket',
-  platform_id: 'openframe',
   is_active: true,
   created_at: now,
   updated_at: now,
@@ -55,10 +41,16 @@ const meta = {
     docs: {
       description: {
         component:
-          'A top-of-page announcement bar that fetches the active announcement from the API. Supports SVG/PNG icons, CTA buttons, dismiss functionality, and responsive mobile layout.',
+          'A top-of-page announcement bar. The host seeds it with `initialAnnouncement` (SSR path) or lets it self-fetch via the endpoints runtime. Supports SVG/PNG icons, CTA buttons, contrast-aware text, animated dismiss, and responsive mobile layout.',
       },
     },
   },
+  decorators: [
+    (Story) => {
+      clearDismissals()
+      return <Story />
+    },
+  ],
   tags: ['autodocs'],
 } satisfies Meta<typeof AnnouncementBar>
 
@@ -69,190 +61,189 @@ type Story = StoryObj<typeof meta>
  * Default announcement with an icon and description.
  */
 export const Default: Story = {
-  decorators: [
-    (Story) => {
-      const cleanup = mockAnnouncement(baseAnnouncement)
-      return (
-        <>
-          <Story />
-          {/* cleanup on unmount is handled by storybook re-renders */}
-        </>
-      )
-    },
-  ],
+  args: { initialAnnouncement: baseAnnouncement },
 }
 
 /**
  * Announcement with a CTA button.
  */
 export const WithCTA: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-cta',
-        title: 'OpenFrame v2.0 is here!',
-        description: 'Explore the new dashboard, improved device management, and more.',
-        background_color: '#FFD951',
-        icon_name: 'star',
-        cta_enabled: true,
-        cta_text: 'Learn More',
-        cta_url: 'https://example.com',
-        cta_target: '_blank',
-        cta_icon_name: 'rocket',
-        cta_show_icon: true,
-        cta_button_background_color: '#1A1A1A',
-        cta_button_text_color: '#FFFFFF',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-cta',
+      title: 'OpenFrame v2.0 is here!',
+      description: 'Explore the new dashboard, improved device management, and more.',
+      background_color: '#FFD951',
+      icon_name: 'star',
+      cta_enabled: true,
+      cta_text: 'Learn More',
+      cta_url: 'https://example.com',
+      cta_target: '_blank',
+      cta_icon_name: 'rocket',
+      cta_show_icon: true,
+      cta_button_background_color: '#1A1A1A',
+      cta_button_text_color: '#FFFFFF',
     },
-  ],
+  },
 }
 
 /**
  * Announcement with a CTA button that opens in the same tab.
  */
 export const WithCTASameTab: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-cta-same',
-        title: 'Scheduled Maintenance',
-        description: 'We will perform maintenance on Saturday from 2:00 AM to 4:00 AM UTC.',
-        background_color: '#FFE082',
-        icon_name: 'info',
-        cta_enabled: true,
-        cta_text: 'View Status',
-        cta_url: '/status',
-        cta_target: '_self',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-cta-same',
+      title: 'Scheduled Maintenance',
+      description: 'We will perform maintenance on Saturday from 2:00 AM to 4:00 AM UTC.',
+      background_color: '#FFE082',
+      icon_name: 'info',
+      cta_enabled: true,
+      cta_text: 'View Status',
+      cta_url: '/status',
+      cta_target: '_self',
     },
-  ],
+  },
+}
+
+/**
+ * Dark background — text flips to the light shade via pickReadableTextColor.
+ */
+export const DarkBackground: Story = {
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-dark',
+      title: 'Contrast-aware text',
+      description: 'On a dark admin-chosen background the foreground goes light automatically.',
+      background_color: '#1F2937',
+      icon_name: 'megaphone',
+    },
+  },
 }
 
 /**
  * Announcement with a blue background.
  */
 export const BlueBackground: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-blue',
-        title: 'Join our Community',
-        description: 'Connect with other MSPs and share best practices.',
-        background_color: '#60A5FA',
-        icon_name: 'megaphone',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-blue',
+      title: 'Join our Community',
+      description: 'Connect with other MSPs and share best practices.',
+      background_color: '#60A5FA',
+      icon_name: 'megaphone',
     },
-  ],
+  },
 }
 
 /**
  * Announcement with a green background.
  */
 export const GreenBackground: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-green',
-        title: 'All Systems Operational',
-        description: 'Everything is running smoothly. No issues detected.',
-        background_color: '#86EFAC',
-        icon_name: 'bell',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-green',
+      title: 'All Systems Operational',
+      description: 'Everything is running smoothly. No issues detected.',
+      background_color: '#86EFAC',
+      icon_name: 'bell',
     },
-  ],
+  },
 }
 
 /**
  * Announcement with OpenFrame logo icon.
  */
 export const WithOpenFrameLogo: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-logo',
-        title: 'Welcome to OpenFrame',
-        description: 'Your open-source IT infrastructure management platform.',
-        background_color: '#FFD951',
-        icon_name: 'openframe-logo',
-        cta_enabled: true,
-        cta_text: 'Get Started',
-        cta_url: '/getting-started',
-        cta_target: '_self',
-        cta_button_background_color: '#000000',
-        cta_button_text_color: '#FFD951',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-logo',
+      title: 'Welcome to OpenFrame',
+      description: 'Your open-source IT infrastructure management platform.',
+      background_color: '#FFD951',
+      icon_name: 'openframe-logo',
+      cta_enabled: true,
+      cta_text: 'Get Started',
+      cta_url: '/getting-started',
+      cta_target: '_self',
+      cta_button_background_color: '#000000',
+      cta_button_text_color: '#FFD951',
     },
-  ],
+  },
 }
 
 /**
  * Announcement with a PNG icon.
  */
 export const WithPNGIcon: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-png',
-        title: 'Partner Program Launch',
-        description: 'Become an OpenFrame certified partner and grow your business.',
-        background_color: '#C4B5FD',
-        icon_url: 'https://placehold.co/32x32/1a1a1a/white?text=OF',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-png',
+      title: 'Partner Program Launch',
+      description: 'Become an OpenFrame certified partner and grow your business.',
+      background_color: '#C4B5FD',
+      icon_url: 'https://placehold.co/32x32/1a1a1a/white?text=OF',
     },
-  ],
+  },
 }
 
 /**
  * Long title and description to test truncation.
  */
 export const LongContent: Story = {
-  decorators: [
-    (Story) => {
-      mockAnnouncement({
-        ...baseAnnouncement,
-        id: 'story-long',
-        title: 'This is a very long announcement title that should be truncated on smaller screens to prevent layout issues',
-        description:
-          'This is an extremely long description that goes into great detail about the announcement. It should be truncated on the desktop view and hidden on mobile view to keep the bar compact and readable.',
-        background_color: '#FCA5A5',
-        icon_name: 'info',
-        cta_enabled: true,
-        cta_text: 'Read Full Announcement',
-        cta_url: '/announcements/long',
-        cta_target: '_self',
-      })
-      return <Story />
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-long',
+      title: 'This is a very long announcement title that should be truncated on smaller screens to prevent layout issues',
+      description:
+        'This is an extremely long description that goes into great detail about the announcement. It should be truncated on the desktop view and hidden on mobile view to keep the bar compact and readable.',
+      background_color: '#FCA5A5',
+      icon_name: 'info',
+      cta_enabled: true,
+      cta_text: 'Read Full Announcement',
+      cta_url: '/announcements/long',
+      cta_target: '_self',
     },
-  ],
+  },
+}
+
+/**
+ * previewMode — the admin live-preview path: render-only, inert dismiss,
+ * no fetch and no storage side effects.
+ */
+export const PreviewMode: Story = {
+  args: {
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-preview',
+      title: 'Admin preview',
+      description: 'Exactly the live bar, but inert: dismiss does nothing.',
+    },
+    previewMode: true,
+  },
 }
 
 /**
  * No active announcement — the bar renders nothing.
  */
 export const NoAnnouncement: Story = {
+  args: { initialAnnouncement: null },
   decorators: [
-    (Story) => {
-      mockAnnouncement(null)
-      return (
-        <div>
-          <Story />
-          <p className="p-4 text-sm text-gray-500">
-            No announcement is active — the bar renders nothing above this text.
-          </p>
-        </div>
-      )
-    },
+    (Story) => (
+      <div>
+        <Story />
+        <p className="p-4 text-sm text-gray-500">
+          No announcement is active — the bar renders nothing above this text.
+        </p>
+      </div>
+    ),
   ],
 }

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -3,6 +3,7 @@ import type { Announcement } from '../types/announcement'
 import { AnnouncementBar } from '../components/announcement-bar'
 import { announcementDismissCookieName } from '../utils/announcement-storage'
 import { getAppType } from '../utils/app-config'
+import { EndpointsRuntimeContext, type EndpointsRuntime } from '../contexts/endpoints-runtime-context'
 
 /**
  * Stories drive the bar through its real `initialAnnouncement` prop (the hub's
@@ -249,28 +250,33 @@ export const NoAnnouncement: Story = {
 }
 
 /**
- * Client-only mode (no SSR): a bare React host passes `announcementsUrl` and
- * `platform` — no `initialAnnouncement`, no EndpointsRuntime provider. The
- * bar self-fetches on mount and animates in. The decorator mocks the fetch.
+ * Client-only mode (no SSR) — the react-embedding-example structure: the
+ * embedder mounts an EndpointsRuntime provider (announcementsUrl is a fixed
+ * suffix under its one content base) and drops in a PROP-LESS bar. No
+ * platform knob anywhere on the client: the proxied server resolves its own
+ * platform via currentPlatform(). The decorator mocks the fetch.
  */
+const embedEndpoints: EndpointsRuntime = {
+  announcementsUrl: '/content/api/announcements/active',
+  accessCode: { validateUrl: '/content/api/validate-access-code', consumeUrl: '/content/api/consume-access-code' },
+  contactUrl: '/content/api/contact',
+}
+
 export const ClientOnlyEmbed: Story = {
-  args: {
-    announcementsUrl: '/mock/announcements/active',
-    platform: 'openframe',
-  },
+  args: {},
   decorators: [
     (Story) => {
       const originalFetch = window.fetch
       window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
         const requestUrl = typeof input === 'string' ? input : input.toString()
-        if (requestUrl.includes('/mock/announcements/active')) {
+        if (requestUrl.includes('/content/api/announcements/active')) {
           return new Response(
             JSON.stringify({
               announcement: {
                 ...baseAnnouncement,
                 id: 'story-embed',
                 title: 'Client-only embed',
-                description: 'Fetched on mount by a host with no SSR and no provider.',
+                description: 'Fetched on mount through the EndpointsRuntime provider, no SSR.',
               },
             }),
             { status: 200, headers: { 'Content-Type': 'application/json' } },
@@ -278,7 +284,11 @@ export const ClientOnlyEmbed: Story = {
         }
         return originalFetch(input, init)
       }) as typeof window.fetch
-      return <Story />
+      return (
+        <EndpointsRuntimeContext.Provider value={embedEndpoints}>
+          <Story />
+        </EndpointsRuntimeContext.Provider>
+      )
     },
   ],
 }

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -247,3 +247,38 @@ export const NoAnnouncement: Story = {
     ),
   ],
 }
+
+/**
+ * Client-only mode (no SSR): a bare React host passes `announcementsUrl` and
+ * `platform` — no `initialAnnouncement`, no EndpointsRuntime provider. The
+ * bar self-fetches on mount and animates in. The decorator mocks the fetch.
+ */
+export const ClientOnlyEmbed: Story = {
+  args: {
+    announcementsUrl: '/mock/announcements/active',
+    platform: 'openframe',
+  },
+  decorators: [
+    (Story) => {
+      const originalFetch = window.fetch
+      window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const requestUrl = typeof input === 'string' ? input : input.toString()
+        if (requestUrl.includes('/mock/announcements/active')) {
+          return new Response(
+            JSON.stringify({
+              announcement: {
+                ...baseAnnouncement,
+                id: 'story-embed',
+                title: 'Client-only embed',
+                description: 'Fetched on mount by a host with no SSR and no provider.',
+              },
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          )
+        }
+        return originalFetch(input, init)
+      }) as typeof window.fetch
+      return <Story />
+    },
+  ],
+}

--- a/openframe-frontend-core/src/types/.announcement.md
+++ b/openframe-frontend-core/src/types/.announcement.md
@@ -4,7 +4,7 @@ TypeScript type definitions for the announcement system, providing comprehensive
 ## Key Components
 
 ### Core Database Models
-- **`Announcement`** - Main announcement entity with title, description, platform targeting, and visual customization
+- **`Announcement`** - Main announcement entity; platform targeting via hydrated `announcement_platforms?: EntityPlatformAssoc[]` (no singular platform_id/platform)
 - **`AnnouncementAsset`** - File attachments linked to announcements (images, documents, etc.)
 
 ### API Types
@@ -30,7 +30,7 @@ const newAnnouncement: CreateAnnouncementData = {
   background_color: "#FFC008",
   icon_type: "svg",
   icon_svg_name: "rocket",
-  platform_id: "openframe-platform-id",
+  platforms: ["openframe-platform-id"],
   is_active: true,
   cta_enabled: true,
   cta_text: "Learn More",

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -234,21 +234,12 @@ export interface AnnouncementBarProps {
    * SSR mode seed. `null` = the server resolved "nothing to show" (no active
    * announcement, or dismissed via cookie) — seeds the fetch hook and skips
    * the mount fetch. Absent (`undefined`) = client-only mode: the bar
-   * self-fetches on mount (see `announcementsUrl`).
+   * self-fetches on mount from the EndpointsRuntime provider's
+   * `announcementsUrl` (see react-embedding-example — no per-component URL
+   * or platform knobs; the server resolves its own platform via
+   * currentPlatform()).
    */
   initialAnnouncement?: Announcement | null;
-  /**
-   * Client-only mode fetch URL for hosts WITHOUT SSR and without an
-   * EndpointsRuntime provider (bare React apps: Vite/CRA embeds). Takes
-   * precedence over the provider's `announcementsUrl`. With neither prop nor
-   * provider, the bar renders nothing and never fetches (silent no-op).
-   */
-  announcementsUrl?: string;
-  /**
-   * Dismissal-namespace platform for hosts where NEXT_PUBLIC_APP_TYPE is not
-   * available at runtime (non-Next embeds). Defaults to `getAppType()`.
-   */
-  platform?: string;
   /**
    * Render-only mode for the admin live preview: no fetch/revalidation, inert
    * dismiss button, and no storage side effects (never writes dismissal

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -1,7 +1,7 @@
 // Announcement system TypeScript types
-import type { LegacyPlatform, PlatformFilter, PlatformRecord } from './platform';
+import type { LegacyPlatform, PlatformFilter } from './platform';
+import type { EntityPlatformAssoc } from './entity-platform';
 
-// For backward compatibility, maintain the old Platform type temporarily
 // Database Models
 export interface Announcement {
   id: string;
@@ -12,8 +12,9 @@ export interface Announcement {
   icon_url?: string;
   /** Extra props for the main bar/icon */
   icon_props?: Record<string, any>;
-  platform_id: string;  // Foreign key to platforms table
-  platform?: PlatformRecord;  // Joined platform data
+  /** Hydrated entity_platforms associations (featured-first) — what the hub
+   *  DAL's attachPlatformsToRow(s) emits. No singular platform/platform_id. */
+  announcement_platforms?: EntityPlatformAssoc[];
   is_active: boolean;
   // CTA (Call-To-Action) fields
   cta_enabled?: boolean;
@@ -109,9 +110,24 @@ export interface AnnouncementListResponse {
   };
 }
 
+/**
+ * Wire shape of GET /api/announcements/active — the single typed home for the
+ * `{ announcement }` envelope (hub route return + AnnouncementBar's
+ * useSelfFetch generic). `null` when no active announcement exists.
+ */
 export interface AnnouncementResponse {
-  announcement: Announcement;
+  announcement: Announcement | null;
 }
+
+/**
+ * Default CTA button colors — one home for the pair the DAL create/update
+ * defaults and the admin form both reference. Announcement colors are
+ * admin-chosen data (not ODS-token surfaces) by design.
+ */
+export const ANNOUNCEMENT_CTA_DEFAULTS = {
+  background: '#1A1A1A',
+  text: '#FAFAFA',
+} as const;
 
 // Form Data Types
 export interface AnnouncementFormData {
@@ -214,8 +230,18 @@ export interface AnnouncementStats {
 
 // Component Props Types
 export interface AnnouncementBarProps {
-  announcement?: Announcement;
-  onDismiss?: (announcementId: string) => void;
+  /**
+   * SSR seed. `null` = server resolved "nothing to show" (no active
+   * announcement, or dismissed via cookie) — seeds the fetch hook and skips
+   * the mount fetch. Absent (`undefined`) = self-fetch mode (embeds).
+   */
+  initialAnnouncement?: Announcement | null;
+  /**
+   * Render-only mode for the admin live preview: no fetch/revalidation, inert
+   * dismiss button, and no storage side effects (never writes dismissal
+   * cookies or touches localStorage).
+   */
+  previewMode?: boolean;
   className?: string;
 }
 

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -231,11 +231,24 @@ export interface AnnouncementStats {
 // Component Props Types
 export interface AnnouncementBarProps {
   /**
-   * SSR seed. `null` = server resolved "nothing to show" (no active
+   * SSR mode seed. `null` = the server resolved "nothing to show" (no active
    * announcement, or dismissed via cookie) — seeds the fetch hook and skips
-   * the mount fetch. Absent (`undefined`) = self-fetch mode (embeds).
+   * the mount fetch. Absent (`undefined`) = client-only mode: the bar
+   * self-fetches on mount (see `announcementsUrl`).
    */
   initialAnnouncement?: Announcement | null;
+  /**
+   * Client-only mode fetch URL for hosts WITHOUT SSR and without an
+   * EndpointsRuntime provider (bare React apps: Vite/CRA embeds). Takes
+   * precedence over the provider's `announcementsUrl`. With neither prop nor
+   * provider, the bar renders nothing and never fetches (silent no-op).
+   */
+  announcementsUrl?: string;
+  /**
+   * Dismissal-namespace platform for hosts where NEXT_PUBLIC_APP_TYPE is not
+   * available at runtime (non-Next embeds). Defaults to `getAppType()`.
+   */
+  platform?: string;
   /**
    * Render-only mode for the admin live preview: no fetch/revalidation, inert
    * dismiss button, and no storage side effects (never writes dismissal

--- a/openframe-frontend-core/src/utils/.announcement-storage.md
+++ b/openframe-frontend-core/src/utils/.announcement-storage.md
@@ -1,36 +1,31 @@
-<!-- source-hash: eb9e1e114c43007debee28971d977a02 -->
-A utility module for managing announcement data persistence in browser localStorage with safe server-side rendering support.
+<!-- source-hash: pending-regeneration -->
+Announcement dismissal store. The dismissal COOKIE is the single source of truth — the hub's root layout reads it server-side to decide whether to SSR-seed the AnnouncementBar (no flash for dismissed users); the legacy per-id localStorage key is read-only legacy consulted only when no cookie exists (migration trigger).
 
 ## Key Components
 
-- **`AnnouncementStorageOptions`** - Interface defining storage configuration with key and optional default value
-- **`getStoredAnnouncement(key)`** - Retrieves and parses announcement data from localStorage
-- **`setStoredAnnouncement(key, value)`** - Stores announcement data as JSON in localStorage
-- **`clearStoredAnnouncement(key?)`** - Removes announcement data from localStorage (defaults to 'announcement' key)
+- **`announcementDismissCookieName(platform)`** - The ONE home for the cookie-name encoding (`<platform>-announcement-dismissed`), shared by the client writer and the hub's SSR reader
+- **`isDismissedCookieValue(cookieValue, id)`** - THE dismissal match rule (id-match, never mere cookie presence), pure and isomorphic — shared across the server/client boundary
+- **`dismissAnnouncement(platform, id)`** - Persists a dismissal (cookie only, 1 year, SameSite=Lax); localStorage is intentionally not written
+- **`isAnnouncementDismissed(platform, id)`** - Client-side check, cookie-first with legacy-localStorage fallback; reads browser storage so it must be called from effects, never during render
+- **`clearLegacyAnnouncementCache(platform)`** - One-time cleanup of the pre-refactor localStorage "instant paint" cache blob
 
 ## Usage Example
 
 ```typescript
-import { 
-  getStoredAnnouncement, 
-  setStoredAnnouncement, 
-  clearStoredAnnouncement 
+import {
+  dismissAnnouncement,
+  isAnnouncementDismissed,
+  announcementDismissCookieName,
+  isDismissedCookieValue,
 } from './announcement-storage';
 
-// Store announcement dismissal state
-setStoredAnnouncement('banner-dismissed', { 
-  dismissed: true, 
-  timestamp: Date.now() 
-});
+// Client (in an effect):
+if (isAnnouncementDismissed('openframe', announcement.id)) { /* collapse */ }
+dismissAnnouncement('openframe', announcement.id);
 
-// Check if announcement was dismissed
-const dismissalState = getStoredAnnouncement('banner-dismissed');
-if (dismissalState?.dismissed) {
-  console.log('Banner was dismissed');
-}
-
-// Clear announcement data
-clearStoredAnnouncement('banner-dismissed');
+// Server (hub root layout):
+const cookieValue = (await cookies()).get(announcementDismissCookieName(platform))?.value;
+const dismissed = isDismissedCookieValue(cookieValue, announcement?.id);
 ```
 
-All functions include browser environment checks and error handling to prevent issues during server-side rendering or when localStorage is unavailable.
+No `"use client"` directive on purpose — the name/match helpers are imported by the hub's server layout; DOM-touching helpers guard on `typeof document`.

--- a/openframe-frontend-core/src/utils/announcement-storage.ts
+++ b/openframe-frontend-core/src/utils/announcement-storage.ts
@@ -1,36 +1,82 @@
-// Stub for announcement storage
-export interface AnnouncementStorageOptions {
-  key: string;
-  defaultValue?: any;
+/**
+ * Announcement dismissal store.
+ *
+ * The dismissal COOKIE is the single source of truth: the hub's root layout
+ * reads it server-side to decide whether to SSR-seed the bar (no flash for
+ * dismissed users), and the client reads it via `isAnnouncementDismissed`.
+ * One cookie per platform holding the LAST dismissed announcement id —
+ * dismissal is an id-match, never mere cookie presence, so a new announcement
+ * always shows after an old one was dismissed, and re-activating an old
+ * announcement intentionally re-shows it.
+ *
+ * The legacy per-id localStorage key (`<platform>-announcement-<id>-dismissed`)
+ * is READ-ONLY legacy: consulted only when no cookie exists for the platform,
+ * purely as the migration trigger (the bar's mount effect backfills the
+ * cookie). New dismissals write the cookie only, so the second store dies out.
+ *
+ * No `"use client"` directive on purpose — `announcementDismissCookieName` and
+ * `isDismissedCookieValue` are pure/isomorphic and imported by the hub's
+ * server layout; the DOM-touching helpers guard on `typeof document`.
+ */
+
+/** Cookie name for a platform's dismissed-announcement id — the ONE home for
+ *  the encoding, shared by the client writer and the hub's SSR reader. */
+export function announcementDismissCookieName(platform: string): string {
+  return `${platform}-announcement-dismissed`
 }
 
-export function getStoredAnnouncement(key: string): any {
-  if (typeof window !== 'undefined') {
-    try {
-      return JSON.parse(localStorage.getItem(key) || 'null');
-    } catch {
-      return null;
-    }
+/** THE dismissal match rule (id-match, not presence), shared across the
+ *  server/client boundary. `undefined` id (no active announcement) → false. */
+export function isDismissedCookieValue(
+  cookieValue: string | undefined,
+  id: string | undefined,
+): boolean {
+  return !!id && cookieValue === id
+}
+
+function readCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined
+  const match = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${name}=`))
+  return match ? decodeURIComponent(match.slice(name.length + 1)) : undefined
+}
+
+const legacyDismissKey = (platform: string, id: string) =>
+  `${platform}-announcement-${id}-dismissed`
+
+/** Persist a dismissal: cookie only (1 year). The SSR layout sees it on the
+ *  next request; localStorage is intentionally NOT written (read-only legacy). */
+export function dismissAnnouncement(platform: string, id: string): void {
+  if (typeof document === 'undefined') return
+  const name = announcementDismissCookieName(platform)
+  document.cookie = `${name}=${encodeURIComponent(id)}; path=/; max-age=31536000; SameSite=Lax`
+}
+
+/**
+ * Client-side dismissal check — cookie-first: the legacy localStorage key is
+ * consulted ONLY when no cookie exists for the platform. Reads browser
+ * storage, so callers must invoke it from effects, never during render
+ * (a render-time read would desync hydration from the SSR HTML).
+ */
+export function isAnnouncementDismissed(platform: string, id: string): boolean {
+  if (typeof document === 'undefined') return false
+  const cookieValue = readCookie(announcementDismissCookieName(platform))
+  if (cookieValue !== undefined) return isDismissedCookieValue(cookieValue, id)
+  try {
+    return localStorage.getItem(legacyDismissKey(platform, id)) !== null
+  } catch {
+    return false
   }
-  return null;
 }
 
-export function setStoredAnnouncement(key: string, value: any): void {
-  if (typeof window !== 'undefined') {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch {
-      // Ignore storage errors
-    }
-  }
-}
-
-export function clearStoredAnnouncement(key: string = 'announcement'): void {
-  if (typeof window !== 'undefined') {
-    try {
-      localStorage.removeItem(key);
-    } catch {
-      // Ignore storage errors
-    }
+/** One-time cleanup of pre-refactor storage: the orphaned announcement cache
+ *  (the old "instant paint" blob) — called from the bar's mount effect. */
+export function clearLegacyAnnouncementCache(platform: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.removeItem(`${platform}-announcement-cache`)
+  } catch {
+    // ignore storage errors
   }
 }

--- a/openframe-frontend-core/src/utils/app-config.ts
+++ b/openframe-frontend-core/src/utils/app-config.ts
@@ -16,5 +16,14 @@ export function getAppConfig() {
 }
 
 export function getAppType() {
-  return process.env.NEXT_PUBLIC_APP_TYPE || 'openmsp';
+  // The exact `process.env.NEXT_PUBLIC_APP_TYPE` member expression is kept so
+  // Next/webpack can statically inline it. The try/catch makes the call safe
+  // in non-Next React hosts (Vite/CRA embeds) where `process` does not exist
+  // at runtime — those hosts fall back to 'openmsp' or pass an explicit
+  // platform where it matters (e.g. AnnouncementBar's `platform` prop).
+  try {
+    return process.env.NEXT_PUBLIC_APP_TYPE || 'openmsp';
+  } catch {
+    return 'openmsp';
+  }
 }

--- a/openframe-frontend-core/src/utils/color-analysis.ts
+++ b/openframe-frontend-core/src/utils/color-analysis.ts
@@ -48,8 +48,10 @@ export function getContrastRatio(color1: [number, number, number], color2: [numb
 /**
  * Pick the readable foreground shade for an arbitrary background hex — 'dark'
  * when dark text has the better WCAG contrast on it, 'light' otherwise.
- * Callers map the result to their surface's dark/light pair (e.g. the
- * announcement bar maps to --ods-system-greys-black / --ods-system-greys-white).
+ * Callers map the result to an ODS THEME, not to color literals (e.g. the
+ * announcement bar scopes its content with .theme-light when the background
+ * needs dark-on-light, .theme-dark otherwise — every color then resolves
+ * from the active theme's own tokens).
  */
 export function pickReadableTextColor(bgHex: string): 'dark' | 'light' {
   const bg = hexToRgb(bgHex);

--- a/openframe-frontend-core/src/utils/color-analysis.ts
+++ b/openframe-frontend-core/src/utils/color-analysis.ts
@@ -26,7 +26,7 @@ export function hexToRgb(hex: string): [number, number, number] {
 /**
  * Calculate relative luminance for contrast calculations
  */
-function getLuminance(rgb: [number, number, number]): number {
+export function getLuminance(rgb: [number, number, number]): number {
   const [r, g, b] = rgb.map(c => {
     c = c / 255;
     return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
@@ -43,6 +43,19 @@ export function getContrastRatio(color1: [number, number, number], color2: [numb
   const brightest = Math.max(lum1, lum2);
   const darkest = Math.min(lum1, lum2);
   return (brightest + 0.05) / (darkest + 0.05);
+}
+
+/**
+ * Pick the readable foreground shade for an arbitrary background hex — 'dark'
+ * when dark text has the better WCAG contrast on it, 'light' otherwise.
+ * Callers map the result to their surface's dark/light pair (e.g. the
+ * announcement bar maps to --ods-system-greys-black / --ods-system-greys-white).
+ */
+export function pickReadableTextColor(bgHex: string): 'dark' | 'light' {
+  const bg = hexToRgb(bgHex);
+  const darkContrast = getContrastRatio(bg, [26, 26, 26]);
+  const lightContrast = getContrastRatio(bg, [250, 250, 250]);
+  return darkContrast >= lightContrast ? 'dark' : 'light';
 }
 
 /**

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -85,6 +85,9 @@ export * from './generic-domain-utils'
 // Color analysis (canvas-based image color extraction)
 export * from './color-analysis'
 
+// Announcement dismissal store (cookie SSOT; server-safe name/match helpers)
+export * from './announcement-storage'
+
 // Image-proxy URL builder (pure, runtime-configurable)
 export {
   type GetProxiedImageUrlOptions,

--- a/react-embedding-example/README.md
+++ b/react-embedding-example/README.md
@@ -103,6 +103,19 @@ All client calls use `/content/api/...`. Per-surface retargeting:
 | Contact | `/content/api/contact` | `EndpointsRuntime.contactUrl` |
 | Announcements | `/content/api/announcements/active` | `EndpointsRuntime.announcementsUrl` |
 
+### Announcement bar (dual mode, this app = client-only)
+
+`<AnnouncementBar />` is mounted prop-less in `app-shell.tsx` — client-only mode for
+hosts without SSR. It reads `EndpointsRuntime.announcementsUrl`; the `/content` proxy
+forwards the request and the hub returns ITS OWN active announcement (resolved
+server-side via `currentPlatform()`) — the platform is never sent as a parameter and
+no per-component URL exists. The bar fetches once on mount (animated entrance),
+refetches only on tab refocus when its data is older than 60s (no polling), and
+persists dismissal in a cookie on this embed's domain. SSR hosts (e.g. the hub
+itself) use the other mode instead: resolve the announcement plus the dismissal
+cookie server-side and pass `initialAnnouncement` so the bar renders in the first
+HTML byte with zero layout shift.
+
 ### Two documented `/api` exceptions (dev only)
 
 Two lib surfaces still hardcode bare `/api` with no override prop today:

--- a/react-embedding-example/src/components/app-shell.tsx
+++ b/react-embedding-example/src/components/app-shell.tsx
@@ -25,7 +25,15 @@ export function AppShell() {
   // router directly. No runtime.navigation callback, no document-click interceptor.
   return (
     <div className="min-h-full bg-ods-bg text-ods-text-primary">
-      {/* No props — reads its endpoint from EndpointsRuntime.announcementsUrl. */}
+      {/* Client-only mode (no SSR), mounted PROP-LESS: reads its endpoint from
+          EndpointsRuntime.announcementsUrl (/content/api/announcements/active).
+          The /content proxy forwards the request to the hub, which resolves
+          ITS OWN platform via currentPlatform() and returns the announcement
+          object verbatim — no URL or platform knob exists on the client.
+          Fetches once on mount (animated entrance, no layout snap), refetches
+          only on tab refocus when data is >60s old; dismissal persists in a
+          cookie on THIS embed's domain. SSR hosts use the other mode: resolve
+          server-side and pass `initialAnnouncement`. */}
       <AnnouncementBar />
       <header className="sticky top-0 z-40 border-b border-ods-border bg-ods-card/95 backdrop-blur">
         <nav className="mx-auto flex max-w-6xl flex-wrap items-center gap-1 px-4 py-3">


### PR DESCRIPTION
## What changed

Full refactor of the `AnnouncementBar` and its support surface in `openframe-frontend-core`. Pairs with the hub PR (announcement system refactor) that SSR-seeds the bar and caches the read path.

### Data flow: polling is gone
- `AnnouncementBar` gains `initialAnnouncement` (SSR seed; `null` = seeded nothing-to-show, absent = embed self-fetch) and `previewMode` (render-only for the admin preview: no fetch, inert dismiss, no storage writes).
- Migrated off the hand-rolled `fetch` + `setInterval(300s)` loop onto `useSelfFetch`, with the `initialData` seed memoized and strict-`undefined`-mapped (the hook re-syncs on `[initialData]` identity; same pattern as faq-section/roadmap-view).
- `useSelfFetch` gains opt-in `revalidateOnVisibleAfterMs`: refetch on tab refocus only when held data is older than the threshold; freshness timestamp is seeded at mount for SSR-hydrated data so the first refocus does not spuriously fire. Idle/background tabs make zero requests.

### Dismissal: cookie is the SSOT
- `announcement-storage.ts` rewritten: `dismissAnnouncement` writes a per-platform cookie (id-match, 1y) that the hub layout reads server-side, so dismissed users never get the bar in SSR HTML (no flash). localStorage is read-only legacy, consulted only when no cookie exists; the mount effect backfills the cookie once (single animated collapse) and cleans the orphaned pre-refactor cache blob.
- `announcementDismissCookieName` / `isDismissedCookieValue` are exported (module is directive-free) so the cookie name and match rule have exactly one home across the server/client boundary. Old `get/set/clearStoredAnnouncement` deleted (bar was the sole consumer).

### Look and feel: industry-standard thin bar
- Single-line 44px strip (was ~61px with two stacked 18px rows): 13-14px text, semibold title, middot-separated description (hidden < sm), truncating as one unit. No em/en dashes in copy.
- Contrast-aware foreground via new `pickReadableTextColor` in the existing `color-analysis.ts` (composes the existing luminance/contrast helpers; maps to `--ods-system-greys-black/white`), so dark admin backgrounds no longer produce invisible text.
- CTA is the design-system `Button` verbatim: `variant="outline" size="small"`, zero inline styles and zero class overrides, so hover/active/focus resolve entirely from ODS tokens. The admin `cta_button_*` colors are no longer applied (they were designed for the legacy bespoke treatment and fight the token system). The `small-legacy` Button size alias comment updated (bar migrated off it; other consumers remain).
- Dismiss target is 44x44 (WCAG 2.5.5 AAA / Apple HIG; AA floor is 24). Height animates via grid `0fr <-> 1fr` (200ms, disabled under `prefers-reduced-motion`); SSR-seeded paint renders at full height with no entrance animation, so hydration markup matches by construction.
- `role="region"` + `aria-label="Announcement"`; whole-bar tap target on mobile retained.

### Types
- `Announcement`: dropped stale `platform_id`/`platform`, added `announcement_platforms?: EntityPlatformAssoc[]` (the shape the hub DAL actually emits).
- `AnnouncementResponse.announcement` is now nullable and is the single wire-shape type for the route + the bar's fetch generic.
- `AnnouncementBarProps` repointed to the real component props; `ANNOUNCEMENT_CTA_DEFAULTS` exported for the hub DAL/admin form.
- Stories rewritten to drive the bar via props (fetch mock deleted); dead `useAnnouncements` stub removed; companion docs updated.

## Why

The bar polled every open tab every 5 minutes against an uncached route, popped in after client fetch (layout shift above a sticky header), could paint a stale cached announcement then yank it, and had rotted types/dead code. The embed contract (optional endpoints runtime; no provider = no fetch, silent no-op) is preserved; all changes are additive props.

## Reviewer notes
- The hub pins an exact lib version: this PR needs to land + release before the hub PR's pin bump.
- Verified live against the hub: SSR HTML contains the bar at full height, zero announcement requests on load, dismiss/reload with no flash, legacy-LS migration path, and ODS hover on the CTA.
- Plan was reviewed by 5 iterating reviewer agents (anti-duplication/DRY/standards/logic/bug-hunter) until all scored >=95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcement bars now support server-rendered content, preview mode, theme-aware text, animated expansion, and improved dismissal handling.
  * Announcements refresh when the page becomes visible after a configurable interval.
  * Announcement targeting now supports multiple platforms.
  * Added automatic contrast selection for announcement text.

* **Bug Fixes**
  * Improved dismissal persistence using cookies, with fallback support for legacy saved preferences.

* **Documentation**
  * Updated announcement, hook, storage, and Storybook documentation to reflect the latest behavior and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->