### PR TITLE
fix(frontend-core): settle elevator scrollbars — overlay mode no layout shift (#1436)

### DIFF
--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -3,12 +3,37 @@
   @apply border-border;
 }
 
-/* Elevator scrollbar (ODS): thin grey draggable thumb on a transparent track.
-   Standard properties only — no ::-webkit-scrollbar, so the platform keeps its
-   native rendering mode (e.g. auto-hiding overlay scrollbars on macOS). */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: var(--ods-system-greys-grey) transparent;
+/* Elevator scrollbar, Firefox fallback. Scoped via @supports because
+   scrollbar-width/color would disable ::-webkit-scrollbar styling in Chrome */
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--ods-system-greys-grey) var(--ods-system-greys-soft-grey);
+  }
+}
+
+/* Elevator scrollbar (ODS): 8px track + draggable rounded thumb */
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+*::-webkit-scrollbar-track {
+  background-color: var(--ods-system-greys-soft-grey);
+  border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb {
+  background-color: var(--ods-system-greys-grey);
+  border-radius: 4px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background-color: var(--ods-system-greys-grey-hover);
+}
+
+*::-webkit-scrollbar-corner {
+  background-color: transparent;
 }
 
 body {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrollbar styling for a more consistent ODS appearance across supported browsers.
  * Added distinct scrollbar sizing, track, thumb, hover, and corner treatments for WebKit/Blink browsers.
  * Preserved thin scrollbar styling for Firefox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->