### PR TITLE
Settle scrollbars: overlay thumb, stable gutter, no scrollbars in tabs and quick actions

### DIFF
--- a/openframe-frontend-core/src/components/chat/guide-welcome.tsx
+++ b/openframe-frontend-core/src/components/chat/guide-welcome.tsx
@@ -196,13 +196,13 @@ export function GuideWelcome({
           `ChatQuickActionRow` in `wrap` mode: ALL chips render (no "⋯" overflow
           collapse) so every action is directly hoverable; hover/focus previews
           the action's full prompt in the composer, click sends it. Capped height
-          + internal scroll so a long (host/admin-driven) list can't grow the
-          pinned area without bound and squeeze the composer on short screens. */}
+          + internal scroll (scrollbar-hide: scrollable, bar never shows) so a
+          long list can't squeeze the composer on short screens. */}
       {quickActions.length > 0 && (
         <ChatQuickActionRow
           wrap
           chips={chipItems}
-          className="max-h-28 overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-ods-border/30"
+          className="max-h-28 overflow-y-auto scrollbar-hide"
         />
       )}
     </div>

--- a/openframe-frontend-core/src/components/ui/tab-navigation.tsx
+++ b/openframe-frontend-core/src/components/ui/tab-navigation.tsx
@@ -214,7 +214,8 @@ export function TabNavigation({
   return (
     <>
       <div className={cn("relative w-full", className)}>
-        <div ref={scrollRef} className="flex gap-[var(--spacing-system-xxs)] items-center justify-start h-full overflow-x-auto overflow-y-hidden">
+        {/* scrollbar-hide: tabs stay swipe/wheel-scrollable, bar never shows */}
+        <div ref={scrollRef} className="flex gap-[var(--spacing-system-xxs)] items-center justify-start h-full overflow-x-auto overflow-y-hidden scrollbar-hide">
           {tabs.map((tab) => {
             const isActive = activeTab === tab.id
 

--- a/openframe-frontend-core/src/styles/app-globals.css
+++ b/openframe-frontend-core/src/styles/app-globals.css
@@ -3,37 +3,12 @@
   @apply border-border;
 }
 
-/* Elevator scrollbar, Firefox fallback. Scoped via @supports because
-   scrollbar-width/color would disable ::-webkit-scrollbar styling in Chrome */
-@supports not selector(::-webkit-scrollbar) {
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: var(--ods-system-greys-grey) var(--ods-system-greys-soft-grey);
-  }
-}
-
-/* Elevator scrollbar (ODS): 8px track + draggable rounded thumb */
-*::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-*::-webkit-scrollbar-track {
-  background-color: var(--ods-system-greys-soft-grey);
-  border-radius: 4px;
-}
-
-*::-webkit-scrollbar-thumb {
-  background-color: var(--ods-system-greys-grey);
-  border-radius: 4px;
-}
-
-*::-webkit-scrollbar-thumb:hover {
-  background-color: var(--ods-system-greys-grey-hover);
-}
-
-*::-webkit-scrollbar-corner {
-  background-color: transparent;
+/* Elevator scrollbar (ODS): thin grey draggable thumb on a transparent track.
+   Standard properties only — no ::-webkit-scrollbar, so the platform keeps its
+   native rendering mode (e.g. auto-hiding overlay scrollbars on macOS). */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--ods-system-greys-grey) transparent;
 }
 
 body {
@@ -76,12 +51,30 @@ html {
      can't re-enable it for an ancestor scroll container. The self-driven rAF
      tween in scroll-into-view.ts is the primary fix; this is belt-and-braces. */
   overflow-anchor: none;
+  /* Reserve the scrollbar gutter permanently (classic scrollbars only — on
+     macOS overlay scrollbars this is a no-op). When a Drawer/Dialog locks the
+     page with `overflow: hidden`, the gutter stays reserved (per spec `stable`
+     applies to hidden too), so the content never shifts when the scrollbar
+     comes and goes. Pairs with the `data-scroll-locked` override below. */
+  scrollbar-gutter: stable;
 }
 
 body {
   background-color: var(--color-bg);
   color: var(--color-text-primary);
   overflow-anchor: none;
+}
+
+/* Radix Dialog/Drawer scroll-lock (react-remove-scroll-bar) compensates for
+   the disappearing scrollbar by injecting
+   `body[data-scroll-locked] { margin-right: <gap>px !important }`.
+   With `scrollbar-gutter: stable` above, the scrollbar space never collapses,
+   so that compensation is no longer needed — it becomes the layout shift
+   itself (and it never fixed `position: fixed` chrome like the header anyway).
+   The doubled attribute selector out-specifies the injected rule (0,2,1 vs
+   0,1,1) so our `!important` wins. */
+body[data-scroll-locked][data-scroll-locked] {
+  margin-right: 0 !important;
 }
 
 /* Light mode specific styles (used in alternatives-list.tsx) */


### PR DESCRIPTION
## Description
- Re-apply standard-properties-only scrollbar styling in openframe-frontend-core globals (thin grey draggable thumb, transparent track) instead of ::-webkit-scrollbar
- Add scrollbar-gutter: stable on html and neutralize the Radix scroll-lock margin-right compensation so drawers/dialogs don't shift the layout
- Hide the scrollbar in the TabNavigation tab strip (keep it scrollable)
- Hide the scrollbar in the wrap-mode quick-actions block above the composer (admin Mingo + client Fae chats)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scrollbar appearance across the application for a more consistent, streamlined design.
  * Hidden scrollbars in horizontally scrollable quick-action and tab navigation areas while preserving scrolling.
  * Prevented layout shifts when scrollbars appear or disappear.
  * Improved page behavior when scrolling is temporarily locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->