### PR TITLE
chore: bump openframe-frontend-core to 0.0.417

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flamingo-stack/openframe-frontend-core",
-  "version": "0.0.108",
+  "version": "0.0.417",
   "description": "Shared design system and components for all Flamingo platforms",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bump for the unified-header release (#1351 merged): 0.0.108 → 0.0.417. The hub's `feat/header` (PR flamingo-stack/multi-platform-hub#722) pins 0.0.417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)