### PR TITLE
feat(sdk-fleetmdm): send X-Tenant-Id to Fleet for shared multi-tenancy

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/transformer/FleetMdmAgentIdTransformer.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/transformer/FleetMdmAgentIdTransformer.java
@@ -7,9 +7,12 @@ import com.openframe.data.document.tool.ToolUrlType;
 import com.openframe.data.service.IntegratedToolService;
 import com.openframe.data.service.ToolUrlService;
 import com.openframe.sdk.fleetmdm.FleetMdmClient;
+import com.openframe.sdk.fleetmdm.FleetTenantHeader;
 import com.openframe.sdk.fleetmdm.model.Host;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.Comparator;
@@ -28,6 +31,17 @@ public class FleetMdmAgentIdTransformer implements ToolAgentIdTransformer {
 
     private final IntegratedToolService integratedToolService;
     private final ToolUrlService toolUrlService;
+
+    @Value("${TENANT_ID:}")
+    private String tenantId;
+
+    @Value("${openframe.fleet.multi-tenancy.enabled:false}")
+    private boolean fleetMultiTenancyEnabled;
+
+    @PostConstruct
+    void validateTenantConfig() {
+        FleetTenantHeader.validate(fleetMultiTenancyEnabled, tenantId);
+    }
 
     @Override
     public ToolType getToolType() {
@@ -54,7 +68,7 @@ public class FleetMdmAgentIdTransformer implements ToolAgentIdTransformer {
             String apiUrl = toolUrl.getUrl() + ":" + toolUrl.getPort();
             String apiToken = integratedTool.getCredentials().getApiKey().getKey();
 
-            FleetMdmClient fleetClient = new FleetMdmClient(apiUrl, apiToken);
+            FleetMdmClient fleetClient = new FleetMdmClient(apiUrl, apiToken, tenantId);
 
             List<Host> hosts = fleetClient.searchHosts(agentToolId, 0, 2);
             

--- a/openframe-management-service-core/src/main/java/com/openframe/management/service/FleetApiKeyResolver.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/service/FleetApiKeyResolver.java
@@ -11,10 +11,13 @@ import com.openframe.sdk.fleetmdm.model.CreateUserRequest;
 import com.openframe.sdk.fleetmdm.model.CreateUserResponse;
 import com.openframe.sdk.fleetmdm.model.LoginRequest;
 import com.openframe.sdk.fleetmdm.model.LoginResponse;
+import com.openframe.sdk.fleetmdm.FleetTenantHeader;
 import com.openframe.sdk.fleetmdm.model.SetupRequest;
 import com.openframe.sdk.fleetmdm.model.SetupResponse;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,9 +30,20 @@ public class FleetApiKeyResolver {
 
     private final FleetMdmSetupProperties fleetMdmSetupProperties;
 
+    @Value("${TENANT_ID:}")
+    private String tenantId;
+
+    @Value("${openframe.fleet.multi-tenancy.enabled:false}")
+    private boolean fleetMultiTenancyEnabled;
+
+    @PostConstruct
+    void validateTenantConfig() {
+        FleetTenantHeader.validate(fleetMultiTenancyEnabled, tenantId);
+    }
+
     public String resolve(IntegratedTool tool) {
         String fleetUrl = extractApiUrl(tool);
-        FleetMdmSetupClient client = new FleetMdmSetupClient(fleetUrl);
+        FleetMdmSetupClient client = new FleetMdmSetupClient(fleetUrl, tenantId);
 
         ToolCredentials credentials = tool.getCredentials();
 

--- a/openframe-stream-service-core/src/main/java/com/openframe/stream/service/FleetMdmCacheService.java
+++ b/openframe-stream-service-core/src/main/java/com/openframe/stream/service/FleetMdmCacheService.java
@@ -4,9 +4,11 @@ import com.openframe.data.document.tool.IntegratedTool;
 import com.openframe.data.document.tool.IntegratedToolId;
 import com.openframe.data.service.IntegratedToolService;
 import com.openframe.sdk.fleetmdm.FleetMdmClient;
+import com.openframe.sdk.fleetmdm.FleetTenantHeader;
 import com.openframe.sdk.fleetmdm.model.Host;
 import com.openframe.sdk.fleetmdm.model.Policy;
 import com.openframe.sdk.fleetmdm.model.Query;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,9 +35,20 @@ public class FleetMdmCacheService {
     @Value("${fleet.mdm.base-url}")
     private String baseUrl;
 
+    @Value("${TENANT_ID:}")
+    private String tenantId;
+
+    @Value("${openframe.fleet.multi-tenancy.enabled:false}")
+    private boolean fleetMultiTenancyEnabled;
+
     private FleetMdmClient fleetMdmClient;
 
     private final IntegratedToolService integratedToolService;
+
+    @PostConstruct
+    void validateTenantConfig() {
+        FleetTenantHeader.validate(fleetMultiTenancyEnabled, tenantId);
+    }
 
     /**
      * Get agent ID from cache or Fleet MDM API
@@ -135,7 +148,7 @@ public class FleetMdmCacheService {
                 return null;
             }
             log.info("Initializing FleetMdmClient with baseUrl: {}", baseUrl);
-            this.fleetMdmClient = new FleetMdmClient(baseUrl, tool.getCredentials().getApiKey().getKey());
+            this.fleetMdmClient = new FleetMdmClient(baseUrl, tool.getCredentials().getApiKey().getKey(), tenantId);
         }
         return fleetMdmClient;
     }

--- a/openframe-tool-agent-nats-installation/src/main/java/com/openframe/data/service/secretretriver/FleetMdmAgentRegistrationSecretRetriever.java
+++ b/openframe-tool-agent-nats-installation/src/main/java/com/openframe/data/service/secretretriver/FleetMdmAgentRegistrationSecretRetriever.java
@@ -6,8 +6,11 @@ import com.openframe.data.document.tool.ToolUrlType;
 import com.openframe.data.service.IntegratedToolService;
 import com.openframe.data.service.ToolUrlService;
 import com.openframe.sdk.fleetmdm.FleetMdmClient;
+import com.openframe.sdk.fleetmdm.FleetTenantHeader;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +24,17 @@ public class FleetMdmAgentRegistrationSecretRetriever implements ToolAgentRegist
 
     private final IntegratedToolService integratedToolService;
     private final ToolUrlService toolUrlService;
+
+    @Value("${TENANT_ID:}")
+    private String tenantId;
+
+    @Value("${openframe.fleet.multi-tenancy.enabled:false}")
+    private boolean fleetMultiTenancyEnabled;
+
+    @PostConstruct
+    void validateTenantConfig() {
+        FleetTenantHeader.validate(fleetMultiTenancyEnabled, tenantId);
+    }
 
     @Override
     public String getToolId() {
@@ -41,7 +55,7 @@ public class FleetMdmAgentRegistrationSecretRetriever implements ToolAgentRegist
             String apiToken = integratedTool.getCredentials().getApiKey().getKey();
 
             // Create Fleet MDM client and get enroll secret
-            FleetMdmClient client = new FleetMdmClient(apiUrl, apiToken);
+            FleetMdmClient client = new FleetMdmClient(apiUrl, apiToken, tenantId);
             String enrollSecret = client.getEnrollSecret();
             
             log.info("Successfully retrieved enroll secret from Fleet MDM");

--- a/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetMdmClient.java
+++ b/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetMdmClient.java
@@ -41,8 +41,11 @@ public class FleetMdmClient {
     private static final String LIVE_QUERY_RUN_URL = "/api/v1/fleet/queries/run";
     private static final String POLICIES_DELETE_URL = "/api/latest/fleet/policies/delete";
 
+    static final String TENANT_ID_HEADER = "X-Tenant-Id";
+
     private final String baseUrl;
     private final String apiToken;
+    private final String tenantId;
     private final HttpClient httpClient;
 
     /**
@@ -55,8 +58,13 @@ public class FleetMdmClient {
      * Constructor intended for unit-tests – allows passing a pre-configured or mocked {@link HttpClient}.
      */
     FleetMdmClient(String baseUrl, String apiToken, HttpClient httpClient) {
+        this(baseUrl, apiToken, null, httpClient);
+    }
+
+    FleetMdmClient(String baseUrl, String apiToken, String tenantId, HttpClient httpClient) {
         this.baseUrl  = baseUrl;
         this.apiToken = apiToken;
+        this.tenantId = tenantId;
         this.httpClient = httpClient;
     }
 
@@ -65,8 +73,13 @@ public class FleetMdmClient {
      * @param apiToken API token for authorization
      */
     public FleetMdmClient(String baseUrl, String apiToken) {
+        this(baseUrl, apiToken, (String) null);
+    }
+
+    public FleetMdmClient(String baseUrl, String apiToken, String tenantId) {
         this.baseUrl = baseUrl;
         this.apiToken = apiToken;
+        this.tenantId = tenantId;
         this.httpClient = HttpClient.newHttpClient();
     }
 
@@ -810,8 +823,12 @@ public class FleetMdmClient {
     }
 
     private HttpRequest.Builder addHeaders(HttpRequest.Builder builder) {
-        return builder
+        builder
                 .header("Authorization", "Bearer " + apiToken)
                 .header("Accept", "application/json");
+        if (tenantId != null && !tenantId.isBlank()) {
+            builder.header(TENANT_ID_HEADER, tenantId);
+        }
+        return builder;
     }
 }

--- a/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetMdmSetupClient.java
+++ b/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetMdmSetupClient.java
@@ -25,13 +25,25 @@ public class FleetMdmSetupClient {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final String baseUrl;
+    private final String tenantId;
     private final HttpClient httpClient;
 
     public FleetMdmSetupClient(String baseUrl) {
+        this(baseUrl, null);
+    }
+
+    public FleetMdmSetupClient(String baseUrl, String tenantId) {
         this.baseUrl = baseUrl;
+        this.tenantId = tenantId;
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
                 .build();
+    }
+
+    FleetMdmSetupClient(String baseUrl, String tenantId, HttpClient httpClient) {
+        this.baseUrl = baseUrl;
+        this.tenantId = tenantId;
+        this.httpClient = httpClient;
     }
 
     public SetupResponse setup(SetupRequest request) {
@@ -62,6 +74,9 @@ public class FleetMdmSetupClient {
                     .POST(HttpRequest.BodyPublishers.ofString(json));
             if (bearerToken != null) {
                 builder.header("Authorization", "Bearer " + bearerToken);
+            }
+            if (tenantId != null && !tenantId.isBlank()) {
+                builder.header(FleetMdmClient.TENANT_ID_HEADER, tenantId);
             }
             return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
         } catch (Exception e) {

--- a/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetTenantHeader.java
+++ b/sdk/fleetmdm/src/main/java/com/openframe/sdk/fleetmdm/FleetTenantHeader.java
@@ -1,0 +1,36 @@
+package com.openframe.sdk.fleetmdm;
+
+/**
+ * Startup-time guard for the {@code X-Tenant-Id} header value consumers pass into
+ * {@link FleetMdmClient}/{@link FleetMdmSetupClient}.
+ *
+ * <p>The header itself is value-driven (blank ⇒ not sent) and always safe: a Fleet server without
+ * multi-tenancy ignores it, and a shared multi-tenant Fleet fails closed (401) without it — a
+ * missing header can never read another tenant's data. This guard exists for operability: in a
+ * deployment that declares {@code openframe.fleet.multi-tenancy.enabled=true}, a blank tenant id is
+ * a misconfiguration that would otherwise surface as opaque 401s at runtime; failing at
+ * construction names the problem instead.
+ */
+public final class FleetTenantHeader {
+
+    private FleetTenantHeader() {
+    }
+
+    /**
+     * Validates the tenant id against the deployment's multi-tenancy declaration and returns it for
+     * pass-through into a client constructor.
+     *
+     * @param multiTenancyEnabled the deployment's {@code openframe.fleet.multi-tenancy.enabled}
+     * @param tenantId            the tenant UUID (typically the {@code TENANT_ID} env var); may be
+     *                            null/blank when multi-tenancy is disabled
+     * @throws IllegalStateException when multi-tenancy is enabled but the tenant id is blank
+     */
+    public static String validate(boolean multiTenancyEnabled, String tenantId) {
+        if (multiTenancyEnabled && (tenantId == null || tenantId.isBlank())) {
+            throw new IllegalStateException(
+                    "openframe.fleet.multi-tenancy.enabled=true but no tenant id is configured "
+                            + "(TENANT_ID env var missing?)");
+        }
+        return tenantId;
+    }
+}

--- a/sdk/fleetmdm/src/test/java/com/openframe/sdk/fleetmdm/FleetMdmClientTenantHeaderTest.java
+++ b/sdk/fleetmdm/src/test/java/com/openframe/sdk/fleetmdm/FleetMdmClientTenantHeaderTest.java
@@ -1,0 +1,104 @@
+package com.openframe.sdk.fleetmdm;
+
+import com.openframe.sdk.fleetmdm.model.LoginRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FleetMdmClientTenantHeaderTest {
+
+    private static final String TENANT_ID = "3f2c9a1e-0000-0000-0000-tenant";
+
+    @Mock HttpClient httpClient;
+    @Mock HttpResponse<String> httpResponse;
+
+    private HttpRequest sentRequest(FleetMdmClient client) throws Exception {
+        when(httpResponse.statusCode()).thenReturn(404);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+
+        client.getHostById(1);
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+        return captor.getValue();
+    }
+
+    @Test
+    void sendsTenantHeaderWhenTenantIdProvided() throws Exception {
+        FleetMdmClient client = new FleetMdmClient("https://fleet.example.com", "token", TENANT_ID, httpClient);
+
+        HttpRequest request = sentRequest(client);
+
+        assertEquals(List.of(TENANT_ID), request.headers().allValues(FleetMdmClient.TENANT_ID_HEADER));
+    }
+
+    @Test
+    void sendsNoTenantHeaderWithoutTenantId() throws Exception {
+        FleetMdmClient client = new FleetMdmClient("https://fleet.example.com", "token", httpClient);
+
+        HttpRequest request = sentRequest(client);
+
+        assertTrue(request.headers().allValues(FleetMdmClient.TENANT_ID_HEADER).isEmpty());
+    }
+
+    @Test
+    void sendsNoTenantHeaderForBlankTenantId() throws Exception {
+        FleetMdmClient client = new FleetMdmClient("https://fleet.example.com", "token", " ", httpClient);
+
+        HttpRequest request = sentRequest(client);
+
+        assertTrue(request.headers().allValues(FleetMdmClient.TENANT_ID_HEADER).isEmpty());
+    }
+
+    @Test
+    void setupClientSendsTenantHeaderWhenTenantIdProvided() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn("{\"token\":\"t\"}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+        FleetMdmSetupClient setupClient =
+                new FleetMdmSetupClient("https://fleet.example.com", TENANT_ID, httpClient);
+
+        setupClient.login(new LoginRequest());
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+        assertEquals(List.of(TENANT_ID), captor.getValue().headers().allValues(FleetMdmClient.TENANT_ID_HEADER));
+    }
+
+    @Test
+    void setupClientSendsNoTenantHeaderWithoutTenantId() throws Exception {
+        when(httpResponse.statusCode()).thenReturn(200);
+        when(httpResponse.body()).thenReturn("{\"token\":\"t\"}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(httpResponse);
+        FleetMdmSetupClient setupClient = new FleetMdmSetupClient("https://fleet.example.com", null, httpClient);
+
+        setupClient.login(new LoginRequest());
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+        assertTrue(captor.getValue().headers().allValues(FleetMdmClient.TENANT_ID_HEADER).isEmpty());
+    }
+
+    @Test
+    void validateRejectsBlankTenantIdWhenMultiTenancyEnabled() {
+        assertThrows(IllegalStateException.class, () -> FleetTenantHeader.validate(true, " "));
+        assertThrows(IllegalStateException.class, () -> FleetTenantHeader.validate(true, null));
+        assertEquals(TENANT_ID, FleetTenantHeader.validate(true, TENANT_ID));
+        assertEquals(null, FleetTenantHeader.validate(false, null));
+    }
+}


### PR DESCRIPTION
## Description

Makes the control-plane Fleet SDK (`sdk/fleetmdm`) tenant-safe for Fleet shared-DB multi-tenancy.

Unlike the browser UI, the SDK talks to Fleet **directly** (not through the `/tools/fleetmdm-server` gateway proxy), so it is covered by neither the endpoint allowlist (#1453) nor the proxy's `X-Tenant-Id` forwarding (#1467). Under shared multi-tenancy Fleet resolves the tenant's team **per request** from the trusted `X-Tenant-Id` header and **fails closed (401)** without it — so every SDK call (including provisioning: `login`/`setup`/`users/admin`, which are NOT exempt from Fleet's tenant middleware) would 401 in shared mode. This adds the header.

Ticket: https://app.clickup.com/t/9013925967/86ajjk3ne

## Improvements
- **`FleetMdmClient` / `FleetMdmSetupClient`** — new `tenantId` constructor argument; the header is attached in the single `addHeaders` / request-builder choke point whenever the tenant id is non-blank. The existing 2-arg constructors delegate with `null` ⇒ header not sent ⇒ a flag-off Fleet is unaffected (backward compatible).
- **`FleetTenantHeader.validate`** — shared helper that **fails fast at startup** when `openframe.fleet.multi-tenancy.enabled=true` but no tenant id is configured (turns opaque runtime 401s into a clear boot error). This is operability only — isolation rests on Fleet's fail-closed middleware, not on this guard.
- **Consumers** (`FleetMdmAgentRegistrationSecretRetriever`, `FleetMdmCacheService`, `FleetMdmAgentIdTransformer`, `FleetApiKeyResolver`) — inject `@Value("${TENANT_ID:}")` (the tenant UUID in the tenant plane, blank elsewhere) and run the guard in `@PostConstruct`.
- **Always-on, deliberately not gated by the flag** — the header is value-driven (sent whenever a tenant id exists), so the gateway / Fleet / SDK planes can roll out independently; a flag-off Fleet ignores it. Single-tenant (OSS) and cross-tenant (shared) planes have no `TENANT_ID` ⇒ no header ⇒ unchanged.
- **Tests** — `FleetMdmClientTenantHeaderTest`: header present when a tenant id is given / absent for the 2-arg + null + blank cases, for both clients; `validate` rejects blank-when-enabled and passes otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
