### PR TITLE
feat(chat): EmbeddableChat Mingo avatar from agent config icon

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -42,6 +42,7 @@ import { Button } from '../ui/button'
 import { Drawer, DrawerContent } from '../ui/drawer'
 import { HoverDropdown, type HoverDropdownItem } from '../ui/hover-dropdown'
 import { MingoIcon } from '../icons'
+import { EntityIcon } from '../icon-display'
 
 import { MingoOnboardingCard } from './mingo-onboarding-card'
 import { MingoOnboardingCardSkeleton } from './mingo-onboarding-card-skeleton'
@@ -1316,9 +1317,18 @@ function EmbeddableChatInner({
   // REFERENCE. Created inline in JSX it was a fresh element on every render,
   // defeating the memo for all assistant messages (re-rendering completed
   // bubbles — and re-mounting their inline cards — on every realtime chunk).
+  // The Mingo avatar comes from the resolved agent CONFIG icon when one is
+  // available (same server-driven path as every other identity glyph, via
+  // `<EntityIcon>`) — falling back to the built-in `MingoIcon` when no config is
+  // in play (host mode with no `activeAgentSlug`).
   const mingoAssistantIcon = useMemo(
-    () => <MingoIcon className="h-6 w-6" cornerColor="var(--ods-flamingo-cyan-base)" />,
-    [],
+    () =>
+      effectiveAssistantIcon ? (
+        <EntityIcon icon={effectiveAssistantIcon} size={24} />
+      ) : (
+        <MingoIcon className="h-6 w-6" cornerColor="var(--ods-flamingo-cyan-base)" />
+      ),
+    [effectiveAssistantIcon],
   )
 
   // Stable per-message timestamps. The memoized `<ChatMessageEnhanced>`


### PR DESCRIPTION
## What

The `EmbeddableChat` Mingo message avatar now comes from the **resolved agent config icon** (server-driven) instead of the hardcoded `MingoIcon`.

When a config icon is available (i.e. `activeAgentSlug` is set, so the agent config is fetched), the Mingo avatar is rendered from it via `<EntityIcon>` — the same server-driven identity path every other glyph uses, and consistent with how Fae's avatar is resolved. Falls back to the built-in `MingoIcon` when no config is in play (host mode with no `activeAgentSlug`), so existing consumers are unaffected.

Backing a hub review comment ("mingo logo should come from config like for fae") on the homepage hero demos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The chat now displays the configured assistant avatar when available.
  * Falls back to the default Mingo icon when no custom avatar is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->