### PR TITLE
FE CORE: add Biome config synced from openframe-frontend

### DIFF
--- a/openframe-frontend-core/biome.json
+++ b/openframe-frontend-core/biome.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": [
+      "**",
+      "!**/node_modules/",
+      "!**/dist",
+      "!**/.tsbuildinfo",
+      "!**/.yalc",
+      "!**/storybook-static",
+      "!**/src/components/icons-v2-generated/**"
+    ]
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "json": {
+    "formatter": { "enabled": true, "indentWidth": 2, "indentStyle": "space" }
+  },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 120,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "complexity": {
+        "noUselessConstructor": "error",
+        "useLiteralKeys": "error"
+      },
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUndeclaredDependencies": "error",
+        "useHookAtTopLevel": "error",
+        "useExhaustiveDependencies": "warn"
+      },
+      "style": {
+        "noParameterAssign": "error",
+        "useArrayLiterals": "error",
+        "useConst": "error",
+        "useDefaultParameterLast": "error",
+        "useNamingConvention": {
+          "level": "error",
+          "options": {
+            "strictCase": true,
+            "conventions": [
+              {
+                "selector": { "kind": "variable" },
+                "formats": ["camelCase", "CONSTANT_CASE", "PascalCase"]
+              },
+              {
+                "selector": { "kind": "function" },
+                "formats": ["camelCase", "PascalCase"]
+              },
+              { "selector": { "kind": "class" }, "formats": ["PascalCase"] },
+              {
+                "selector": { "kind": "interface" },
+                "formats": ["PascalCase"]
+              },
+              {
+                "selector": { "kind": "typeAlias" },
+                "formats": ["PascalCase"]
+              },
+              { "selector": { "kind": "enum" }, "formats": ["PascalCase"] },
+              {
+                "selector": { "kind": "enumMember" },
+                "formats": ["PascalCase"]
+              },
+              {
+                "selector": { "kind": "objectLiteralMember" },
+                "formats": ["camelCase", "PascalCase", "snake_case", "CONSTANT_CASE"]
+              },
+              {
+                "selector": { "kind": "typeMember" },
+                "formats": ["camelCase", "PascalCase", "snake_case", "CONSTANT_CASE"]
+              },
+              {
+                "selector": { "kind": "importAlias" },
+                "formats": ["camelCase", "PascalCase", "CONSTANT_CASE"]
+              },
+              {
+                "selector": { "kind": "exportAlias" },
+                "formats": ["camelCase", "PascalCase", "CONSTANT_CASE"]
+              }
+            ]
+          }
+        }
+      },
+      "suspicious": {
+        "noDuplicateClassMembers": "error",
+        "noRedeclare": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "all",
+      "semicolons": "always",
+      "arrowParentheses": "asNeeded",
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": { "correctness": { "noUndeclaredDependencies": "off" } }
+      }
+    },
+    {
+      "includes": ["**/*.stories.tsx"],
+      "linter": {
+        "rules": { "correctness": { "noUndeclaredDependencies": "off" } }
+      }
+    }
+  ]
+}

--- a/openframe-frontend-core/package.json
+++ b/openframe-frontend-core/package.json
@@ -267,6 +267,10 @@
     "yalc:push": "yalc push ${YALC_STORE_FOLDER:+--store-folder \"$YALC_STORE_FOLDER\"}",
     "yalc:publish": "yalc publish ${YALC_STORE_FOLDER:+--store-folder \"$YALC_STORE_FOLDER\"}",
     "generate:icons": "node scripts/generate-icons.mjs",
+    "lint:biome": "biome check .",
+    "lint:biome:fix": "biome check --fix .",
+    "format": "biome format .",
+    "format:fix": "biome format --fix .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -362,6 +366,7 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.4",
     "@hookform/resolvers": "^5.4.0",
     "@storybook/nextjs-vite": "^10.1.11",
     "@svgr/cli": "^8.1.0",


### PR DESCRIPTION
## Description
Adopt the canonical FE biome.json (2.4.4) verbatim — same formatter settings, linter rules and naming conventions — with repo-specific ignores (storybook-static, icons-v2-generated) and a stories override mirroring the FE test override. Adds @biomejs/biome devDependency and lint:biome / lint:biome:fix / format / format:fix scripts matching FE.

Config-only sync: existing violations (2041 errors, mostly formatting) are NOT fixed here — cleanup is a separate pass.