### PR TITLE
feat(ticket-card): add approved status with green check icon

### DIFF
--- a/openframe-frontend-core/src/components/features/board/ticket-card.tsx
+++ b/openframe-frontend-core/src/components/features/board/ticket-card.tsx
@@ -4,7 +4,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import Link from '../../../embed-shims/next-link'
 import * as React from 'react'
-import { LaptopIcon, Flag02Icon, MessagesIcon } from '../../icons-v2-generated'
+import { LaptopIcon, Flag02Icon, MessagesIcon, CheckCircleIcon } from '../../icons-v2-generated'
 import { SquareAvatar } from '../../ui/square-avatar'
 import { Tag } from '../../ui/tag'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../ui/tooltip'
@@ -31,6 +31,7 @@ export interface TicketCardProps {
   href?: string
   isOverlay?: boolean
   dragDisabled?: boolean
+  approved?: boolean
   renderAssignSlot?: (ticket: BoardTicket) => React.ReactNode
   onApprove?: (ticketId: string, requestId?: string) => void | Promise<void>
   onReject?: (ticketId: string, requestId?: string) => void | Promise<void>
@@ -43,6 +44,7 @@ export function TicketCard({
   href,
   isOverlay = false,
   dragDisabled,
+  approved = false,
   renderAssignSlot,
   onApprove,
   onReject,
@@ -78,7 +80,7 @@ export function TicketCard({
     if (sortable.isDragging) e.preventDefault()
   }
 
-  const hasRightSection = !!(ticket.priority || ticket.assignees?.length || renderAssignSlot)
+  const hasRightSection = !!(approved || ticket.priority || ticket.assignees?.length || renderAssignSlot)
 
   const rightSection = hasRightSection ? (
     <div className="pointer-events-auto flex shrink-0 items-center gap-[var(--spacing-system-xsf)]">
@@ -86,6 +88,14 @@ export function TicketCard({
         <Flag02Icon
           className={cn('size-4', PRIORITY_COLOR_CLASS[ticket.priority])}
           aria-label={`Priority: ${ticket.priority}`}
+        />
+      )}
+      {approved && (
+        <CheckCircleIcon
+          size={20}
+          color="var(--ods-attention-green-success)"
+          className="shrink-0"
+          aria-label="Approved"
         />
       )}
       {renderAssignSlot ? (

--- a/openframe-frontend-core/src/stories/TicketCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/TicketCard.stories.tsx
@@ -191,6 +191,21 @@ export const PendingTechApproval: Story = {
   },
 }
 
+/** `approved` — green check mark in the header right section (resolved look). */
+export const Approved: Story = {
+  args: {
+    ticket: {
+      id: 'ticket-approved',
+      title: 'Slack Installation',
+      ticketNumber: '#1042',
+      status: 'RESOLVED',
+      deviceHostnames: ['PR-OFFICE-02'],
+      organizationName: 'TechFlow Solutions',
+    },
+    approved: true,
+  },
+}
+
 /** `href` set — the whole card is a link (Link anchor overlays the surface). */
 export const AsLink: Story = {
   args: {


### PR DESCRIPTION
- [ ] Does this touch shared lib code used by OpenFrame? If yes, blast radius described below.
- [x] Change is backwards-compatible (no removed/renamed props or exports).
- [x] New components have a Storybook story; touched components without one got a story added.
- [x] `type-check` passes, no new `any`.
- [x] Lint passes (real linter), no new `@ts-ignore` / `eslint-disable`.
- [ ] Tests pass; added tests for new money-path flows / bug fixes.
- [ ] Build passes; preview deploy reviewed.
- [x] Correct reviewer assigned (MPH → [@michaelassraf](https://github.com/michaelassraf); lib → [@oleksandr-blip](https://github.com/oleksandr-blip) / [@pavlo-flamingo](https://github.com/pavlo-flamingo)).

## Description
- Green checkmark status for the TicketCard.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ticket cards can now display a clear approval indicator.
  * Added a Storybook example showing a resolved ticket in its approved state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->