### PR TITLE
fix(announcement-bar): implementation-review round (contrast SSOT, exit animation, focus + URL semantics)

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { Button } from './ui/button';
 import { EntityIcon } from './icon-display';
@@ -9,7 +9,7 @@ import {
   isAnnouncementDismissed,
   clearLegacyAnnouncementCache,
 } from '../utils/announcement-storage';
-import type { AnnouncementBarProps, AnnouncementResponse } from '../types/announcement';
+import type { Announcement, AnnouncementBarProps, AnnouncementResponse } from '../types/announcement';
 import { getAppType } from '../utils/app-config';
 import { useEndpointsRuntime } from '../contexts/endpoints-runtime-context';
 import { useSelfFetch } from '../hooks/use-self-fetch';
@@ -71,6 +71,15 @@ export function AnnouncementBar({
   });
   const announcement = data?.announcement ?? null;
 
+  // Hold the last non-null announcement so DEACTIVATION (a revalidation that
+  // returns null) collapses with the same 1fr->0fr animation as dismissal
+  // instead of unmounting in place (a hard 44px jump).
+  const lastAnnouncementRef = useRef<Announcement | null>(initialAnnouncement ?? null);
+  useEffect(() => {
+    if (announcement) lastAnnouncementRef.current = announcement;
+  }, [announcement]);
+  const displayAnnouncement = announcement ?? lastAnnouncementRef.current;
+
   // Expanded (height) state — initial value is a pure function of props so
   // the SSR HTML and the hydration render agree for every cohort.
   const [expandedState, setExpandedState] = useState<boolean>(() => initialAnnouncement != null);
@@ -109,6 +118,10 @@ export function AnnouncementBar({
   const handleDismiss = () => {
     if (previewMode || !announcement) return;
     dismissAnnouncement(platform, announcement.id);
+    // Release focus BEFORE the wrapper goes aria-hidden — a focused descendant
+    // inside an aria-hidden subtree strands screen-reader focus (and Chrome
+    // refuses to apply the attribute).
+    (document.activeElement as HTMLElement | null)?.blur?.();
     setExpandedState(false);
   };
 
@@ -119,7 +132,9 @@ export function AnnouncementBar({
     // via location.href / window.open (stored XSS).
     let safeUrl: string;
     try {
-      const parsed = new URL(announcement.cta_url, window.location.origin);
+      // Resolve against the CURRENT page (not the origin) so path-relative and
+      // fragment CTAs keep their pre-guard semantics.
+      const parsed = new URL(announcement.cta_url, window.location.href);
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return;
       safeUrl = parsed.href;
     } catch {
@@ -130,10 +145,10 @@ export function AnnouncementBar({
       : (window.location.href = safeUrl);
   };
 
-  // Nothing to show (and nothing to animate around): render nothing. The
-  // dismissed/deactivated case keeps the element mounted at 0fr so the
-  // collapse animates.
-  if (!announcement) return null;
+  // Never had anything to show: render nothing. Dismissal AND deactivation
+  // keep the element mounted (displayAnnouncement holds the last content) at
+  // 0fr so the collapse animates.
+  if (!displayAnnouncement) return null;
 
   // Contrast is solved with the ODS THEME system, not color literals: the
   // admin background's tone selects which ODS theme scopes the bar's content
@@ -141,7 +156,7 @@ export function AnnouncementBar({
   // dark-toned needs the dark theme's). `.theme-light` / `.theme-dark` are
   // the design system's own scoping classes (ods-colors.css) and flip every
   // Tier-1 `--ods-*` primitive for descendants.
-  const themeScope = pickReadableTextColor(announcement.background_color) === 'dark' ? 'theme-light' : 'theme-dark';
+  const themeScope = pickReadableTextColor(displayAnnouncement.background_color) === 'dark' ? 'theme-light' : 'theme-dark';
 
   // Inside the scope, colors reference Tier-1 theme primitives directly
   // (Tier-2 `--color-*` aliases resolve once at :root and do NOT re-resolve
@@ -152,7 +167,7 @@ export function AnnouncementBar({
   const barButtonClasses =
     'text-[color:var(--ods-system-greys-white)] hover:bg-[var(--ods-system-greys-black-hover)] active:bg-[var(--ods-system-greys-black-action)]';
 
-  const hasCta = Boolean(announcement.cta_enabled && announcement.cta_url);
+  const hasCta = Boolean(displayAnnouncement.cta_enabled && displayAnnouncement.cta_url && displayAnnouncement.cta_text);
 
   return (
     <div
@@ -171,9 +186,11 @@ export function AnnouncementBar({
         compact CTA on the right, and a ghost-icon dismiss (design-system
         icon-sm: 32px target, >= the 24px WCAG 2.2 SC 2.5.8 AA floor).
       */}
-      <div className={`min-h-0 overflow-hidden ${themeScope}`} style={{ backgroundColor: announcement.background_color }}>
+      <div className={`min-h-0 overflow-hidden ${themeScope}`} style={{ backgroundColor: displayAnnouncement.background_color }}>
         <div className="flex items-center w-full max-w-full min-h-11 text-[color:var(--ods-system-greys-white)]">
-          {/* Mobile: Clickable content area, Desktop: Regular content */}
+          {/* Mobile: whole-bar tap target (touch-first by design; the CTA
+              Button below is the keyboard/AT path and is CSS-hidden < md —
+              known tradeoff carried from the original bar). */}
           <div
             className={`flex flex-row gap-2 md:gap-3 items-center pl-4 md:pl-6 py-1.5 flex-1 min-w-0 ${
               hasCta ? 'md:cursor-default cursor-pointer' : ''
@@ -190,9 +207,9 @@ export function AnnouncementBar({
                 wins, else a library glyph by name (+ props), via <EntityIcon>. */}
             <EntityIcon
               icon={{
-                name: announcement.icon_name || 'openframe-logo',
-                url: announcement.icon_url,
-                props: announcement.icon_props,
+                name: displayAnnouncement.icon_name || 'openframe-logo',
+                url: displayAnnouncement.icon_url,
+                props: displayAnnouncement.icon_props,
               }}
               size={24}
               className="relative shrink-0 w-5 h-5 md:w-6 md:h-6"
@@ -202,9 +219,9 @@ export function AnnouncementBar({
                 truncating as one unit. Separator is a middot (house rule: no
                 en/em dashes in copy). */}
             <p className="font-body flex-1 min-w-0 max-w-full text-[13px] md:text-sm leading-snug truncate mb-0">
-              <span className="font-semibold">{announcement.title}</span>
-              {announcement.description && (
-                <span className="hidden sm:inline opacity-80"> · {announcement.description}</span>
+              <span className="font-semibold">{displayAnnouncement.title}</span>
+              {displayAnnouncement.description && (
+                <span className="hidden sm:inline opacity-80"> · {displayAnnouncement.description}</span>
               )}
             </p>
 
@@ -214,7 +231,7 @@ export function AnnouncementBar({
                 admin color. The admin cta_button_* colors are NOT applied:
                 they were designed for the legacy bespoke treatment. Hidden
                 on mobile, where the whole bar is the tap target. */}
-            {hasCta && announcement.cta_text && (
+            {hasCta && displayAnnouncement.cta_text && (
               <div className="hidden md:flex flex-shrink-0 ml-1">
                 <Button
                   onClick={handleCtaClick}
@@ -223,10 +240,10 @@ export function AnnouncementBar({
                   className={barButtonClasses}
                   tabIndex={expanded ? 0 : -1}
                   leftIcon={
-                    announcement.cta_show_icon && announcement.cta_icon_name
+                    displayAnnouncement.cta_show_icon && displayAnnouncement.cta_icon_name
                       ? (
                           <EntityIcon
-                            icon={{ name: announcement.cta_icon_name, props: announcement.cta_icon_props }}
+                            icon={{ name: displayAnnouncement.cta_icon_name, props: displayAnnouncement.cta_icon_props }}
                             size={14}
                             className="w-3.5 h-3.5"
                           />
@@ -234,7 +251,7 @@ export function AnnouncementBar({
                       : undefined
                   }
                 >
-                  {announcement.cta_text}
+                  {displayAnnouncement.cta_text}
                 </Button>
               </div>
             )}

--- a/openframe-frontend-core/src/contexts/endpoints-runtime-context.tsx
+++ b/openframe-frontend-core/src/contexts/endpoints-runtime-context.tsx
@@ -24,7 +24,7 @@
 import { createContext, useContext } from 'react'
 
 export interface EndpointsRuntime {
-  /** GET active announcement (used by `<AnnouncementBar>` polling). */
+  /** GET active announcement (used by `<AnnouncementBar>` mount fetch + refocus revalidation). */
   announcementsUrl: string
   accessCode: {
     /** POST validate access code. */

--- a/openframe-frontend-core/src/hooks/use-self-fetch.ts
+++ b/openframe-frontend-core/src/hooks/use-self-fetch.ts
@@ -112,6 +112,13 @@ export function useSelfFetch<T>(
     // `url` folds in every query param; `reloadKey` drives retry.
   }, [url, reloadKey])
 
+  // ONE force-refetch mechanic shared by reload() and the visibility
+  // revalidation: clear the held-url skip, bump the effect key.
+  const forceReload = () => {
+    dataUrlRef.current = null
+    setReloadKey((k) => k + 1)
+  }
+
   // Opt-in visibility-driven revalidation. Registered only when the option is
   // set and fetching is enabled; SSR-safe (effects don't run on the server)
   // and StrictMode-safe (idempotent listener, cleaned up per mount cycle).
@@ -120,9 +127,7 @@ export function useSelfFetch<T>(
     const onVisible = () => {
       if (document.visibilityState !== 'visible') return
       if (Date.now() - dataAtRef.current < revalidateOnVisibleAfterMs) return
-      // Same mechanics as reload(): clear the held-url skip, bump the key.
-      dataUrlRef.current = null
-      setReloadKey((k) => k + 1)
+      forceReload()
     }
     document.addEventListener('visibilitychange', onVisible)
     return () => document.removeEventListener('visibilitychange', onVisible)
@@ -133,11 +138,7 @@ export function useSelfFetch<T>(
     setData,
     isLoading,
     error,
-    // Force a re-fetch of the current url: clear the held-url ref so the skip above
-    // doesn't short-circuit, then bump the effect key.
-    reload: () => {
-      dataUrlRef.current = null
-      setReloadKey((k) => k + 1)
-    },
+    // Force a re-fetch of the current url (error-retry affordance).
+    reload: forceReload,
   }
 }

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import type { Announcement } from '../types/announcement'
 import { AnnouncementBar } from '../components/announcement-bar'
-import { announcementDismissCookieName } from '../utils/announcement-storage'
+import { announcementDismissCookieName, legacyDismissKey } from '../utils/announcement-storage'
 import { getAppType } from '../utils/app-config'
 import { EndpointsRuntimeContext, type EndpointsRuntime } from '../contexts/endpoints-runtime-context'
 
@@ -14,8 +14,9 @@ import { EndpointsRuntimeContext, type EndpointsRuntime } from '../contexts/endp
 function clearDismissals() {
   const platform = getAppType()
   document.cookie = `${announcementDismissCookieName(platform)}=; path=/; max-age=0`
+  const legacySuffixProbe = legacyDismissKey(platform, '')
   Object.keys(localStorage).forEach((key) => {
-    if (key.includes('-announcement-') && key.endsWith('-dismissed')) {
+    if (key.startsWith(legacySuffixProbe.replace('-dismissed', '')) && key.endsWith('-dismissed')) {
       localStorage.removeItem(key)
     }
   })
@@ -110,7 +111,7 @@ export const WithCTASameTab: Story = {
 }
 
 /**
- * Dark background — text flips to the light shade via pickReadableTextColor.
+ * Dark background: text flips to the light shade via pickReadableTextColor.
  */
 export const DarkBackground: Story = {
   args: {
@@ -217,7 +218,7 @@ export const LongContent: Story = {
 }
 
 /**
- * previewMode — the admin live-preview path: render-only, inert dismiss,
+ * previewMode, the admin live-preview path: render-only, inert dismiss,
  * no fetch and no storage side effects.
  */
 export const PreviewMode: Story = {
@@ -233,7 +234,7 @@ export const PreviewMode: Story = {
 }
 
 /**
- * No active announcement — the bar renders nothing.
+ * No active announcement: the bar renders nothing.
  */
 export const NoAnnouncement: Story = {
   args: { initialAnnouncement: null },
@@ -241,8 +242,8 @@ export const NoAnnouncement: Story = {
     (Story) => (
       <div>
         <Story />
-        <p className="p-4 text-sm text-gray-500">
-          No announcement is active — the bar renders nothing above this text.
+        <p className="p-4 text-sm text-ods-text-secondary">
+          No announcement is active. The bar renders nothing above this text.
         </p>
       </div>
     ),
@@ -250,7 +251,7 @@ export const NoAnnouncement: Story = {
 }
 
 /**
- * Client-only mode (no SSR) — the react-embedding-example structure: the
+ * Client-only mode (no SSR), the react-embedding-example structure: the
  * embedder mounts an EndpointsRuntime provider (announcementsUrl is a fixed
  * suffix under its one content base) and drops in a PROP-LESS bar. No
  * platform knob anywhere on the client: the proxied server resolves its own

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import type { Announcement } from '../types/announcement'
 import { AnnouncementBar } from '../components/announcement-bar'
-import { announcementDismissCookieName, legacyDismissKey } from '../utils/announcement-storage'
+import { clearAnnouncementDismissals } from '../utils/announcement-storage'
 import { getAppType } from '../utils/app-config'
 import { EndpointsRuntimeContext, type EndpointsRuntime } from '../contexts/endpoints-runtime-context'
 
@@ -12,14 +12,7 @@ import { EndpointsRuntimeContext, type EndpointsRuntime } from '../contexts/endp
  * by a previous interaction so every story starts visible.
  */
 function clearDismissals() {
-  const platform = getAppType()
-  document.cookie = `${announcementDismissCookieName(platform)}=; path=/; max-age=0`
-  const legacySuffixProbe = legacyDismissKey(platform, '')
-  Object.keys(localStorage).forEach((key) => {
-    if (key.startsWith(legacySuffixProbe.replace('-dismissed', '')) && key.endsWith('-dismissed')) {
-      localStorage.removeItem(key)
-    }
-  })
+  clearAnnouncementDismissals(getAppType())
 }
 
 const now = new Date().toISOString()

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -220,14 +220,6 @@ export interface AnnouncementValidation {
 // Import unified platform configuration (removed duplicate definition)
 export type { PlatformConfig } from './platform';
 
-// Admin Dashboard Types
-export interface AnnouncementStats {
-  total_announcements: number;
-  active_announcements: number;
-  announcements_by_platform: Record<LegacyPlatform, number>;
-  recent_announcements: Announcement[];
-}
-
 // Component Props Types
 export interface AnnouncementBarProps {
   /**

--- a/openframe-frontend-core/src/utils/announcement-storage.ts
+++ b/openframe-frontend-core/src/utils/announcement-storage.ts
@@ -42,9 +42,7 @@ function readCookie(name: string): string | undefined {
   return match ? decodeURIComponent(match.slice(name.length + 1)) : undefined
 }
 
-/** Legacy per-id localStorage key (read-only legacy store; exported so
- *  stories/tests reference the encoding instead of re-deriving it). */
-export const legacyDismissKey = (platform: string, id: string) =>
+const legacyDismissKey = (platform: string, id: string) =>
   `${platform}-announcement-${id}-dismissed`
 
 /** Persist a dismissal: cookie only (1 year). The SSR layout sees it on the
@@ -69,6 +67,23 @@ export function isAnnouncementDismissed(platform: string, id: string): boolean {
     return localStorage.getItem(legacyDismissKey(platform, id)) !== null
   } catch {
     return false
+  }
+}
+
+/** Remove ALL dismissal state for a platform (cookie + legacy localStorage
+ *  keys) — test/story helper so callers never restate the key encoding. */
+export function clearAnnouncementDismissals(platform: string): void {
+  if (typeof document === 'undefined') return
+  document.cookie = `${announcementDismissCookieName(platform)}=; path=/; max-age=0`
+  try {
+    const prefix = `${platform}-announcement-`
+    Object.keys(localStorage).forEach((key) => {
+      if (key.startsWith(prefix) && key.endsWith('-dismissed')) {
+        localStorage.removeItem(key)
+      }
+    })
+  } catch {
+    // ignore storage errors
   }
 }
 

--- a/openframe-frontend-core/src/utils/announcement-storage.ts
+++ b/openframe-frontend-core/src/utils/announcement-storage.ts
@@ -42,7 +42,9 @@ function readCookie(name: string): string | undefined {
   return match ? decodeURIComponent(match.slice(name.length + 1)) : undefined
 }
 
-const legacyDismissKey = (platform: string, id: string) =>
+/** Legacy per-id localStorage key (read-only legacy store; exported so
+ *  stories/tests reference the encoding instead of re-deriving it). */
+export const legacyDismissKey = (platform: string, id: string) =>
   `${platform}-announcement-${id}-dismissed`
 
 /** Persist a dismissal: cookie only (1 year). The SSR layout sees it on the

--- a/openframe-frontend-core/src/utils/app-config.ts
+++ b/openframe-frontend-core/src/utils/app-config.ts
@@ -19,8 +19,9 @@ export function getAppType() {
   // The exact `process.env.NEXT_PUBLIC_APP_TYPE` member expression is kept so
   // Next/webpack can statically inline it. The try/catch makes the call safe
   // in non-Next React hosts (Vite/CRA embeds) where `process` does not exist
-  // at runtime — those hosts fall back to 'openmsp' or pass an explicit
-  // platform where it matters (e.g. AnnouncementBar's `platform` prop).
+  // at runtime — those hosts get the 'openmsp' fallback, which is fine for
+  // embeds: dismissal cookies are domain-scoped and an embed domain serves
+  // one platform's announcements.
   try {
     return process.env.NEXT_PUBLIC_APP_TYPE || 'openmsp';
   } catch {

--- a/openframe-frontend-core/src/utils/color-analysis.ts
+++ b/openframe-frontend-core/src/utils/color-analysis.ts
@@ -17,7 +17,10 @@ export const DESIGN_PALETTE: ColorPalette[] = [
  * Convert hex color to RGB
  */
 export function hexToRgb(hex: string): [number, number, number] {
-  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  // Expand shorthand (#fc0 -> #ffcc00) so legacy/hand-entered values classify
+  // by their real color instead of falling through to black.
+  const normalized = hex.replace(/^#?([a-f\d])([a-f\d])([a-f\d])$/i, (_, r, g, b) => `${r}${r}${g}${g}${b}${b}`);
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(normalized);
   return result
     ? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
     : [0, 0, 0];
@@ -26,7 +29,7 @@ export function hexToRgb(hex: string): [number, number, number] {
 /**
  * Calculate relative luminance for contrast calculations
  */
-export function getLuminance(rgb: [number, number, number]): number {
+function getLuminance(rgb: [number, number, number]): number {
   const [r, g, b] = rgb.map(c => {
     c = c / 255;
     return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);

--- a/openframe-frontend-core/src/utils/ods-color-utils.ts
+++ b/openframe-frontend-core/src/utils/ods-color-utils.ts
@@ -4,6 +4,7 @@
  * Provides runtime utilities for working with ODS color tokens
  */
 
+import { pickReadableTextColor } from './color-analysis';
 import { colorTokens as odsTokens } from './ods-color-tokens-stub';
 
 export type Platform = 'openmsp' | 'openframe' | 'flamingo';
@@ -292,15 +293,11 @@ export function usePlatformColors(platform?: Platform) {
 
 /**
  * Picks a near-black or near-white text color with adequate contrast on `hex`.
- * Uses Rec. 601 luminance.
+ * Thin wrapper over `pickReadableTextColor` (color-analysis.ts) — ONE
+ * light-or-dark decision formula (WCAG relative luminance) for the whole lib.
  */
 export function getReadableTextColor(hex: string): string {
-  const n = parseInt(hex.replace('#', ''), 16)
-  const r = (n >> 16) & 0xff
-  const g = (n >> 8) & 0xff
-  const b = n & 0xff
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-  return luminance > 0.5 ? '#212121' : '#fafafa'
+  return pickReadableTextColor(hex) === 'dark' ? '#212121' : '#fafafa'
 }
 
 // Hex <-> RGB <-> HSL. Hex is #rrggbb lowercase; hexToRgb returns null on invalid.


### PR DESCRIPTION
Follow-up to #1422 (merged): fixes from a 5-lens implementation review (anti-duplication, DRY, standards, logic, bug-hunter). Pairs with the hub branch's review-fix commit.

- One light-or-dark formula lib-wide: getReadableTextColor (ods-color-utils) now delegates to pickReadableTextColor — previously two independent luminance formulas (Rec. 601 vs WCAG) could disagree on mid-tones.
- hexToRgb expands shorthand hex (#fc0) instead of classifying it black (a light background would have gotten the dark theme scope → white-on-yellow text).
- Bar behavior: CTA URLs resolve against the current page, not the origin (keeps relative/fragment semantics under the javascript: scheme guard); dismiss blurs the active element before the wrapper goes aria-hidden (no stranded screen-reader focus); hasCta also requires cta_text (legacy rows with enabled+url+empty text no longer make the whole mobile bar a blind tap target); deactivation now animates — the last announcement is held so a revalidation that returns null collapses 1fr→0fr instead of unmounting in place.
- use-self-fetch: one forceReload shared by reload() and the visibility revalidation (was duplicated inline).
- Type hygiene: stale AnnouncementStats (LegacyPlatform shape, zero consumers) deleted; getLuminance back to private; legacyDismissKey exported so stories reference the encoding's one home.
- Copy/docs: em dashes removed from rendered Storybook copy; text-gray-500 → ODS token; stale comments fixed.

No public-API breaks for the hub at 0.0.405 (deleted exports had zero hub consumers, grep-verified). Lib type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Announcement bars now remain visible during temporary deactivation updates, preventing abrupt layout shifts.
  * Dismissing an announcement no longer leaves keyboard focus inside hidden content.
  * Call-to-action links now correctly preserve relative paths and fragments.
  * Announcement buttons require complete configuration before appearing.
  * Improved readable text color selection, including support for three-digit hex colors.
* **Accessibility**
  * Announcement text and actions now maintain consistent rendering during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->