### PR TITLE
Forward X-Tenant-Id to Fleet on the tenant gateway

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
@@ -68,6 +68,7 @@ public class RestProxyService {
 
                     HttpMethod method = request.getMethod();
                     Map<String, String> headers = buildApiRequestHeaders(tool);
+                    addFleetTenantHeader(headers, toolId, request);
 
                     return proxy(tool, targetUri, method, headers, body);
                 })
@@ -113,6 +114,16 @@ public class RestProxyService {
         int idx = fullPath.indexOf(toolPath);
         String rest = idx >= 0 ? fullPath.substring(idx + toolPath.length()) : fullPath;
         return rest.isEmpty() ? "/" : rest;
+    }
+
+    void addFleetTenantHeader(Map<String, String> headers, String toolId, ServerHttpRequest request) {
+        if (!FleetEndpointAllowlist.FLEET_TOOL_ID.equals(toolId)) {
+            return;
+        }
+        String tenantId = TenantRoutingHeaders.tenantId(request);
+        if (isNotBlank(tenantId)) {
+            headers.put(TenantRoutingHeaders.TENANT_ID_HEADER, tenantId);
+        }
     }
 
     private Map<String, String> buildApiRequestHeaders(IntegratedTool tool) {

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceFleetTenantHeaderTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceFleetTenantHeaderTest.java
@@ -1,0 +1,80 @@
+package com.openframe.gateway.service;
+
+import com.openframe.data.reactive.repository.tool.ReactiveIntegratedToolRepository;
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import com.openframe.gateway.upstream.ToolUpstreamResolverRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class RestProxyServiceFleetTenantHeaderTest {
+
+    private static final String FLEET = "fleetmdm-server";
+    private static final String OTHER_TOOL = "tactical-rmm";
+    private static final String TENANT_ID_HEADER = "X-Tenant-Id";
+    private static final String TENANT_ID = "3f2c9a1e-tenant";
+
+    private RestProxyService service(boolean multiTenancyEnabled) {
+        FleetMultiTenancyProperties props = new FleetMultiTenancyProperties();
+        props.setEnabled(multiTenancyEnabled);
+        props.setAllowedEndpoints(List.of("GET /api/{v}/fleet/hosts"));
+        return new RestProxyService(
+                mock(ReactiveIntegratedToolRepository.class),
+                mock(ToolUpstreamResolverRegistry.class),
+                mock(ToolApiKeyHeadersResolver.class),
+                new FleetEndpointAllowlist(props));
+    }
+
+    private ServerHttpRequest request(String tenantId) {
+        MockServerHttpRequest.BaseBuilder<?> builder =
+                MockServerHttpRequest.get("/tools/" + FLEET + "/api/latest/fleet/hosts");
+        if (tenantId != null) {
+            builder.header(TENANT_ID_HEADER, tenantId);
+        }
+        return builder.build();
+    }
+
+    @Test
+    void addsTenantHeaderForFleet() {
+        Map<String, String> headers = new HashMap<>();
+
+        service(true).addFleetTenantHeader(headers, FLEET, request(TENANT_ID));
+
+        assertThat(headers).containsEntry(TENANT_ID_HEADER, TENANT_ID);
+    }
+
+    /** Deliberately not gated by the multi-tenancy flag — a flag-off Fleet ignores the header. */
+    @Test
+    void addsTenantHeaderForFleetEvenWhenMultiTenancyDisabled() {
+        Map<String, String> headers = new HashMap<>();
+
+        service(false).addFleetTenantHeader(headers, FLEET, request(TENANT_ID));
+
+        assertThat(headers).containsEntry(TENANT_ID_HEADER, TENANT_ID);
+    }
+
+    @Test
+    void neverAddsTenantHeaderForOtherTools() {
+        Map<String, String> headers = new HashMap<>();
+
+        service(true).addFleetTenantHeader(headers, OTHER_TOOL, request(TENANT_ID));
+
+        assertThat(headers).doesNotContainKey(TENANT_ID_HEADER);
+    }
+
+    @Test
+    void doesNotAddBlankHeaderWhenRequestCarriesNoTenantId() {
+        Map<String, String> headers = new HashMap<>();
+
+        service(true).addFleetTenantHeader(headers, FLEET, request(null));
+
+        assertThat(headers).doesNotContainKey(TENANT_ID_HEADER);
+    }
+}


### PR DESCRIPTION
## Description

Under Fleet shared-DB multi-tenancy, Fleet resolves the tenant's team **per request** from the trusted `X-Tenant-Id` header and fails closed (401) without it. The browser proxy (`RestProxyService.proxyApiRequest`) rebuilds upstream headers from scratch (`buildApiRequestHeaders`), so the gateway-injected `X-Tenant-Id` was silently dropped — every allowlisted Fleet request would 401 once Fleet's multi-tenancy flag is enabled. This closes that gap.

Companion to #1453 (Fleet endpoint allowlist) — that PR restricts *which* endpoints the browser can reach; this one makes the requests that do pass resolve to the correct tenant on the Fleet side.

Ticket: https://app.clickup.com/t/9013925967/86ajjf6az

## Improvements
- **`RestProxyService.addFleetTenantHeader`** — re-adds the `X-Tenant-Id` from `TenantRoutingHeaders` (set by the upstream tenant-context enforcement — never the raw client header in multi-tenant routing mode) to the upstream request headers, right after `buildApiRequestHeaders` in `proxyApiRequest`.
- **Scoped to `fleetmdm-server` only** — no other tool (`tactical-rmm`, `meshcentral-server`, …) ever receives tenant headers.
- **Always on, deliberately not gated by `openframe.fleet.multi-tenancy.enabled`** — the gateway and Fleet flags can roll out independently: a flag-off Fleet simply ignores the header, while gating would make "Fleet flag on, gateway flag off" config drift 401 every UI request. Trust boundary note: the value is trusted because the apex strips client-supplied `X-Tenant-*` in multi-tenant routing mode; a gateway without that enforcement must not be pointed at a multi-tenant Fleet.
- **Blank/absent tenant header → nothing forwarded** — Fleet's own fail-closed 401 stays the authority rather than the proxy forwarding an empty header.
- **Agent plane untouched** — `proxyAgentRequest` is deliberately not modified: agents authenticate to Fleet via host node-key / enroll secret, and Fleet's tenant middleware exempts those paths (`/osquery/`, `/fleet/orbit/`, `/fleet/device/`, `/mdm/`) since the tenant comes from the host record, not a header.
- **`RestProxyServiceFleetTenantHeaderTest`** (new) — 4 cases: fleet + tenant header present → forwarded; fleet with multi-tenancy flag **off** → still forwarded (pins the always-on decision against future re-gating); other tool → never added; no tenant header on the request → nothing added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet requests now automatically forward the tenant identifier to the upstream service when provided.

* **Bug Fixes**
  * Prevented tenant-routing headers from being added to non-Fleet requests or when no tenant identifier is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->