### PR TITLE
fix(announcement-bar): restore admin-configured CTA button colors

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -235,7 +235,7 @@ export function AnnouncementBar({
                 nothing can render dark-on-dark. Hidden on mobile, where the
                 whole bar is the tap target. */}
             {hasCta && displayAnnouncement.cta_text && (
-              <div className="hidden md:flex flex-shrink-0 ml-1">
+              <div className="hidden md:flex flex-shrink-0 ml-2 md:ml-4">
                 <Button
                   onClick={handleCtaClick}
                   variant="outline"
@@ -269,7 +269,7 @@ export function AnnouncementBar({
               (size="icon-sm": 32px target, >= the 24px WCAG 2.5.8 AA floor,
               16px glyph) with the bar's quiet tint hover. Inert in
               previewMode. */}
-          <div className="flex-shrink-0 mr-1 md:mr-3">
+          <div className="flex-shrink-0 ml-1 md:ml-2 mr-2 md:mr-4">
             <Button
               onClick={(e) => {
                 e.stopPropagation(); // Prevent triggering the mobile CTA click

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -9,6 +9,7 @@ import {
   isAnnouncementDismissed,
   clearLegacyAnnouncementCache,
 } from '../utils/announcement-storage';
+import { ANNOUNCEMENT_CTA_DEFAULTS } from '../types/announcement';
 import type { Announcement, AnnouncementBarProps, AnnouncementResponse } from '../types/announcement';
 import { getAppType } from '../utils/app-config';
 import { useEndpointsRuntime } from '../contexts/endpoints-runtime-context';
@@ -225,19 +226,26 @@ export function AnnouncementBar({
               )}
             </p>
 
-            {/* CTA - the common Button in the bar's quiet treatment: ghost
-                surface, computed-foreground text, translucent fg-tint hover
-                (barButtonClasses) so nothing renders as a dark slab on the
-                admin color. The admin cta_button_* colors are NOT applied:
-                they were designed for the legacy bespoke treatment. Hidden
-                on mobile, where the whole bar is the tap target. */}
+            {/* CTA - the common Button carrying the ADMIN-CONFIGURED colors
+                (cta_button_background_color / cta_button_text_color are an
+                admin FEATURE, defaults from ANNOUNCEMENT_CTA_DEFAULTS —
+                announcement colors are data, not token surfaces). Inline
+                styles win over the variant's hover classes on every state,
+                so hover feedback is opacity (the bar's original treatment);
+                nothing can render dark-on-dark. Hidden on mobile, where the
+                whole bar is the tap target. */}
             {hasCta && displayAnnouncement.cta_text && (
               <div className="hidden md:flex flex-shrink-0 ml-1">
                 <Button
                   onClick={handleCtaClick}
-                  variant="transparent"
+                  variant="outline"
                   size="small"
-                  className={barButtonClasses}
+                  className="transition-opacity hover:opacity-90"
+                  style={{
+                    backgroundColor: displayAnnouncement.cta_button_background_color || ANNOUNCEMENT_CTA_DEFAULTS.background,
+                    color: displayAnnouncement.cta_button_text_color || ANNOUNCEMENT_CTA_DEFAULTS.text,
+                    borderColor: displayAnnouncement.cta_button_background_color || ANNOUNCEMENT_CTA_DEFAULTS.background,
+                  }}
                   tabIndex={expanded ? 0 : -1}
                   leftIcon={
                     displayAnnouncement.cta_show_icon && displayAnnouncement.cta_icon_name


### PR DESCRIPTION
Restores the admin CTA color customization the redesign dropped: cta_button_background_color / cta_button_text_color render on the bar's CTA again (defaults from ANNOUNCEMENT_CTA_DEFAULTS). The admin form's pickers were never removed — the bar just stopped honoring the values; this closes that gap.

Implementation: common Button (variant=outline size=small) with the admin colors as inline styles. Inline styles win over the variant's hover classes on every state, so hover feedback is opacity (the bar's original treatment) — no dark-on-dark state is reachable, unlike the earlier text-only override that broke hover. Dismiss keeps the theme-scoped ghost treatment.

After merge + release, bump the hub pin (currently 0.0.407) to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)