### PR TITLE
feat(video-bites): stable element id + source_url on VideoTeaser + identity utils

### DIFF
--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -198,6 +198,12 @@
       "require": "./dist/utils/humanity-signals.cjs",
       "default": "./dist/utils/humanity-signals.js"
     },
+    "./utils/video-bite-id": {
+      "types": "./dist/utils/video-bite-id.d.ts",
+      "import": "./dist/utils/video-bite-id.js",
+      "require": "./dist/utils/video-bite-id.cjs",
+      "default": "./dist/utils/video-bite-id.js"
+    },
     "./styles": {
       "types": "./src/styles/index.d.ts",
       "import": "./src/styles/index.css",

--- a/openframe-frontend-core/src/types/video-processing.ts
+++ b/openframe-frontend-core/src/types/video-processing.ts
@@ -12,7 +12,9 @@
  * below stays a separate shape by design.
  */
 export interface VideoTeaser {
+  id?: string // Stable 8-char lowercase-hex element id (see utils/video-bite-id.ts). Stamped at creation (editor + AI save) and lazily backfilled by the Mux reconciliation sweep. Identity key for the Mux transcode pipeline — never derived from url (urls have real-world duplicates).
   url: string
+  source_url?: string // Original storage URL, set by the Mux pipeline when it flips `url` to the HLS playback URL. Merge-identity leg for redelivered ingests + transcode dedup. Never set by editors.
   title?: string
   thumbnail_url?: string // Optional thumbnail image URL for video preview. If not provided, video player will show first frame automatically.
   published?: boolean // Controls visibility on public preview page (default: false, admin must select)

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -76,6 +76,9 @@ export { getPlatformIconComponent as getPlatformLogo } from './platform-config'
 export * from './tool-utils'
 // Shell type utilities
 export * from './shell-utils'
+// Video-bite element identity (id stamping + the ONE matching predicate) —
+// isomorphic; used by the admin bites editor AND the hub's Mux sweep/writers.
+export * from './video-bite-id'
 // OS type utilities
 export * from './os-utils'
 // Phone utilities

--- a/openframe-frontend-core/src/utils/video-bite-id.ts
+++ b/openframe-frontend-core/src/utils/video-bite-id.ts
@@ -1,0 +1,68 @@
+// Video-bite element identity — SSOT for the stable per-element `id` on
+// `video_bites` / `teasers` jsonb elements (see types/video-processing.ts
+// `VideoTeaser.id`) and for the ONE element-matching predicate shared by the
+// hub's bite writers (`saveEntityVideoBitesResult` merge + the
+// `reconcileIncomingBites` clobber guard).
+//
+// Isomorphic by design: runs in the admin editor (browser) and in the hub's
+// Mux reconciliation sweep (Node). Zero dependencies.
+
+/** Shape every matcher/stamper here operates on — the identity-relevant subset of VideoTeaser. */
+export interface BiteIdentity {
+  id?: string
+  url: string
+  source_url?: string
+}
+
+/** 8 lowercase hex chars. Collision-safe within one array (n≤~100 → p≈1e-6); identity is always scoped to (table, row, column). */
+export const BITE_ID_RE = /^[0-9a-f]{8}$/
+
+/** Generate a new 8-hex bite element id. */
+export function generateBiteId(): string {
+  return crypto.randomUUID().replace(/-/g, '').slice(0, 8)
+}
+
+/**
+ * Stamp missing ids and re-stamp in-array duplicates (copy/pasted bites).
+ * Returns the SAME array reference when nothing changed so callers can cheaply
+ * skip persistence (`changed === false` ⇒ no write needed).
+ */
+export function ensureBiteIds<T extends { id?: string }>(bites: readonly T[]): { bites: T[]; changed: boolean } {
+  const seen = new Set<string>()
+  let changed = false
+  const out = bites.map(bite => {
+    const valid = typeof bite.id === 'string' && BITE_ID_RE.test(bite.id) && !seen.has(bite.id)
+    if (valid) {
+      seen.add(bite.id as string)
+      return bite
+    }
+    changed = true
+    let id = generateBiteId()
+    while (seen.has(id)) id = generateBiteId()
+    seen.add(id)
+    return { ...bite, id }
+  })
+  return changed ? { bites: out, changed } : { bites: bites as T[], changed }
+}
+
+/**
+ * The ONE element-identity predicate. Matching legs (any-of, NOT
+ * short-circuit-on-id-inequality — two sides can carry DIFFERENT ids for
+ * the same clip, e.g. a redelivered Vizard ingest regenerates ids):
+ *   1. `id` equality — when both sides carry one and they match.
+ *   2. `incoming.url === existing.url` — plain url (pre-flip stale sessions,
+ *      plain re-saves).
+ *   3. `incoming.url === existing.source_url` — the incoming side still holds
+ *      the original storage URL of an element the Mux pipeline already flipped
+ *      to HLS (redelivered ingests, stale editor arrays).
+ *
+ * Callers that match a whole incoming array against an existing array MUST
+ * consume each existing element at most once (multiset matching) — duplicate
+ * incoming urls must not all bind to one element and clone its id.
+ */
+export function matchBiteElement(existing: BiteIdentity, incoming: BiteIdentity): boolean {
+  if (existing.id && incoming.id && existing.id === incoming.id) return true
+  if (incoming.url === existing.url) return true
+  if (existing.source_url && incoming.url === existing.source_url) return true
+  return false
+}

--- a/openframe-frontend-core/tsup.config.ts
+++ b/openframe-frontend-core/tsup.config.ts
@@ -36,6 +36,10 @@ export default defineConfig([
       // Its own entry so the hub's server-side `verifyHuman` can import
       // `./utils/humanity-signals` without pulling the full utils barrel.
       'utils/humanity-signals': 'src/utils/humanity-signals.ts',
+      // Bite element identity — pure + isomorphic (no React, no browser
+      // APIs beyond crypto.randomUUID). Its own entry so the hub's Mux
+      // pipeline DALs import `./utils/video-bite-id` without the barrel.
+      'utils/video-bite-id': 'src/utils/video-bite-id.ts',
       // Zod schema — server-safe (no React, no browser APIs). Used by
       // BOTH the lib's `<ContactForm>` for validation AND the hub's
       // server-side /api/contact + admin routes for payload validation.


### PR DESCRIPTION
## What

Lib half of the universal video → Mux + thumbnail coverage work (hub PR follows and depends on this):

- **`VideoTeaser.id?`** — stable 8-char-hex element id. Stamped at creation (editor + AI save) and lazily backfilled by the hub's Mux reconciliation sweep. Identity key for the transcode pipeline — never derived from `url` (urls have real-world duplicates).
- **`VideoTeaser.source_url?`** — original storage URL, set by the pipeline when it flips `url` to the Mux HLS playback URL. Merge-identity leg for redelivered ingests + transcode dedup.
- **New `src/utils/video-bite-id.ts`** (isomorphic, zero deps): `generateBiteId()`, `ensureBiteIds()` (stamps missing + re-stamps in-array duplicates, same-reference when unchanged), `BITE_ID_RE`, and `matchBiteElement()` — the ONE element-identity predicate (id → url → source_url legs; any-of, not short-circuit-on-id-inequality).
- Own `exports` subpath + tsup entry (`./utils/video-bite-id`, mirroring the `humanity-signals` precedent) so the hub's server DALs import it without the utils barrel.

Both fields are optional and round-trip through every existing full-array writer unchanged.

## Why

The hub's Mux transcode pipeline is being extended to JSONB bite arrays (`video_bites`/`teasers`) — the homepage Testimonials strip currently paints first frames of raw ~20 MB no-cache MP4s. Element-level outbox dedup, webhook writeback, and clobber-guard merging all need a durable per-element key.

Plan: 5-reviewer-hardened design (all lenses ≥95) — see the hub PR for the full picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable identity support for video bites, including automatic ID generation and duplicate repair.
  * Improved video-bite matching across URL and source URL changes.
  * Added optional video bite identifiers and original source URLs to video teaser data.
  * Exposed video-bite utilities through the public package interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->