### PR TITLE
fix(nav): bare-hash and query hrefs are same-document, never cross-origin

### DIFF
--- a/openframe-frontend-core/src/components/chat/utils/__tests__/is-cross-origin-url.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/is-cross-origin-url.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { isCrossOriginUrl } from '../is-cross-origin-url'
+import { decideNewTab } from '../decide-new-tab'
+
+describe('isCrossOriginUrl', () => {
+  it('treats falsy values as same-origin', () => {
+    expect(isCrossOriginUrl(null)).toBe(false)
+    expect(isCrossOriginUrl(undefined)).toBe(false)
+    expect(isCrossOriginUrl('')).toBe(false)
+  })
+
+  it('treats same-document references as same-origin', () => {
+    // Regression: bare-hash anchors ("More coming in Next Generations" on
+    // /pricing) were classified cross-origin and opened in a new tab.
+    expect(isCrossOriginUrl('#next-generations')).toBe(false)
+    expect(isCrossOriginUrl('?tab=pricing')).toBe(false)
+  })
+
+  it('treats rooted relative paths as same-origin', () => {
+    expect(isCrossOriginUrl('/support')).toBe(false)
+    expect(isCrossOriginUrl('/roadmap#top')).toBe(false)
+  })
+
+  it('treats explicit-host URLs as cross-origin', () => {
+    expect(isCrossOriginUrl('https://flamingo.run/support')).toBe(true)
+    expect(isCrossOriginUrl('http://example.com')).toBe(true)
+    expect(isCrossOriginUrl('//cdn.example.com/file.js')).toBe(true)
+  })
+})
+
+describe('decideNewTab fallback (no targetPlatform)', () => {
+  it('keeps same-page hash CTAs in the same tab', () => {
+    expect(
+      decideNewTab({ href: '#next-generations', currentSource: 'flamingo' }),
+    ).toBe(false)
+  })
+
+  it('still opens explicit-host URLs in a new tab', () => {
+    expect(
+      decideNewTab({ href: 'https://example.com', currentSource: 'flamingo' }),
+    ).toBe(true)
+  })
+})

--- a/openframe-frontend-core/src/components/chat/utils/is-cross-origin-url.ts
+++ b/openframe-frontend-core/src/components/chat/utils/is-cross-origin-url.ts
@@ -20,6 +20,10 @@
  */
 export function isCrossOriginUrl(url: string | null | undefined): boolean {
   if (!url) return false
+  // Same-document references — a bare fragment (`#anchor`) or query
+  // (`?tab=x`) resolves against the current page and can never leave
+  // the origin.
+  if (url.startsWith('#') || url.startsWith('?')) return false
   // Relative URL — by definition same origin.
   if (url.startsWith('/') && !url.startsWith('//')) return false
   // Anything else — absolute URL (http(s)://) or protocol-relative (//)


### PR DESCRIPTION
## Problem

On https://www.flamingo.run/pricing, the **"More coming in Next Generations / Check the Roadmap"** card opens in a **new tab** even though its href is the same-page anchor `#next-generations`.

## Root cause

The card links via `useNavLink({ href: '#next-generations' })` with no `targetPlatform`, so `decideNewTab` falls through to the legacy `isCrossOriginUrl(href)` fallback. That helper only recognized `/`-rooted paths as same-origin — anything else (including a bare `#hash`) was classified cross-origin → `target="_blank"`.

## Fix

`isCrossOriginUrl` now returns `false` for same-document references (`#hash`, `?query`) — they resolve against the current page and can never leave the origin. This restores the intended `navigateSamePageHash` smooth-scroll path for every bare-hash CTA that flows through the unified nav rule (`useNavLink` / `useUnifiedNav` / autocomplete).

Added a regression test covering `isCrossOriginUrl` and the `decideNewTab` fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Same-page hash and query links are now correctly recognized as internal links.
  * Cross-origin links continue to open in a new tab when no target platform is specified.

* **Tests**
  * Added coverage for internal, relative, protocol, and protocol-relative URL handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->