### PR TITLE
FE CORE: fix ambiguous star-exports dropped from the root barrel 

### DIFF
--- a/openframe-frontend-core/src/index.ts
+++ b/openframe-frontend-core/src/index.ts
@@ -17,3 +17,31 @@ export * from './hooks'
 export * from './utils'
 export * from './types'
 export * from './assets'
+
+// Disambiguation: these names are star-exported by BOTH './components/chat'
+// (chat entity-card payload types) and './types' (CMS domain types). With two
+// star exports TypeScript treats the names as ambiguous and DROPS them from
+// this barrel (consumers see TS2308). Explicitly re-export the CMS domain
+// shapes as canonical here; the chat payload variants stay available from the
+// './components/chat' subpath.
+export type {
+  BlogAuthor,
+  BlogCategory,
+  BlogMediaAsset,
+  BlogPagination,
+  BlogPost,
+  BlogPostCategory,
+  BlogPostPlatform,
+  BlogPostSummary,
+  BlogPostTag,
+  BlogSearchParams,
+  BlogStatus,
+  BlogTag,
+  CaseStudy,
+  CaseStudyFilters,
+  CaseStudyListResponse,
+  CustomerInterview,
+  CustomerInterviewConfig,
+  CustomerInterviewFilters,
+  CustomerInterviewListResponse,
+} from './types'


### PR DESCRIPTION
## Description
19 type names (Blog*, CaseStudy*, CustomerInterview*) are star-exported by BOTH ./components/chat (entity-card payload types) and ./types (CMS domain types); TypeScript treats duplicate star exports as ambiguous and silently drops the names from the root barrel — downstream compilers that consume the source (multi-platform-hub sibling tsconfig) report TS2308 for every one.

Explicitly re-export the CMS domain shapes from ./types as canonical at the root; the chat payload variants remain available from the ./components/chat subpath. Hub tsc TS2308 count: 19 -> 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CMS content types are now consistently available from the package’s main entry point.
  * Existing chat-specific type variants remain accessible through the chat module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->