### PR TITLE
fix(video-bites): pin poster <Image> sizes to card width (stop ~2500px over-fetch)

### DIFF
--- a/openframe-frontend-core/src/components/features/video-bites-strip.tsx
+++ b/openframe-frontend-core/src/components/features/video-bites-strip.tsx
@@ -381,6 +381,12 @@ export function VideoBiteCard({
               src={posterSrc}
               alt=""
               fill
+              // Bite cards are portrait 9:16 at ~234px wide (Figma: 416px tall).
+              // Without `sizes`, `fill` makes the Supabase-optimizing <Image>
+              // assume a full-viewport width and request a ~2500px render for a
+              // 234px slot. Pin it to the card width so the render endpoint
+              // returns a ~2x-retina image instead of the near-full-res poster.
+              sizes="234px"
               unoptimized
               onError={onPosterError}
               className="object-cover"


### PR DESCRIPTION
## Problem

In `VideoBiteCard` the poster layer renders the bite thumbnail with a `fill` `<Image>` but **no `sizes`**:

```tsx
<Image src={posterSrc} alt="" fill unoptimized className="object-cover" />
```

The hub registers a Supabase-optimizing `<Image>` implementation (`SupabaseOptimizedImage`) behind this shim, which rewrites Supabase Storage URLs to the render/resize endpoint. For a `fill` image with no `sizes`, its width heuristic falls back to a full-viewport assumption (~1280px) and then doubles for retina → it requests a **~2496px-wide render** for a card that is only **~234px wide** (portrait 9:16, Figma 416px tall). That's a ~10x oversized transform on every visible poster.

## Fix

Pin `sizes="234px"` (the portrait card's CSS width), so the render endpoint returns a ~2x-retina image (~468px) instead of a near-full-res poster.

```tsx
<Image src={posterSrc} alt="" fill sizes="234px" unoptimized className="object-cover" />
```

Featured bites are 94% portrait 9:16 (50×`9:16` + 26 null/default vs 5×`16:9`), so the card width is a stable target. The handful of 16:9 bites render a slightly smaller-than-native poster behind a play badge — still a large net win, and the video itself plays full-res on hover.

## Impact (measured against live posters)

| Poster | Before (2496px req) | After (468px req) |
|---|---|---|
| product_releases-37-10 | 58,124 B | 18,496 B (−68%) |
| webinars-e6cff6f8-…-0 | 44,330 B | 32,098 B (−28%) |
| what_i_shipped-…-1 | 50,390 B | 36,056 B (−28%) |

Smaller initial paint on the homepage "Testimonials" video-bites strip, and less Supabase render/transform work per poster.

## Verification

- `tsc --noEmit` — no type errors in the changed file (the shim's `ImageProps` already accepts `sizes`).
- Byte comparison above run against the live render endpoint.

## Related

Pairs with hub PR flamingo-stack/multi-platform-hub#851 (Cache-Control on media uploads). This lib change lands via the normal release → hub version-pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)