### PR TITLE
fix(video): set referrerPolicy on YouTube facade iframe (fixes Error 153)

### DIFF
--- a/openframe-frontend-core/src/components/features/video.tsx
+++ b/openframe-frontend-core/src/components/features/video.tsx
@@ -892,6 +892,14 @@ function YouTubeFacadeInner({
           src={embedUrl}
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           allowFullScreen
+          // YouTube verifies the embedding domain from the Referer header. When the
+          // host page runs under a strict `Referrer-Policy: no-referrer` (common on
+          // deployed environments behind a gateway/CDN), the iframe would otherwise
+          // inherit it, send no referrer, and YouTube rejects playback with
+          // "Error 153 — Video player configuration error". Pin the policy to the
+          // value YouTube's own recommended embed code uses so the origin is always
+          // sent and embedding is authorized.
+          referrerPolicy="strict-origin-when-cross-origin"
           title={title}
           className="absolute inset-0 w-full h-full border-0 rounded-lg"
         />


### PR DESCRIPTION
## Problem
On deployed environments the YouTube facade loaded the poster and the embed HTML (both `200`), but **playback broke on click with "Error 153 — Video player configuration error"**. Works fine on `localhost`.

Root cause: the facade `<iframe>` set no `referrerPolicy`, so it inherited the host page's policy. Deployed environments (behind a gateway/CDN) run under `Referrer-Policy: no-referrer`, so the iframe sent **no Referer**, and YouTube couldn't verify the embedding domain → Error 153. `localhost` uses a laxer policy, which is why it only reproduced on deploy.

Confirmed from the network trace: `youtube-nocookie.com/embed/…` → `200`, poster → `200`, request `Referrer Policy: no-referrer`.

## Fix
Pin the facade iframe to `referrerPolicy="strict-origin-when-cross-origin"` — the exact value in YouTube's own recommended embed code — so the origin is always sent regardless of the host's page-level referrer policy.

## Why it's non-breaking
Purely additive attribute on the `<iframe>`. No API change, no behavior change for pages that already sent a referrer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YouTube video embedding compatibility by ensuring the expected referrer information is sent.
  * Prevented configuration errors when the host page uses a restrictive referrer policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->