### PR TITLE
fix(chat): lock composer while agent executes approved commands

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-input.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-input.tsx
@@ -580,7 +580,11 @@ const ChatInput = forwardRef<ChatInputRef, ChatInputProps>((allProps, ref) => {
               disabled={isStopMode ? isStopping : sendDisabled}
               className={cn(
                 "flex h-6 shrink-0 items-center text-ods-text-secondary transition-colors duration-200",
-                focused && "text-ods-accent",
+                // Focus accent applies to the SEND icon only. Stop stays neutral
+                // regardless of where focus sits — otherwise it reads yellow after
+                // an Enter-send (editor keeps focus) but gray after an approve
+                // click (focus moved to the card button).
+                focused && !isStopMode && "text-ods-accent",
                 "[&_svg]:size-4 md:[&_svg]:size-6",
                 "cursor-pointer hover:text-ods-text-primary",
                 "focus-visible:outline-none focus-visible:text-ods-accent",

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -459,6 +459,18 @@ export function useNatsChatAdapter(
 
   const [messages, setMessages] = useState<UnifiedChatMessage[]>([])
   const [streamingPhase, setStreamingPhase] = useState<StreamingPhase>('idle')
+  // Live mirror for click handlers that must read the CURRENT phase without
+  // re-creating on every phase change (handleApprove's scoped revert).
+  const streamingPhaseRef = useRef(streamingPhase)
+  streamingPhaseRef.current = streamingPhase
+  // Gate: suppress onAgentBusy while the initial catchup replays historical
+  // chunks. A dead tail (approval approved / tool started, then Stop or a
+  // crash — no continuation ever persisted) replays its APPROVAL_RESULT /
+  // EXECUTING_TOOL chunks on every dialog (re)open, and the releasing
+  // MESSAGE_END never replays — locking the composer forever. Live chunks
+  // after catchup lock normally; a reopened mid-execution dialog re-locks on
+  // the next live chunk instead.
+  const suppressAgentBusyRef = useRef(false)
 
   // Approval status map. Used both to dedupe pending segments at render
   // time and to feed `processHistoricalMessagesWithErrors` so previously
@@ -508,6 +520,13 @@ export function useNatsChatAdapter(
     async (requestId: string) => {
       if (!approveRequestCallback) return
       setApprovalStatuses((prev) => ({ ...prev, [requestId]: 'approved' }))
+      // Approval hands the turn back to the agent — lock the composer now
+      // rather than waiting for the APPROVAL_RESULT/EXECUTING_TOOL chunks.
+      // Remember whether THIS click took the lock: if the phase was already
+      // busy (another approval's command executing), a failure of this
+      // request must not release a lock it doesn't own.
+      const tookLock = streamingPhaseRef.current === 'idle'
+      setStreamingPhase((p) => (p === 'idle' ? 'thinking' : p))
       try {
         await approveRequestCallback(requestId)
       } catch (err) {
@@ -517,6 +536,9 @@ export function useNatsChatAdapter(
           delete next[requestId]
           return next
         })
+        if (tookLock) {
+          setStreamingPhase((p) => (p === 'thinking' ? 'idle' : p))
+        }
         console.error('[useNatsChatAdapter] approveRequest failed:', err)
       }
     },
@@ -526,6 +548,11 @@ export function useNatsChatAdapter(
   const handleReject = useCallback(
     async (requestId: string, reason?: string) => {
       if (!rejectRequestCallback) return
+      // Deliberately NO phase lock here (asymmetric with handleApprove):
+      // rejection keeps the composer free so the user can type a correction
+      // right away — see the matching `approved`-only onAgentBusy guard in
+      // use-realtime-chunk-processor's approval_result case. If the agent
+      // does stream an acknowledgment, MESSAGE_START locks the composer then.
       setApprovalStatuses((prev) => ({ ...prev, [requestId]: 'rejected' }))
       try {
         await rejectRequestCallback(requestId, reason)
@@ -569,6 +596,8 @@ export function useNatsChatAdapter(
     onSegmentsUpdate: (segments: MessageSegment[]) => void
     onStreamStart: () => void
     onStreamEnd: () => void
+    onAgentBusy: () => void
+    onError: () => void
     onTokenUsage: (data: DialogTokenUsage) => void
     onMetadata: (meta: {
       modelDisplayName?: string
@@ -582,6 +611,18 @@ export function useNatsChatAdapter(
     },
     onStreamStart: () => setStreamingPhase('streaming'),
     onStreamEnd: () => setStreamingPhase('idle'),
+    // Agent is executing (approved) commands outside an open stream — keep
+    // the composer locked exactly like the in-stream phases. An open stream
+    // keeps ownership: only 'idle' upgrades to 'thinking'. Suppressed during
+    // initial catchup so a replayed dead tail can't lock a finished dialog.
+    onAgentBusy: () => {
+      if (suppressAgentBusyRef.current) return
+      setStreamingPhase((p) => (p === 'idle' ? 'thinking' : p))
+    },
+    // Terminal turn failures can arrive without a MESSAGE_END; unlock the
+    // composer unless an open stream still owns the phase (in-stream errors
+    // are followed by the stream's own MESSAGE_END).
+    onError: () => setStreamingPhase((p) => (p === 'streaming' ? p : 'idle')),
     // Live cumulative token counter for the active dialog — drives the
     // composer's "X / Y tokens used" tail as the assistant streams.
     onTokenUsage: (data: DialogTokenUsage) => setDialogTokenUsage(data),
@@ -602,6 +643,8 @@ export function useNatsChatAdapter(
       onSegmentsUpdate: (segments) => callbacksRef.current.onSegmentsUpdate(segments),
       onStreamStart: () => callbacksRef.current.onStreamStart(),
       onStreamEnd: () => callbacksRef.current.onStreamEnd(),
+      onAgentBusy: () => callbacksRef.current.onAgentBusy(),
+      onError: () => callbacksRef.current.onError(),
       onTokenUsage: (data) => callbacksRef.current.onTokenUsage(data),
       onMetadata: (meta) => callbacksRef.current.onMetadata(meta),
       onApprove: accumApprove,
@@ -733,11 +776,17 @@ export function useNatsChatAdapter(
   // was already snapshotted.
   useEffect(() => {
     if (!active || !dialogId) return
+    // Gate onAgentBusy for the replay window (see suppressAgentBusyRef).
+    suppressAgentBusyRef.current = true
     resetChunkTracking()
     startInitialBuffering()
-    catchUpChunks().catch((err) => {
-      console.error('[useNatsChatAdapter] initial catchup failed:', err)
-    })
+    catchUpChunks()
+      .catch((err) => {
+        console.error('[useNatsChatAdapter] initial catchup failed:', err)
+      })
+      .finally(() => {
+        suppressAgentBusyRef.current = false
+      })
   }, [active, dialogId, resetChunkTracking, startInitialBuffering, catchUpChunks])
 
   // ─── Live NATS subscription ───────────────────────────────────────────────

--- a/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
@@ -80,6 +80,12 @@ export function useRealtimeChunkProcessor(
   // by the host flag (optimistic) or by an in-order DIRECT_MESSAGE chunk.
   const directModeFlagRef = useRef(isDirectMode)
   const sawDirectMessageRef = useRef(false)
+  // One-shot teardown guard for the barrier. Busy state can be asserted
+  // OUTSIDE an open stream (onAgentBusy on tool/approval chunks), so the
+  // teardown must fire once even when isInStreamRef is false — otherwise a
+  // human takeover right after an approval leaves the consumer's composer
+  // locked forever (all releasing AI chunks get dropped by the barrier).
+  const directTeardownFiredRef = useRef(false)
   useEffect(() => {
     directModeFlagRef.current = isDirectMode
   }, [isDirectMode])
@@ -110,10 +116,14 @@ export function useRealtimeChunkProcessor(
       if (action.action === 'direct_message') sawDirectMessageRef.current = true
 
       if ((directModeFlagRef.current || sawDirectMessageRef.current) && !DIRECT_MODE_ALLOWED.has(action.action)) {
-        // Hard stop: tear down an open AI stream exactly once so the typing
-        // indicator and half-rendered bubble clear, then drop the chunk.
-        if (isInStreamRef.current) {
+        // Hard stop: tear down AI activity exactly once so the typing
+        // indicator, composer lock, and half-rendered bubble clear, then drop
+        // the chunk. Fires even when no stream is open — an onAgentBusy lock
+        // (approved commands executing post-MESSAGE_END) has no other release
+        // once the barrier starts dropping the continuation chunks.
+        if (isInStreamRef.current || !directTeardownFiredRef.current) {
           isInStreamRef.current = false
+          directTeardownFiredRef.current = true
           callbacks.onStreamEnd?.()
           accumulator.resetSegments()
         }
@@ -164,6 +174,12 @@ export function useRealtimeChunkProcessor(
         }
 
         case 'tool_execution': {
+          // A starting tool run means the agent's turn is in progress even
+          // when this lands after MESSAGE_END (approved commands execute
+          // between the approval bubble and the continuation stream).
+          if (action.segment.data.type === 'EXECUTING_TOOL') {
+            callbacks.onAgentBusy?.()
+          }
           // Post-MESSAGE_END tool chunks (cancellations / async batch
           // results for a batch in a prior bubble) flow only through the
           // cross-message updater. Skipping the accumulator avoids
@@ -254,6 +270,11 @@ export function useRealtimeChunkProcessor(
 
         case 'approval_result': {
           const { requestId, approved, approvalType, resolvedByName } = action
+          // Approved → the agent resumes to execute the command(s); surface
+          // busy immediately so the composer locks before EXECUTING_TOOL
+          // lands. Rejection keeps the input free — the user may want to
+          // type a correction right away.
+          if (approved) callbacks.onAgentBusy?.()
           const escalatedData = pendingEscalatedRef.current.get(requestId)
           const status: ChatApprovalStatus = approved ? 'approved' : 'rejected'
 
@@ -397,6 +418,7 @@ export function useRealtimeChunkProcessor(
     pendingEscalatedRef.current.clear()
     hasInitializedWithData.current = false
     sawDirectMessageRef.current = false
+    directTeardownFiredRef.current = false
   }, [])
 
   const updateApprovalStatus = useCallback(

--- a/openframe-frontend-core/src/components/chat/types/api.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/api.types.ts
@@ -199,6 +199,16 @@ export interface RealtimeChunkCallbacks {
    * outlived its message scope. Idempotent.
    */
   onToolExecuted?: (segment: ToolExecutionSegment) => void
+  /**
+   * Called when a chunk implies the agent is actively working OUTSIDE an open
+   * MESSAGE_START/MESSAGE_END window: an `EXECUTING_TOOL` chunk, or an
+   * `APPROVAL_RESULT` that approved execution. Approved commands run between
+   * the approval bubble's MESSAGE_END and the continuation stream, so without
+   * this signal a phase keyed on stream boundaries reads as idle while tools
+   * execute. The busy window is closed by the continuation's MESSAGE_END, an
+   * ERROR chunk, or a user stop.
+   */
+  onAgentBusy?: () => void
   /** Called when a DIALOG_CLOSED chunk is received */
   onDialogClosed?: () => void
 }


### PR DESCRIPTION
## Problem

When the AI agent processes an approved command (or batch), the chat composer input did not lock. The busy state was keyed solely on `MESSAGE_START`/`MESSAGE_END` stream boundaries, but the backend closes the stream right after the approval card — `APPROVAL_RESULT` / `EXECUTING_TOOL` / `EXECUTED_TOOL` chunks arrive **outside** that window, so `streamingPhase` read as `idle` while commands executed and the user could type mid-execution.

## Changes

### `use-realtime-chunk-processor.ts` + `api.types.ts`
- New **optional** callback `RealtimeChunkCallbacks.onAgentBusy`, fired on `EXECUTING_TOOL` chunks and on **approved** `APPROVAL_RESULT` chunks. Rejection deliberately keeps the input free (the user may want to type a correction right away). Additive and backward compatible — consumers that don't wire it are unaffected.
- Direct-mode barrier teardown now fires **once even when no stream is open**: an out-of-stream busy lock (approved commands executing) is released when a human takes over the dialog; previously the teardown was gated on `isInStreamRef` and the lock would survive forever.

### `use-nats-chat-adapter.ts`
- Wires `onAgentBusy` → `streamingPhase: idle → thinking` (an open stream keeps ownership).
- Optimistic lock on approve **click** (bridges the mutation round-trip), with an **ownership-scoped** catch revert (`tookLock`): a failed approve of card B no longer releases a lock owned by card A's still-executing command.
- `onError` → `idle` safety: terminal turn failures without a `MESSAGE_END` no longer leave the composer stuck in `thinking`.
- `onAgentBusy` is **suppressed during initial catchup**: a replayed dead tail (user hit Stop mid-execution / backend crashed; `MESSAGE_END` is non-persisted and never replays) can no longer lock a finished dialog on every reopen.
- `handleReject` documents the deliberate no-lock asymmetry with `handleApprove`.

### `chat-input.tsx`
- Stop button stays neutral gray regardless of editor focus — the focus accent now applies to the send icon only (previously the stop icon read yellow after an Enter-send but gray after an approve click).

## Verification
- `tsc --noEmit` and build clean; multi-agent review (8 finder angles + per-finding adversarial verification) ran over the diff, and all confirmed findings are addressed in this PR or in the paired consumer-side PR.

## Shipping note
The paired `openframe-frontend` (oss-tenant) change consumes `onAgentBusy` — **publish this package first**. The callback is optional, so ordering is only about feature completeness, not type breakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat composer state handling during approvals, tool execution, initial message loading, and streaming errors.
  * Prevented the composer from remaining locked or showing an incorrect typing indicator after approval or continuation events.
  * Ensured busy indicators activate consistently when the assistant begins background work.
  * Corrected send button focus styling so stop mode no longer displays send-mode accent text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->