### PR TITLE
FE CORE: hotfix realtime chat pipeline — lost tool/approval chunks, reconnect gaps, multi-connection NATS

### DIFF
--- a/openframe-frontend-core/.claude/skills/realtime-chat-review/SKILL.md
+++ b/openframe-frontend-core/.claude/skills/realtime-chat-review/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: realtime-chat-review
+description: Extra review angles for the NATS/JetStream realtime chat pipeline (chunk processors, accumulators, adapters, consumer stores). Use IN ADDITION to /code-review whenever a diff touches src/components/chat/**, src/nats/**, or any consumer copy of the chat pipeline.
+---
+
+# Realtime chat pipeline review
+
+Line-level review misses the dominant bug class in this code: **event-sequence
+bugs** — every line is individually correct, but a specific ordering of events
+over time corrupts state. Run the standard /code-review angles, PLUS the two
+angles below as additional finders, and give their candidates equal rank with
+correctness findings.
+
+## Domain invariants (presume these; do not treat them as "speculative")
+
+- **JetStream is at-least-once.** Any chunk can be redelivered after later
+  chunks were already applied. Every message/segment updater MUST be
+  idempotent and must never downgrade state (EXECUTED → EXECUTING, resolved
+  approval → pending, completed compaction → started).
+- **CHAT_CHUNKS retention is 10 minutes.** A reconnect after a gap cannot be
+  healed from the stream alone — history refetch is mandatory; missing it is
+  a bug, not an edge case.
+- **Sequence spaces are per (dialogId, chatType).** CLIENT_CHAT and
+  ADMIN_AI_CHAT counters are independent; a single scalar checkpoint or
+  seen-set shared across types is a bug.
+- **Post-MESSAGE_END chunks are normal**, not exceptional: approved-command
+  executions, retries after errors, and catchup replay all deliver tool and
+  approval chunks outside the START…END window. "Update-existing-only"
+  updaters silently drop the first such chunk.
+- **SYSTEM / DIRECT_MESSAGE are instant types** — never stored in the chunk
+  store, recoverable only from Mongo history.
+
+## Angle I — event-sequence adversary
+
+For EVERY handler, updater, and effect the diff touches, enumerate these
+adversarial timelines and check each one produces correct state:
+
+1. **Duplicate delivery** — the same chunk applied twice, including after a
+   later chunk already advanced the state (no-downgrade, no duplicate cards).
+2. **Reorder** — chunk N+1 before chunk N across a resubscribe boundary.
+3. **Stale context** — the async operation (fetch, catchup, history load)
+   resolves AFTER the user switched dialogs: does its completion/finally
+   block touch the NEW dialog's state (flags, buffers, checkpoints, queues)?
+   Is every queued continuation scoped to its originating dialogId?
+4. **Double trigger** — the same lifecycle event fires twice in a row
+   (reconnect during reconnect handling, two rapid MESSAGE_ENDs, effect
+   re-run under StrictMode): are buffer-arming and reset paths idempotent?
+5. **Replay after completion** — catchup re-emits chunks for an already
+   rendered message: do upserts key on stable ids (approvalRequestId,
+   toolExecutionRequestId, streamSeq) rather than blind append?
+6. **Cross-type interleaving** — CLIENT_CHAT and ADMIN_AI_CHAT streams
+   interleave on one dialog: are checkpoints, START/END windows, and
+   seen-sets keyed per messageType?
+
+A candidate from this angle is reportable when you can write the concrete
+timeline (event 1 → event 2 → event 3 → wrong state). Do not discard it as
+"depends on runtime timing" — for this transport, that timing is guaranteed
+to occur.
+
+## Angle J — parallel-path consistency
+
+The pipeline is intentionally copy-adapted in four places. For every behavior
+the diff changes in one copy, diff it against the other three AND against the
+history path:
+
+| Copy | Location |
+|------|----------|
+| Lib adapter | `openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts` (+ `use-chunk-catchup`, `use-realtime-chunk-processor`, `message-segment-accumulator`) |
+| Admin tickets | `openframe-frontend/src/app/(app)/tickets/` (store + `use-side-chunk-processor`) |
+| Admin mingo | `openframe-frontend/src/app/(app)/mingo/` (store + realtime subscription) |
+| Tauri client | `openframe-oss-tenant/clients/openframe-chat/src/hooks/` (`useChatMessages`, `useChat`) |
+
+And the paired paths inside each copy:
+
+- realtime processing vs `process-historical-messages` (defaults MUST match:
+  `displayApprovalTypes`, `batchApprovalsEnabled`, segment shapes);
+- live subscription vs catchup replay (same dedup keys, same boundaries);
+- standalone `tool_execution` segment vs `approval_batch.executions[execId]`
+  slot (guards added to one MUST exist in the other).
+
+Report any copy where a guard, default, dedup key, scan direction, or
+fallback added by the diff is absent or differs — that asymmetry IS the
+finding, even if the lagging copy "works today".
+
+## Verification guidance
+
+When verifying candidates from these angles, redelivery/reorder/stale-context
+timelines are PLAUSIBLE by default (the transport guarantees them). REFUTED
+requires citing an existing guard in the code that covers the exact timeline.

--- a/openframe-frontend-core/src/components/chat/hooks/__tests__/nats-adapter-message-updaters.test.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/__tests__/nats-adapter-message-updaters.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Pure message-updater helpers behind `useNatsChatAdapter`'s realtime
+ * callbacks. These guard the post-MESSAGE_END paths that used to corrupt the
+ * thread: continuation fragments replacing the whole trailing bubble, tool
+ * chunks wiping completed replies, and standalone compaction duplication.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  appendToTrailingAssistant,
+  applyToolExecutionToMessages,
+  upsertTrailingCompaction,
+} from '../use-nats-chat-adapter'
+import type { UnifiedChatMessage } from '../../types/unified-chat-state.types'
+import type { MessageSegment, ToolExecutionSegment } from '../../types'
+
+const assistant = (id: string, segments: MessageSegment[]): UnifiedChatMessage => ({
+  id,
+  role: 'assistant',
+  content: '',
+  segments,
+})
+
+const user = (id: string, content: string): UnifiedChatMessage => ({
+  id,
+  role: 'user',
+  content,
+})
+
+const executing = (execId?: string, toolFunction = 'run_command'): ToolExecutionSegment => ({
+  type: 'tool_execution',
+  data: {
+    type: 'EXECUTING_TOOL',
+    integratedToolType: 'SHELL',
+    toolFunction,
+    toolTitle: 'Run command',
+    ...(execId ? { toolExecutionRequestId: execId } : {}),
+  },
+})
+
+const executed = (execId?: string, toolFunction = 'run_command'): ToolExecutionSegment => ({
+  type: 'tool_execution',
+  data: {
+    type: 'EXECUTED_TOOL',
+    integratedToolType: 'SHELL',
+    toolFunction,
+    result: 'ok',
+    success: true,
+    ...(execId ? { toolExecutionRequestId: execId } : {}),
+  },
+})
+
+describe('appendToTrailingAssistant', () => {
+  it('appends into the trailing assistant bubble without dropping prior segments', () => {
+    const prev = [
+      user('u1', 'hi'),
+      assistant('a1', [{ type: 'text', text: 'done. ' }]),
+    ]
+    const next = appendToTrailingAssistant(prev, [{ type: 'text', text: 'continuing' }])
+    expect(next).toHaveLength(2)
+    expect(next[1].segments).toEqual([{ type: 'text', text: 'done. continuing' }])
+  })
+
+  it('pushes a new segment when types differ instead of merging', () => {
+    const prev = [assistant('a1', [{ type: 'text', text: 'answer' }])]
+    const next = appendToTrailingAssistant(prev, [{ type: 'thinking', text: 'hmm' }])
+    expect(next[0].segments).toEqual([
+      { type: 'text', text: 'answer' },
+      { type: 'thinking', text: 'hmm' },
+    ])
+  })
+
+  it('opens a fresh assistant bubble when the thread ends with a user message', () => {
+    const prev = [user('u1', 'hi')]
+    const next = appendToTrailingAssistant(prev, [{ type: 'text', text: 'reply' }])
+    expect(next).toHaveLength(2)
+    expect(next[1].role).toBe('assistant')
+    expect(next[1].segments).toEqual([{ type: 'text', text: 'reply' }])
+  })
+
+  it('returns the input untouched for an empty fragment list', () => {
+    const prev = [assistant('a1', [{ type: 'text', text: 'answer' }])]
+    expect(appendToTrailingAssistant(prev, [])).toBe(prev)
+  })
+})
+
+describe('applyToolExecutionToMessages', () => {
+  it('replaces a matching EXECUTING segment in place (same bubble intact)', () => {
+    const prev = [
+      user('u1', 'run it'),
+      assistant('a1', [{ type: 'text', text: 'running…' }, executing('exec-1')]),
+    ]
+    const next = applyToolExecutionToMessages(prev, executed('exec-1'))
+    expect(next).toHaveLength(2)
+    const segs = next[1].segments!
+    expect(segs[0]).toEqual({ type: 'text', text: 'running…' })
+    expect(segs[1].type).toBe('tool_execution')
+    expect((segs[1] as ToolExecutionSegment).data.type).toBe('EXECUTED_TOOL')
+    // toolTitle restored from the EXECUTING twin (backend omits it on EXECUTED)
+    expect((segs[1] as ToolExecutionSegment).data.toolTitle).toBe('Run command')
+  })
+
+  it('updates a tool in an EARLIER bubble, not just the trailing one', () => {
+    const prev = [
+      assistant('a1', [executing('exec-1')]),
+      assistant('a2', [{ type: 'text', text: 'meanwhile' }]),
+    ]
+    const next = applyToolExecutionToMessages(prev, executed('exec-1'))
+    expect((next[0].segments![0] as ToolExecutionSegment).data.type).toBe('EXECUTED_TOOL')
+    expect(next[1].segments).toEqual([{ type: 'text', text: 'meanwhile' }])
+  })
+
+  it('merges execution state into an approval_batch containing the exec id', () => {
+    const prev: UnifiedChatMessage[] = [
+      assistant('a1', [
+        {
+          type: 'approval_batch',
+          data: {
+            approvalRequestId: 'req-1',
+            approvalType: 'CLIENT',
+            toolCalls: [
+              {
+                toolExecutionRequestId: 'exec-1',
+                toolName: 'run_command',
+                requiresApproval: true,
+                approvalType: 'CLIENT',
+                toolCallArguments: null,
+              },
+            ],
+          },
+          status: 'approved',
+        },
+      ]),
+    ]
+    const next = applyToolExecutionToMessages(prev, executed('exec-1'))
+    const batch = next[0].segments![0]
+    expect(batch.type).toBe('approval_batch')
+    expect((batch as Extract<MessageSegment, { type: 'approval_batch' }>).data.executions).toEqual({
+      'exec-1': { status: 'done', result: 'ok', success: true },
+    })
+  })
+
+  it('appends to the trailing bubble when nothing matches (never replaces content)', () => {
+    const prev = [assistant('a1', [{ type: 'text', text: 'full reply' }])]
+    const next = applyToolExecutionToMessages(prev, executing('exec-9'))
+    const segs = next[0].segments!
+    expect(segs).toHaveLength(2)
+    expect(segs[0]).toEqual({ type: 'text', text: 'full reply' })
+    expect((segs[1] as ToolExecutionSegment).data.toolExecutionRequestId).toBe('exec-9')
+  })
+
+  it('never downgrades an EXECUTED segment back to EXECUTING (replayed chunk)', () => {
+    const prev = [assistant('a1', [executed('exec-1')])]
+    const next = applyToolExecutionToMessages(prev, executing('exec-1'))
+    expect(next).toBe(prev)
+  })
+
+  it('falls back to (toolType, toolFunction) pairing when no exec id is present', () => {
+    const prev = [assistant('a1', [executing(undefined, 'get_devices')])]
+    const next = applyToolExecutionToMessages(prev, executed(undefined, 'get_devices'))
+    expect((next[0].segments![0] as ToolExecutionSegment).data.type).toBe('EXECUTED_TOOL')
+  })
+})
+
+describe('upsertTrailingCompaction', () => {
+  it('appends a started compaction into the trailing bubble', () => {
+    const prev = [assistant('a1', [{ type: 'text', text: 'reply' }])]
+    const next = upsertTrailingCompaction(prev, [{ type: 'context_compaction', status: 'started' }])
+    expect(next[0].segments).toEqual([
+      { type: 'text', text: 'reply' },
+      { type: 'context_compaction', status: 'started' },
+    ])
+  })
+
+  it('replaces the started segment on completion instead of duplicating', () => {
+    const prev = [
+      assistant('a1', [
+        { type: 'text', text: 'reply' },
+        { type: 'context_compaction', status: 'started' },
+      ]),
+    ]
+    const next = upsertTrailingCompaction(prev, [
+      { type: 'context_compaction', status: 'completed', summary: 'compacted' },
+    ])
+    expect(next[0].segments).toEqual([
+      { type: 'text', text: 'reply' },
+      { type: 'context_compaction', status: 'completed', summary: 'compacted' },
+    ])
+  })
+
+  it('applies ONLY the compaction segment from a cumulative emission', () => {
+    const prev = [assistant('a1', [{ type: 'text', text: 'reply' }])]
+    // Accumulator emits its whole array — interleaved text must not duplicate.
+    const next = upsertTrailingCompaction(prev, [
+      { type: 'context_compaction', status: 'completed' },
+      { type: 'text', text: 'reply' },
+    ])
+    expect(next[0].segments).toEqual([
+      { type: 'text', text: 'reply' },
+      { type: 'context_compaction', status: 'completed' },
+    ])
+  })
+})

--- a/openframe-frontend-core/src/components/chat/hooks/__tests__/nats-adapter-message-updaters.test.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/__tests__/nats-adapter-message-updaters.test.ts
@@ -82,6 +82,46 @@ describe('appendToTrailingAssistant', () => {
     const prev = [assistant('a1', [{ type: 'text', text: 'answer' }])]
     expect(appendToTrailingAssistant(prev, [])).toBe(prev)
   })
+
+  it('upserts approval deltas by request id instead of duplicating (replayed emit)', () => {
+    const card = (status: 'pending' | 'approved'): MessageSegment => ({
+      type: 'approval_batch',
+      data: {
+        approvalRequestId: 'req-1',
+        approvalType: 'USER',
+        toolCalls: [
+          {
+            toolExecutionRequestId: 'exec-1',
+            toolName: 'run_command',
+            requiresApproval: true,
+            approvalType: 'USER',
+            toolCallArguments: null,
+          },
+        ],
+      },
+      status,
+    })
+    const prev = [assistant('a1', [{ type: 'text', text: 'reply' }, card('pending')])]
+    const next = appendToTrailingAssistant(prev, [card('approved')])
+    const segs = next[0].segments!
+    expect(segs).toHaveLength(2)
+    expect(segs[1].type).toBe('approval_batch')
+    expect((segs[1] as Extract<MessageSegment, { type: 'approval_batch' }>).status).toBe('approved')
+  })
+
+  it('upserts legacy approval cards by (requestId, command)', () => {
+    const legacy = (command: string, status: 'pending' | 'approved'): MessageSegment => ({
+      type: 'approval_request',
+      data: { requestId: 'req-1', command, approvalType: 'USER' },
+      status,
+    })
+    const prev = [assistant('a1', [legacy('ls', 'pending'), legacy('rm x', 'pending')])]
+    const next = appendToTrailingAssistant(prev, [legacy('rm x', 'approved')])
+    const segs = next[0].segments!
+    expect(segs).toHaveLength(2)
+    expect((segs[0] as Extract<MessageSegment, { type: 'approval_request' }>).status).toBe('pending')
+    expect((segs[1] as Extract<MessageSegment, { type: 'approval_request' }>).status).toBe('approved')
+  })
 })
 
 describe('applyToolExecutionToMessages', () => {
@@ -151,6 +191,33 @@ describe('applyToolExecutionToMessages', () => {
 
   it('never downgrades an EXECUTED segment back to EXECUTING (replayed chunk)', () => {
     const prev = [assistant('a1', [executed('exec-1')])]
+    const next = applyToolExecutionToMessages(prev, executing('exec-1'))
+    expect(next).toBe(prev)
+  })
+
+  it('never downgrades a done batch slot back to executing (replayed chunk)', () => {
+    const prev: UnifiedChatMessage[] = [
+      assistant('a1', [
+        {
+          type: 'approval_batch',
+          data: {
+            approvalRequestId: 'req-1',
+            approvalType: 'CLIENT',
+            toolCalls: [
+              {
+                toolExecutionRequestId: 'exec-1',
+                toolName: 'run_command',
+                requiresApproval: true,
+                approvalType: 'CLIENT',
+                toolCallArguments: null,
+              },
+            ],
+            executions: { 'exec-1': { status: 'done', result: 'ok', success: true } },
+          },
+          status: 'approved',
+        },
+      ]),
+    ]
     const next = applyToolExecutionToMessages(prev, executing('exec-1'))
     expect(next).toBe(prev)
   })

--- a/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
@@ -349,8 +349,14 @@ export function useChunkCatchup({
       // dialog's cycle state — `resetChunkTracking` already re-armed the
       // flags for it, and clearing `fetchingInProgress` / finalizing the
       // buffer here would corrupt the new dialog's in-flight catch-up.
+      // That includes the pending queue: only discard an entry that belongs
+      // to THIS stale dialog — a reconnect during the new dialog's initial
+      // fetch queues an entry for the new dialog, and wiping it here would
+      // silently drop that gap's re-fetch (permanent transcript hole).
       if (dialogId !== dialogIdRef.current) {
-        pendingCatchupRef.current = null
+        if (pendingCatchupRef.current?.dialogId === dialogId) {
+          pendingCatchupRef.current = null
+        }
       } else {
         fetchingInProgress.current = false
 
@@ -375,7 +381,16 @@ export function useChunkCatchup({
             hasCompletedInitialCatchup.current = false
             lastFetchParams.current = null
             bufferUntilInitialCatchupComplete.current = true
-            void catchUpChunksRef.current?.(pending.fromSequenceId)
+            // AWAIT the re-run (not fire-and-forget): callers chain their own
+            // finally on this promise — the adapter lowers its onAgentBusy
+            // suppression there, and a detached re-run would replay a dead
+            // tail's EXECUTING chunk with suppression already off, locking
+            // the composer with no MESSAGE_END ever coming.
+            try {
+              await catchUpChunksRef.current?.(pending.fromSequenceId)
+            } catch (rerunError) {
+              console.error('Queued catch-up re-run failed:', rerunError)
+            }
           } else if (bufferUntilInitialCatchupComplete.current) {
             bufferUntilInitialCatchupComplete.current = false
             hasCompletedInitialCatchup.current = true

--- a/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
@@ -65,6 +65,11 @@ export function useChunkCatchup({
 
   const fetchingInProgress = useRef(false)
   const lastFetchParams = useRef<{ dialogId: string; fromSequenceId?: number | null } | null>(null)
+  // A catch-up requested while another fetch is in flight (double reconnect,
+  // reconnect during the initial catchup). Queued instead of dropped: the old
+  // behaviour returned early and the stale fetch's completion marked catchup
+  // done, so the new gap was never fetched — a permanent transcript hole.
+  const pendingCatchupRef = useRef<{ fromSequenceId?: number | null } | null>(null)
 
   // Buffer for NATS chunks that arrive during catchup
   const chunkBuffer = useRef<BufferedChunk[]>([])
@@ -92,7 +97,13 @@ export function useChunkCatchup({
 
     if (chunk.sequenceId !== undefined && chunk.sequenceId !== null) {
       const chunkType = typeof chunk.type === 'string' ? chunk.type : ''
-      processedSequenceKeys.current.add(makeSeqKey(messageType, chunkType, chunk.sequenceId))
+      const key = makeSeqKey(messageType, chunkType, chunk.sequenceId)
+      // A live chunk can also be in the catchup fetch result (published just
+      // before the fetch resolved, delivered just after the flush). Without
+      // this check the live path only RECORDED keys and never consulted
+      // them, so the overlap rendered twice (duplicated text / tool cards).
+      if (processedSequenceKeys.current.has(key)) return true
+      processedSequenceKeys.current.add(key)
       lastSequenceId.current = chunk.sequenceId
     }
 
@@ -108,9 +119,11 @@ export function useChunkCatchup({
     const buffered = [...chunkBuffer.current]
     chunkBuffer.current = []
 
+    // Chunks WITHOUT a sequence id are live deliveries — the newest events.
+    // Sorting them as seq 0 (the old behaviour) pushed them BEFORE history.
     buffered.sort((a, b) => {
-      const seqA = a.chunk.sequenceId ?? 0
-      const seqB = b.chunk.sequenceId ?? 0
+      const seqA = a.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
+      const seqB = b.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
       return seqA - seqB
     })
 
@@ -132,10 +145,23 @@ export function useChunkCatchup({
     }
 
     if (hasCompletedInitialCatchup.current) {
+      // Safety valve: never leave the buffering flag stuck on a completed
+      // catchup — buffered live chunks would otherwise queue forever and the
+      // dialog would look frozen.
+      if (bufferUntilInitialCatchupComplete.current) {
+        bufferUntilInitialCatchupComplete.current = false
+        flushBufferedRealtimeChunks()
+      }
       return
     }
 
     if (fetchingInProgress.current) {
+      // Queue instead of dropping — the in-flight fetch's finally block
+      // re-runs catch-up with these params once it settles. An explicit
+      // fromSequenceId wins; a queued INITIAL call (undefined) falls back to
+      // the last seq seen so far (null on a fresh dialog → backend returns
+      // everything, same as the original undefined semantics).
+      pendingCatchupRef.current = { fromSequenceId: fromSequenceId ?? lastSequenceId.current }
       return
     }
 
@@ -183,64 +209,98 @@ export function useChunkCatchup({
       chunkBuffer.current = []
       const allChunks = [...allCatchupChunks, ...bufferedNatsChunks]
       
-      // Sort by sequence ID
+      // Sort by sequence ID. Chunks without one are buffered live deliveries
+      // (the newest events) — sort them AFTER history, not before it.
       allChunks.sort((a, b) => {
-        const seqA = a.chunk.sequenceId ?? 0
-        const seqB = b.chunk.sequenceId ?? 0
+        const seqA = a.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
+        const seqB = b.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
         return seqA - seqB
       })
-    
-      // Deduplicate
+
+      // Deduplicate — only chunks that carry a sequence id. Id-less live
+      // chunks get no key: two identical streaming deltas ("the ", "yes")
+      // are distinct content, and collapsing them (the old behaviour, where
+      // the key degraded to type+text) silently dropped text.
       const uniqueAllChunks: BufferedChunk[] = []
       const seenInBatch = new Set<string>()
       for (const item of allChunks) {
-        const k = makeBatchDedupKey(item)
-        if (seenInBatch.has(k)) continue
-        seenInBatch.add(k)
+        const hasSeq = item.chunk.sequenceId !== undefined && item.chunk.sequenceId !== null
+        if (hasSeq) {
+          const k = makeBatchDedupKey(item)
+          if (seenInBatch.has(k)) continue
+          seenInBatch.add(k)
+        }
         uniqueAllChunks.push(item)
       }
       
-      // Find last complete message boundary
-      let lastMessageStartSeqId: number | null = null
-      let lastMessageEndSeqId: number | null = null
-      
-      for (let i = uniqueAllChunks.length - 1; i >= 0; i--) {
-        const seq = uniqueAllChunks[i].chunk.sequenceId
-        if (uniqueAllChunks[i].chunk.type === MESSAGE_TYPE.MESSAGE_END && seq !== undefined && seq !== null) {
-          lastMessageEndSeqId = seq
-          break
-        }
+      // Id-less chunks are buffered live deliveries (newer than anything the
+      // fetch returned) — the boundary filters must KEEP them, not drop them.
+      const hasNoSeq = (item: BufferedChunk) =>
+        item.chunk.sequenceId === undefined || item.chunk.sequenceId === null
+
+      // Boundary detection runs PER messageType. In the legacy Redis
+      // transport each (dialog, chatType) stream has its OWN independent
+      // sequence counter, so a MESSAGE_END boundary found in one stream must
+      // never truncate the other stream's chunks (tool/approval chunks of an
+      // admin mirror used to vanish this way). With JetStream's global seqs
+      // the per-type grouping is still correct — it just partitions the same
+      // ordered list.
+      const byType = new Map<NatsMessageType, BufferedChunk[]>()
+      for (const item of uniqueAllChunks) {
+        const list = byType.get(item.messageType)
+        if (list) list.push(item)
+        else byType.set(item.messageType, [item])
       }
-      
-      for (let i = uniqueAllChunks.length - 1; i >= 0; i--) {
-        const chunk = uniqueAllChunks[i].chunk
-        const seq = chunk.sequenceId
-        if (chunk.type === MESSAGE_TYPE.MESSAGE_START && seq !== undefined && seq !== null) {
-          if (lastMessageEndSeqId === null || seq > lastMessageEndSeqId) {
-            lastMessageStartSeqId = seq
+
+      const chunksToProcess: BufferedChunk[] = []
+      for (const items of byType.values()) {
+        // Find the last complete message boundary within this stream.
+        let lastMessageStartSeqId: number | null = null
+        let lastMessageEndSeqId: number | null = null
+
+        for (let i = items.length - 1; i >= 0; i--) {
+          const seq = items[i].chunk.sequenceId
+          if (items[i].chunk.type === MESSAGE_TYPE.MESSAGE_END && seq !== undefined && seq !== null) {
+            lastMessageEndSeqId = seq
             break
           }
         }
+
+        for (let i = items.length - 1; i >= 0; i--) {
+          const chunk = items[i].chunk
+          const seq = chunk.sequenceId
+          if (chunk.type === MESSAGE_TYPE.MESSAGE_START && seq !== undefined && seq !== null) {
+            if (lastMessageEndSeqId === null || seq > lastMessageEndSeqId) {
+              lastMessageStartSeqId = seq
+              break
+            }
+          }
+        }
+
+        if (lastMessageStartSeqId !== null) {
+          // Process from the last incomplete message
+          chunksToProcess.push(
+            ...items.filter(item => hasNoSeq(item) || item.chunk.sequenceId! >= lastMessageStartSeqId!),
+          )
+        } else if (lastMessageEndSeqId !== null) {
+          // Process only after the last complete message
+          chunksToProcess.push(
+            ...items.filter(item => hasNoSeq(item) || item.chunk.sequenceId! > lastMessageEndSeqId!),
+          )
+        } else {
+          // Process all
+          chunksToProcess.push(...items)
+        }
       }
-      
-      let chunksToProcess: BufferedChunk[]
-      
-      if (lastMessageStartSeqId !== null) {
-        // Process from the last incomplete message
-        chunksToProcess = uniqueAllChunks.filter(item => 
-          item.chunk.sequenceId !== undefined && 
-          item.chunk.sequenceId >= lastMessageStartSeqId!
-        )
-      } else if (lastMessageEndSeqId !== null) {
-        // Process only after the last complete message
-        chunksToProcess = uniqueAllChunks.filter(item => 
-          item.chunk.sequenceId !== undefined && 
-          item.chunk.sequenceId > lastMessageEndSeqId!
-        )
-      } else {
-        // Process all
-        chunksToProcess = uniqueAllChunks
-      }
+
+      // Restore cross-stream order (concatenation above grouped by type).
+      // Stable sort keeps per-type order; JetStream seqs interleave globally,
+      // Redis-mode cross-type order is inherently undefined either way.
+      chunksToProcess.sort((a, b) => {
+        const seqA = a.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
+        const seqB = b.chunk.sequenceId ?? Number.MAX_SAFE_INTEGER
+        return seqA - seqB
+      })
       
       // Process the chunks
       chunksToProcess.forEach(({ chunk, messageType }) => {
@@ -261,13 +321,37 @@ export function useChunkCatchup({
     } finally {
       fetchingInProgress.current = false
 
-      if (bufferUntilInitialCatchupComplete.current) {
+      // A reset was requested mid-fetch: re-arm and re-run with the queued
+      // params instead of finalizing on this (stale) fetch's results. The
+      // success path above may have already flipped the completion flags —
+      // reset them so the re-run isn't rejected by its own guards.
+      //
+      // KNOWN LIMIT: the stale fetch may already have processed (and flushed)
+      // chunks NEWER than the queued gap, so on an extreme double-flap the
+      // gap's chunks can render after later ones — order skew inside the
+      // bubble, but no content loss (strictly better than the pre-fix
+      // permanent hole). Perfect ordering would require holding the stale
+      // fetch's flush until the re-run completes, which isn't worth the
+      // complexity for this corner.
+      const pending = pendingCatchupRef.current
+      if (pending) {
+        pendingCatchupRef.current = null
+        hasCompletedInitialCatchup.current = false
+        lastFetchParams.current = null
+        bufferUntilInitialCatchupComplete.current = true
+        void catchUpChunksRef.current?.(pending.fromSequenceId)
+      } else if (bufferUntilInitialCatchupComplete.current) {
         bufferUntilInitialCatchupComplete.current = false
         hasCompletedInitialCatchup.current = true
         flushBufferedRealtimeChunks()
       }
     }
   }, [flushBufferedRealtimeChunks])
+
+  // Self-reference for the queued re-run above (the callback can't name
+  // itself inside its own useCallback initializer).
+  const catchUpChunksRef = useRef<typeof catchUpChunks | null>(null)
+  catchUpChunksRef.current = catchUpChunks
 
   /**
    * Reset all tracking state
@@ -305,8 +389,15 @@ export function useChunkCatchup({
     const fromSeq = lastSequenceId.current
     hasCompletedInitialCatchup.current = false
     lastFetchParams.current = null
-    bufferUntilInitialCatchupComplete.current = true
-    chunkBuffer.current = []
+    if (!bufferUntilInitialCatchupComplete.current) {
+      // Starting buffering fresh — drop stale leftovers. When the CALLER
+      // already armed buffering (e.g. `startInitialBuffering()` before an
+      // async history refetch on reconnect), KEEP the chunks it collected:
+      // clearing here would silently discard everything delivered during
+      // that await.
+      chunkBuffer.current = []
+      bufferUntilInitialCatchupComplete.current = true
+    }
     await catchUpChunks(fromSeq)
   }, [catchUpChunks])
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chunk-catchup.ts
@@ -62,6 +62,12 @@ export function useChunkCatchup({
 }: UseChunkCatchupOptions): UseChunkCatchupReturn {
   const processedSequenceKeys = useRef<Set<string>>(new Set())
   const lastSequenceId = useRef<number | null>(null)
+  // Per-messageType resume checkpoints. The legacy Redis transport keeps an
+  // INDEPENDENT sequence counter per (dialog, chatType), so resuming every
+  // stream from the single global `lastSequenceId` would permanently skip
+  // the slower stream's newer chunks (one stream at seq 100, the other at
+  // 20 → resuming both from 100 loses the second stream's 21+).
+  const lastSequenceIdByType = useRef<Map<NatsMessageType, number>>(new Map())
 
   const fetchingInProgress = useRef(false)
   const lastFetchParams = useRef<{ dialogId: string; fromSequenceId?: number | null } | null>(null)
@@ -69,7 +75,9 @@ export function useChunkCatchup({
   // reconnect during the initial catchup). Queued instead of dropped: the old
   // behaviour returned early and the stale fetch's completion marked catchup
   // done, so the new gap was never fetched — a permanent transcript hole.
-  const pendingCatchupRef = useRef<{ fromSequenceId?: number | null } | null>(null)
+  // Scoped to its originating dialog — a rerun must never apply one dialog's
+  // offset to another after a switch.
+  const pendingCatchupRef = useRef<{ dialogId: string; fromSequenceId?: number | null } | null>(null)
 
   // Buffer for NATS chunks that arrive during catchup
   const chunkBuffer = useRef<BufferedChunk[]>([])
@@ -105,6 +113,10 @@ export function useChunkCatchup({
       if (processedSequenceKeys.current.has(key)) return true
       processedSequenceKeys.current.add(key)
       lastSequenceId.current = chunk.sequenceId
+      const prevTypeSeq = lastSequenceIdByType.current.get(messageType)
+      if (prevTypeSeq === undefined || chunk.sequenceId > prevTypeSeq) {
+        lastSequenceIdByType.current.set(messageType, chunk.sequenceId)
+      }
     }
 
     onChunkReceivedRef.current(chunk, messageType)
@@ -161,7 +173,7 @@ export function useChunkCatchup({
       // fromSequenceId wins; a queued INITIAL call (undefined) falls back to
       // the last seq seen so far (null on a fresh dialog → backend returns
       // everything, same as the original undefined semantics).
-      pendingCatchupRef.current = { fromSequenceId: fromSequenceId ?? lastSequenceId.current }
+      pendingCatchupRef.current = { dialogId, fromSequenceId: fromSequenceId ?? lastSequenceId.current }
       return
     }
 
@@ -185,7 +197,17 @@ export function useChunkCatchup({
       // Fetch chunks for all configured chat types
       const chunkPromises = chatTypes.map(async (chatType) => {
         try {
-          const chunks = await fetchChunks(dialogId, chatType, fromSequenceId)
+          // Resume each stream from ITS OWN checkpoint: the legacy Redis
+          // transport numbers each (dialog, chatType) stream independently,
+          // so passing one global offset to every type would skip the slower
+          // stream's newer chunks. `undefined` (initial load) still fetches
+          // everything; a type we've never seen resumes from null (= all
+          // unsaved chunks) rather than borrowing another stream's offset.
+          const typeFromSequenceId =
+            fromSequenceId === undefined
+              ? undefined
+              : (lastSequenceIdByType.current.get(getChatTypeMessageType(chatType)) ?? null)
+          const chunks = await fetchChunks(dialogId, chatType, typeFromSequenceId)
           const messageType = getChatTypeMessageType(chatType)
           return chunks.map(chunk => ({ chunk, messageType }))
         } catch (error) {
@@ -310,6 +332,10 @@ export function useChunkCatchup({
           if (processedSequenceKeys.current.has(key)) return
           processedSequenceKeys.current.add(key)
           lastSequenceId.current = chunk.sequenceId
+          const prevTypeSeq = lastSequenceIdByType.current.get(messageType)
+          if (prevTypeSeq === undefined || chunk.sequenceId > prevTypeSeq) {
+            lastSequenceIdByType.current.set(messageType, chunk.sequenceId)
+          }
         }
         onChunkReceivedRef.current(chunk, messageType)
       })
@@ -319,31 +345,47 @@ export function useChunkCatchup({
     } catch (error) {
       console.error('Error during chunk catchup:', error)
     } finally {
-      fetchingInProgress.current = false
-
-      // A reset was requested mid-fetch: re-arm and re-run with the queued
-      // params instead of finalizing on this (stale) fetch's results. The
-      // success path above may have already flipped the completion flags —
-      // reset them so the re-run isn't rejected by its own guards.
-      //
-      // KNOWN LIMIT: the stale fetch may already have processed (and flushed)
-      // chunks NEWER than the queued gap, so on an extreme double-flap the
-      // gap's chunks can render after later ones — order skew inside the
-      // bubble, but no content loss (strictly better than the pre-fix
-      // permanent hole). Perfect ordering would require holding the stale
-      // fetch's flush until the re-run completes, which isn't worth the
-      // complexity for this corner.
-      const pending = pendingCatchupRef.current
-      if (pending) {
+      // A fetch whose dialog is no longer active must not touch the NEW
+      // dialog's cycle state — `resetChunkTracking` already re-armed the
+      // flags for it, and clearing `fetchingInProgress` / finalizing the
+      // buffer here would corrupt the new dialog's in-flight catch-up.
+      if (dialogId !== dialogIdRef.current) {
         pendingCatchupRef.current = null
-        hasCompletedInitialCatchup.current = false
-        lastFetchParams.current = null
-        bufferUntilInitialCatchupComplete.current = true
-        void catchUpChunksRef.current?.(pending.fromSequenceId)
-      } else if (bufferUntilInitialCatchupComplete.current) {
-        bufferUntilInitialCatchupComplete.current = false
-        hasCompletedInitialCatchup.current = true
-        flushBufferedRealtimeChunks()
+      } else {
+        fetchingInProgress.current = false
+
+        // A reset was requested mid-fetch: re-arm and re-run with the queued
+        // params instead of finalizing on this (stale) fetch's results. The
+        // success path above may have already flipped the completion flags —
+        // reset them so the re-run isn't rejected by its own guards. A
+        // pending entry from a DIFFERENT dialog is discarded, never replayed
+        // against the current one.
+        //
+        // KNOWN LIMIT: the stale fetch may already have processed (and
+        // flushed) chunks NEWER than the queued gap, so on an extreme
+        // double-flap the gap's chunks can render after later ones — order
+        // skew inside the bubble, but no content loss (strictly better than
+        // the pre-fix permanent hole). Perfect ordering would require holding
+        // the stale fetch's flush until the re-run completes, which isn't
+        // worth the complexity for this corner.
+        const pending = pendingCatchupRef.current
+        if (pending) {
+          pendingCatchupRef.current = null
+          if (pending.dialogId === dialogId) {
+            hasCompletedInitialCatchup.current = false
+            lastFetchParams.current = null
+            bufferUntilInitialCatchupComplete.current = true
+            void catchUpChunksRef.current?.(pending.fromSequenceId)
+          } else if (bufferUntilInitialCatchupComplete.current) {
+            bufferUntilInitialCatchupComplete.current = false
+            hasCompletedInitialCatchup.current = true
+            flushBufferedRealtimeChunks()
+          }
+        } else if (bufferUntilInitialCatchupComplete.current) {
+          bufferUntilInitialCatchupComplete.current = false
+          hasCompletedInitialCatchup.current = true
+          flushBufferedRealtimeChunks()
+        }
       }
     }
   }, [flushBufferedRealtimeChunks])
@@ -359,8 +401,10 @@ export function useChunkCatchup({
   const resetChunkTracking = useCallback(() => {
     processedSequenceKeys.current.clear()
     lastSequenceId.current = null
+    lastSequenceIdByType.current.clear()
     fetchingInProgress.current = false
     lastFetchParams.current = null
+    pendingCatchupRef.current = null
     chunkBuffer.current = []
     bufferUntilInitialCatchupComplete.current = false
     hasCompletedInitialCatchup.current = false
@@ -370,8 +414,13 @@ export function useChunkCatchup({
    * Start buffering NATS chunks for initial catchup
    */
   const startInitialBuffering = useCallback(() => {
-    chunkBuffer.current = []
-    bufferUntilInitialCatchupComplete.current = true
+    // Idempotent: a second reconnect while a back-fill is already buffering
+    // (its history refetch still awaiting) must NOT clear the live chunks
+    // collected so far — only a fresh start owns the buffer.
+    if (!bufferUntilInitialCatchupComplete.current) {
+      chunkBuffer.current = []
+      bufferUntilInitialCatchupComplete.current = true
+    }
     hasCompletedInitialCatchup.current = false
   }, [])
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-jetstream-dialog-subscription.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-jetstream-dialog-subscription.ts
@@ -213,6 +213,18 @@ export function useJetStreamDialogSubscription({
     }
   }, [enabled, wsUrl])
 
+  // Reset the highest-seen sequence whenever the dialog changes so a new dialog
+  // starts from optStartSeq (or DeliverPolicy.New) rather than the previous
+  // dialog's offset. MUST be declared BEFORE the subscription effect below:
+  // React runs effects in declaration order, and when this ran after it, the
+  // new dialog's consumer was created with the PREVIOUS dialog's stale
+  // `highestStreamSeq + 1` as its start sequence (skipping messages /
+  // ignoring optStartSeq).
+  useEffect(() => {
+    highestStreamSeqRef.current = null
+    setCurrentStreamSeq(null)
+  }, [dialogId])
+
   // Subscription lifecycle: (re)create the ephemeral JetStream consumer whenever
   // we transition into a connected state for a dialog, and whenever the dialog
   // changes. On reconnect we resume from highestStreamSeq + 1.
@@ -314,14 +326,6 @@ export function useJetStreamDialogSubscription({
       setIsSubscribed(false)
     }
   }, [enabled, dialogId, isConnected, streamName, topic, reconnectionCount])
-
-  // Reset the highest-seen sequence whenever the dialog changes so a new dialog
-  // starts from optStartSeq (or DeliverPolicy.New) rather than the previous
-  // dialog's offset.
-  useEffect(() => {
-    highestStreamSeqRef.current = null
-    setCurrentStreamSeq(null)
-  }, [dialogId])
 
   return { isConnected, isSubscribed, reconnectionCount, currentStreamSeq }
 }

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -70,6 +70,7 @@ import { useNatsDialogSubscription } from './use-nats-dialog-subscription'
 import { useRealtimeChunkProcessor } from './use-realtime-chunk-processor'
 import { useChunkCatchup } from './use-chunk-catchup'
 import { processHistoricalMessagesWithErrors } from '../utils/process-historical-messages'
+import { extractIncompleteMessageState } from '../utils/extract-incomplete-message-state'
 import type {
   ChunkData,
   FetchChunksFunction,
@@ -79,6 +80,9 @@ import type {
   NatsMessageType,
   StreamingPhase,
   ChatApprovalStatus,
+  SegmentsUpdateMetadata,
+  ToolExecutionSegment,
+  ApprovalBatchExecutionState,
 } from '../types'
 import type {
   ChatConnectionState,
@@ -211,6 +215,16 @@ export interface UseNatsChatAdapterConfig {
    * `toolCalls[]`. Set `false` to fall back to legacy per-tool cards.
    */
   batchApprovalsEnabled?: boolean
+
+  /**
+   * Approval types rendered as actionable cards inline. Mirrors
+   * `UseRealtimeChunkProcessorOptions.displayApprovalTypes` (default
+   * `['CLIENT']`) and is forwarded to the history processor so both paths
+   * agree. Hosts whose backend emits other types (e.g. `USER`) MUST set this
+   * — otherwise those approvals are escalated to a callback this adapter
+   * doesn't surface and the card never renders.
+   */
+  displayApprovalTypes?: string[]
 
   // ─── Managed-dialog mode (sidebar + history) ─────────────────────────────
 
@@ -369,6 +383,186 @@ function updateTrailingAssistant(
 }
 
 /**
+ * Realtime user/direct/system chunks can be replays of rows already on
+ * screen (our own optimistic send echoed back, catchup replaying the tail
+ * over just-loaded history, reconnect back-fill). Content-dedupe against a
+ * small trailing window — the twin is always near the end of the thread.
+ *
+ * KNOWN TRADE-OFF: content matching cannot tell a replay from a genuinely
+ * repeated message, so an OBSERVER session (no own optimistic append) that
+ * receives the same short text twice within the window renders it once.
+ * The principled discriminator is `streamSeq` (already delivered in the
+ * callbacks' meta, and what history-merge keys on) — switch to it if the
+ * adapter ever backs a mirror/observer surface; content-dedup then only
+ * needs to cover the own-optimistic echo, whose seq is unknown at append
+ * time.
+ */
+const REALTIME_DEDUP_WINDOW = 10
+
+function hasRecentMessage(
+  prev: UnifiedChatMessage[],
+  predicate: (message: UnifiedChatMessage) => boolean,
+): boolean {
+  const start = Math.max(0, prev.length - REALTIME_DEDUP_WINDOW)
+  for (let i = prev.length - 1; i >= start; i--) {
+    if (predicate(prev[i])) return true
+  }
+  return false
+}
+
+/**
+ * Append-mode counterpart of `updateTrailingAssistant` for post-MESSAGE_END
+ * continuation chunks (`SegmentsUpdateMetadata.append`). The processor emits
+ * single text/thinking fragments there — replacing the bubble with them (the
+ * old behaviour, which dropped the metadata) wiped everything the bubble
+ * already showed. Coalesces trailing fragments of the same type, mirroring
+ * the accumulator.
+ *
+ * Exported for host reuse (custom stores wiring the same processor) + tests.
+ */
+export function appendToTrailingAssistant(
+  prev: UnifiedChatMessage[],
+  segments: MessageSegment[],
+): UnifiedChatMessage[] {
+  if (segments.length === 0) return prev
+  const last = prev[prev.length - 1]
+  if (!last || last.role !== 'assistant') {
+    return [
+      ...prev,
+      { id: nextId('assistant'), role: 'assistant', content: '', segments },
+    ]
+  }
+  const merged = [...(last.segments ?? [])]
+  for (const seg of segments) {
+    const tail = merged[merged.length - 1]
+    if (seg.type === 'text' && tail?.type === 'text') {
+      merged[merged.length - 1] = { type: 'text', text: tail.text + seg.text }
+    } else if (seg.type === 'thinking' && tail?.type === 'thinking') {
+      merged[merged.length - 1] = { type: 'thinking', text: tail.text + seg.text }
+    } else {
+      // Non-text segments are pushed RAW on purpose: EXECUTING↔EXECUTED
+      // pairing and batch merging are `applyToolExecutionToMessages`'s job
+      // (post-END tool chunks never reach this helper — the processor routes
+      // them to onToolExecuted), and approval upserts happen store-side.
+      // Running the accumulator here would double-apply those rules.
+      merged.push(seg)
+    }
+  }
+  return [...prev.slice(0, -1), { ...last, segments: merged }]
+}
+
+/**
+ * Upsert a standalone context-compaction segment into the trailing assistant
+ * bubble. Compaction emissions arrive as the accumulator's CUMULATIVE array —
+ * only the compaction segment itself may be applied, or interleaved
+ * continuation text would duplicate. A `completed` segment replaces the last
+ * `started` one in place.
+ *
+ * Exported for host reuse + tests.
+ */
+export function upsertTrailingCompaction(
+  prev: UnifiedChatMessage[],
+  segments: MessageSegment[],
+): UnifiedChatMessage[] {
+  const compaction = [...segments].reverse().find((s) => s.type === 'context_compaction')
+  if (!compaction) return prev
+  const last = prev[prev.length - 1]
+  if (!last || last.role !== 'assistant') {
+    return [
+      ...prev,
+      { id: nextId('assistant'), role: 'assistant', content: '', segments: [compaction] },
+    ]
+  }
+  const existing = last.segments ?? []
+  // LAST 'started' segment (not first): with repeated compactions in one
+  // bubble the earlier ones are already completed-in-place, so the newest
+  // 'started' is the only one this completion can belong to.
+  const startedIdx = existing.map((s) => s.type === 'context_compaction' && s.status === 'started').lastIndexOf(true)
+  const merged =
+    startedIdx !== -1
+      ? existing.map((s, i) => (i === startedIdx ? compaction : s))
+      : [...existing, compaction]
+  return [...prev.slice(0, -1), { ...last, segments: merged }]
+}
+
+/**
+ * Cross-message tool-execution updater for post-MESSAGE_END tool chunks
+ * (approved commands executing after the approval bubble, async batch
+ * results). Scans messages from the end:
+ *  1) an `approval_batch` whose `toolCalls` contains the execution id →
+ *     merge into its `executions` map;
+ *  2) a matching `tool_execution` segment (same id, or EXECUTING with the
+ *     same tool for legacy id-less backends) → update in place;
+ *  3) no match → append the segment to the trailing assistant bubble.
+ *
+ * Exported for host reuse + tests.
+ */
+export function applyToolExecutionToMessages(
+  prev: UnifiedChatMessage[],
+  segment: ToolExecutionSegment,
+): UnifiedChatMessage[] {
+  const toolData = segment.data
+  const execId = toolData.toolExecutionRequestId
+
+  for (let i = prev.length - 1; i >= 0; i--) {
+    const message = prev[i]
+    if (message.role !== 'assistant' || !message.segments) continue
+
+    for (let j = message.segments.length - 1; j >= 0; j--) {
+      const seg = message.segments[j]
+
+      if (
+        execId &&
+        seg.type === 'approval_batch' &&
+        seg.data.toolCalls.some((c) => c.toolExecutionRequestId === execId)
+      ) {
+        const prevExec: ApprovalBatchExecutionState | undefined = seg.data.executions?.[execId]
+        const nextExec: ApprovalBatchExecutionState =
+          toolData.type === 'EXECUTED_TOOL'
+            ? { status: 'done', result: toolData.result, success: toolData.success }
+            : { status: 'executing', result: prevExec?.result, success: prevExec?.success }
+        const nextSegments = [...message.segments]
+        nextSegments[j] = {
+          ...seg,
+          data: { ...seg.data, executions: { ...(seg.data.executions ?? {}), [execId]: nextExec } },
+        }
+        const next = [...prev]
+        next[i] = { ...message, segments: nextSegments }
+        return next
+      }
+
+      if (seg.type === 'tool_execution') {
+        const matches = execId
+          ? seg.data.toolExecutionRequestId === execId
+          : seg.data.type === 'EXECUTING_TOOL' &&
+            seg.data.integratedToolType === toolData.integratedToolType &&
+            seg.data.toolFunction === toolData.toolFunction
+        if (!matches) continue
+        // Never downgrade a completed segment back to EXECUTING (replayed
+        // EXECUTING chunk after its EXECUTED already landed).
+        if (toolData.type === 'EXECUTING_TOOL' && seg.data.type === 'EXECUTED_TOOL') {
+          return prev
+        }
+        const nextSegments = [...message.segments]
+        nextSegments[j] = {
+          type: 'tool_execution',
+          data: {
+            ...toolData,
+            toolTitle: toolData.toolTitle ?? seg.data.toolTitle,
+            parameters: toolData.parameters || seg.data.parameters,
+          },
+        }
+        const next = [...prev]
+        next[i] = { ...message, segments: nextSegments }
+        return next
+      }
+    }
+  }
+
+  return appendToTrailingAssistant(prev, [segment])
+}
+
+/**
  * Map `ProcessedMessage` (lib's historical-message format) into
  * `UnifiedChatMessage` (the unified-chat-state contract). Only `user`
  * and `assistant` roles round-trip; `error` is dropped on the floor
@@ -450,6 +644,7 @@ export function useNatsChatAdapter(
     fetchChunks,
     topics,
     batchApprovalsEnabled,
+    displayApprovalTypes,
     fetchDialogs,
     fetchDialogMessages,
     createDialog: createDialogCallback,
@@ -500,6 +695,20 @@ export function useNatsChatAdapter(
   // after catchup lock normally; a reopened mid-execution dialog re-locks on
   // the next live chunk instead.
   const suppressAgentBusyRef = useRef(false)
+
+  // True when the trailing assistant loaded from history is an INCOMPLETE
+  // turn (mid-stream / mid-approval tail). The catchup replay re-streams that
+  // turn from its MESSAGE_START, and the replayed stream must ADOPT (replace)
+  // the partial history bubble. Any other MESSAGE_START over a non-empty
+  // trailing assistant is a NEW turn (observer / second device / post-approval
+  // continuation) and must open a fresh bubble instead of overwriting the
+  // completed one. Consumed (reset) by the first MESSAGE_START.
+  const adoptTrailingAssistantRef = useRef(false)
+
+  // Set after the first successful NATS connect. Later 'connected' events are
+  // RECONNECTS: plain NATS replays nothing, so the adapter must back-fill the
+  // disconnect gap via `resetAndCatchUp` or those chunks are lost forever.
+  const hasConnectedOnceRef = useRef(false)
 
   // Approval status map. Used both to dedupe pending segments at render
   // time and to feed `processHistoricalMessagesWithErrors` so previously
@@ -622,7 +831,7 @@ export function useNatsChatAdapter(
   // Stable callback ref so `useRealtimeChunkProcessor`'s options object
   // doesn't churn every render and tear down the accumulator state.
   const callbacksRef: MutableRefObject<{
-    onSegmentsUpdate: (segments: MessageSegment[]) => void
+    onSegmentsUpdate: (segments: MessageSegment[], meta?: SegmentsUpdateMetadata) => void
     onStreamStart: () => void
     onStreamEnd: () => void
     onAgentBusy: () => void
@@ -634,11 +843,60 @@ export function useNatsChatAdapter(
       providerName: string
       contextWindow: number
     }) => void
+    onToolExecuted: (segment: ToolExecutionSegment) => void
+    onApprovalResolved: (
+      requestId: string,
+      status: ChatApprovalStatus,
+      approvalType: string,
+      resolvedByName?: string | null,
+    ) => void
+    onUserMessage: (
+      text: string,
+      meta?: { ownerType?: string; displayName?: string; userId?: string; streamSeq?: number; contextItems?: Array<{ type: string; id: string }> },
+    ) => void
+    onDirectMessage: (
+      text: string,
+      meta?: { ownerType?: string; displayName?: string; userId?: string; streamSeq?: number },
+    ) => void
+    onSystemMessage: (text: string) => void
   }> = useRef({
-    onSegmentsUpdate: (segments: MessageSegment[]) => {
+    onSegmentsUpdate: (segments: MessageSegment[], meta?: SegmentsUpdateMetadata) => {
+      // Standalone compaction updates carry the accumulator's cumulative
+      // array — apply only the compaction segment (upsert) or interleaved
+      // continuation text would duplicate.
+      if (meta?.append && meta.isCompacting) {
+        setMessages((prev) => upsertTrailingCompaction(prev, segments))
+        return
+      }
+      // Post-MESSAGE_END continuation fragments append into the existing
+      // bubble; replacing (the pre-fix behaviour, which dropped `meta`)
+      // wiped the completed reply and left only the newest fragment.
+      if (meta?.append) {
+        setMessages((prev) => appendToTrailingAssistant(prev, segments))
+        return
+      }
       setMessages((prev) => updateTrailingAssistant(prev, segments))
     },
-    onStreamStart: () => setStreamingPhase('streaming'),
+    onStreamStart: () => {
+      setStreamingPhase('streaming')
+      // A new stream must never overwrite a COMPLETED trailing assistant
+      // bubble (observer tab / second device / post-approval continuation
+      // turn). Open a fresh bubble unless the trailing assistant is empty
+      // (our own optimistic placeholder) or is the incomplete history tail
+      // the catchup replay is legitimately re-streaming (adopt-once flag).
+      const adoptTail = adoptTrailingAssistantRef.current
+      adoptTrailingAssistantRef.current = false
+      setMessages((prev) => {
+        const last = prev[prev.length - 1]
+        if (!last || last.role !== 'assistant' || adoptTail) return prev
+        const hasContent = (last.segments?.length ?? 0) > 0 || last.content !== ''
+        if (!hasContent) return prev
+        return [
+          ...prev,
+          { id: nextId('assistant'), role: 'assistant', content: '', segments: [] },
+        ]
+      })
+    },
     onStreamEnd: () => setStreamingPhase('idle'),
     // Agent is executing (approved) commands outside an open stream — keep
     // the composer locked exactly like the in-stream phases. An open stream
@@ -662,6 +920,112 @@ export function useNatsChatAdapter(
         modelLabel: meta.modelDisplayName || meta.modelName || null,
         contextWindowMaxTokens: meta.contextWindow || null,
       }),
+    // Post-MESSAGE_END tool chunks (approved commands executing after the
+    // approval bubble, async batch results). Routed through the cross-message
+    // updater — the accumulator was reset at MESSAGE_END, so the old
+    // fallthrough replaced the whole trailing bubble with one tool segment.
+    onToolExecuted: (segment: ToolExecutionSegment) => {
+      setMessages((prev) => applyToolExecutionToMessages(prev, segment))
+    },
+    // Cross-message approval status flip. Wiring this also makes the
+    // processor skip its cumulative re-emit for resolved approvals — which,
+    // post-MESSAGE_END, was an empty array that blanked the trailing bubble.
+    onApprovalResolved: (requestId, status, _approvalType, resolvedByName) => {
+      setMessages((prev) => {
+        let changed = false
+        const next = prev.map((m) => {
+          if (m.role !== 'assistant' || !m.segments) return m
+          let msgChanged = false
+          const segs = m.segments.map((s) => {
+            if (s.type === 'approval_request' && s.data.requestId === requestId && s.status !== status) {
+              msgChanged = true
+              return { ...s, status }
+            }
+            if (s.type === 'approval_batch' && s.data.approvalRequestId === requestId) {
+              const nextResolvedBy = resolvedByName ?? s.resolvedByName
+              if (s.status === status && nextResolvedBy === s.resolvedByName) return s
+              msgChanged = true
+              return { ...s, status, resolvedByName: nextResolvedBy }
+            }
+            return s
+          })
+          if (!msgChanged) return m
+          changed = true
+          return { ...m, segments: segs }
+        })
+        return changed ? next : prev
+      })
+      // Mirror into the status map so history re-processing (dialog reopen,
+      // pagination) renders the card resolved instead of actionable.
+      setApprovalStatuses((prev) =>
+        prev[requestId] === status ? prev : { ...prev, [requestId]: status },
+      )
+    },
+    // MESSAGE_REQUEST echo — a user message from THIS or another session.
+    // Deduped by content against recent bubbles: covers our own optimistic
+    // append and catchup replays over already-loaded history rows.
+    onUserMessage: (text, meta) => {
+      if (!text) return
+      setMessages((prev) => {
+        if (hasRecentMessage(prev, (m) => m.role === 'user' && m.authorType !== 'system' && m.content === text)) {
+          return prev
+        }
+        return [
+          ...prev,
+          {
+            id: nextId('user'),
+            role: 'user',
+            content: text,
+            ...(meta?.displayName ? { name: meta.displayName } : {}),
+            authorType: meta?.ownerType === 'ADMIN' ? 'admin' : 'user',
+            ...(meta?.contextItems && meta.contextItems.length > 0
+              ? {
+                  contextItems: meta.contextItems.map((ci) => ({
+                    type: ci.type,
+                    id: ci.id,
+                    label: (ci as { label?: string }).label ?? ci.id,
+                  })),
+                }
+              : {}),
+          },
+        ]
+      })
+    },
+    // Technician / admin direct message into the dialog.
+    onDirectMessage: (text, meta) => {
+      if (!text) return
+      setMessages((prev) => {
+        if (hasRecentMessage(prev, (m) => m.role === 'user' && m.content === text)) return prev
+        return [
+          ...prev,
+          {
+            id: `direct-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+            role: 'user',
+            content: text,
+            name: meta?.displayName ?? 'Admin',
+            authorType: 'admin',
+          },
+        ]
+      })
+    },
+    // System notice — rendered as a name-only row (same shape the history
+    // processor produces via `pushStandaloneMessages`).
+    onSystemMessage: (text) => {
+      if (!text) return
+      setMessages((prev) => {
+        if (hasRecentMessage(prev, (m) => m.authorType === 'system' && m.name === text)) return prev
+        return [
+          ...prev,
+          {
+            id: `system-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+            role: 'user',
+            content: '',
+            name: text,
+            authorType: 'system',
+          },
+        ]
+      })
+    },
   })
 
   // Real-time chunk → segment processor. Approval handlers route through
@@ -669,17 +1033,25 @@ export function useNatsChatAdapter(
   // host) doesn't tear down the accumulator.
   const { processChunk, reset: resetAccumulator } = useRealtimeChunkProcessor({
     callbacks: {
-      onSegmentsUpdate: (segments) => callbacksRef.current.onSegmentsUpdate(segments),
+      onSegmentsUpdate: (segments, meta) => callbacksRef.current.onSegmentsUpdate(segments, meta),
       onStreamStart: () => callbacksRef.current.onStreamStart(),
       onStreamEnd: () => callbacksRef.current.onStreamEnd(),
       onAgentBusy: () => callbacksRef.current.onAgentBusy(),
       onError: () => callbacksRef.current.onError(),
       onTokenUsage: (data) => callbacksRef.current.onTokenUsage(data),
       onMetadata: (meta) => callbacksRef.current.onMetadata(meta),
+      onToolExecuted: (segment) => callbacksRef.current.onToolExecuted(segment),
+      onApprovalResolved: (requestId, status, approvalType, resolvedByName) =>
+        callbacksRef.current.onApprovalResolved(requestId, status, approvalType, resolvedByName),
+      onUserMessage: (text, meta) => callbacksRef.current.onUserMessage(text, meta),
+      onDirectMessage: (text, meta) => callbacksRef.current.onDirectMessage(text, meta),
+      onSystemMessage: (text) => callbacksRef.current.onSystemMessage(text),
       onApprove: accumApprove,
       onReject: accumReject,
     },
     batchApprovalsEnabled,
+    approvalStatuses,
+    ...(displayApprovalTypes ? { displayApprovalTypes } : {}),
   })
 
   // History catchup — back-fills chunks emitted while the adapter was
@@ -689,6 +1061,7 @@ export function useNatsChatAdapter(
     catchUpChunks,
     startInitialBuffering,
     resetChunkTracking,
+    resetAndCatchUp,
   } = useChunkCatchup({
     dialogId: active ? dialogId : null,
     onChunkReceived: (chunk: ChunkData) => processChunk(chunk),
@@ -731,11 +1104,17 @@ export function useNatsChatAdapter(
             onReject: accumReject,
             approvalStatuses,
             batchApprovalsEnabled,
+            ...(displayApprovalTypes ? { displayApprovalTypes } : {}),
           },
         )
         const unified = mapProcessedToUnified(rawProcessed)
         if (cursor === undefined) {
-          // First page — replace.
+          // First page — replace. When the trailing assistant is an
+          // INCOMPLETE turn, the catchup replay will re-stream it from its
+          // MESSAGE_START — let that stream adopt (replace) the partial
+          // bubble instead of opening a duplicate one.
+          adoptTrailingAssistantRef.current =
+            extractIncompleteMessageState(rawProcessed[rawProcessed.length - 1]) !== undefined
           setMessages(unified)
         } else {
           // Older page — prepend.
@@ -762,6 +1141,7 @@ export function useNatsChatAdapter(
       chatTypeFilter,
       approvalStatuses,
       batchApprovalsEnabled,
+      displayApprovalTypes,
       accumApprove,
       accumReject,
     ],
@@ -781,6 +1161,7 @@ export function useNatsChatAdapter(
 
     // Drop accumulator + message state for the previous dialog.
     resetAccumulator()
+    adoptTrailingAssistantRef.current = false
     setMessages([])
     setMessagesNextCursor(null)
     setDialogTokenUsage(null)
@@ -838,6 +1219,45 @@ export function useNatsChatAdapter(
       catchupProcessChunk(payload as ChunkData, messageType)
       // First successful event marks the connection as up.
       setConnectionState('connected')
+    },
+    onConnect: () => {
+      // Plain NATS pub/sub has no replay: chunks published while the socket
+      // was down are gone unless we back-fill. The FIRST connect is covered
+      // by the initial catchup effect; every later one is a reconnect.
+      if (!hasConnectedOnceRef.current) {
+        hasConnectedOnceRef.current = true
+        return
+      }
+      suppressAgentBusyRef.current = true
+      // Buffer live deliveries for the WHOLE back-fill, including the history
+      // await — otherwise chunks landing mid-fetch are processed unbuffered
+      // (advancing lastSequenceId + dedup keys) and the history replace then
+      // wipes their content with no way to replay them. `resetAndCatchUp`
+      // keeps an already-active buffer, so nothing collected here is lost.
+      startInitialBuffering()
+      void (async () => {
+        try {
+          // History FIRST: the backend never stores DIRECT_MESSAGE/SYSTEM
+          // chunks in its catchup store (instant types go straight to Mongo),
+          // so the chunk back-fill can't recover them — the persisted history
+          // page is the only source. Then replay the unsaved chunk tail on
+          // top of the fresh snapshot.
+          if (dialogId && fetchDialogMessages) {
+            await loadDialogHistory(dialogId)
+          }
+          await resetAndCatchUp()
+        } catch (err) {
+          console.error('[useNatsChatAdapter] reconnect catchup failed:', err)
+        } finally {
+          suppressAgentBusyRef.current = false
+          // The adopt-once flag targets the replayed MESSAGE_START of the
+          // incomplete tail — but on reconnect that START was already
+          // consumed live and is dedup-skipped by the replay, so it never
+          // fires onStreamStart. Clear the flag or the NEXT genuine turn
+          // adopts (and overwrites) the completed trailing bubble.
+          adoptTrailingAssistantRef.current = false
+        }
+      })()
     },
   })
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -561,6 +561,14 @@ export function applyToolExecutionToMessages(
       }
 
       if (seg.type === 'tool_execution') {
+        // KNOWN LIMIT (id-less chunks only — current backends always send
+        // toolExecutionRequestId): the fuzzy fallback pairs only with a
+        // segment still EXECUTING, so a replayed id-less EXECUTING/EXECUTED
+        // arriving after the pair completed matches nothing and falls to the
+        // append below (duplicate card). Widening the predicate to EXECUTED
+        // twins would instead swallow a LEGITIMATE second run of the same
+        // tool — without ids the two are indistinguishable, and losing a
+        // real run is worse than a duplicate card on a legacy transport.
         const matches = execId
           ? seg.data.toolExecutionRequestId === execId
           : seg.data.type === 'EXECUTING_TOOL' &&
@@ -708,6 +716,13 @@ export function useNatsChatAdapter(
     ? controlledDialogId
     : null
 
+  // Render-synchronous mirror of the active dialog. Async continuations
+  // (reconnect back-fill, catchup finallys) capture `dialogId` at start and
+  // compare against this ref when they resume — a continuation whose dialog
+  // is no longer active must not touch the new dialog's flags.
+  const currentDialogIdRef = useRef<string | null>(dialogId)
+  currentDialogIdRef.current = dialogId
+
   // ─── Message thread + streaming phase ─────────────────────────────────────
 
   const [messages, setMessages] = useState<UnifiedChatMessage[]>([])
@@ -723,7 +738,11 @@ export function useNatsChatAdapter(
   // MESSAGE_END never replays — locking the composer forever. Live chunks
   // after catchup lock normally; a reopened mid-execution dialog re-locks on
   // the next live chunk instead.
-  const suppressAgentBusyRef = useRef(false)
+  // A COUNTER, not a boolean: the initial-catchup window and a reconnect
+  // back-fill window can overlap (reconnect during the initial fetch), and
+  // with a boolean whichever finished FIRST dropped the other's suppression
+  // mid-replay. Each window increments on entry / decrements in its finally.
+  const suppressAgentBusyRef = useRef(0)
 
   // True when the trailing assistant loaded from history is an INCOMPLETE
   // turn (mid-stream / mid-approval tail). The catchup replay re-streams that
@@ -941,7 +960,7 @@ export function useNatsChatAdapter(
     // keeps ownership: only 'idle' upgrades to 'thinking'. Suppressed during
     // initial catchup so a replayed dead tail can't lock a finished dialog.
     onAgentBusy: () => {
-      if (suppressAgentBusyRef.current) return
+      if (suppressAgentBusyRef.current > 0) return
       setStreamingPhase((p) => (p === 'idle' ? 'thinking' : p))
     },
     // Terminal turn failures can arrive without a MESSAGE_END; unlock the
@@ -1002,6 +1021,18 @@ export function useNatsChatAdapter(
     // MESSAGE_REQUEST echo — a user message from THIS or another session.
     onUserMessage: (text, meta) => {
       if (!text) return
+      // Layer 1 FIRST: exact event identity. A seq we've handled is a
+      // replay; a fresh seq is appended with NO content matching, so
+      // genuinely repeated texts from other participants always render.
+      // Must run (and RECORD) before the echo consume below — the echo
+      // branch early-returns, and skipping the record there let an
+      // at-least-once redelivery of the same event pass as fresh (and eat
+      // a second pending echo entry).
+      const seq = meta?.streamSeq
+      if (typeof seq === 'number') {
+        if (seenParticipantSeqsRef.current.has(seq)) return
+        seenParticipantSeqsRef.current.add(seq)
+      }
       // Layer 2: our own optimistic echo — consume exactly one recorded send.
       if (meta?.ownerType !== 'ADMIN') {
         const echoIdx = pendingEchoTextsRef.current.indexOf(text)
@@ -1009,14 +1040,6 @@ export function useNatsChatAdapter(
           pendingEchoTextsRef.current.splice(echoIdx, 1)
           return
         }
-      }
-      // Layer 1: exact event identity. A seq we've rendered is a replay;
-      // a fresh seq is appended with NO content matching, so genuinely
-      // repeated texts from other participants always render.
-      const seq = meta?.streamSeq
-      if (typeof seq === 'number') {
-        if (seenParticipantSeqsRef.current.has(seq)) return
-        seenParticipantSeqsRef.current.add(seq)
       }
       const authorType = meta?.ownerType === 'ADMIN' ? 'admin' : 'user'
       setMessages((prev) => {
@@ -1150,6 +1173,7 @@ export function useNatsChatAdapter(
     startInitialBuffering,
     resetChunkTracking,
     resetAndCatchUp,
+    isBufferingActive,
   } = useChunkCatchup({
     dialogId: active ? dialogId : null,
     onChunkReceived: (chunk: ChunkData) => processChunk(chunk),
@@ -1201,7 +1225,13 @@ export function useNatsChatAdapter(
           // INCOMPLETE turn, the catchup replay will re-stream it from its
           // MESSAGE_START — let that stream adopt (replace) the partial
           // bubble instead of opening a duplicate one.
+          // Gated on an ACTIVE catchup buffer: when the catchup already
+          // finalized before this history page resolved, no replay is coming
+          // to consume the flag — arming it anyway would hand the adoption
+          // to the NEXT genuine turn, which would overwrite the partial
+          // bubble instead of opening a fresh one.
           adoptTrailingAssistantRef.current =
+            isBufferingActive() &&
             extractIncompleteMessageState(rawProcessed[rawProcessed.length - 1]) !== undefined
           setMessages(unified)
         } else {
@@ -1232,6 +1262,7 @@ export function useNatsChatAdapter(
       displayApprovalTypes,
       accumApprove,
       accumReject,
+      isBufferingActive,
     ],
   )
 
@@ -1277,7 +1308,7 @@ export function useNatsChatAdapter(
   useEffect(() => {
     if (!active || !dialogId) return
     // Gate onAgentBusy for the replay window (see suppressAgentBusyRef).
-    suppressAgentBusyRef.current = true
+    suppressAgentBusyRef.current += 1
     resetChunkTracking()
     startInitialBuffering()
     catchUpChunks()
@@ -1285,7 +1316,16 @@ export function useNatsChatAdapter(
         console.error('[useNatsChatAdapter] initial catchup failed:', err)
       })
       .finally(() => {
-        suppressAgentBusyRef.current = false
+        suppressAgentBusyRef.current = Math.max(0, suppressAgentBusyRef.current - 1)
+        // The adopt-once flag targets the replayed MESSAGE_START of the
+        // incomplete history tail. When the replay produced none (chunk
+        // store expired past its ~10-min retention / empty), the armed flag
+        // would survive and make the NEXT genuine turn (post-approval
+        // continuation, second device) adopt-and-overwrite the partial
+        // bubble. Scoped: only the still-active dialog clears its own flag.
+        if (dialogId === currentDialogIdRef.current) {
+          adoptTrailingAssistantRef.current = false
+        }
       })
   }, [active, dialogId, resetChunkTracking, startInitialBuffering, catchUpChunks])
 
@@ -1318,7 +1358,7 @@ export function useNatsChatAdapter(
         hasConnectedOnceRef.current = true
         return
       }
-      suppressAgentBusyRef.current = true
+      suppressAgentBusyRef.current += 1
       // Buffer live deliveries for the WHOLE back-fill, including the history
       // await — otherwise chunks landing mid-fetch are processed unbuffered
       // (advancing lastSequenceId + dedup keys) and the history replace then
@@ -1335,17 +1375,26 @@ export function useNatsChatAdapter(
           if (dialogId && fetchDialogMessages) {
             await loadDialogHistory(dialogId)
           }
+          // The user may have switched dialogs during the await — the new
+          // dialog's own effects run their catchup cycle; re-running it here
+          // (via refs it would target the NEW dialog) would reset that cycle
+          // mid-flight.
+          if (dialogId !== currentDialogIdRef.current) return
           await resetAndCatchUp()
         } catch (err) {
           console.error('[useNatsChatAdapter] reconnect catchup failed:', err)
         } finally {
-          suppressAgentBusyRef.current = false
+          suppressAgentBusyRef.current = Math.max(0, suppressAgentBusyRef.current - 1)
           // The adopt-once flag targets the replayed MESSAGE_START of the
           // incomplete tail — but on reconnect that START was already
           // consumed live and is dedup-skipped by the replay, so it never
           // fires onStreamStart. Clear the flag or the NEXT genuine turn
-          // adopts (and overwrites) the completed trailing bubble.
-          adoptTrailingAssistantRef.current = false
+          // adopts (and overwrites) the completed trailing bubble. Scoped:
+          // a stale back-fill must not clear the NEW dialog's freshly armed
+          // flag.
+          if (dialogId === currentDialogIdRef.current) {
+            adoptTrailingAssistantRef.current = false
+          }
         }
       })()
     },

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -385,25 +385,28 @@ function updateTrailingAssistant(
 /**
  * Realtime user/direct/system chunks can be replays of rows already on
  * screen (our own optimistic send echoed back, catchup replaying the tail
- * over just-loaded history, reconnect back-fill). Content-dedupe against a
- * small trailing window — the twin is always near the end of the thread.
+ * over just-loaded history, reconnect back-fill).
  *
- * KNOWN TRADE-OFF: content matching cannot tell a replay from a genuinely
- * repeated message, so an OBSERVER session (no own optimistic append) that
- * receives the same short text twice within the window renders it once.
- * The principled discriminator is `streamSeq` (already delivered in the
- * callbacks' meta, and what history-merge keys on) — switch to it if the
- * adapter ever backs a mirror/observer surface; content-dedup then only
- * needs to cover the own-optimistic echo, whose seq is unknown at append
- * time.
+ * Dedup layers, in priority order:
+ *  1. `streamSeq` identity (JetStream) — exact, never confuses a genuinely
+ *     repeated text with a replay; tracked in a per-dialog seen-set.
+ *  2. One-shot optimistic-echo consumption — `sendMessage` records the text
+ *     it optimistically rendered; the backend's MESSAGE_REQUEST echo removes
+ *     exactly one entry.
+ *  3. Content match over a SHORT same-author tail window — only for
+ *     seq-less transports (plain NATS replay over just-loaded history, where
+ *     the persisted twin sits at most a couple of rows up). Same-author so
+ *     an admin message can never suppress a user's identical text.
  */
-const REALTIME_DEDUP_WINDOW = 10
+const CONTENT_DEDUP_WINDOW = 4
+const SYSTEM_DEDUP_WINDOW = 10
 
 function hasRecentMessage(
   prev: UnifiedChatMessage[],
   predicate: (message: UnifiedChatMessage) => boolean,
+  window: number,
 ): boolean {
-  const start = Math.max(0, prev.length - REALTIME_DEDUP_WINDOW)
+  const start = Math.max(0, prev.length - window)
   for (let i = prev.length - 1; i >= start; i--) {
     if (predicate(prev[i])) return true
   }
@@ -439,12 +442,32 @@ export function appendToTrailingAssistant(
       merged[merged.length - 1] = { type: 'text', text: tail.text + seg.text }
     } else if (seg.type === 'thinking' && tail?.type === 'thinking') {
       merged[merged.length - 1] = { type: 'thinking', text: tail.text + seg.text }
+    } else if (seg.type === 'approval_batch') {
+      // Approval deltas must be IDEMPOTENT: the escalated-result emit can be
+      // seen twice (live + catch-up replay over hydrated history), so upsert
+      // by request id instead of raw-appending a duplicate card.
+      const idx = merged.findIndex(
+        (m) => m.type === 'approval_batch' && m.data.approvalRequestId === seg.data.approvalRequestId,
+      )
+      if (idx !== -1) merged[idx] = seg
+      else merged.push(seg)
+    } else if (seg.type === 'approval_request') {
+      // Legacy cards share one requestId across an unfolded batch — key on
+      // (requestId, command) so each tool's card upserts its own twin.
+      const idx = merged.findIndex(
+        (m) =>
+          m.type === 'approval_request' &&
+          m.data.requestId === seg.data.requestId &&
+          m.data.command === seg.data.command,
+      )
+      if (idx !== -1) merged[idx] = seg
+      else merged.push(seg)
     } else {
-      // Non-text segments are pushed RAW on purpose: EXECUTING↔EXECUTED
+      // Other non-text segments are pushed RAW on purpose: EXECUTING↔EXECUTED
       // pairing and batch merging are `applyToolExecutionToMessages`'s job
       // (post-END tool chunks never reach this helper — the processor routes
-      // them to onToolExecuted), and approval upserts happen store-side.
-      // Running the accumulator here would double-apply those rules.
+      // them to onToolExecuted). Running the accumulator here would
+      // double-apply those rules.
       merged.push(seg)
     }
   }
@@ -517,6 +540,12 @@ export function applyToolExecutionToMessages(
         seg.data.toolCalls.some((c) => c.toolExecutionRequestId === execId)
       ) {
         const prevExec: ApprovalBatchExecutionState | undefined = seg.data.executions?.[execId]
+        // Never downgrade a done batch slot back to executing (JetStream
+        // redelivery of the EXECUTING chunk after EXECUTED landed). Returning
+        // prev = matched-with-no-change, so the caller doesn't append either.
+        if (toolData.type === 'EXECUTING_TOOL' && prevExec?.status === 'done') {
+          return prev
+        }
         const nextExec: ApprovalBatchExecutionState =
           toolData.type === 'EXECUTED_TOOL'
             ? { status: 'done', result: toolData.result, success: toolData.success }
@@ -710,6 +739,15 @@ export function useNatsChatAdapter(
   // disconnect gap via `resetAndCatchUp` or those chunks are lost forever.
   const hasConnectedOnceRef = useRef(false)
 
+  // Exact-identity dedup for participant chunks (user/direct/system): the
+  // JetStream streamSeq of every rendered participant row. Cleared per
+  // dialog. See the dedup-layers note above `hasRecentMessage`.
+  const seenParticipantSeqsRef = useRef<Set<number>>(new Set())
+  // Texts `sendMessage` rendered optimistically and whose MESSAGE_REQUEST
+  // echo hasn't come back yet — the echo consumes exactly ONE entry, so a
+  // genuinely repeated send ("yes", "yes") still renders twice.
+  const pendingEchoTextsRef = useRef<string[]>([])
+
   // Approval status map. Used both to dedupe pending segments at render
   // time and to feed `processHistoricalMessagesWithErrors` so previously
   // resolved approvals don't re-render as actionable on dialog switch.
@@ -858,7 +896,7 @@ export function useNatsChatAdapter(
       text: string,
       meta?: { ownerType?: string; displayName?: string; userId?: string; streamSeq?: number },
     ) => void
-    onSystemMessage: (text: string) => void
+    onSystemMessage: (text: string, meta?: { streamSeq?: number }) => void
   }> = useRef({
     onSegmentsUpdate: (segments: MessageSegment[], meta?: SegmentsUpdateMetadata) => {
       // Standalone compaction updates carry the accumulator's cumulative
@@ -962,12 +1000,36 @@ export function useNatsChatAdapter(
       )
     },
     // MESSAGE_REQUEST echo — a user message from THIS or another session.
-    // Deduped by content against recent bubbles: covers our own optimistic
-    // append and catchup replays over already-loaded history rows.
     onUserMessage: (text, meta) => {
       if (!text) return
+      // Layer 2: our own optimistic echo — consume exactly one recorded send.
+      if (meta?.ownerType !== 'ADMIN') {
+        const echoIdx = pendingEchoTextsRef.current.indexOf(text)
+        if (echoIdx !== -1) {
+          pendingEchoTextsRef.current.splice(echoIdx, 1)
+          return
+        }
+      }
+      // Layer 1: exact event identity. A seq we've rendered is a replay;
+      // a fresh seq is appended with NO content matching, so genuinely
+      // repeated texts from other participants always render.
+      const seq = meta?.streamSeq
+      if (typeof seq === 'number') {
+        if (seenParticipantSeqsRef.current.has(seq)) return
+        seenParticipantSeqsRef.current.add(seq)
+      }
+      const authorType = meta?.ownerType === 'ADMIN' ? 'admin' : 'user'
       setMessages((prev) => {
-        if (hasRecentMessage(prev, (m) => m.role === 'user' && m.authorType !== 'system' && m.content === text)) {
+        // Layer 3: seq-less transports only — same-author content twin in the
+        // immediate tail (replay over just-loaded history).
+        if (
+          typeof seq !== 'number' &&
+          hasRecentMessage(
+            prev,
+            (m) => m.role === 'user' && (m.authorType ?? 'user') === authorType && m.content === text,
+            CONTENT_DEDUP_WINDOW,
+          )
+        ) {
           return prev
         }
         return [
@@ -977,7 +1039,7 @@ export function useNatsChatAdapter(
             role: 'user',
             content: text,
             ...(meta?.displayName ? { name: meta.displayName } : {}),
-            authorType: meta?.ownerType === 'ADMIN' ? 'admin' : 'user',
+            authorType,
             ...(meta?.contextItems && meta.contextItems.length > 0
               ? {
                   contextItems: meta.contextItems.map((ci) => ({
@@ -994,8 +1056,24 @@ export function useNatsChatAdapter(
     // Technician / admin direct message into the dialog.
     onDirectMessage: (text, meta) => {
       if (!text) return
+      const seq = meta?.streamSeq
+      if (typeof seq === 'number') {
+        if (seenParticipantSeqsRef.current.has(seq)) return
+        seenParticipantSeqsRef.current.add(seq)
+      }
       setMessages((prev) => {
-        if (hasRecentMessage(prev, (m) => m.role === 'user' && m.content === text)) return prev
+        // Seq-less fallback matches only prior ADMIN-authored twins — a
+        // client's identical text must never suppress the technician's.
+        if (
+          typeof seq !== 'number' &&
+          hasRecentMessage(
+            prev,
+            (m) => m.role === 'user' && m.authorType === 'admin' && m.content === text,
+            CONTENT_DEDUP_WINDOW,
+          )
+        ) {
+          return prev
+        }
         return [
           ...prev,
           {
@@ -1010,10 +1088,20 @@ export function useNatsChatAdapter(
     },
     // System notice — rendered as a name-only row (same shape the history
     // processor produces via `pushStandaloneMessages`).
-    onSystemMessage: (text) => {
+    onSystemMessage: (text, meta) => {
       if (!text) return
+      const seq = meta?.streamSeq
+      if (typeof seq === 'number') {
+        if (seenParticipantSeqsRef.current.has(seq)) return
+        seenParticipantSeqsRef.current.add(seq)
+      }
       setMessages((prev) => {
-        if (hasRecentMessage(prev, (m) => m.authorType === 'system' && m.name === text)) return prev
+        if (
+          typeof seq !== 'number' &&
+          hasRecentMessage(prev, (m) => m.authorType === 'system' && m.name === text, SYSTEM_DEDUP_WINDOW)
+        ) {
+          return prev
+        }
         return [
           ...prev,
           {
@@ -1045,7 +1133,7 @@ export function useNatsChatAdapter(
         callbacksRef.current.onApprovalResolved(requestId, status, approvalType, resolvedByName),
       onUserMessage: (text, meta) => callbacksRef.current.onUserMessage(text, meta),
       onDirectMessage: (text, meta) => callbacksRef.current.onDirectMessage(text, meta),
-      onSystemMessage: (text) => callbacksRef.current.onSystemMessage(text),
+      onSystemMessage: (text, meta) => callbacksRef.current.onSystemMessage(text, meta),
       onApprove: accumApprove,
       onReject: accumReject,
     },
@@ -1162,6 +1250,8 @@ export function useNatsChatAdapter(
     // Drop accumulator + message state for the previous dialog.
     resetAccumulator()
     adoptTrailingAssistantRef.current = false
+    seenParticipantSeqsRef.current.clear()
+    pendingEchoTextsRef.current = []
     setMessages([])
     setMessagesNextCursor(null)
     setDialogTokenUsage(null)
@@ -1333,6 +1423,12 @@ export function useNatsChatAdapter(
       sendOptions?: UnifiedSendMessageOptions,
     ): Promise<void> => {
       const hidden = sendOptions?.hidden ?? false
+
+      // Record the text so the backend's MESSAGE_REQUEST echo consumes this
+      // send instead of rendering a duplicate row (cap keeps the list from
+      // growing if a backend never echoes).
+      pendingEchoTextsRef.current.push(text)
+      if (pendingEchoTextsRef.current.length > 5) pendingEchoTextsRef.current.shift()
 
       // Optimistically append the user bubble + an empty assistant
       // placeholder. The assistant body fills in as NATS chunks land.

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-dialog-subscription.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-dialog-subscription.ts
@@ -182,7 +182,13 @@ export function useNatsDialogSubscription({
     }
   }, [enabled, wsUrl])
 
+  // Key the subscription effects on the topics CONTENT, not the array
+  // identity — hosts often pass an inline array, and an identity dep made
+  // every render tear down + recreate the subscriptions (plain NATS delivers
+  // nothing during that gap, so chunks were silently lost).
   const topicsKey = topics.join(',')
+  const topicsRef = useRef(topics)
+  topicsRef.current = topics
   const lastSubscribedDialogIdRef = useRef<string | null>(null)
   const isConnectedRef = useRef(isConnected)
   
@@ -260,7 +266,7 @@ export function useNatsDialogSubscription({
         }
       }
       
-      topics.forEach((topic) => {
+      topicsRef.current.forEach((topic) => {
         const subscription = client.subscribeBytes(
           `chat.${dialogId}.${topic}`,
           handleMessage(topic),
@@ -268,7 +274,7 @@ export function useNatsDialogSubscription({
         )
         subscriptionRefs.current.set(topic, subscription)
       })
-      
+
       lastSubscribedDialogIdRef.current = dialogId
       setIsSubscribed(true)
       onSubscribedRef.current?.()
@@ -292,7 +298,7 @@ export function useNatsDialogSubscription({
       lastSubscribedDialogIdRef.current = null
       abortControllerRef.current = null
     }
-  }, [enabled, dialogId, topicsKey, topics])
+  }, [enabled, dialogId, topicsKey])
 
   useEffect(() => {
     if (!enabled || !currentDialogIdRef.current || !isConnected) {
@@ -322,7 +328,7 @@ export function useNatsDialogSubscription({
         }
       }
       
-      topics.forEach((topic) => {
+      topicsRef.current.forEach((topic) => {
         const subscription = client.subscribeBytes(
           `chat.${dialogId}.${topic}`,
           handleMessage(topic),
@@ -330,14 +336,14 @@ export function useNatsDialogSubscription({
         )
         subscriptionRefs.current.set(topic, subscription)
       })
-      
+
       lastSubscribedDialogIdRef.current = dialogId
       setIsSubscribed(true)
       onSubscribedRef.current?.()
     } else if (subscriptionRefs.current.size > 0) {
       setIsSubscribed(true)
     }
-  }, [isConnected, enabled, topics, topicsKey])
+  }, [isConnected, enabled, topicsKey])
 
   return { isConnected, isSubscribed, reconnectionCount }
 }

--- a/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-realtime-chunk-processor.ts
@@ -193,6 +193,16 @@ export function useRealtimeChunkProcessor(
           // is the source of truth. Don't fire onToolExecuted here — its
           // cross-message scan is first-match-wins and could touch a
           // same-execId segment in a prior bubble (agent retry case).
+          //
+          // KNOWN EDGE (accepted): a slow async batch tool whose EXECUTED
+          // lands only AFTER the continuation stream's MESSAGE_START takes
+          // this path too — the freshly reset accumulator has no batch
+          // segment to merge into, so the chunk renders as a standalone card
+          // in the new bubble while the prior batch card's executions slot
+          // stays 'executing' until the next history refetch. Routing such
+          // chunks cross-message would reintroduce the retry hazard above;
+          // revisit only if the backend confirms batch executions can
+          // overlap the continuation stream.
           const segments = accumulator.addToolExecution(action.segment)
           emitSegments(segments)
           break
@@ -286,6 +296,26 @@ export function useRealtimeChunkProcessor(
               approvalType: escalatedData.approvalType,
             })
 
+            // The escalated card was never displayed inline, so this emit is
+            // what surfaces it after resolution. In-stream the cumulative
+            // array is correct; post-MESSAGE_END the accumulator was RESET,
+            // so a cumulative (replace-mode) emit would wipe the trailing
+            // bubble down to the lone card — emit only the resolved card(s)
+            // as an append instead. Store hosts upsert batches by request id,
+            // so a replayed append stays idempotent.
+            const emitResolved = (segments: MessageSegment[]) => {
+              if (isInStreamRef.current) {
+                emitSegments(segments)
+                return
+              }
+              const delta = segments.filter(
+                (s) =>
+                  (s.type === 'approval_request' && s.data.requestId === requestId) ||
+                  (s.type === 'approval_batch' && s.data.approvalRequestId === requestId),
+              )
+              emitSegments(delta, { append: true })
+            }
+
             if (escalatedData.toolCalls && escalatedData.toolCalls.length > 0) {
               if (batchApprovalsEnabled) {
                 const segments = accumulator.addApprovalBatch(
@@ -296,7 +326,7 @@ export function useRealtimeChunkProcessor(
                   undefined,
                   resolvedByName,
                 )
-                emitSegments(segments)
+                emitResolved(segments)
               } else {
                 let segments = accumulator.getSegments()
                 for (const call of escalatedData.toolCalls) {
@@ -309,7 +339,7 @@ export function useRealtimeChunkProcessor(
                     status,
                   )
                 }
-                emitSegments(segments)
+                emitResolved(segments)
               }
             } else {
               const segments = accumulator.addApprovalRequest(
@@ -319,7 +349,7 @@ export function useRealtimeChunkProcessor(
                 escalatedData.approvalType,
                 status,
               )
-              emitSegments(segments)
+              emitResolved(segments)
             }
           } else {
             // Always keep the in-memory accumulator in sync so a following
@@ -419,6 +449,13 @@ export function useRealtimeChunkProcessor(
     hasInitializedWithData.current = false
     sawDirectMessageRef.current = false
     directTeardownFiredRef.current = false
+    // Stream-state flags are per-dialog too. Leaking them across a reset
+    // made the next dialog's cold-start chunks take the post-stream append
+    // path (hasEverStreamed stuck true) — which consumers may silently drop
+    // when no assistant bubble exists yet — and left tool/compaction routing
+    // thinking a stream was still open (isInStream stuck true).
+    isInStreamRef.current = false
+    hasEverStreamedRef.current = false
   }, [])
 
   const updateApprovalStatus = useCallback(

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/process-historical-messages-approvals.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/process-historical-messages-approvals.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression guard for `displayApprovalTypes` semantics in the history
+ * processors. An OMITTED option must render EVERY approval type inline —
+ * consumers (tickets/mingo admin surfaces) that pass a wider list to their
+ * realtime processor but omit it on the history path relied on this, and a
+ * silent `['CLIENT']` default made their pending ADMIN approval cards vanish
+ * on every reload/reconnect refetch. Parity with realtime is opt-in via an
+ * explicit list.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { processHistoricalMessagesWithErrors } from '../process-historical-messages'
+import type { HistoricalMessage, MessageSegment } from '../../types'
+
+const adminApprovalMessage = (id: string): HistoricalMessage => ({
+  id,
+  createdAt: '2026-07-17T12:00:00Z',
+  owner: { type: 'ASSISTANT' },
+  messageData: [
+    {
+      type: 'APPROVAL_REQUEST',
+      approvalRequestId: `req-${id}`,
+      approvalType: 'ADMIN',
+      command: 'systemctl restart nats',
+    },
+  ],
+})
+
+const approvalSegments = (segments: MessageSegment[] | string | undefined) =>
+  Array.isArray(segments)
+    ? segments.filter((s) => s.type === 'approval_request' || s.type === 'approval_batch')
+    : []
+
+describe('processHistoricalMessagesWithErrors — displayApprovalTypes', () => {
+  it('renders non-CLIENT approvals inline when the option is OMITTED', () => {
+    const { messages, escalatedApprovals } = processHistoricalMessagesWithErrors([
+      adminApprovalMessage('m1'),
+    ])
+    const rendered = messages.flatMap((m) => approvalSegments(m.content))
+    expect(rendered).toHaveLength(1)
+    expect(escalatedApprovals.size).toBe(0)
+  })
+
+  it('escalates (does not render) approval types excluded by an explicit list', () => {
+    const { messages, escalatedApprovals } = processHistoricalMessagesWithErrors(
+      [adminApprovalMessage('m1')],
+      { displayApprovalTypes: ['CLIENT'] },
+    )
+    const rendered = messages.flatMap((m) => approvalSegments(m.content))
+    expect(rendered).toHaveLength(0)
+    expect(escalatedApprovals.has('req-m1')).toBe(true)
+  })
+
+  it('renders approval types included by an explicit list', () => {
+    const { messages } = processHistoricalMessagesWithErrors(
+      [adminApprovalMessage('m1')],
+      { displayApprovalTypes: ['CLIENT', 'ADMIN'] },
+    )
+    const rendered = messages.flatMap((m) => approvalSegments(m.content))
+    expect(rendered).toHaveLength(1)
+  })
+})

--- a/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
+++ b/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
@@ -225,6 +225,12 @@ export class MessageSegmentAccumulator {
       if (!hasCall) return seg
 
       const prev: ApprovalBatchExecutionState | undefined = seg.data.executions?.[execId]
+      // Never downgrade a done slot back to executing (redelivered EXECUTING
+      // after its EXECUTED already landed) — matched, but unchanged.
+      if (toolData.type === 'EXECUTING_TOOL' && prev?.status === 'done') {
+        matched = true
+        return seg
+      }
       const next: ApprovalBatchExecutionState =
         toolData.type === 'EXECUTED_TOOL'
           ? { status: 'done', result: toolData.result, success: toolData.success }

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -78,7 +78,10 @@ export function processHistoricalMessages(
     onReject,
     chatTypeFilter,
     approvalStatuses = {},
-    displayApprovalTypes,
+    // Match the realtime processor's default (['CLIENT']) — an omitted option
+    // used to mean "display every approval type" here, so non-client
+    // approvals rendered as actionable cards only after a reload.
+    displayApprovalTypes = ['CLIENT'],
     batchApprovalsEnabled,
   } = options
 
@@ -480,7 +483,9 @@ export function processHistoricalMessagesWithErrors(
   messages: HistoricalMessage[],
   options: MessageProcessingOptions = {}
 ): ProcessHistoricalMessagesResult {
-  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes, batchApprovalsEnabled } = options
+  // displayApprovalTypes defaults to the realtime processor's ['CLIENT'] so
+  // history and live rendering agree on which approval types show inline.
+  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes = ['CLIENT'], batchApprovalsEnabled } = options
 
   const processedMessages: ProcessedMessage[] = []
   const accumulator = createMessageSegmentAccumulator({ onApprove, onReject })

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -78,10 +78,14 @@ export function processHistoricalMessages(
     onReject,
     chatTypeFilter,
     approvalStatuses = {},
-    // Match the realtime processor's default (['CLIENT']) — an omitted option
-    // used to mean "display every approval type" here, so non-client
-    // approvals rendered as actionable cards only after a reload.
-    displayApprovalTypes = ['CLIENT'],
+    // An omitted option means "display every approval type" — the original
+    // history semantics. Deliberately NOT defaulted to the realtime
+    // processor's ['CLIENT']: consumers that pass a wider list to their
+    // realtime processor but omit it on the history path would silently lose
+    // pending non-CLIENT approval cards on every reload/reconnect refetch
+    // (they also ignore `escalatedApprovals`). Realtime/history parity is
+    // opt-in: pass the same explicit list to both.
+    displayApprovalTypes,
     batchApprovalsEnabled,
   } = options
 
@@ -483,9 +487,9 @@ export function processHistoricalMessagesWithErrors(
   messages: HistoricalMessage[],
   options: MessageProcessingOptions = {}
 ): ProcessHistoricalMessagesResult {
-  // displayApprovalTypes defaults to the realtime processor's ['CLIENT'] so
-  // history and live rendering agree on which approval types show inline.
-  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes = ['CLIENT'], batchApprovalsEnabled } = options
+  // displayApprovalTypes omitted = display every approval type (original
+  // history semantics — see the matching note in processHistoricalMessages).
+  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes, batchApprovalsEnabled } = options
 
   const processedMessages: ProcessedMessage[] = []
   const accumulator = createMessageSegmentAccumulator({ onApprove, onReject })

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -79,6 +79,7 @@ export function processHistoricalMessages(
     chatTypeFilter,
     approvalStatuses = {},
     displayApprovalTypes,
+    batchApprovalsEnabled,
   } = options
 
   const processedMessages: ProcessedMessage[] = []
@@ -174,7 +175,13 @@ export function processHistoricalMessages(
       lastAssistantId = msg.id
 
       messageDataArray.forEach((data) => {
-        processMessageData(data, accumulator, approvalStatuses, { displayApprovalTypes }, escalatedApprovals)
+        processMessageData(
+          data,
+          accumulator,
+          approvalStatuses,
+          { displayApprovalTypes, batchApprovalsEnabled },
+          escalatedApprovals,
+        )
       })
 
       // Check if we should flush (next message is from user or last message)
@@ -473,7 +480,7 @@ export function processHistoricalMessagesWithErrors(
   messages: HistoricalMessage[],
   options: MessageProcessingOptions = {}
 ): ProcessHistoricalMessagesResult {
-  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes } = options
+  const { chatTypeFilter, assistantName = 'Fae', assistantType = 'fae', assistantAvatar, onApprove, onReject, approvalStatuses = {}, displayApprovalTypes, batchApprovalsEnabled } = options
 
   const processedMessages: ProcessedMessage[] = []
   const accumulator = createMessageSegmentAccumulator({ onApprove, onReject })
@@ -563,7 +570,13 @@ export function processHistoricalMessagesWithErrors(
       lastAssistantId = msg.id
 
       messageDataArray.forEach((data) => {
-        processMessageData(data, accumulator, approvalStatuses, { displayApprovalTypes }, escalatedApprovals)
+        processMessageData(
+          data,
+          accumulator,
+          approvalStatuses,
+          { displayApprovalTypes, batchApprovalsEnabled },
+          escalatedApprovals,
+        )
       })
 
       const nextMsg = messages[index + 1]

--- a/openframe-frontend-core/src/nats/shared-connection.ts
+++ b/openframe-frontend-core/src/nats/shared-connection.ts
@@ -52,21 +52,30 @@ export interface ReleaseClientOptions {
   delayMs?: number
 }
 
-let shared: SharedConnection | null = null
+// One shared connection PER URL. The previous single-slot implementation
+// force-closed whatever was connected the moment any consumer acquired a
+// DIFFERENT URL — even with live refs on it. With two chat surfaces on
+// distinct endpoints (`/ws/nats` client chat vs `/ws/nats-api` dashboard)
+// mounted at once, each acquire killed the other's socket, and the loser's
+// retry loop self-cancelled (connection identity mismatch) leaving a dead
+// subscription that silently received nothing.
+const connections = new Map<string, SharedConnection>()
 
+/** Legacy accessor from the single-slot era: returns the first live shared
+ *  connection, or null. With MULTIPLE URLs connected (e.g. `/ws/nats` client
+ *  chat + `/ws/nats-api` dashboard mounted together) "first" is whichever
+ *  surface acquired first — an arbitrary, mount-order-dependent answer.
+ *  Prefer `getSharedConnectionFor(url)`; this stays only for external
+ *  registry-pinned consumers of the old single-connection API. */
 export function getSharedConnection(): SharedConnection | null {
-  return shared
+  const first = connections.values().next()
+  return first.done ? null : first.value
 }
 
 export function acquireClient(url: string, opts?: AcquireClientOptions): SharedConnection {
-  if (shared?.wsUrl !== url) {
-    if (shared) {
-      if (shared.closeTimer) clearTimeout(shared.closeTimer)
-      const old = shared
-      shared = null
-      void old.client.close().catch(() => {})
-    }
+  let conn = connections.get(url)
 
+  if (!conn) {
     const {
       name = 'openframe-frontend',
       user = 'machine',
@@ -87,7 +96,7 @@ export function acquireClient(url: string, opts?: AcquireClientOptions): SharedC
       maxPingOut,
     })
 
-    shared = {
+    conn = {
       wsUrl: url,
       client,
       connectPromise: null,
@@ -96,39 +105,43 @@ export function acquireClient(url: string, opts?: AcquireClientOptions): SharedC
       retryTimer: null,
       retryOwner: null,
     }
+    connections.set(url, conn)
   }
 
-  shared.refCount += 1
-  if (shared.closeTimer) {
-    clearTimeout(shared.closeTimer)
-    shared.closeTimer = null
+  conn.refCount += 1
+  if (conn.closeTimer) {
+    clearTimeout(conn.closeTimer)
+    conn.closeTimer = null
   }
-  return shared
+  return conn
 }
 
 export function releaseClient(url: string, opts?: ReleaseClientOptions): void {
-  if (!shared || shared.wsUrl !== url) return
+  const conn = connections.get(url)
+  if (!conn) return
 
-  shared.refCount = Math.max(0, shared.refCount - 1)
-  if (shared.refCount > 0) return
+  conn.refCount = Math.max(0, conn.refCount - 1)
+  if (conn.refCount > 0) return
 
   const delay = opts?.delayMs ?? NATS_DEFAULTS.SHARED_CLOSE_DELAY_MS
-  shared.closeTimer = setTimeout(() => {
-    const s = shared
-    shared = null
-    if (s) {
-      if (s.retryTimer) {
-        clearTimeout(s.retryTimer)
-        s.retryTimer = null
-      }
-      void s.client.close().catch(() => {})
+  conn.closeTimer = setTimeout(() => {
+    conn.closeTimer = null
+    // A new acquire may have raced in during the grace period.
+    if (conn.refCount > 0) return
+    if (connections.get(url) === conn) {
+      connections.delete(url)
     }
+    if (conn.retryTimer) {
+      clearTimeout(conn.retryTimer)
+      conn.retryTimer = null
+    }
+    void conn.client.close().catch(() => {})
   }, delay)
 }
 
 export function getSharedConnectionFor(url: string | null | undefined): SharedConnection | null {
   if (!url) return null
-  return shared && shared.wsUrl === url ? shared : null
+  return connections.get(url) ?? null
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Hotfix: realtime chat chunk pipeline

Fixes the "not all messages resolve correctly" family of bugs: missing tool
cards, wiped/blank assistant bubbles, dropped multi-party messages, and
permanent transcript holes after reconnects. Root causes were traced against
the `openframe-saas-ai-agent` backend (JetStream `CHAT_CHUNKS`, `maxAge` ~10
min; `APPROVAL_REQUEST` → immediate `MESSAGE_END`; post-END tool execution).

## What was broken

Chunks arriving **outside the `MESSAGE_START…MESSAGE_END` window** — exactly
tool executions of approved commands, approval results, and continuation
text — were either dropped or rendered by replacing the trailing bubble,
wiping its content. Plus a set of transport-level losses.

## Changes

### `useNatsChatAdapter`
- Honor `SegmentsUpdateMetadata.append` — post-END continuation fragments
  append into the trailing bubble (was: replace with the lone fragment).
- Wire the previously unwired processor callbacks: `onToolExecuted`
  (cross-message merge + append fallback via new exported
  `applyToolExecutionToMessages`), `onApprovalResolved` (kills the
  empty-emit bubble wipe), `onUserMessage` / `onDirectMessage` /
  `onSystemMessage` (second device / technician / system rows render).
- Reconnect back-fill: history refetch (DIRECT/SYSTEM live only in Mongo)
  + chunk catch-up, with live chunks **buffered before** the history await
  and the adopt-once flag cleared in `finally`.
- `displayApprovalTypes` / `approvalStatuses` forwarded to the processor
  and the history pipeline.

### `useRealtimeChunkProcessor`
- `reset()` clears `isInStream` / `hasEverStreamed` — stream state no
  longer leaks across dialog switches.
- Escalated `approval_result` post-END emits the resolved card as an
  **append delta**; the cumulative emit replaced the completed bubble with
  a lone approval card.

### `useChunkCatchup`
- Live path now **checks** dedup keys (fetch/live overlap rendered twice).
- Id-less chunks survive boundary filters, sort as newest (was seq 0), and
  are no longer collapsed by the content-keyed dedup (identical streaming
  deltas were dropped).
- Boundaries computed **per messageType** — in the legacy Redis transport
  each `(dialog, chatType)` stream has its own counter, and one stream's
  `MESSAGE_END` used to truncate the other stream's tool chunks.
- A catch-up requested while a fetch is in flight is queued and re-run
  (was: silently dropped → permanent gap).
- `resetAndCatchUp` keeps a caller-armed buffer.

### Subscriptions
- `useNatsDialogSubscription`: `topics` array identity removed from effect
  deps — unmemoized configs caused teardown/resubscribe churn every render,
  losing messages on plain NATS.
- `useJetStreamDialogSubscription`: `highestStreamSeq` reset moved **before**
  the subscribe effect — switching dialogs no longer creates the consumer at
  the previous dialog's offset (skipped replay).

### `shared-connection`
- `Map` keyed by URL instead of a single global slot: `/ws/nats` (client
  chat) and `/ws/nats-api` (dashboard) mounted together no longer force-close
  each other's socket, which left the loser permanently dead.

### `process-historical-messages`
- `batchApprovalsEnabled` forwarded into `processMessageData` — history now
  renders approvals the same way realtime does.

## Tests
- New unit tests for the adapter's message updaters
  (`nats-adapter-message-updaters.test.ts`); full suite 264 passing,
  `tsc --noEmit` clean.

## Notes for consumers
- Adapter hosts whose backend emits non-`CLIENT` approval types must pass
  the new `displayApprovalTypes` config.
- Companion app-side fixes (mingo/tickets stores, openframe-chat) land in
  their own repos; they depend on this package version for the lib-side
  behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat transcript recovery so messages are not lost or duplicated during catch-up, reconnects, or dialog changes.
  - Preserved streamed assistant text, tool execution updates, compaction status, and approval results across message boundaries.
  - Fixed approval displays to remain consistent after reopening dialogs or loading message history.
  - Prevented unnecessary subscription interruptions when chat topics remain unchanged.
  - Enabled simultaneous connections to different chat service URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->