### PR TITLE
feat(button): compact size variant; announcement bar CTA at caption scale

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -235,19 +235,24 @@ export function AnnouncementBar({
                 nothing can render dark-on-dark. Hidden on mobile, where the
                 whole bar is the tap target.
 
-                In-bar geometry: size="small" is 32px tall — nearly flush in
-                the 44px strip (6px clearance). Banner pills run ~28px with
-                horizontal-dominant padding (Polaris micro, Vercel/Tailwind UI
-                banners), so the bar pins h-7 (28px = 8px clearance, above the
-                24px WCAG 2.5.8 floor) and swaps the uniform pad for
-                py-0 px-sf (12px sides at every breakpoint). */}
+                In-bar geometry + type: banner-CTA convention (Primer/Polaris
+                banner actions, Vercel/Tailwind UI promo bars) is a 24-28px
+                pill whose label is caption-scale, medium weight, and NEVER
+                louder than the message. size="small"'s text-h5 (Azeret Mono
+                UPPERCASE) is the app-surface control style and overpowers a
+                44px strip, so the bar swaps it for text-h6 — the system
+                caption token (DM Sans medium, sentence case, 12/14px, same
+                responsive scale as the message) — via the ods-typography
+                tw-merge group. Pill pinned h-6 (24px = the WCAG 2.5.8 target
+                floor, 10px clearance in the strip) with horizontal-dominant
+                py-0 px-sf (12px) padding. */}
             {hasCta && displayAnnouncement.cta_text && (
               <div className="hidden md:flex flex-shrink-0 ml-2 md:ml-4">
                 <Button
                   onClick={handleCtaClick}
                   variant="outline"
                   size="small"
-                  className="h-7 md:h-7 py-0 px-[var(--spacing-system-sf)] transition-opacity hover:opacity-90"
+                  className="text-h6 h-6 md:h-6 py-0 px-[var(--spacing-system-sf)] transition-opacity hover:opacity-90"
                   style={{
                     backgroundColor: displayAnnouncement.cta_button_background_color || ANNOUNCEMENT_CTA_DEFAULTS.background,
                     color: displayAnnouncement.cta_button_text_color || ANNOUNCEMENT_CTA_DEFAULTS.text,

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -235,24 +235,16 @@ export function AnnouncementBar({
                 nothing can render dark-on-dark. Hidden on mobile, where the
                 whole bar is the tap target.
 
-                In-bar geometry + type: banner-CTA convention (Primer/Polaris
-                banner actions, Vercel/Tailwind UI promo bars) is a 24-28px
-                pill whose label is caption-scale, medium weight, and NEVER
-                louder than the message. size="small"'s text-h5 (Azeret Mono
-                UPPERCASE) is the app-surface control style and overpowers a
-                44px strip, so the bar swaps it for text-h6 — the system
-                caption token (DM Sans medium, sentence case, 12/14px, same
-                responsive scale as the message) — via the ods-typography
-                tw-merge group. Pill pinned h-6 (24px = the WCAG 2.5.8 target
-                floor, 10px clearance in the strip) with horizontal-dominant
-                py-0 px-sf (12px) padding. */}
+                Geometry + type come from the design system's size="compact"
+                (24px caption-scale pill for slim strips — rationale documented
+                on the variant in button.tsx). */}
             {hasCta && displayAnnouncement.cta_text && (
               <div className="hidden md:flex flex-shrink-0 ml-2 md:ml-4">
                 <Button
                   onClick={handleCtaClick}
                   variant="outline"
-                  size="small"
-                  className="text-h6 h-6 md:h-6 py-0 px-[var(--spacing-system-sf)] transition-opacity hover:opacity-90"
+                  size="compact"
+                  className="transition-opacity hover:opacity-90"
                   style={{
                     backgroundColor: displayAnnouncement.cta_button_background_color || ANNOUNCEMENT_CTA_DEFAULTS.background,
                     color: displayAnnouncement.cta_button_text_color || ANNOUNCEMENT_CTA_DEFAULTS.text,

--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -30,6 +30,15 @@ const buttonVariants = cva(
         default: "py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-10",
         small: "p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8",
         "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small" — deprecated; grep size="small-legacy" (lib + hub) and migrate the remaining consumers before removal
+        // Caption-scale 24px pill for slim strips (announcement/promo bars,
+        // inline banner actions — Primer banner / Polaris banner / Vercel-bar
+        // convention). Label is text-h6, the system caption token (DM Sans
+        // medium, sentence case, 12/14px): in-strip CTAs must never read
+        // louder than the message beside them, so this deliberately does NOT
+        // use the mono-uppercase control style of "small". Pinned h-6 across
+        // breakpoints (24px = the WCAG 2.5.8 target-size floor) with
+        // horizontal-dominant padding and a 14px glyph.
+        compact: "py-0 px-[var(--spacing-system-sf)] text-h6 h-6 [&_svg]:h-3.5 [&_svg]:w-3.5",
         icon: "p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6",
         // Quiet 32px icon target with a 16px glyph, fixed across breakpoints
         // (Carbon ghost sm / Primer medium / shadcn icon-sm all pin 32px;

--- a/openframe-frontend-core/src/stories/Button.stories.tsx
+++ b/openframe-frontend-core/src/stories/Button.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
     },
     size: {
       control: 'select',
-      options: ['default', 'small', 'icon'],
+      options: ['default', 'small', 'compact', 'icon'],
     },
     fullWidth: { control: 'boolean' },
     disabled: { control: 'boolean' },
@@ -50,6 +50,11 @@ export const SizeDefault: Story = {
 
 export const SizeSmall: Story = {
   args: { children: 'Button', size: 'small' },
+};
+
+// Caption-scale 24px pill for slim strips (announcement/promo bars).
+export const SizeCompact: Story = {
+  args: { children: 'Read Article', size: 'compact', variant: 'outline', leftIcon: <Bell /> },
 };
 
 // === Icon-only ===


### PR DESCRIPTION
## Problem

The announcement bar CTA rendered in `size="small"`'s `text-h5` — 14px **Azeret Mono UPPERCASE** — which visually outweighs the bar message and clashes with the site's real buttons (sentence-case DM Sans). On a 44px strip the CTA read louder than the announcement itself.

## Best-practice reference

Banner CTAs across Primer banner actions, Polaris banner buttons, and Vercel/Tailwind UI promo bars converge on: 24–28px pill, caption-scale label (12–14px), medium weight, sentence case — the CTA must never be louder than the message.

## Fix — new design-system size variant

**`size="compact"`** added to the `Button` SSOT (documented on the variant, exposed in the Storybook size matrix):

```
compact: "py-0 px-[var(--spacing-system-sf)] text-h6 h-6 [&_svg]:h-3.5 [&_svg]:w-3.5"
```

- `text-h6` — the system caption token: DM Sans, medium 500, sentence case, 12px mobile / 14px desktop (same responsive scale as bar messages)
- `h-6` pinned across breakpoints — 24px, exactly the WCAG 2.5.8 target-size floor, 10px clearance in a 44px strip
- horizontal-dominant 12px padding, 14px glyph

The announcement bar consumes `size="compact"` with zero className geometry/typography overrides; admin-configured CTA colors untouched. The `small` variant is unchanged (10+ app-surface consumers keep the mono control style).

## Verification

Applied the exact computed values inline on the live flamingo.run bar and screenshot-compared: the pill reads as a quiet, site-consistent "Read Article" chip instead of a mono-caps slab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)