### PR TITLE
fix(chat): fill-mode message-list skeleton in previewMode so it doesn't scroll

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -1782,8 +1782,15 @@ function EmbeddableChatInner({
                       // skeleton → bubbles doesn't shift the column. The panel
                       // wrapper above already pads (`p-[var(--spacing-system-m)]`),
                       // so the skeleton sits flush (no inner px/pb).
+                      //
+                      // In `previewMode` the chat lives in a fixed-height host box
+                      // (e.g. the Mingo hero demo). The default bottom-anchored
+                      // skeleton overflows a short panel and grows its OWN
+                      // scrollbar — ugly. `fill` top-anchors + clips overflow so
+                      // it reads as "the whole panel is loading" and never scrolls.
                       <ChatMessageListSkeleton
                         fullWidth
+                        fill={previewMode}
                         className="flex-1"
                       />
                     ) : (


### PR DESCRIPTION
## What

Stops the Mingo chat's loading skeleton from growing its own scrollbar and overflowing the fixed-height hero panel on the homepage's **AI Runs Operations** tab.

## Root cause

`EmbeddableChat`'s initial-loading skeleton (`messagesInitialLoading` branch) renders `ChatMessageListSkeleton` in its **non-`fill`** variant — `messageCount=6` rows × `bodyLines=3` each. In a `previewMode` demo the chat lives in a fixed-height host box (the Mingo hero panel is `h-[420px]`); six 3-line rows are much taller than that, so the skeleton's own `overflow-y-auto` container grows a scrollbar and the placeholder rows overflow — visually ugly.

The Fae ("AI Closes Tickets") tab looks correct because it uses a different, `fill`-mode skeleton (`HeroChatSkeleton`). The Mingo tab reuses `EmbeddableChat`'s internal skeleton (to keep the real header + composer chrome), which was non-`fill`.

## Fix

Render the internal skeleton in `fill` mode when `previewMode` is set:

```tsx
<ChatMessageListSkeleton
  fullWidth
  fill={previewMode}
  className="flex-1"
/>
```

`fill` swaps `overflow-y-auto` for `overflow-hidden` and top-anchors the rows, so the skeleton covers the panel and **clips** the excess instead of scrolling — the same "whole panel is loading" pattern the Fae skeleton already uses.

- Scoped to `previewMode`, so real full-height host chats keep the existing bottom-anchored, scrollable-if-needed skeleton — no behavior change there.
- Complements the hub-side fix (flamingo-stack/multi-platform-hub#849) that stopped the demo's stick-to-bottom effect from animating the skeleton.

## Follow-up

After this releases, the hub's pinned `@flamingo-stack/openframe-frontend-core` version needs a bump to pick it up in production.

## Verification

Homepage → **AI Runs Operations** tab → watch the Mingo panel load/reload: the skeleton now fills the panel with no scrollbar and no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)