### PR TITLE
fix(button): compact label matches strip message type ramp (13/14px regular)

### DIFF
--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -30,15 +30,16 @@ const buttonVariants = cva(
         default: "py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-10",
         small: "p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8",
         "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small" — deprecated; grep size="small-legacy" (lib + hub) and migrate the remaining consumers before removal
-        // Caption-scale 24px pill for slim strips (announcement/promo bars,
-        // inline banner actions — Primer banner / Polaris banner / Vercel-bar
-        // convention). Label is text-h6, the system caption token (DM Sans
-        // medium, sentence case, 12/14px): in-strip CTAs must never read
-        // louder than the message beside them, so this deliberately does NOT
-        // use the mono-uppercase control style of "small". Pinned h-6 across
-        // breakpoints (24px = the WCAG 2.5.8 target-size floor) with
-        // horizontal-dominant padding and a 14px glyph.
-        compact: "py-0 px-[var(--spacing-system-sf)] text-h6 h-6 [&_svg]:h-3.5 [&_svg]:w-3.5",
+        // 24px pill for slim strips (announcement/promo bars, inline banner
+        // actions — Primer banner / Polaris banner / Vercel-bar convention).
+        // The label matches the strip's MESSAGE type ramp exactly (DM Sans
+        // regular, 13px -> md:14px, snug leading — the announcement bar's
+        // subtitle styling): in-strip CTAs must never read louder than the
+        // message beside them, so this deliberately uses neither the
+        // mono-uppercase control style of "small" nor a heavier weight.
+        // Pinned h-6 across breakpoints (24px = the WCAG 2.5.8 target-size
+        // floor) with horizontal-dominant padding and a 14px glyph.
+        compact: "py-0 px-[var(--spacing-system-sf)] font-body font-normal text-[13px] md:text-sm leading-snug h-6 [&_svg]:h-3.5 [&_svg]:w-3.5",
         icon: "p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6",
         // Quiet 32px icon target with a 16px glyph, fixed across breakpoints
         // (Carbon ghost sm / Primer medium / shadcn icon-sm all pin 32px;


### PR DESCRIPTION
Follow-up to #1429. The `compact` label used `text-h6` (DM Sans **medium 500**, caption ramp 12→14px), which still reads a step heavier than the announcement bar's subtitle (`font-body text-[13px] md:text-sm` **regular 400**, snug leading) sitting next to it.

Measured on live tmcg.miami: message 13px/400 vs pill 12px/500 (mobile tier) — same mismatch at md+ (14px/400 vs 14px/500).

`compact` now uses the strip message's exact type ramp:

```
compact: "py-0 px-[var(--spacing-system-sf)] font-body font-normal text-[13px] md:text-sm leading-snug h-6 [&_svg]:h-3.5 [&_svg]:w-3.5"
```

Geometry unchanged (24px pill, 12px horizontal padding, 14px glyph). Variant doc comment updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined compact pill button typography for improved consistency across screen sizes.
  * Updated font sizing, weight, and line height while preserving existing button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->