### PR TITLE
fix(frontend-core): settle elevator scrollbars — overlay mode, no layout shift

### DIFF
--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -3,10 +3,9 @@
   @apply border-border;
 }
 
-/* Elevator scrollbar (ODS): standard properties only, no ::-webkit-scrollbar —
-   keeps the browser in overlay mode (auto-hiding thumb, zero layout width on
-   macOS), so scrollbars never push content or cause layout jumps. Thumb stays
-   natively draggable; track is transparent to keep idle UI quiet. */
+/* Elevator scrollbar (ODS): thin grey draggable thumb on a transparent track.
+   Standard properties only — no ::-webkit-scrollbar, so the platform keeps its
+   native rendering mode (e.g. auto-hiding overlay scrollbars on macOS). */
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--ods-system-greys-grey) transparent;

--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -3,37 +3,13 @@
   @apply border-border;
 }
 
-/* Elevator scrollbar, Firefox fallback. Scoped via @supports because
-   scrollbar-width/color would disable ::-webkit-scrollbar styling in Chrome */
-@supports not selector(::-webkit-scrollbar) {
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: var(--ods-system-greys-grey) var(--ods-system-greys-soft-grey);
-  }
-}
-
-/* Elevator scrollbar (ODS): 8px track + draggable rounded thumb */
-*::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-*::-webkit-scrollbar-track {
-  background-color: var(--ods-system-greys-soft-grey);
-  border-radius: 4px;
-}
-
-*::-webkit-scrollbar-thumb {
-  background-color: var(--ods-system-greys-grey);
-  border-radius: 4px;
-}
-
-*::-webkit-scrollbar-thumb:hover {
-  background-color: var(--ods-system-greys-grey-hover);
-}
-
-*::-webkit-scrollbar-corner {
-  background-color: transparent;
+/* Elevator scrollbar (ODS): standard properties only, no ::-webkit-scrollbar —
+   keeps the browser in overlay mode (auto-hiding thumb, zero layout width on
+   macOS), so scrollbars never push content or cause layout jumps. Thumb stays
+   natively draggable; track is transparent to keep idle UI quiet. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--ods-system-greys-grey) transparent;
 }
 
 body {


### PR DESCRIPTION
## Description

Drop ::-webkit-scrollbar styling (it forced classic mode: 8px layout width, always-visible track, layout jumps when content overflows). Use standard scrollbar-width/scrollbar-color with transparent track: overlay auto-hiding thumb on macOS, still natively draggable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified scrollbar styling for a cleaner, more consistent appearance.
  * Standardized scrollbar width and colors using broadly supported CSS properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->