### PR TITLE
FRONTEND CORE: StackedRowsPanel — leadingIcon column slot for info-banner rows

### DIFF
--- a/openframe-frontend-core/src/components/ui/stacked-rows-panel.tsx
+++ b/openframe-frontend-core/src/components/ui/stacked-rows-panel.tsx
@@ -35,6 +35,9 @@ export interface PanelColumn {
   label?: string
   /** Icon shown before the value. */
   icon?: React.ReactNode
+  /** Icon shown before the whole value/label stack, vertically centered against
+   *  both lines (the info-banner pattern: 24px glyph + title + caption). */
+  leadingIcon?: React.ReactNode
   /** When set, the cell becomes an external link. */
   href?: string
   /** Tailwind width class. Defaults to `flex-[1_0_0] min-w-0`. */
@@ -127,6 +130,17 @@ function PanelCell({ column }: { column: PanelColumn }) {
   if (column.content !== undefined) {
     return (
       <div className={cn(hideClass, "flex-col", ALIGN_CLASS[column.align ?? "left"], widthClass)}>{column.content}</div>
+    )
+  }
+
+  if (column.leadingIcon) {
+    return (
+      <div className={cn(hideClass, "items-center gap-[var(--spacing-system-s)]", widthClass)}>
+        <span className="shrink-0">{column.leadingIcon}</span>
+        <div className={cn("flex min-w-0 flex-1 flex-col justify-center", CELL_ITEMS_ALIGN[column.align ?? "left"])}>
+          <CellValue column={column} />
+        </div>
+      </div>
     )
   }
 

--- a/openframe-frontend-core/src/stories/StackedRowsPanel.stories.tsx
+++ b/openframe-frontend-core/src/stories/StackedRowsPanel.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { useMemo } from 'react'
+import { InfoCircleIcon } from '../components/icons-v2-generated/signs-and-symbols'
 import { type ColumnDef, DataTable, type Row, useDataTable } from '../components/ui/data-table'
 import { EntityImage } from '../components/ui/entity-image'
 import { StackedRowsPanel } from '../components/ui/stacked-rows-panel'
@@ -102,6 +103,26 @@ export const StandardTable: Story = {
 export const SingleRow: Story = {
   args: {
     rows: [{ id: 'only', columns: [{ key: 'only', value: 'High CPU Usage >85%', label: 'Policy' }] }],
+  },
+}
+
+/** Info-banner row: `leadingIcon` centers a 24px glyph against both text lines. */
+export const InfoBanner: Story = {
+  args: {
+    rows: [
+      {
+        id: 'banner',
+        className: 'p-[var(--spacing-system-s)]',
+        columns: [
+          {
+            key: 'banner',
+            leadingIcon: <InfoCircleIcon className="size-6 text-ods-text-secondary" />,
+            value: 'Using OpenFrame default actions',
+            label: 'These quick actions are curated and approved by OpenFrame.',
+          },
+        ],
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Description

PanelColumn.leadingIcon renders a glyph before the whole value/label stack, vertically centered against both lines (unlike `icon`, which sits inline with the value). Covers the settings info-banner pattern ("Using OpenFrame default actions") shared with the website; includes an InfoBanner story.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional leading icons in stacked row panels.
  * Icons can now appear beside vertically centered labels and values.
  * Added an example banner row demonstrating the new icon layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->