### PR TITLE
FE CORE: auth-forms: SSO providers on initial login and signup screens

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/create-organization-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/create-organization-form.tsx
@@ -46,14 +46,18 @@ export interface CreateOrganizationFormProps {
   /** Extra content rendered under the domain field, e.g. suggested available domains. */
   domainSlot?: React.ReactNode
   /**
-   * SSO providers to offer. When non-empty the form switches to SSO mode:
-   * fields and the terms checkbox are disabled and the primary submit is
-   * replaced by a stack of provider buttons.
+   * SSO registration alternatives rendered below the primary submit behind an
+   * "or continue with" divider. The form fields stay editable — gate the
+   * buttons with `ssoDisabled` (e.g. until the form validates).
    */
   ssoProviders?: AuthSsoProvider[]
   onSsoClick?: (provider: AuthSsoProvider) => void
+  /** Disables the provider buttons (e.g. until the form validates). */
+  ssoDisabled?: boolean
   /** Verb prefix for provider buttons, e.g. "Continue with". Ignored for "openframe". */
   ssoActionLabel?: string
+  /** Divider text between the primary submit and the SSO buttons. */
+  dividerLabel?: string
   className?: string
 }
 
@@ -86,11 +90,13 @@ export function CreateOrganizationForm({
   domainSlot,
   ssoProviders,
   onSsoClick,
+  ssoDisabled = false,
   ssoActionLabel = 'Continue with',
+  dividerLabel = 'or continue with',
   className,
 }: CreateOrganizationFormProps) {
-  const isSsoMode = !!ssoProviders && ssoProviders.length > 0
-  const fieldsDisabled = disabled || loading || isSsoMode
+  const hasSso = !!ssoProviders && ssoProviders.length > 0
+  const fieldsDisabled = disabled || loading
 
   // Validation messages are deferred while the user is typing (shown on blur or after a pause).
   const emailErr = useDeferredError(errors?.email, email)
@@ -169,29 +175,32 @@ export function CreateOrganizationForm({
       />
 
       {/* Actions */}
-      {isSsoMode ? (
-        <SsoProviderButtons
-          providers={ssoProviders!}
-          onSsoClick={onSsoClick}
-          actionLabel={ssoActionLabel}
-          disabled={disabled || loading}
-        />
-      ) : (
-        <div className="flex items-center gap-[var(--spacing-system-l)]">
-          {/* Spacer keeps the button on the right half, matching the design */}
-          <div className="hidden flex-1 md:block" />
-          <Button
-            type="button"
-            variant="accent"
-            fullWidth
-            className="md:flex-1"
-            loading={loading}
-            disabled={disabled || submitDisabled}
-            onClick={onSubmit}
-          >
-            {submitLabel}
-          </Button>
-        </div>
+      <Button
+        type="button"
+        variant="accent"
+        fullWidth
+        loading={loading}
+        disabled={disabled || submitDisabled}
+        onClick={onSubmit}
+      >
+        {submitLabel}
+      </Button>
+
+      {/* SSO registration alternatives */}
+      {hasSso && (
+        <>
+          <div className="flex items-center gap-[var(--spacing-system-s)]">
+            <div className="h-px flex-1 bg-ods-border" />
+            <span className="text-h6 text-ods-text-secondary">{dividerLabel}</span>
+            <div className="h-px flex-1 bg-ods-border" />
+          </div>
+          <SsoProviderButtons
+            providers={ssoProviders!}
+            onSsoClick={onSsoClick}
+            actionLabel={ssoActionLabel}
+            disabled={disabled || loading || ssoDisabled}
+          />
+        </>
       )}
     </div>
   )

--- a/openframe-frontend-core/src/components/features/auth/login-form.tsx
+++ b/openframe-frontend-core/src/components/features/auth/login-form.tsx
@@ -3,7 +3,6 @@
 import type * as React from 'react'
 import { cn } from '../../../utils/cn'
 import { useDeferredError } from '../../../hooks/ui/use-deferred-error'
-import { Button } from '../../ui/button'
 import { Input } from '../../ui/input'
 import type { AuthSsoProvider } from './sso-providers'
 import { SsoProviderButtons } from './sso-providers'
@@ -12,26 +11,26 @@ export interface LoginFormProps {
   /** Controlled email value */
   email: string
   onEmailChange: (value: string) => void
-  /** Primary submit ("Continue") */
-  onSubmit: () => void
-  /** When set, renders a "Forgot Password?" button next to Continue. */
-  onForgotPassword?: () => void
+  /** Enter-key handler on the email field (optional). */
+  onSubmit?: () => void
   emailPlaceholder?: string
-  submitLabel?: string
-  forgotPasswordLabel?: string
-  /** Disables just the primary submit (field stays editable). */
-  submitDisabled?: boolean
   loading?: boolean
   disabled?: boolean
   errors?: {
     email?: string
   }
+  /** Informational status under the email field (e.g. live tenant discovery). `errors.email` wins. */
+  emailStatus?: { message: string; variant: 'error' | 'warning' | 'success' | 'muted' }
   /**
-   * SSO providers to offer. When non-empty the form switches to SSO mode:
-   * the primary submit is replaced by a stack of provider buttons.
+   * SSO providers rendered below the email field. Always visible; gate
+   * clickability with `ssoDisabled` / `ssoEnabledProviders`.
    */
-  ssoProviders?: AuthSsoProvider[]
+  ssoProviders: AuthSsoProvider[]
   onSsoClick?: (provider: AuthSsoProvider) => void
+  /** Disables every provider button (e.g. until the email passes discovery). */
+  ssoDisabled?: boolean
+  /** When set, only these providers are clickable; the rest stay disabled. */
+  ssoEnabledProviders?: AuthSsoProvider[]
   /** Verb prefix for provider buttons, e.g. "Continue with". Ignored for "openframe". */
   ssoActionLabel?: string
   className?: string
@@ -39,35 +38,34 @@ export interface LoginFormProps {
 
 /**
  * Login form (Login tab). Presentational + controlled — the consumer owns
- * state, validation and submission. Covers the empty and SSO states from the
- * auth redesign: enter an email, then Continue or pick an SSO provider.
+ * state, validation and discovery. Single-screen design: the email field and
+ * the SSO provider buttons are always visible; the buttons unlock once the
+ * consumer validates the email (real-time tenant discovery).
  */
 export function LoginForm({
   email,
   onEmailChange,
   onSubmit,
-  onForgotPassword,
   emailPlaceholder = 'username@mail.com',
-  submitLabel = 'Continue',
-  forgotPasswordLabel = 'Forgot Password?',
-  submitDisabled = false,
   loading = false,
   disabled = false,
   errors,
+  emailStatus,
   ssoProviders,
   onSsoClick,
+  ssoDisabled = false,
+  ssoEnabledProviders,
   ssoActionLabel = 'Continue with',
   className,
 }: LoginFormProps) {
-  const isSsoMode = !!ssoProviders && ssoProviders.length > 0
-  const fieldDisabled = disabled || loading || isSsoMode
+  const fieldDisabled = disabled || loading
 
   // Validation messages are deferred while the user is typing (shown on blur or after a pause).
   const emailErr = useDeferredError(errors?.email, email)
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && !fieldDisabled) {
-      onSubmit()
+      onSubmit?.()
     }
   }
 
@@ -90,51 +88,22 @@ export function LoginForm({
         label="Email"
         placeholder={emailPlaceholder}
         value={email}
-        error={emailErr.error}
+        error={emailErr.error ?? emailStatus?.message}
+        errorVariant={emailErr.error ? 'error' : emailStatus?.variant}
         disabled={fieldDisabled}
         onBlur={emailErr.onBlur}
         onChange={(event) => onEmailChange(event.target.value)}
         onKeyDown={handleKeyDown}
       />
 
-      {/* Actions */}
-      {isSsoMode ? (
-        <SsoProviderButtons
-          providers={ssoProviders!}
-          onSsoClick={onSsoClick}
-          actionLabel={ssoActionLabel}
-          disabled={disabled || loading}
-        />
-      ) : (
-        <div className="flex items-center gap-[var(--spacing-system-l)]">
-          {onForgotPassword ? (
-            <Button
-              type="button"
-              variant="transparent"
-              fullWidth
-              className="flex-1"
-              disabled={disabled || loading}
-              onClick={onForgotPassword}
-            >
-              {forgotPasswordLabel}
-            </Button>
-          ) : (
-            // Spacer keeps the button on the right half, matching the design
-            <div className="hidden flex-1 md:block" />
-          )}
-          <Button
-            type="button"
-            variant="accent"
-            fullWidth
-            className={onForgotPassword ? 'flex-1' : 'md:flex-1'}
-            loading={loading}
-            disabled={disabled || submitDisabled}
-            onClick={onSubmit}
-          >
-            {submitLabel}
-          </Button>
-        </div>
-      )}
+      {/* SSO providers — always visible, unlocked by the consumer */}
+      <SsoProviderButtons
+        providers={ssoProviders}
+        onSsoClick={onSsoClick}
+        actionLabel={ssoActionLabel}
+        disabled={disabled || loading || ssoDisabled}
+        enabledProviders={ssoEnabledProviders}
+      />
     </div>
   )
 }

--- a/openframe-frontend-core/src/components/features/auth/sso-providers.tsx
+++ b/openframe-frontend-core/src/components/features/auth/sso-providers.tsx
@@ -33,6 +33,12 @@ export interface SsoProviderButtonsProps {
   /** Verb prefix for provider buttons, e.g. "Continue with". Ignored for "openframe". */
   actionLabel?: string
   disabled?: boolean
+  /**
+   * When set, only these providers are clickable and the rest render disabled —
+   * e.g. unlock just the providers a discovered tenant actually offers.
+   * `disabled` still wins over this list.
+   */
+  enabledProviders?: AuthSsoProvider[]
 }
 
 /** Stacked full-width SSO provider buttons shared by the auth forms. */
@@ -41,6 +47,7 @@ export function SsoProviderButtons({
   onSsoClick,
   actionLabel = 'Continue with',
   disabled = false,
+  enabledProviders,
 }: SsoProviderButtonsProps) {
   return (
     <div className="flex flex-col gap-[var(--spacing-system-l)]">
@@ -53,7 +60,7 @@ export function SsoProviderButtons({
             type="button"
             variant="outline"
             fullWidth
-            disabled={disabled}
+            disabled={disabled || (enabledProviders ? !enabledProviders.includes(provider) : false)}
             // Disabled buttons recede to the page background (like a disabled input), per design
             className="disabled:bg-ods-bg"
             leftIcon={<Icon className="h-5 w-5" />}


### PR DESCRIPTION
## Description

LoginForm: single-screen layout — email field plus always-visible SSO buttons gated by ssoDisabled/ssoEnabledProviders, with an emailStatus line for live tenant discovery; drops the Continue/Forgot-Password step. CreateOrganizationForm: SSO buttons now render additively below the primary submit behind an 'or continue with' divider instead of the old replace-the-form SSO mode. SsoProviderButtons: per-provider unlock via enabledProviders.

## Task
[Move SSO buttons to initial screens for sign up and login](https://app.clickup.com/t/9013925967/86ajhdz65)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Login now consistently displays available SSO sign-in options alongside email-based login.
  - SSO providers can be selectively enabled or disabled.
  - Login forms can display email status messages with appropriate visual indicators.
  - Organization registration keeps the primary “Continue” action available while offering SSO alternatives below a customizable divider.
  - SSO provider buttons can be disabled independently from the rest of the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->