### PR TITLE
FRONTEND CORE: complete-account-form): optional children slot for consumer extra fields

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/complete-account-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/complete-account-form.tsx
@@ -42,6 +42,8 @@ export interface CompleteAccountFormProps {
     confirmPassword?: string
   }
   className?: string
+  /** Extra consumer-provided fields rendered below the built-in fields, above the actions. */
+  children?: React.ReactNode
 }
 
 /**
@@ -73,6 +75,7 @@ export function CompleteAccountForm({
   disabled = false,
   errors,
   className,
+  children,
 }: CompleteAccountFormProps) {
   const fieldsDisabled = disabled || loading
 
@@ -159,6 +162,8 @@ export function CompleteAccountForm({
         onChange={(event) => onConfirmPasswordChange(event.target.value)}
         onKeyDown={handleKeyDown}
       />
+
+      {children}
 
       {/* Actions — optional back + submit */}
       <div className="flex items-center gap-[var(--spacing-system-l)]">


### PR DESCRIPTION
## Description
Rendered between the built-in fields and the actions row, so consumers (e.g. OpenFrame signup's dev-only PR Number input) can add fields inside the form card without forking the component.

## Task
[Add PR number field to registration form behind feature flag (dev only)](https://app.clickup.com/t/9013925967/86ajhzqf3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom content within the account completion form, displayed between the password fields and form actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->