### PR TITLE
fix(chat): scripted-stream loader stays up until replay finishes (no flicker)

### DIFF
--- a/openframe-frontend-core/src/components/chat/utils/scripted-stream.ts
+++ b/openframe-frontend-core/src/components/chat/utils/scripted-stream.ts
@@ -107,5 +107,16 @@ export function buildStreamFrames(messages: HistoricalMessage[]): StreamFrame[] 
   })
 
   if (frames.length === 0) push(revealed, 'idle', false, 0)
+
+  // The streaming/"thinking" indicator must stay up for the WHOLE replay and be
+  // removed only when the stream FINISHES — never blink off between turns or
+  // while text streams (that reads as flicker). So `typing` is true for every
+  // frame except the terminal one; `phase` is left accurate for other logic.
+  // (`ChatMessageList`'s `showStreamingLoader` still hides it on a frame whose
+  // last segment is a pending approval, i.e. when the agent is truly paused.)
+  const lastIdx = frames.length - 1
+  frames.forEach((f, i) => {
+    f.typing = i < lastIdx
+  })
   return frames
 }


### PR DESCRIPTION
## What

Fixes the scripted-conversation streaming indicator flicker in `buildStreamFrames` (the replay engine added in #1460). The "thinking"/streaming loader (`ChatMessageList`'s footer `showStreamingLoader`) was blinking **off** mid-stream: `typing` was set true only on the brief `thinking` frame and false during token streaming + at every between-turn `idle` frame, so the loader disappeared and reappeared repeatedly while the conversation was still streaming.

## Fix

Keep `typing` true for **every frame except the terminal one**, so the loader stays up continuously for the whole replay and is removed only when the stream finishes. `phase` is left accurate for other logic, and `ChatMessageList` still hides the loader on a frame whose last segment is a pending approval (agent genuinely paused).

Verified in the consuming hero demos: loader now goes ON once at replay start → OFF once at completion (or when it pauses on an approval). No mid-stream flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
