### PR TITLE
Add whitelist on shared gateway for Fleet endpoints

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/prop/FleetMultiTenancyProperties.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/prop/FleetMultiTenancyProperties.java
@@ -1,0 +1,44 @@
+package com.openframe.gateway.config.prop;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for OpenFrame Fleet MDM multi-tenancy at the gateway.
+ *
+ * <p>Bound from {@code openframe.fleet.multi-tenancy.*} — the same platform switch that enables
+ * Fleet's shared-DB multi-tenancy. When {@code enabled} is true, the Fleet browser proxy
+ * ({@code /tools/fleetmdm-server/**}) is restricted to {@code allowedEndpoints}; every other tool and
+ * the disabled state are unaffected.
+ *
+ * <pre>
+ * openframe:
+ *   fleet:
+ *     multi-tenancy:
+ *       enabled: true
+ *       allowed-endpoints:
+ *         - "GET /api/{v}/fleet/hosts"
+ *         - "DELETE /api/{v}/fleet/labels/id/{id}"
+ * </pre>
+ */
+@Data
+@Component
+@ConfigurationProperties(prefix = "openframe.fleet.multi-tenancy")
+public class FleetMultiTenancyProperties {
+
+    /**
+     * Master switch for Fleet multi-tenancy behavior at the gateway (the endpoint allowlist).
+     */
+    private boolean enabled = false;
+
+    /**
+     * Allowlisted Fleet endpoints for the browser proxy, each {@code "METHOD pattern"} in Spring
+     * PathPattern syntax matched against the path after {@code /tools/fleetmdm-server}. Only consulted
+     * when {@link #enabled} is true.
+     */
+    private List<String> allowedEndpoints = new ArrayList<>();
+}

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/FleetEndpointAllowlist.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/FleetEndpointAllowlist.java
@@ -1,0 +1,89 @@
+package com.openframe.gateway.service;
+
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.server.PathContainer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Global endpoint allowlist for the Fleet MDM browser proxy ({@code /tools/fleetmdm-server/**}).
+ *
+ * <p>Under shared multi-tenancy the tenant UI reaches Fleet through a raw pass-through proxy,
+ * authenticated as the tenant's Fleet global-admin token — so a browser could call any of Fleet's
+ * ~188 REST endpoints, far more than the ~30 the UI actually uses. This allowlist restricts the
+ * proxy to a configured set, blocking everything else with 403. It is defense in depth over Fleet's
+ * own datastore tenant fences.
+ *
+ * <p><b>Scope and gating (deliberately narrow):</b>
+ * <ul>
+ *   <li>Applies to <b>only</b> {@code fleetmdm-server}. Every other tool proxies unfiltered.</li>
+ *   <li>Active <b>only</b> when {@code openframe.fleet.multi-tenancy.enabled=true}. Off ⇒ no
+ *       filtering at all.</li>
+ * </ul>
+ *
+ * <p>The allowed set is <b>gateway-global configuration</b> (not per-tenant): every tenant runs the
+ * identical Fleet UI, so the list is one value on the shared gateway
+ * ({@code openframe.fleet.multi-tenancy.allowed-endpoints}, see {@link FleetMultiTenancyProperties}).
+ * Entries are {@code "METHOD pattern"} in Spring {@link PathPattern} syntax, matched against the path
+ * <em>after</em> {@code /tools/fleetmdm-server}. Only the browser plane ({@code proxyApiRequest}) is
+ * checked; the agent plane uses a separate proxy method and is never filtered here.
+ */
+@Component
+public class FleetEndpointAllowlist {
+
+    static final String FLEET_TOOL_ID = "fleetmdm-server";
+
+    private final boolean multiTenancyEnabled;
+    private final Map<HttpMethod, List<PathPattern>> fleetPatterns;
+
+    public FleetEndpointAllowlist(FleetMultiTenancyProperties properties) {
+        this.multiTenancyEnabled = properties.isEnabled();
+        this.fleetPatterns = compile(properties.getAllowedEndpoints());
+    }
+
+    /**
+     * @return true if the browser proxy may forward this request. Always true unless multi-tenancy
+     * is enabled and the tool is {@code fleetmdm-server}, in which case only the configured
+     * method+path combinations pass.
+     */
+    public boolean isAllowed(String toolId, HttpMethod method, String path) {
+        if (!multiTenancyEnabled || !FLEET_TOOL_ID.equals(toolId)) {
+            return true;
+        }
+        List<PathPattern> patterns = fleetPatterns.get(method);
+        if (patterns == null) {
+            return false;
+        }
+        PathContainer container = PathContainer.parsePath(path);
+        for (PathPattern pattern : patterns) {
+            if (pattern.matches(container)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Map<HttpMethod, List<PathPattern>> compile(List<String> entries) {
+        PathPatternParser parser = new PathPatternParser();
+        Map<HttpMethod, List<PathPattern>> byMethod = new HashMap<>();
+        if (entries == null) {
+            return byMethod;
+        }
+        for (String entry : entries) {
+            String[] parts = entry.trim().split("\\s+", 2);
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid allowlist entry (expected \"METHOD pattern\"): " + entry);
+            }
+            HttpMethod method = HttpMethod.valueOf(parts[0].toUpperCase());
+            byMethod.computeIfAbsent(method, m -> new ArrayList<>()).add(parser.parse(parts[1]));
+        }
+        return byMethod;
+    }
+}

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
@@ -2,7 +2,6 @@ package com.openframe.gateway.service;
 
 import com.openframe.data.document.tool.IntegratedTool;
 import com.openframe.data.reactive.repository.tool.ReactiveIntegratedToolRepository;
-import com.openframe.data.service.TenantIdProvider;
 import com.openframe.gateway.config.CurlLoggingHandler;
 import com.openframe.gateway.tenant.TenantRoutingHeaders;
 import com.openframe.gateway.upstream.ToolUpstreamResolverRegistry;
@@ -41,6 +40,7 @@ public class RestProxyService {
     private final ReactiveIntegratedToolRepository toolRepository;
     private final ToolUpstreamResolverRegistry upstreamRegistry;
     private final ToolApiKeyHeadersResolver apiKeyHeadersResolver;
+    private final FleetEndpointAllowlist fleetEndpointAllowlist;
 
     /**
      * Whether this gateway runs in shared multi-tenant routing mode. When true, a tool lookup with no
@@ -56,6 +56,11 @@ public class RestProxyService {
                     if (!tool.isEnabled()) {
                         return Mono
                                 .just(ResponseEntity.badRequest().body("Tool " + tool.getName() + " is not enabled"));
+                    }
+
+                    if (!isProxyEndpointAllowed(toolId, request)) {
+                        return Mono.just(ResponseEntity.status(HttpStatus.FORBIDDEN)
+                                .body("Endpoint not permitted for tool: " + toolId));
                     }
 
                     URI targetUri = upstreamRegistry.resolve(toolId).resolveRest(tool, request, "/tools");
@@ -82,6 +87,32 @@ public class RestProxyService {
             return toolRepository.findByTenantIdAndKey(TenantRoutingHeaders.tenantId(request), toolId);
         }
         return toolRepository.findByKey(toolId);
+    }
+
+    /**
+     * Whether the browser proxy may forward this request per the endpoint allowlist (see
+     * {@link FleetEndpointAllowlist}). Logs a warning when it rejects.
+     */
+    private boolean isProxyEndpointAllowed(String toolId, ServerHttpRequest request) {
+        String pathToProxy = pathAfterToolPrefix(request, toolId);
+        boolean allowed = fleetEndpointAllowlist.isAllowed(toolId, request.getMethod(), pathToProxy);
+        if (!allowed) {
+            log.warn("Blocked non-allowlisted endpoint for tool {}: {} {}", toolId, request.getMethod(), pathToProxy);
+        }
+        return allowed;
+    }
+
+    /**
+     * The request path after the {@code /tools/{toolId}} prefix — the segment actually forwarded to
+     * the tool (same slice {@link com.openframe.core.service.ProxyUrlResolver} proxies), matched
+     * against the tool's endpoint allowlist.
+     */
+    private static String pathAfterToolPrefix(ServerHttpRequest request, String toolId) {
+        String fullPath = request.getPath().value();
+        String toolPath = "/tools/" + toolId;
+        int idx = fullPath.indexOf(toolPath);
+        String rest = idx >= 0 ? fullPath.substring(idx + toolPath.length()) : fullPath;
+        return rest.isEmpty() ? "/" : rest;
     }
 
     private Map<String, String> buildApiRequestHeaders(IntegratedTool tool) {
@@ -141,14 +172,14 @@ public class RestProxyService {
             Map<String, String> proxyHeaders,
             String body) {
         HttpClient httpClient = buildHttpClient(targetUri);
-        
+
         WebClient webClient = WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .codecs(configurer -> configurer
                         .defaultCodecs()
                         .maxInMemorySize(16 * 1024 * 1024)) // Increase to 16MB
                 .build();
-                
+
         WebClient.RequestBodySpec requestSpec = webClient
                 .method(method)
                 .uri(targetUri)

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/FleetEndpointAllowlistTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/FleetEndpointAllowlistTest.java
@@ -1,0 +1,85 @@
+package com.openframe.gateway.service;
+
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FleetEndpointAllowlistTest {
+
+    private static final String FLEET = "fleetmdm-server";
+
+    /** A representative slice of the configured Fleet allowlist (see the gateway dev config). */
+    private static final List<String> FLEET_ENDPOINTS = List.of(
+            "GET /api/{v}/fleet/hosts",
+            "GET /api/{v}/fleet/hosts/count",
+            "GET /api/{v}/fleet/hosts/{id}",
+            "GET /api/{v}/fleet/hosts/{id}/policies",
+            "POST /api/{v}/fleet/policies/delete",
+            "POST /api/{v}/fleet/queries/run",
+            "DELETE /api/{v}/fleet/labels/id/{id}",
+            "PUT /api/{v}/fleet/queries/{id}/hosts"
+    );
+
+    private FleetEndpointAllowlist allowlist(boolean enabled, List<String> endpoints) {
+        FleetMultiTenancyProperties props = new FleetMultiTenancyProperties();
+        props.setEnabled(enabled);
+        props.setAllowedEndpoints(endpoints);
+        return new FleetEndpointAllowlist(props);
+    }
+
+    @Test
+    void allowsFleetEndpointsInTheConfiguredList() {
+        FleetEndpointAllowlist a = allowlist(true, FLEET_ENDPOINTS);
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/hosts")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/v1/fleet/hosts/count")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/hosts/1")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/hosts/1/policies")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.POST, "/api/latest/fleet/policies/delete")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.POST, "/api/latest/fleet/queries/run")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.DELETE, "/api/latest/fleet/labels/id/5")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.PUT, "/api/v1/fleet/queries/9/hosts")).isTrue();
+    }
+
+    @Test
+    void blocksFleetEndpointsNotInTheList() {
+        FleetEndpointAllowlist a = allowlist(true, FLEET_ENDPOINTS);
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/software")).isFalse();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/vulnerabilities")).isFalse();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/os_versions")).isFalse();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/activities")).isFalse();
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/users")).isFalse();
+        assertThat(a.isAllowed(FLEET, HttpMethod.POST, "/api/latest/fleet/hosts/transfer")).isFalse();
+    }
+
+    @Test
+    void blocksAllowedFleetPathUnderAWrongMethod() {
+        FleetEndpointAllowlist a = allowlist(true, FLEET_ENDPOINTS);
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/hosts/1")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.DELETE, "/api/latest/fleet/hosts/1")).isFalse();
+    }
+
+    @Test
+    void doesNotFilterOtherTools() {
+        FleetEndpointAllowlist a = allowlist(true, FLEET_ENDPOINTS);
+        assertThat(a.isAllowed("tactical-rmm", HttpMethod.POST, "/anything/at/all")).isTrue();
+        assertThat(a.isAllowed("meshcentral-server", HttpMethod.DELETE, "/api/whatever")).isTrue();
+    }
+
+    @Test
+    void doesNotFilterWhenMultiTenancyDisabled() {
+        FleetEndpointAllowlist a = allowlist(false, FLEET_ENDPOINTS);
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/software")).isTrue();
+        assertThat(a.isAllowed(FLEET, HttpMethod.POST, "/api/latest/fleet/hosts/transfer")).isTrue();
+    }
+
+    @Test
+    void enabledWithEmptyListBlocksAllFleetRequests() {
+        // Fail closed: enabling the flag without configuring the list blocks the Fleet proxy entirely.
+        FleetEndpointAllowlist a = allowlist(true, List.of());
+        assertThat(a.isAllowed(FLEET, HttpMethod.GET, "/api/latest/fleet/hosts")).isFalse();
+    }
+}


### PR DESCRIPTION
## Description

Adds a defense-in-depth **endpoint allowlist** to the shared gateway's Fleet browser proxy (`/tools/fleetmdm-server/**`), in support of Fleet shared-DB multi-tenancy.

**Scoped and flag-gated deliberately:**
- Applies to **`fleetmdm-server` only** — every other tool (`tactical-rmm`, `meshcentral-server`, …) proxies unfiltered.
- Active **only when `openframe.fleet.multi-tenancy.enabled=true`** (the same platform switch that turns on Fleet shared-DB multi-tenancy). Off ⇒ no filtering, behaves exactly as before.
- The allowed set is **shared gateway config** (`openframe.fleet.multi-tenancy.allowed-endpoints`), not per-tenant Mongo — every tenant runs the identical Fleet UI.
- The agent plane (`proxyAgentRequest`) is untouched.

The dev config lives in the shared-gateway overlay (`openframe-saas-shared/configs/dev/openframe-saas-gateway.yml`) and is tracked in that repo. The full mechanism and the canonical endpoint list are documented in `fleetmdm/openframe/docs/gateway-endpoint-allowlist.md`.

## Improvements
- **`FleetEndpointAllowlist`** — new `@Component` that compiles the configured `"METHOD pattern"` list (Spring `PathPattern`; `{v}` = API version, `{id}` = one segment) once at startup into `HttpMethod → List<PathPattern>`. `isAllowed(toolId, method, path)` returns `true` unless the request is for `fleetmdm-server` **and** multi-tenancy is enabled, in which case only allowlisted method+path pass.
- **`FleetMultiTenancyProperties`** — `@ConfigurationProperties(prefix = "openframe.fleet.multi-tenancy")` binding `enabled` + `allowed-endpoints` (no hardcoded list).
- **`RestProxyService.proxyApiRequest`** — returns **403** for non-allowlisted requests before resolving the upstream, via a boolean guard (`isProxyEndpointAllowed`) matching the neighboring `isEnabled` check style.
- **`FleetEndpointAllowlistTest`** — allowed UI calls pass; software/users/vulns/`hosts/transfer` blocked; wrong-method blocked; other tools never filtered; flag-off ⇒ nothing filtered.

Ticket: https://app.clickup.com/t/9013925967/86ajgg91e

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Fleet MDM multi-tenancy controls.
  * Added endpoint allowlisting by HTTP method and path.
  * Blocked non-allowlisted Fleet requests with HTTP 403 responses.
  * Requests for other tools remain unaffected.
  * Disabled multi-tenancy permits all Fleet endpoints; an empty allowlist blocks Fleet requests.

* **Tests**
  * Added coverage for allowed, blocked, method-mismatched, disabled, and empty-allowlist scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->