### PR TITLE
fix(embed-shims): soft-navigate in next/navigation router fallback

### DIFF
--- a/openframe-frontend-core/src/embed-shims/__tests__/next-navigation.test.ts
+++ b/openframe-frontend-core/src/embed-shims/__tests__/next-navigation.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/**
+ * Regression tests for the `next/navigation` shim fallback (unregistered host).
+ *
+ * The guarantee under test: an unregistered `useRouter().push/replace` must
+ * perform a same-origin SPA navigation via the History API and NEVER hard-load
+ * the document — a `?search=` write from `useApiParams` used to hard-reload via
+ * `window.location.replace`. The registered path must delegate to the host
+ * router untouched.
+ *
+ * `impl` is module-level singleton state, so each test re-imports the module
+ * fresh via `vi.resetModules()` to isolate registration state. We also stub
+ * `window.location` with a spy object so any hard navigation (assign/replace/
+ * reload) is observable — jsdom leaves those methods unimplemented anyway.
+ */
+
+const ORIGIN = 'http://localhost:3000'
+
+async function freshModule() {
+  vi.resetModules()
+  return import('../next-navigation')
+}
+
+let assignSpy: ReturnType<typeof vi.fn>
+let replaceSpy: ReturnType<typeof vi.fn>
+let reloadSpy: ReturnType<typeof vi.fn>
+let pushStateSpy: ReturnType<typeof vi.spyOn>
+let replaceStateSpy: ReturnType<typeof vi.spyOn>
+let originalLocation: Location
+
+beforeEach(() => {
+  originalLocation = window.location
+  assignSpy = vi.fn()
+  replaceSpy = vi.fn()
+  reloadSpy = vi.fn()
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: {
+      href: `${ORIGIN}/`,
+      origin: ORIGIN,
+      pathname: '/',
+      search: '',
+      assign: assignSpy,
+      replace: replaceSpy,
+      reload: reloadSpy,
+    },
+  })
+  // Real jsdom history — spy without changing behavior so we can assert which
+  // History API the fallback used (push vs replace encodes the nav semantics).
+  pushStateSpy = vi.spyOn(window.history, 'pushState')
+  replaceStateSpy = vi.spyOn(window.history, 'replaceState')
+})
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation })
+  vi.restoreAllMocks()
+})
+
+describe('fallback useRouter (unregistered host)', () => {
+  it('replace() writes the URL via history.replaceState — never a hard navigation', async () => {
+    const { useRouter } = await freshModule()
+    const popstate = vi.fn()
+    window.addEventListener('popstate', popstate)
+
+    useRouter().replace('?search=laptop')
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', `${ORIGIN}/?search=laptop`)
+    expect(pushStateSpy).not.toHaveBeenCalled()
+    // No full-document navigation of any kind — this is the reported bug.
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+    // Subscribers (usePathname/useSearchParams) get a re-render signal.
+    expect(popstate).toHaveBeenCalledTimes(1)
+
+    window.removeEventListener('popstate', popstate)
+  })
+
+  it('push() uses history.pushState (new entry) — never a hard navigation', async () => {
+    const { useRouter } = await freshModule()
+    useRouter().push('/scripts?tab=list')
+
+    expect(pushStateSpy).toHaveBeenCalledWith(null, '', `${ORIGIN}/scripts?tab=list`)
+    expect(replaceStateSpy).not.toHaveBeenCalled()
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real navigation for cross-origin targets', async () => {
+    const { useRouter } = await freshModule()
+    useRouter().replace('https://example.com/evil')
+
+    expect(assignSpy).toHaveBeenCalledWith('https://example.com/evil')
+    expect(replaceStateSpy).not.toHaveBeenCalled()
+    expect(pushStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real navigation for a malformed href', async () => {
+    const { useRouter } = await freshModule()
+    useRouter().push('http://[invalid')
+
+    expect(assignSpy).toHaveBeenCalledWith('http://[invalid')
+    expect(pushStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('back/forward remain history-based (unchanged)', async () => {
+    const { useRouter } = await freshModule()
+    const backSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {})
+    const forwardSpy = vi.spyOn(window.history, 'forward').mockImplementation(() => {})
+    useRouter().back()
+    useRouter().forward()
+    expect(backSpy).toHaveBeenCalledTimes(1)
+    expect(forwardSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('registered useRouter (Next host)', () => {
+  it('delegates to the host router and never touches window.location or history', async () => {
+    const { useRouter, registerNavigation } = await freshModule()
+    const hostRouter = {
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    }
+    registerNavigation({ useRouter: () => hostRouter })
+
+    const r = useRouter()
+    r.replace('?search=laptop', { scroll: false })
+    r.push('/scripts')
+
+    expect(hostRouter.replace).toHaveBeenCalledWith('?search=laptop', { scroll: false })
+    expect(hostRouter.push).toHaveBeenCalledWith('/scripts')
+    // The fallback path is completely bypassed — no navigation side effects.
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(reloadSpy).not.toHaveBeenCalled()
+    expect(pushStateSpy).not.toHaveBeenCalled()
+    expect(replaceStateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/openframe-frontend-core/src/embed-shims/__tests__/next-navigation.test.ts
+++ b/openframe-frontend-core/src/embed-shims/__tests__/next-navigation.test.ts
@@ -87,21 +87,42 @@ describe('fallback useRouter (unregistered host)', () => {
     expect(reloadSpy).not.toHaveBeenCalled()
   })
 
-  it('falls back to a real navigation for cross-origin targets', async () => {
+  it('falls back to a real navigation for cross-origin targets, honoring replace semantics', async () => {
     const { useRouter } = await freshModule()
     useRouter().replace('https://example.com/evil')
 
-    expect(assignSpy).toHaveBeenCalledWith('https://example.com/evil')
+    // replace() must use location.replace (no back-button entry), not assign.
+    expect(replaceSpy).toHaveBeenCalledWith('https://example.com/evil')
+    expect(assignSpy).not.toHaveBeenCalled()
     expect(replaceStateSpy).not.toHaveBeenCalled()
     expect(pushStateSpy).not.toHaveBeenCalled()
   })
 
-  it('falls back to a real navigation for a malformed href', async () => {
+  it('uses location.assign for a cross-origin push (new history entry)', async () => {
+    const { useRouter } = await freshModule()
+    useRouter().push('https://example.com/evil')
+
+    expect(assignSpy).toHaveBeenCalledWith('https://example.com/evil')
+    expect(replaceSpy).not.toHaveBeenCalled()
+    expect(pushStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real navigation for a malformed href (push → assign)', async () => {
     const { useRouter } = await freshModule()
     useRouter().push('http://[invalid')
 
     expect(assignSpy).toHaveBeenCalledWith('http://[invalid')
+    expect(replaceSpy).not.toHaveBeenCalled()
     expect(pushStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a real navigation for a malformed href (replace → replace)', async () => {
+    const { useRouter } = await freshModule()
+    useRouter().replace('http://[invalid')
+
+    expect(replaceSpy).toHaveBeenCalledWith('http://[invalid')
+    expect(assignSpy).not.toHaveBeenCalled()
+    expect(replaceStateSpy).not.toHaveBeenCalled()
   })
 
   it('back/forward remain history-based (unchanged)', async () => {

--- a/openframe-frontend-core/src/embed-shims/next-navigation.tsx
+++ b/openframe-frontend-core/src/embed-shims/next-navigation.tsx
@@ -22,9 +22,11 @@
  * After registration, every exported hook in this file delegates to
  * the real implementation. Without registration, the stubs run:
  *
- *   - `useRouter()` → push/replace use `window.location.assign/replace`;
- *     back/forward use `history.back/forward`; refresh reloads; prefetch
- *     is a no-op.
+ *   - `useRouter()` → push/replace do a same-origin SPA navigation via the
+ *     History API (`pushState`/`replaceState` + a synthetic `popstate`), so a
+ *     query-param write never reloads the document; cross-origin/malformed
+ *     hrefs fall back to `window.location`. back/forward use
+ *     `history.back/forward`; refresh reloads; prefetch is a no-op.
  *   - `usePathname()` → returns `window.location.pathname` (popstate-
  *     subscribed so back/forward re-renders).
  *   - `useSearchParams()` → returns `URLSearchParams` view of
@@ -34,10 +36,12 @@
  *   - `notFound()` / `redirect()` / `permanentRedirect()` —
  *     best-effort equivalents using `window.location`.
  *
- * The fallback path subscribes to `popstate` only. Programmatic
- * `pushState`/`replaceState` does NOT fire popstate, so the fallback
- * does not auto-re-render on programmatic navigation. Embedders that
- * need that should register a real router or supply their own.
+ * The fallback path subscribes to `popstate`. Native `pushState`/
+ * `replaceState` do NOT fire popstate, but the fallback `useRouter`'s
+ * push/replace dispatch a synthetic `popstate` so this file's own
+ * `usePathname`/`useSearchParams` subscribers re-render. A URL mutated
+ * through some OTHER API still won't auto-re-render here — embedders
+ * that need that should register a real router or supply their own.
  */
 'use client'
 import { useEffect, useState } from 'react'
@@ -95,11 +99,39 @@ const noopRouter: RouterStub = {
   prefetch: () => {},
 }
 
+/**
+ * SPA navigation for the unregistered fallback. Uses the History API instead of
+ * `window.location.assign/replace` so a same-origin URL change (e.g. a table's
+ * `?search=` write via `useApiParams`) never triggers a full document reload —
+ * even if a real router was never registered, or the registration landed on a
+ * DIFFERENT module instance than this one (duplicate lib copy / ESM-CJS dual
+ * package). A synthetic `popstate` is dispatched so this file's own
+ * `usePathname`/`useSearchParams` subscribers re-render in response.
+ * Cross-origin or malformed hrefs still fall back to a real `window.location`
+ * navigation, which is the only correct behavior there.
+ */
+function softNavigate(href: string, mode: 'push' | 'replace'): void {
+  if (typeof window === 'undefined') return
+  try {
+    const url = new URL(href, window.location.href)
+    if (url.origin !== window.location.origin) {
+      window.location.assign(url.href)
+      return
+    }
+    if (mode === 'push') window.history.pushState(null, '', url.href)
+    else window.history.replaceState(null, '', url.href)
+    window.dispatchEvent(new PopStateEvent('popstate'))
+  } catch {
+    // Malformed href — a real navigation is safer than swallowing it.
+    window.location.assign(href)
+  }
+}
+
 function fallbackUseRouter(): RouterStub {
   if (typeof window === 'undefined') return noopRouter
   return {
-    push: (href: string) => window.location.assign(href),
-    replace: (href: string) => window.location.replace(href),
+    push: (href: string) => softNavigate(href, 'push'),
+    replace: (href: string) => softNavigate(href, 'replace'),
     back: () => window.history.back(),
     forward: () => window.history.forward(),
     refresh: () => window.location.reload(),

--- a/openframe-frontend-core/src/embed-shims/next-navigation.tsx
+++ b/openframe-frontend-core/src/embed-shims/next-navigation.tsx
@@ -115,15 +115,20 @@ function softNavigate(href: string, mode: 'push' | 'replace'): void {
   try {
     const url = new URL(href, window.location.href)
     if (url.origin !== window.location.origin) {
-      window.location.assign(url.href)
+      // Preserve the caller's history semantics: replace() must not leave a
+      // back-button entry, so it uses `location.replace`, not `location.assign`.
+      if (mode === 'push') window.location.assign(url.href)
+      else window.location.replace(url.href)
       return
     }
     if (mode === 'push') window.history.pushState(null, '', url.href)
     else window.history.replaceState(null, '', url.href)
     window.dispatchEvent(new PopStateEvent('popstate'))
   } catch {
-    // Malformed href — a real navigation is safer than swallowing it.
-    window.location.assign(href)
+    // Malformed href — a real navigation is safer than swallowing it, but still
+    // honor push vs replace history semantics.
+    if (mode === 'push') window.location.assign(href)
+    else window.location.replace(href)
   }
 }
 


### PR DESCRIPTION
## Проблема

В шиме `src/embed-shims/next-navigation.tsx` незарегистрированный фолбэк `useRouter().push/replace` использовал `window.location.assign/replace`. Из-за этого same-origin запись `?search=` (например, из `useApiParams`) вызывала полную перезагрузку документа вместо SPA-навигации — в том числе когда реальный роутер не зарегистрирован либо регистрация попала в другой инстанс модуля (дубликат библиотеки / ESM-CJS dual package).

## Решение

`softNavigate()` роутит same-origin push/replace через History API (`pushState`/`replaceState` + синтетический `popstate`), поэтому запись query-параметров остаётся SPA и подписчики этого файла (`usePathname`/`useSearchParams`) ре-рендерятся. Cross-origin и malformed href по-прежнему уходят в реальную `window.location`-навигацию — единственно корректное поведение там.

## Тесты

Добавлены регрессионные тесты (`__tests__/next-navigation.test.ts`), покрывающие фолбэк push/replace, cross-origin и malformed фолбэки, back/forward и путь с зарегистрированным host-роутером. Все 6 проходят.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedded navigation so same-origin route changes update the page without a full reload.
  * Ensured pathname and search parameter displays refresh after programmatic navigation.
  * Preserved standard navigation for cross-origin and invalid destinations.
  * Maintained host router behavior when available, including browser back and forward navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->