### PR TITLE
FE CORE: fix duplicate + lost messages in history/realtime merge

### DIFF
--- a/openframe-frontend-core/src/components/chat/types/message.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/message.types.ts
@@ -318,6 +318,13 @@ export interface HistoricalMessage {
   createdAt: string
   owner?: MessageOwner
   messageData?: MessageData | MessageData[]
+  /** Persisted stream sequence of this row's last chunk (the backend's
+   *  `lastChunkStreamSeq`). Passed through to the processed message's
+   *  `streamSeq` so `mergeHistoryWithRealtime` can decide coverage per-role
+   *  (a synthetic is covered only by a persisted row of its OWN role reaching
+   *  its seq). Optional — absent for rows the backend doesn't stamp (e.g. user
+   *  MESSAGE_REQUEST rows), which then don't participate in seq coverage. */
+  lastChunkStreamSeq?: number | null
 }
 
 // ========== Processed Message Types ==========
@@ -331,6 +338,12 @@ export interface ProcessedMessage {
   authorType?: AuthorType
   timestamp: Date
   avatar?: string
+  /** Persisted last-chunk stream sequence carried through from
+   *  `HistoricalMessage.lastChunkStreamSeq` (for assistant turns: the MAX
+   *  across the grouped rows). Hosts stamp it onto the rendered message's
+   *  `streamSeq` so the history/realtime merge can do per-role seq coverage.
+   *  Absent when the source row(s) carried no seq. */
+  streamSeq?: number
 }
 
 // ========== Base Message Interface ==========

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
@@ -245,19 +245,61 @@ describe('mergeHistoryWithRealtime', () => {
     expect(ids(merged)).toEqual([U0.id, A0.id, U1.id, A1.id])
   })
 
-  it('keeps a `user-` synthetic whose only twin is the TRAILING history row (just-sent, not a replay)', () => {
-    // A newly-sent user message: its persisted twin is the LAST history row
-    // (no assistant reply yet), so it must NOT be treated as a completed-turn
-    // replay — dropping it would erase a message the user just sent.
-    const justSent: TestMessage = { id: 'user-9000-x', role: 'user', content: 'third question', timestamp: t(9000) }
+  it('dedupes a `user-` synthetic against its persisted twin even when that twin is the TRAILING row', () => {
+    // Client→viewer duplicate at the START of a conversation: the user row is
+    // persisted (as the trailing history row — the assistant reply is not saved
+    // yet) and the same MESSAGE_REQUEST is replayed as a `user-` synthetic. The
+    // persisted row renders the message, so the synthetic must be dropped —
+    // keeping it (the old trailing-twin carve-out) IS the reported duplicate.
+    const replay: TestMessage = { id: 'user-9000-x', role: 'user', content: 'third question', timestamp: t(9000) }
     const trailingPersisted: TestMessage = { id: 'aaaa0006', role: 'user', content: 'third question', timestamp: t(3000) }
     const merged = mergeHistoryWithRealtime({
       processedHistory: [U0, A0, U1, A1, trailingPersisted],
-      existingMessages: [U0, A0, U1, A1, trailingPersisted, justSent],
+      existingMessages: [U0, A0, U1, A1, trailingPersisted, replay],
       streamingMessageId: null,
       historyFetchedAt: 5000,
     })
-    expect(ids(merged)).toContain(justSent.id)
+    expect(ids(merged)).toEqual([U0.id, A0.id, U1.id, A1.id, trailingPersisted.id])
+  })
+
+  it('keeps a LATER same-text `user-` synthetic whose own row is not persisted yet (positional match)', () => {
+    // Two identical "continue" turns: the first is persisted, the second was
+    // just sent and its row hasn't landed. Positional content matching covers
+    // the first synthetic with the one persisted row and KEEPS the second — the
+    // old first-match dedup matched the second against the first's row and
+    // dropped it, losing the message (the reported "user message lost" repro).
+    const persistedFirst: TestMessage = { id: 'aaaa0006', role: 'user', content: 'continue', timestamp: t(3000) }
+    const asstFirst: TestMessage = { id: 'aaaa0007', role: 'assistant', content: txt('ok one'), timestamp: t(3100) }
+    const synFirst: TestMessage = { id: 'user-4000-a', role: 'user', content: 'continue', timestamp: t(4000) }
+    const synSecond: TestMessage = { id: 'user-5000-b', role: 'user', content: 'continue', timestamp: t(5000) }
+    const merged = mergeHistoryWithRealtime({
+      processedHistory: [U0, A0, persistedFirst, asstFirst],
+      existingMessages: [U0, A0, persistedFirst, asstFirst, synFirst, synSecond],
+      streamingMessageId: null,
+      historyFetchedAt: 6000,
+    })
+    // Only one persisted "continue" → synFirst covered/dropped, synSecond kept.
+    expect(ids(merged)).toEqual([U0.id, A0.id, persistedFirst.id, asstFirst.id, synSecond.id])
+  })
+
+  it('KEEPS a `user-` synthetic when a seq-stamped ASSISTANT row raised the global max but the user turn is not persisted', () => {
+    // The reload+stop loss: history has a seq-stamped assistant row (so
+    // anyHistoryRowSeq is true and the global max is high) and a live `user-`
+    // message arrived whose own row the backend persists WITHOUT a seq and
+    // hasn't yet. The assistant's seq must NOT cover it — content dedup finds no
+    // twin, so it survives. (On the pre-fix code the `user-` role max was 0 and
+    // the merge fell back to the global coverage, dropping it.)
+    const histAsst: TestMessage = { id: 'aaaa0501', role: 'assistant', content: txt('older answer'), timestamp: t(2100), streamSeq: 200 }
+    const liveUser: TestMessage = { id: 'user-9000-x', role: 'user', content: 'continue', timestamp: t(9000), streamSeq: 150 }
+    const merged = mergeHistoryWithRealtime<TestMessage>({
+      processedHistory: [U0, histAsst],
+      existingMessages: [U0, histAsst, liveUser],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+      historyMaxStreamSeq: 200,
+      realtimeSeenStreamSeq: 200,
+    })
+    expect(ids(merged)).toContain(liveUser.id)
   })
 
   it('keeps a `user-` synthetic when no persisted twin exists yet (persistence lag)', () => {

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
@@ -19,6 +19,11 @@ const batchSeg = {
   type: 'approval_batch',
   data: { approvalRequestId: 'req-9', toolCalls: [] },
 } as unknown as MessageSegment
+const tool = (id: string, state: 'EXECUTING_TOOL' | 'EXECUTED_TOOL'): MessageSegment =>
+  ({
+    type: 'tool_execution',
+    data: { type: state, integratedToolType: 'sqlite', toolFunction: 'query', toolExecutionRequestId: id },
+  }) as unknown as MessageSegment
 
 // Persisted history (Mongo ids), first fetched at t=1000
 const U0: TestMessage = { id: 'aaaa0001', role: 'user', content: 'first question', timestamp: t(500) }
@@ -583,6 +588,88 @@ describe('mergeHistoryWithRealtime', () => {
         historyMaxStreamSeq: 80,
       })
       expect(ids(merged)).toEqual([U0.id, histAsst.id])
+    })
+  })
+
+  // Adoption path for plain TOOL turns (no approval batch). After a mid-stream
+  // reload the trailing assistant is a persisted Mongo-id row; the chunk
+  // processors adopt it and append later chunks IN PLACE, so the store's
+  // same-id copy is richer than history's async-lagging persisted version. The
+  // merge must keep the richer copy or the bubble reverts to stale segments
+  // (the "3 tools collapse to 2, one stuck pending" after reload + stop bug).
+  describe('adopted trailing assistant (post-reload tool turns)', () => {
+    it('pins the same-id realtime copy when it has MORE tool segments than history', () => {
+      const id = 'aaaa0700'
+      const persistedTrailing: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL'), tool('t2', 'EXECUTING_TOOL')],
+        timestamp: t(2100), streamSeq: 60,
+      }
+      const adoptedRicher: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL'), tool('t2', 'EXECUTED_TOOL'), tool('t3', 'EXECUTED_TOOL')],
+        timestamp: t(2100), streamSeq: 80,
+      }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [U0, persistedTrailing],
+        rawHistoryIds: new Set([U0.id, id]),
+        existingMessages: [U0, adoptedRicher], // store holds only the adopted copy
+        streamingMessageId: null, // stream is IDLE after stop — no exemption
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 60,
+        realtimeSeenStreamSeq: 80,
+      })
+      const trailing = merged[merged.length - 1]
+      expect(trailing).toBe(adoptedRicher)
+      expect(Array.isArray(trailing.content) ? trailing.content.length : 0).toBe(3)
+      expect(merged.filter((m) => m.id === id)).toHaveLength(1) // no duplicate turn
+    })
+
+    it('pins the same-id realtime copy when counts tie but its consumed seq is higher', () => {
+      const id = 'aaaa0701'
+      const persistedTrailing: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL'), tool('t2', 'EXECUTING_TOOL')],
+        timestamp: t(2100), streamSeq: 60,
+      }
+      const adoptedResolved: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL'), tool('t2', 'EXECUTED_TOOL')], // t2 resolved, same count
+        timestamp: t(2100), streamSeq: 85,
+      }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [U0, persistedTrailing],
+        existingMessages: [U0, adoptedResolved],
+        streamingMessageId: null,
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 60,
+        realtimeSeenStreamSeq: 85,
+      })
+      expect(merged[merged.length - 1]).toBe(adoptedResolved)
+    })
+
+    it('keeps the persisted trailing when the same-id realtime copy is NOT richer', () => {
+      const id = 'aaaa0702'
+      const persistedTrailing: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL'), tool('t2', 'EXECUTED_TOOL')],
+        timestamp: t(2100), streamSeq: 80,
+      }
+      const staleSameId: TestMessage = {
+        id, role: 'assistant',
+        content: [tool('t1', 'EXECUTED_TOOL')], // fewer segments, lower seq
+        timestamp: t(2100), streamSeq: 50,
+      }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [U0, persistedTrailing],
+        existingMessages: [U0, staleSameId],
+        streamingMessageId: null,
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 80,
+        realtimeSeenStreamSeq: 80,
+      })
+      expect(merged[merged.length - 1]).toBe(persistedTrailing)
+      expect(merged.filter((m) => m.id === id)).toHaveLength(1)
     })
   })
 })

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
@@ -471,6 +471,78 @@ describe('mergeHistoryWithRealtime', () => {
       expect(ids(merged)).toEqual([U0.id, A0.id, histSystem.id])
     })
   })
+
+  // Per-ROLE coverage: when history rows carry their own streamSeq, a synthetic
+  // is covered only by a persisted row of the SAME role reaching its seq. This
+  // prevents the reload/stop message-loss bug where an unrelated other-role or
+  // later row pushed the single global max past a synthetic whose own turn was
+  // never persisted (interrupted / async), dropping a message the user saw.
+  describe('per-role streamSeq coverage', () => {
+    it('KEEPS an assistant synthetic when only an OTHER-role row advances the global max', () => {
+      // The repro: after reload, an interrupted assistant turn (seq 100) is on
+      // screen as a synthetic. A persisted USER row carries a high seq (90) but
+      // the assistant turn itself was never persisted. A stop/new-message
+      // recompute must NOT drop the assistant synthetic just because some row's
+      // seq >= 100 — only a persisted ASSISTANT row reaching 100 may.
+      const histUser: TestMessage = { id: 'aaaa0100', role: 'user', content: 'do a health check', timestamp: t(2000), streamSeq: 90 }
+      const histAsst: TestMessage = { id: 'aaaa0101', role: 'assistant', content: txt('older answer'), timestamp: t(2100), streamSeq: 50 }
+      const interrupted: TestMessage = { id: 'assistant-9000-x', role: 'assistant', content: txt('running tools…'), timestamp: t(9000), streamSeq: 100 }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [histUser, histAsst],
+        existingMessages: [histUser, histAsst, interrupted],
+        streamingMessageId: null, // exemption already lost (stop / new turn)
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 90, // global max — advanced past 100? no, but a bigger user row would
+      })
+      expect(ids(merged)).toContain(interrupted.id)
+    })
+
+    it('KEEPS an assistant synthetic newer than the same-role persisted max', () => {
+      const histAsst: TestMessage = { id: 'aaaa0201', role: 'assistant', content: txt('answer one'), timestamp: t(2100), streamSeq: 50 }
+      const laterUser: TestMessage = { id: 'aaaa0202', role: 'user', content: 'and again', timestamp: t(2200), streamSeq: 120 }
+      const liveAsst: TestMessage = { id: 'assistant-9000-y', role: 'assistant', content: txt('second answer growing'), timestamp: t(9000), streamSeq: 100 }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [histAsst, laterUser],
+        existingMessages: [histAsst, laterUser, liveAsst],
+        streamingMessageId: null,
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 120, // global would cover 100 and wrongly drop it
+      })
+      // assistant same-role max is 50 < 100 → kept.
+      expect(ids(merged)).toContain(liveAsst.id)
+    })
+
+    it('DROPS an assistant synthetic once a same-role persisted row reaches its seq', () => {
+      const histAsst: TestMessage = { id: 'aaaa0301', role: 'assistant', content: txt('final answer'), timestamp: t(2100), streamSeq: 100 }
+      const synAsst: TestMessage = { id: 'assistant-9000-z', role: 'assistant', content: txt('final answer'), timestamp: t(9000), streamSeq: 100 }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [U0, histAsst],
+        rawHistoryIds: new Set([U0.id, histAsst.id]),
+        existingMessages: [U0, histAsst, synAsst],
+        streamingMessageId: null,
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 100,
+      })
+      // same-role assistant max is 100 >= 100 → the replay is deduped.
+      expect(ids(merged)).toEqual([U0.id, histAsst.id])
+    })
+
+    it('DROPS a partial assistant synthetic against the same-role full persisted turn', () => {
+      // Partial realtime text differs from the full persisted text — coverage
+      // is by seq, not content, and the same-role max proves the turn landed.
+      const histAsst: TestMessage = { id: 'aaaa0401', role: 'assistant', content: txt('the full answer'), timestamp: t(2100), streamSeq: 80 }
+      const partial: TestMessage = { id: 'assistant-9000-p', role: 'assistant', content: txt('the full ans'), timestamp: t(9000), streamSeq: 60 }
+      const merged = mergeHistoryWithRealtime<TestMessage>({
+        processedHistory: [U0, histAsst],
+        rawHistoryIds: new Set([U0.id, histAsst.id]),
+        existingMessages: [U0, histAsst, partial],
+        streamingMessageId: null,
+        historyFetchedAt: 5000,
+        historyMaxStreamSeq: 80,
+      })
+      expect(ids(merged)).toEqual([U0.id, histAsst.id])
+    })
+  })
 })
 
 describe('computeHistoryPrepend', () => {

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
@@ -226,6 +226,51 @@ describe('mergeHistoryWithRealtime', () => {
     expect(ids(merged)).toContain(repeat.id)
   })
 
+  it('drops a replayed `user-` synthetic against a COMPLETED persisted turn (missing user seq)', () => {
+    // Repro of the tickets client→viewer duplicate: the backend persists the
+    // user MESSAGE_REQUEST row without a lastChunkStreamSeq, so JetStream
+    // replays the user chunk and mints a fresh `user-` synthetic that neither
+    // seq coverage nor wall-clock can drop. Its persisted twin (U1) is
+    // followed by the assistant turn (A1) — a completed turn — so the replay
+    // is recognised by content and dropped. The assistant replay is collapsed
+    // by the assistant content-fallback, matching "user twice, Fae once".
+    const userSynthetic: TestMessage = { id: 'user-9000-x', role: 'user', content: 'second question', timestamp: t(9000) }
+    const asstSynthetic: TestMessage = { id: 'assistant-9100-x', role: 'assistant', content: txt('second answer'), timestamp: t(9100) }
+    const merged = mergeHistoryWithRealtime({
+      processedHistory: [U0, A0, U1, A1],
+      existingMessages: [U0, A0, U1, A1, userSynthetic, asstSynthetic],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+    })
+    expect(ids(merged)).toEqual([U0.id, A0.id, U1.id, A1.id])
+  })
+
+  it('keeps a `user-` synthetic whose only twin is the TRAILING history row (just-sent, not a replay)', () => {
+    // A newly-sent user message: its persisted twin is the LAST history row
+    // (no assistant reply yet), so it must NOT be treated as a completed-turn
+    // replay — dropping it would erase a message the user just sent.
+    const justSent: TestMessage = { id: 'user-9000-x', role: 'user', content: 'third question', timestamp: t(9000) }
+    const trailingPersisted: TestMessage = { id: 'aaaa0006', role: 'user', content: 'third question', timestamp: t(3000) }
+    const merged = mergeHistoryWithRealtime({
+      processedHistory: [U0, A0, U1, A1, trailingPersisted],
+      existingMessages: [U0, A0, U1, A1, trailingPersisted, justSent],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+    })
+    expect(ids(merged)).toContain(justSent.id)
+  })
+
+  it('keeps a `user-` synthetic when no persisted twin exists yet (persistence lag)', () => {
+    const pending: TestMessage = { id: 'user-9000-x', role: 'user', content: 'brand new question', timestamp: t(9000) }
+    const merged = mergeHistoryWithRealtime({
+      processedHistory: [U0, A0],
+      existingMessages: [U0, A0, pending],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+    })
+    expect(ids(merged)).toContain(pending.id)
+  })
+
   it('pins the streaming twin even when it carries a persisted history id (adoption path)', () => {
     // Chunk processors ADOPT an in-progress trailing assistant after a prior
     // merge, so the streaming twin can have the SAME Mongo id as history's

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/history-merge.test.ts
@@ -318,6 +318,61 @@ describe('mergeHistoryWithRealtime', () => {
     expect(ids(merged)).toContain(pending.id)
   })
 
+  it('KEEPS a repeated `user-` message whose streamSeq is ahead of history (new send after a long tool turn)', () => {
+    // The "many tools + reload, message from the client chat disappears" repro:
+    // an earlier "continue" is persisted and answered (a long tool turn pushed
+    // historyMaxStreamSeq to 200), then the user sends "continue" AGAIN. The new
+    // synthetic's streamSeq (250) is ahead of everything persisted → it is a NEW
+    // message, not a replay of the old turn. Positional content match alone
+    // would drop it against the old "continue"; the seq watermark keeps it.
+    const oldUser: TestMessage = { id: 'aaaa0801', role: 'user', content: 'continue', timestamp: t(2000) }
+    const oldAsst: TestMessage = { id: 'aaaa0802', role: 'assistant', content: txt('ok one'), timestamp: t(2100), streamSeq: 200 }
+    const newSend: TestMessage = { id: 'user-9000-x', role: 'user', content: 'continue', timestamp: t(9000), streamSeq: 250 }
+    const merged = mergeHistoryWithRealtime<TestMessage>({
+      processedHistory: [oldUser, oldAsst],
+      existingMessages: [oldUser, oldAsst, newSend],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+      historyMaxStreamSeq: 200,
+      realtimeSeenStreamSeq: 250,
+    })
+    expect(ids(merged)).toContain(newSend.id)
+  })
+
+  it('DROPS a replayed `user-` message whose streamSeq history already passed', () => {
+    // A replay of the OLD "continue" (streamSeq 150) after history persisted the
+    // turn past it (200): its own row is in the snapshot → drop the duplicate.
+    const oldUser: TestMessage = { id: 'aaaa0811', role: 'user', content: 'continue', timestamp: t(2000) }
+    const oldAsst: TestMessage = { id: 'aaaa0812', role: 'assistant', content: txt('ok one'), timestamp: t(2100), streamSeq: 200 }
+    const replay: TestMessage = { id: 'user-9000-x', role: 'user', content: 'continue', timestamp: t(9000), streamSeq: 150 }
+    const merged = mergeHistoryWithRealtime<TestMessage>({
+      processedHistory: [oldUser, oldAsst],
+      existingMessages: [oldUser, oldAsst, replay],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+      historyMaxStreamSeq: 200,
+      realtimeSeenStreamSeq: 200,
+    })
+    expect(ids(merged)).toEqual([oldUser.id, oldAsst.id])
+  })
+
+  it('DROPS a `user-` echo of a just-sent TRAILING message even when history is behind its seq', () => {
+    // Start of a turn: the just-sent "hello" is the trailing history row (no
+    // reply yet, so historyMaxStreamSeq is behind its seq). Its own row is right
+    // there → drop the echo, don't render "hello" twice.
+    const justSent: TestMessage = { id: 'aaaa0821', role: 'user', content: 'hello', timestamp: t(3000) }
+    const echo: TestMessage = { id: 'user-9000-x', role: 'user', content: 'hello', timestamp: t(9000), streamSeq: 300 }
+    const merged = mergeHistoryWithRealtime<TestMessage>({
+      processedHistory: [U0, A0, justSent],
+      existingMessages: [U0, A0, justSent, echo],
+      streamingMessageId: null,
+      historyFetchedAt: 5000,
+      historyMaxStreamSeq: 100,
+      realtimeSeenStreamSeq: 300,
+    })
+    expect(ids(merged)).toEqual([U0.id, A0.id, justSent.id])
+  })
+
   it('pins the streaming twin even when it carries a persisted history id (adoption path)', () => {
     // Chunk processors ADOPT an in-progress trailing assistant after a prior
     // merge, so the streaming twin can have the SAME Mongo id as history's

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/process-historical-messages-approvals.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/process-historical-messages-approvals.test.ts
@@ -59,4 +59,39 @@ describe('processHistoricalMessagesWithErrors — displayApprovalTypes', () => {
     const rendered = messages.flatMap((m) => approvalSegments(m.content))
     expect(rendered).toHaveLength(1)
   })
+
+  it('does not bleed a stale assistant id/streamSeq across an empty (escalated-only) flush', () => {
+    // a1 is an assistant turn whose ONLY data is an ADMIN approval that gets
+    // escalated (excluded by the explicit list) → it renders nothing, so the
+    // flush triggered by the following user row is EMPTY. Its grouping identity
+    // and streamSeq must be cleared, or the NEXT assistant turn (a2) inherits
+    // a1's id/timestamp and a Math.max-inflated streamSeq (100 instead of 50),
+    // which would over-cover synthetics in the history merge.
+    const messages: HistoricalMessage[] = [
+      {
+        id: 'a1',
+        createdAt: '2026-07-17T12:00:00Z',
+        owner: { type: 'ASSISTANT' },
+        lastChunkStreamSeq: 100,
+        messageData: [{ type: 'APPROVAL_REQUEST', approvalRequestId: 'req-a1', approvalType: 'ADMIN', command: 'x' }],
+      },
+      {
+        id: 'u1',
+        createdAt: '2026-07-17T12:00:01Z',
+        owner: { type: 'CLIENT' },
+        messageData: [{ type: 'TEXT', text: 'hello' }],
+      },
+      {
+        id: 'a2',
+        createdAt: '2026-07-17T12:00:02Z',
+        owner: { type: 'ASSISTANT' },
+        lastChunkStreamSeq: 50,
+        messageData: [{ type: 'TEXT', text: 'hi there' }],
+      },
+    ]
+    const { messages: out } = processHistoricalMessagesWithErrors(messages, { displayApprovalTypes: ['CLIENT'] })
+    const asst = out.find((m) => m.role === 'assistant')
+    expect(asst?.id).toBe('a2')
+    expect(asst?.streamSeq).toBe(50)
+  })
 })

--- a/openframe-frontend-core/src/components/chat/utils/history-merge.ts
+++ b/openframe-frontend-core/src/components/chat/utils/history-merge.ts
@@ -236,6 +236,30 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
       if (m.role === 'assistant' && trailingAssistantText && assistantAnswerText(m.content) === trailingAssistantText) {
         return false
       }
+      // A replayed user MESSAGE_REQUEST re-mints a `user-` synthetic with a
+      // FRESH timestamp, so the wall-clock rule below keeps it; and on backends
+      // that persist the user row WITHOUT a `lastChunkStreamSeq` (unlike
+      // DIRECT/SYSTEM rows, which carry the chunk seq) the seq-coverage rule
+      // can't cover it either — the persisted twin contributes 0 to
+      // `historyMaxStreamSeq`, so `historyMaxStreamSeq >= m.streamSeq` is never
+      // true for this row. The assistant content-fallback above is
+      // assistant-only, so nothing collapses the replayed user turn and it
+      // renders twice (its persisted twin + this synthetic). Recognise it by
+      // an identical-text persisted user twin that is NOT the trailing history
+      // row: a user row FOLLOWED by another message is a COMPLETED turn (its
+      // answer already persisted), so this synthetic is provably that turn's
+      // replay. A trailing (or absent) persisted twin is left alone — it may be
+      // a just-sent message whose live echo must survive, not a replay.
+      // NOTE: this is a targeted workaround for the missing `lastChunkStreamSeq`
+      // on persisted user rows; the durable fix is the backend stamping it (as
+      // it already does for DIRECT/SYSTEM), which also stops the replay at the
+      // source via a correct `optStartSeq`.
+      if (m.role === 'user' && typeof m.content === 'string') {
+        const twinIdx = processedToUse.findIndex((pm) => pm.role === 'user' && pm.content === m.content)
+        if (twinIdx !== -1 && twinIdx < processedToUse.length - 1) {
+          return false
+        }
+      }
       // Per-message coverage: the synthetic carries the highest CONTENT seq
       // that built it (never the MESSAGE_END/TOKEN_USAGE tail), so history has
       // it once its max persisted seq reaches that. This is exact per-turn —

--- a/openframe-frontend-core/src/components/chat/utils/history-merge.ts
+++ b/openframe-frontend-core/src/components/chat/utils/history-merge.ts
@@ -27,10 +27,18 @@ export interface MergeableChatMessage {
   /** Highest CONTENT chunk streamSeq that composed this message (text / tool /
    *  approval / error / compaction — never the non-persisted MESSAGE_END /
    *  TOKEN_USAGE control chunks). Hosts stamp it on realtime synthetics so the
-   *  merge can decide coverage per-message: a synthetic is in history once
-   *  `historyMaxStreamSeq >= streamSeq`. Optional — absent on history messages
-   *  and on hosts that don't stamp it (those fall back to the global seq /
-   *  wall-clock rule). */
+   *  merge can decide coverage per-message: a synthetic is in history once a
+   *  persisted row of the SAME role reaches its seq.
+   *
+   *  Stamp it on HISTORY rows too (from the persisted `lastChunkStreamSeq`)
+   *  when available: the merge then computes a PER-ROLE max from history and a
+   *  synthetic is "covered" only when a persisted row of its own role actually
+   *  reached its seq. Without per-row history seqs the merge falls back to the
+   *  single global `historyMaxStreamSeq`, which a later/other-role row can push
+   *  past a synthetic whose turn is NOT in the snapshot (interrupted /
+   *  async-persisted) — dropping a message the user saw with no replay to
+   *  restore it. Optional — absent on hosts that don't stamp it (those keep the
+   *  global-seq / wall-clock behaviour). */
   streamSeq?: number
 }
 
@@ -150,6 +158,27 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
   const seqCoverageKnown = realtimeSeenStreamSeq > 0 && historyMaxStreamSeq > 0
   const historyCoversRealtime = seqCoverageKnown ? historyMaxStreamSeq >= realtimeSeenStreamSeq : null
 
+  // Per-role max persisted streamSeq, computed from history rows that carry a
+  // per-row `streamSeq` (hosts stamp it from `lastChunkStreamSeq`). The single
+  // global `historyMaxStreamSeq` is a MAX over ALL rows, so a later turn or an
+  // other-role row (e.g. a user MESSAGE_REQUEST) can push it past a synthetic
+  // whose OWN turn is not in the snapshot yet — the merge then "covers" and
+  // drops that synthetic with no twin to replace it (permanent loss on stop /
+  // reload / any recompute). Deciding coverage against the same-role max
+  // instead means a synthetic is dropped only when a persisted row of its role
+  // actually reached its seq. `anyHistoryRowSeq` gates the whole scheme: when
+  // no history row is seq-stamped (legacy hosts) we keep the previous global
+  // behaviour unchanged.
+  const historyMaxSeqByRole = new Map<string, number>()
+  let anyHistoryRowSeq = false
+  for (const pm of processedHistory) {
+    if (typeof pm.streamSeq === 'number') {
+      anyHistoryRowSeq = true
+      const prev = historyMaxSeqByRole.get(pm.role) ?? 0
+      if (pm.streamSeq > prev) historyMaxSeqByRole.set(pm.role, pm.streamSeq)
+    }
+  }
+
   // Persistence is asynchronous per-chunk: an assistant turn ending in an
   // approval can have its APPROVAL_REQUEST document persisted before the
   // leading THINKING/TEXT documents, so history can return a partial trailing
@@ -262,14 +291,24 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
       }
       // Per-message coverage: the synthetic carries the highest CONTENT seq
       // that built it (never the MESSAGE_END/TOKEN_USAGE tail), so history has
-      // it once its max persisted seq reaches that. This is exact per-turn —
-      // it drops earlier finished turns while keeping a later still-streaming
-      // one, which the single global `realtimeSeenStreamSeq` (biased upward by
-      // the tail the client consumed) cannot distinguish. Falls back to the
-      // global coverage / wall-clock for unstamped synthetics (legacy NATS).
+      // it once a persisted row reaches that seq. This is exact per-turn — it
+      // drops earlier finished turns while keeping a later still-streaming one,
+      // which the single global `realtimeSeenStreamSeq` (biased upward by the
+      // tail the client consumed) cannot distinguish.
+      //
+      // Coverage max: prefer the SAME-ROLE persisted max (when history rows are
+      // seq-stamped) so an other-role / later row can't falsely cover a turn
+      // that isn't in the snapshot; else the global `historyMaxStreamSeq`
+      // (legacy hosts / unstamped history). A role with no seq-stamped
+      // persisted row yields 0 → seq-coverage doesn't apply for it and the
+      // synthetic falls through to the content / wall-clock rules (kept unless
+      // a content twin proves it's a replay) rather than being dropped by an
+      // unrelated row's seq. Falls back to global coverage / wall-clock for
+      // unstamped synthetics (legacy NATS).
+      const coverageMax = anyHistoryRowSeq ? (historyMaxSeqByRole.get(m.role) ?? 0) : historyMaxStreamSeq
       const covered =
-        typeof m.streamSeq === 'number' && historyMaxStreamSeq > 0
-          ? historyMaxStreamSeq >= m.streamSeq
+        typeof m.streamSeq === 'number' && coverageMax > 0
+          ? coverageMax >= m.streamSeq
           : historyCoversRealtime !== null
             ? historyCoversRealtime
             : (m.timestamp?.getTime() ?? 0) <= historyFetchedAt

--- a/openframe-frontend-core/src/components/chat/utils/history-merge.ts
+++ b/openframe-frontend-core/src/components/chat/utils/history-merge.ts
@@ -28,7 +28,9 @@ export interface MergeableChatMessage {
    *  approval / error / compaction — never the non-persisted MESSAGE_END /
    *  TOKEN_USAGE control chunks). Hosts stamp it on realtime synthetics so the
    *  merge can decide coverage per-message: a synthetic is in history once a
-   *  persisted row of the SAME role reaches its seq.
+   *  persisted row of the SAME role reaches its seq. (Regular `user-`
+   *  MESSAGE_REQUEST synthetics are the exception — the backend persists their
+   *  rows without a seq, so they are deduped by content, not seq; see the merge.)
    *
    *  Stamp it on HISTORY rows too (from the persisted `lastChunkStreamSeq`)
    *  when available: the merge then computes a PER-ROLE max from history and a
@@ -233,6 +235,24 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
   const trailingAssistantText =
     lastProcessed && lastProcessed.role === 'assistant' ? assistantAnswerText(lastProcessed.content) : ''
 
+  // Positional content multiset for `user-` synthetic dedup. The backend
+  // persists user MESSAGE_REQUEST rows WITHOUT a `lastChunkStreamSeq`, so a
+  // replayed/echoed `user-` synthetic can be covered by neither seq (its twin
+  // adds 0 to every seq max) nor wall-clock (replay re-mints a fresh
+  // timestamp). Match it by TEXT against persisted user rows, positionally: the
+  // k-th `user-` synthetic with a text is the twin of the k-th persisted user
+  // row with that text. This drops a replay/echo once its own row is in the
+  // snapshot (kills the client→viewer duplicate, trailing twin or not) while
+  // keeping a LATER same-text turn whose row hasn't persisted yet — which the
+  // old first-match `findIndex` dropped, losing a repeated message.
+  const persistedUserContentCounts = new Map<string, number>()
+  for (const pm of processedToUse) {
+    if (pm.role === 'user' && typeof pm.content === 'string') {
+      persistedUserContentCounts.set(pm.content, (persistedUserContentCounts.get(pm.content) ?? 0) + 1)
+    }
+  }
+  const seenUserSyntheticByContent = new Map<string, number>()
+
   const realtimeMessages = existingMessages.filter((m) => {
     // Pin wins over everything: the twin may carry a persisted Mongo id (the
     // chunk processors ADOPT an in-progress trailing assistant after a prior
@@ -265,53 +285,54 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
       if (m.role === 'assistant' && trailingAssistantText && assistantAnswerText(m.content) === trailingAssistantText) {
         return false
       }
-      // A replayed user MESSAGE_REQUEST re-mints a `user-` synthetic with a
-      // FRESH timestamp, so the wall-clock rule below keeps it; and on backends
-      // that persist the user row WITHOUT a `lastChunkStreamSeq` (unlike
-      // DIRECT/SYSTEM rows, which carry the chunk seq) the seq-coverage rule
-      // can't cover it either — the persisted twin contributes 0 to
-      // `historyMaxStreamSeq`, so `historyMaxStreamSeq >= m.streamSeq` is never
-      // true for this row. The assistant content-fallback above is
-      // assistant-only, so nothing collapses the replayed user turn and it
-      // renders twice (its persisted twin + this synthetic). Recognise it by
-      // an identical-text persisted user twin that is NOT the trailing history
-      // row: a user row FOLLOWED by another message is a COMPLETED turn (its
-      // answer already persisted), so this synthetic is provably that turn's
-      // replay. A trailing (or absent) persisted twin is left alone — it may be
-      // a just-sent message whose live echo must survive, not a replay.
-      // NOTE: this is a targeted workaround for the missing `lastChunkStreamSeq`
-      // on persisted user rows; the durable fix is the backend stamping it (as
-      // it already does for DIRECT/SYSTEM), which also stops the replay at the
+      // Regular user MESSAGE_REQUEST synthetics (`user-`): the backend persists
+      // the user row WITHOUT a `lastChunkStreamSeq` (unlike DIRECT/SYSTEM rows,
+      // which carry the chunk seq), so seq coverage can NEVER see them (the twin
+      // adds 0 to every seq max) and wall-clock can't either (replay re-mints a
+      // fresh timestamp). Dedup them purely by TEXT, matched positionally
+      // against persisted user rows (see `persistedUserContentCounts`): drop the
+      // synthetic once its own row is in the snapshot — trailing twin or not,
+      // killing the client→viewer duplicate — while keeping a later same-text
+      // turn whose row hasn't persisted yet. `direct-` / `system-` synthetics
+      // are ALSO role 'user' but DO carry a persisted seq, so the `user-` prefix
+      // gate lets them fall through to seq coverage below.
+      // NOTE: content matching is a workaround for the missing user-row
+      // `lastChunkStreamSeq`; the durable fix is the backend stamping it (as it
+      // already does for DIRECT/SYSTEM), which also stops the replay at the
       // source via a correct `optStartSeq`.
-      if (m.role === 'user' && typeof m.content === 'string') {
-        const twinIdx = processedToUse.findIndex((pm) => pm.role === 'user' && pm.content === m.content)
-        if (twinIdx !== -1 && twinIdx < processedToUse.length - 1) {
-          return false
-        }
+      if (m.role === 'user' && m.id.startsWith('user-') && typeof m.content === 'string') {
+        const seen = (seenUserSyntheticByContent.get(m.content) ?? 0) + 1
+        seenUserSyntheticByContent.set(m.content, seen)
+        return (persistedUserContentCounts.get(m.content) ?? 0) < seen
       }
-      // Per-message coverage: the synthetic carries the highest CONTENT seq
+      // Per-message seq coverage for the remaining synthetics (assistant /
+      // direct / system / error). The synthetic carries the highest CONTENT seq
       // that built it (never the MESSAGE_END/TOKEN_USAGE tail), so history has
-      // it once a persisted row reaches that seq. This is exact per-turn — it
-      // drops earlier finished turns while keeping a later still-streaming one,
-      // which the single global `realtimeSeenStreamSeq` (biased upward by the
-      // tail the client consumed) cannot distinguish.
+      // it once a persisted row reaches that seq — exact per-turn: it drops an
+      // earlier finished turn while keeping a later still-streaming one, which
+      // the single global `realtimeSeenStreamSeq` (biased upward by the consumed
+      // tail) cannot distinguish.
       //
-      // Coverage max: prefer the SAME-ROLE persisted max (when history rows are
-      // seq-stamped) so an other-role / later row can't falsely cover a turn
-      // that isn't in the snapshot; else the global `historyMaxStreamSeq`
-      // (legacy hosts / unstamped history). A role with no seq-stamped
-      // persisted row yields 0 → seq-coverage doesn't apply for it and the
-      // synthetic falls through to the content / wall-clock rules (kept unless
-      // a content twin proves it's a replay) rather than being dropped by an
-      // unrelated row's seq. Falls back to global coverage / wall-clock for
-      // unstamped synthetics (legacy NATS).
-      const coverageMax = anyHistoryRowSeq ? (historyMaxSeqByRole.get(m.role) ?? 0) : historyMaxStreamSeq
-      const covered =
-        typeof m.streamSeq === 'number' && coverageMax > 0
-          ? coverageMax >= m.streamSeq
-          : historyCoversRealtime !== null
+      // In the per-role regime (some history row is seq-stamped) decide ONLY
+      // against the SAME-ROLE persisted max and NEVER fall back to the global
+      // (cross-role) coverage: a role whose persisted rows reached no seq >=
+      // this one has no evidence the turn is in the snapshot, so it must be kept
+      // — letting an unrelated role's seq (a user MESSAGE_REQUEST that raised the
+      // global max, a later turn) cover it is exactly the reload/stop
+      // message-loss bug. Only when NO history row is seq-stamped (legacy hosts /
+      // unstamped history) do we use the global seq, then wall-clock.
+      let covered: boolean
+      if (typeof m.streamSeq === 'number' && anyHistoryRowSeq) {
+        const roleMax = historyMaxSeqByRole.get(m.role) ?? 0
+        covered = roleMax > 0 && roleMax >= m.streamSeq
+      } else if (typeof m.streamSeq === 'number' && historyMaxStreamSeq > 0) {
+        covered = historyMaxStreamSeq >= m.streamSeq
+      } else {
+        covered =
+          historyCoversRealtime !== null
             ? historyCoversRealtime
             : (m.timestamp?.getTime() ?? 0) <= historyFetchedAt
+      }
       if (covered) return false
     }
     return true

--- a/openframe-frontend-core/src/components/chat/utils/history-merge.ts
+++ b/openframe-frontend-core/src/components/chat/utils/history-merge.ts
@@ -227,6 +227,44 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
     }
   }
 
+  // Adoption pin, generalised to plain tool turns (no approval batch). After a
+  // mid-stream reload the trailing assistant is a PERSISTED row (Mongo id); the
+  // chunk processors ADOPT it and append later chunks IN PLACE, so the store's
+  // copy keeps that Mongo id but accumulates MORE than history has persisted yet
+  // (a later tool, a tool's terminal state). `processedIds` would then drop that
+  // richer realtime copy as an id-duplicate and revert the bubble to history's
+  // stale segments — the reported "3 tools collapse to 2, one stuck pending
+  // instead of failed" after reload + stop. When a same-id realtime twin is
+  // strictly richer than the persisted trailing (more segments, or an equal
+  // count but a higher consumed `streamSeq`), pin it and drop history's copy —
+  // the same rule the approval-batch branch above applies, for any trailing
+  // assistant. Skipped when that branch already claimed the trailing turn (its
+  // slice moved the last element) or the trailing isn't an assistant. Once the
+  // backend finishes persisting the turn, history's length/seq catch up, the
+  // twin is no longer richer, and the persisted copy wins again (self-heals).
+  if (
+    historyTrailingAssistant &&
+    Array.isArray(historyTrailingAssistant.content) &&
+    processedToUse[processedToUse.length - 1] === historyTrailingAssistant &&
+    !pinnedSyntheticIds.has(historyTrailingAssistant.id)
+  ) {
+    const persistedSize = historyTrailingAssistant.content.length
+    const persistedSeq = historyTrailingAssistant.streamSeq ?? 0
+    const richerTwin = existingMessages.find(
+      (m) =>
+        m !== historyTrailingAssistant &&
+        m.id === historyTrailingAssistant.id &&
+        m.role === 'assistant' &&
+        Array.isArray(m.content) &&
+        (m.content.length > persistedSize ||
+          (m.content.length === persistedSize && typeof m.streamSeq === 'number' && m.streamSeq > persistedSeq)),
+    )
+    if (richerTwin) {
+      processedToUse = processedToUse.slice(0, -1)
+      pinnedSyntheticIds.add(richerTwin.id)
+    }
+  }
+
   // Content-equality fallback for the trailing turn. The backend stamps `lastChunkStreamSeq`
   // asynchronously, so a just-finished assistant can land in history with a seq BELOW the replay's
   // terminal chunk seq; seq coverage then reads "not covered" and the replayed synthetic survives

--- a/openframe-frontend-core/src/components/chat/utils/history-merge.ts
+++ b/openframe-frontend-core/src/components/chat/utils/history-merge.ts
@@ -341,7 +341,28 @@ export function mergeHistoryWithRealtime<M extends MergeableChatMessage>(input: 
       if (m.role === 'user' && m.id.startsWith('user-') && typeof m.content === 'string') {
         const seen = (seenUserSyntheticByContent.get(m.content) ?? 0) + 1
         seenUserSyntheticByContent.set(m.content, seen)
-        return (persistedUserContentCounts.get(m.content) ?? 0) < seen
+        // No persisted row for THIS occurrence slot → keep (nothing renders it).
+        if ((persistedUserContentCounts.get(m.content) ?? 0) < seen) return true
+        // A same-text persisted twin exists for this slot. User rows carry no
+        // persisted seq, so that twin may be THIS message's OWN row (drop — it
+        // renders the message) OR an OLDER identical-text turn while this is a
+        // NEW send repeating the text (keep — dropping it loses a message the
+        // user just sent: the reported "message from the client chat disappears"
+        // when the text repeats an earlier turn, e.g. sending "continue" again).
+        // Disambiguate with signals that DON'T need a user-row seq:
+        //   - seq watermark: if history persisted PAST this synthetic's
+        //     streamSeq, the stream reached this delivery point, so its own row
+        //     is in the snapshot → replay → drop.
+        //   - trailing twin: if the last history row is a same-text user row (no
+        //     reply yet), it's the just-sent message's own row → drop its echo.
+        //   - else history is BEHIND this fresh seq and the twin is an older
+        //     completed turn → NEW repeat → keep.
+        // No seq signal (legacy transport) → positional-only dedup (drop).
+        if (typeof m.streamSeq !== 'number' || historyMaxStreamSeq <= 0) return false
+        if (historyMaxStreamSeq >= m.streamSeq) return false
+        const lastPersisted = processedToUse[processedToUse.length - 1]
+        if (lastPersisted && lastPersisted.role === 'user' && lastPersisted.content === m.content) return false
+        return true
       }
       // Per-message seq coverage for the remaining synthetics (assistant /
       // direct / system / error). The synthetic carries the highest CONTENT seq

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -123,11 +123,18 @@ export function processHistoricalMessages(
         ...(currentAssistantStreamSeq !== undefined ? { streamSeq: currentAssistantStreamSeq } : {}),
       })
       accumulator.resetSegments()
-      currentAssistantId = null
-      currentAssistantTimestamp = null
-      lastAssistantId = null
-      currentAssistantStreamSeq = undefined
     }
+    // Reset grouping identity + seq UNCONDITIONALLY — even on an EMPTY flush (an
+    // assistant turn whose only data was a filtered/escalated approval renders
+    // nothing, so `hasContent()` is false and nothing is pushed). Left inside
+    // the push-block, a stale id/timestamp and (worse) a stale
+    // `currentAssistantStreamSeq` bleed into the NEXT assistant turn: `!currentAssistantId`
+    // stays false so it keeps the old id/timestamp, and `Math.max` inflates its
+    // streamSeq — which then over-covers synthetics in the history merge.
+    currentAssistantId = null
+    currentAssistantTimestamp = null
+    lastAssistantId = null
+    currentAssistantStreamSeq = undefined
   }
 
   messages.forEach((msg, index) => {
@@ -533,11 +540,18 @@ export function processHistoricalMessagesWithErrors(
         ...(currentAssistantStreamSeq !== undefined ? { streamSeq: currentAssistantStreamSeq } : {}),
       })
       accumulator.resetSegments()
-      currentAssistantId = null
-      currentAssistantTimestamp = null
-      lastAssistantId = null
-      currentAssistantStreamSeq = undefined
     }
+    // Reset grouping identity + seq UNCONDITIONALLY — even on an EMPTY flush (an
+    // assistant turn whose only data was a filtered/escalated approval renders
+    // nothing, so `hasContent()` is false and nothing is pushed). Left inside
+    // the push-block, a stale id/timestamp and (worse) a stale
+    // `currentAssistantStreamSeq` bleed into the NEXT assistant turn: `!currentAssistantId`
+    // stays false so it keeps the old id/timestamp, and `Math.max` inflates its
+    // streamSeq — which then over-covers synthetics in the history merge.
+    currentAssistantId = null
+    currentAssistantTimestamp = null
+    lastAssistantId = null
+    currentAssistantStreamSeq = undefined
   }
 
   messages.forEach((msg, index) => {

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -47,6 +47,7 @@ function pushStandaloneMessages(
         name: data.text,
         authorType: 'system',
         timestamp: new Date(msg.createdAt),
+        ...(typeof msg.lastChunkStreamSeq === 'number' ? { streamSeq: msg.lastChunkStreamSeq } : {}),
       })
     }
   })
@@ -99,6 +100,9 @@ export function processHistoricalMessages(
   let currentAssistantId: string | null = null
   let currentAssistantTimestamp: Date | null = null
   let lastAssistantId: string | null = null
+  // MAX persisted seq across the rows grouped into the current assistant turn
+  // — carried onto the flushed message's streamSeq for per-role merge coverage.
+  let currentAssistantStreamSeq: number | undefined
 
   /**
    * Flush the current assistant message to processedMessages.
@@ -116,11 +120,13 @@ export function processHistoricalMessages(
         authorType: assistantType as AuthorType,
         timestamp: currentAssistantTimestamp || new Date(),
         avatar: assistantAvatar,
+        ...(currentAssistantStreamSeq !== undefined ? { streamSeq: currentAssistantStreamSeq } : {}),
       })
       accumulator.resetSegments()
       currentAssistantId = null
       currentAssistantTimestamp = null
       lastAssistantId = null
+      currentAssistantStreamSeq = undefined
     }
   }
 
@@ -171,6 +177,7 @@ export function processHistoricalMessages(
             authorType: userAuthorType,
             timestamp: new Date(msg.createdAt),
             ...(contextItems && contextItems.length > 0 ? { contextItems } : {}),
+            ...(typeof msg.lastChunkStreamSeq === 'number' ? { streamSeq: msg.lastChunkStreamSeq } : {}),
           })
         }
       })
@@ -180,6 +187,12 @@ export function processHistoricalMessages(
         currentAssistantTimestamp = new Date(msg.createdAt)
       }
       lastAssistantId = msg.id
+      if (typeof msg.lastChunkStreamSeq === 'number') {
+        currentAssistantStreamSeq =
+          currentAssistantStreamSeq === undefined
+            ? msg.lastChunkStreamSeq
+            : Math.max(currentAssistantStreamSeq, msg.lastChunkStreamSeq)
+      }
 
       messageDataArray.forEach((data) => {
         processMessageData(
@@ -501,6 +514,9 @@ export function processHistoricalMessagesWithErrors(
   let currentAssistantId: string | null = null
   let currentAssistantTimestamp: Date | null = null
   let lastAssistantId: string | null = null
+  // MAX persisted seq across the rows grouped into the current assistant turn
+  // — carried onto the flushed message's streamSeq for per-role merge coverage.
+  let currentAssistantStreamSeq: number | undefined
 
   const flushAssistantMessage = () => {
     const idToUse = lastAssistantId || currentAssistantId
@@ -514,11 +530,13 @@ export function processHistoricalMessagesWithErrors(
         authorType: assistantType as AuthorType,
         timestamp: currentAssistantTimestamp || new Date(),
         avatar: assistantAvatar,
+        ...(currentAssistantStreamSeq !== undefined ? { streamSeq: currentAssistantStreamSeq } : {}),
       })
       accumulator.resetSegments()
       currentAssistantId = null
       currentAssistantTimestamp = null
       lastAssistantId = null
+      currentAssistantStreamSeq = undefined
     }
   }
 
@@ -568,6 +586,7 @@ export function processHistoricalMessagesWithErrors(
             authorType: userAuthorType,
             timestamp: new Date(msg.createdAt),
             ...(contextItems && contextItems.length > 0 ? { contextItems } : {}),
+            ...(typeof msg.lastChunkStreamSeq === 'number' ? { streamSeq: msg.lastChunkStreamSeq } : {}),
           })
         }
       })
@@ -577,6 +596,12 @@ export function processHistoricalMessagesWithErrors(
         currentAssistantTimestamp = new Date(msg.createdAt)
       }
       lastAssistantId = msg.id
+      if (typeof msg.lastChunkStreamSeq === 'number') {
+        currentAssistantStreamSeq =
+          currentAssistantStreamSeq === undefined
+            ? msg.lastChunkStreamSeq
+            : Math.max(currentAssistantStreamSeq, msg.lastChunkStreamSeq)
+      }
 
       messageDataArray.forEach((data) => {
         processMessageData(


### PR DESCRIPTION
Two focused, related fixes to `mergeHistoryWithRealtime` that stop **user-visible message corruption** in the realtime chat thread. Split out of the larger realtime-chat hotfix (#1488) so they can be reviewed and merged on their own. Backward-compatible; lib type-check clean, 39 merge/processor tests (all green, +7 new).

## 1. Duplicate user message (`dedupe replayed user MESSAGE_REQUEST`)

A CLIENT user message sent from the Tauri client rendered **twice** in the tickets/mingo viewer (assistant reply once). Root cause is a missing backend signal, not a double publish: the AI path persists the user `MESSAGE_REQUEST` row with `lastChunkStreamSeq = null` (DIRECT/SYSTEM rows persist it), so the persisted user row contributes 0 to `maxPersistedStreamSeq` → `optStartSeq` never covers the user chunk → JetStream replays it → a fresh `user-` synthetic is minted that neither seq-coverage nor wall-clock can drop, and the merge's content-fallback was assistant-only.

Fix: the merge also collapses a `user-` synthetic against an identical-text persisted user twin that is **not** the trailing history row (a user row followed by another message is a completed turn → the synthetic is provably its replay; a trailing/absent twin is left alone so a just-sent message survives).

## 2. Message loss on reload / stop / any recompute (`per-role seq coverage`)

Messages the user already saw **vanished** from the thread on ANY merge recompute after a page reload — triggered by a Stop from another client, a new incoming message, or a reconnect. Affected all three surfaces (openframe-chat, tickets, mingo).

Root cause: the per-message seq-coverage test `historyMaxStreamSeq >= m.streamSeq` used a **single global max** over all persisted rows as a proxy for "this synthetic's turn is in history". That proxy is false when persistence is async/out-of-order or the turn was interrupted: a later or **other-role** row (e.g. a user `MESSAGE_REQUEST`) pushes the global max past a synthetic whose own turn isn't in the snapshot, so it's dropped with no twin — and JetStream won't replay it (seq already consumed). The synthetic was only protected while it held the single `streamingMessageId` exemption, which any recompute strips.

Fix: coverage is now decided against the **same-role** persisted max (computed from history rows that carry a per-row `streamSeq`, threaded through the processors from `lastChunkStreamSeq`). A synthetic is dropped only when a persisted row of its **own role** actually reached its seq. Fully backward-compatible: when no history row is seq-stamped (legacy hosts) the previous global behaviour is kept unchanged (`anyHistoryRowSeq` gate).

## Consumer wiring (separate PRs to their repos)

To activate #2, hosts stamp `HistoricalMessage.lastChunkStreamSeq` (→ processed `streamSeq`) onto history rows:
- **openframe-chat** — automatic (already passes the raw node through; no code change needed).
- **openframe-frontend tickets** (`use-historical-messages.ts`) and **mingo** (`use-mingo-dialog-selection.ts`) — two-line passthroughs; ship in their own PRs after this lib version publishes.

## Backend follow-up (recommended, not required)

The durable fix for #1 (and it also removes the replay behind #2) is the backend stamping `lastChunkStreamSeq` on the user `MESSAGE_REQUEST` row, mirroring the DIRECT/SYSTEM path (`MessageProcessingService.handleDirectMessage`). Detailed in #1488.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat history and realtime message merging for more accurate deduplication.
  - Prevented valid user and assistant messages from being incorrectly removed during synchronization.
  - Preserved richer assistant and tool responses when historical and realtime versions overlap.
  - Improved handling of delayed persistence and partially streamed messages.
- **Tests**
  - Added comprehensive coverage for message sequencing, deduplication, and tool-turn scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->