### PR TITLE
fix(announcement-bar): previewMode must not stack above host overlays

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -176,7 +176,7 @@ export function AnnouncementBar({
       aria-label="Announcement"
       aria-hidden={!expanded}
       data-announcement-bar
-      className={`relative w-full z-50 grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${className ?? ''}`}
+      className={`relative w-full grid transition-[grid-template-rows] duration-200 ease-out motion-reduce:transition-none ${previewMode ? '' : 'z-50'} ${className ?? ''}`}
       style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
     >
       {/*


### PR DESCRIPTION
The bar's legacy z-50 made the admin announcement-card previews (which mount the real bar via previewMode) punch through the marketing-hub sidebar drawer — preview bars rendered on top of the open nav. z-50 is now applied only in live mode; previewMode inherits the host card's stacking context, so overlays cover it like any other card content.

One-class change, type-checked. After merge + release, bump the hub pin (currently 0.0.409).

🤖 Generated with [Claude Code](https://claude.com/claude-code)