### PR TITLE
Fix carousel dots + CircularProgress accent to follow platform accent

### DIFF
--- a/openframe-frontend-core/src/components/media-carousel.tsx
+++ b/openframe-frontend-core/src/components/media-carousel.tsx
@@ -30,7 +30,7 @@ const ChevronRightIcon = () => (
  * - Slides render through the SSoT `<Video>` (MuxPlayer / lite-youtube
  *   facade) for `video`/`youtube` items and a broken-image-resilient
  *   `<Image>` shim for `image` items.
- * - Dots: 24px hit target, 8px dot, active = flamingo pink (per design).
+ * - Dots: 24px hit target, 8px dot, active = platform accent (per design).
  * - Hover-revealed prev/next arrows (`showArrows`), keyboard arrows, and
  *   touch swipe all preserved from the previous generation.
  */
@@ -314,7 +314,7 @@ export const MediaCarousel = memo(function MediaCarousel({
         )}
       </div>
 
-      {/* Dot pagination (Figma) — 24px hit target, 8px dot, active pink.
+      {/* Dot pagination (Figma) — 24px hit target, 8px dot, active accent.
           Plain grouped buttons (NOT tablist: no roving tabIndex/arrow-key
           model here — aria-current marks the active slide instead). */}
       {(media.length > 1 || reserveDotRow) && (
@@ -334,7 +334,7 @@ export const MediaCarousel = memo(function MediaCarousel({
                   className={cn(
                     "size-2 rounded-full transition-colors duration-150",
                     isActive
-                      ? "bg-ods-flamingo-pink"
+                      ? "bg-ods-accent"
                       : "bg-ods-bg-surface hover:bg-ods-bg-surface-hover"
                   )}
                 />

--- a/openframe-frontend-core/src/components/ui/circular-progress.tsx
+++ b/openframe-frontend-core/src/components/ui/circular-progress.tsx
@@ -47,7 +47,7 @@ const variantColors: Record<CircularProgressVariant, { progress: string; track: 
     track: SUBTLE_TRACK,
   },
   accent: {
-    progress: 'var(--ods-flamingo-cyan-base)',
+    progress: 'var(--ods-accent)',
     track: SUBTLE_TRACK,
   },
 }


### PR DESCRIPTION
## What

Two shared components hardcoded the Flamingo brand color on state indicators that should track the platform-adaptive accent token. As a result they rendered pink/cyan on **every** platform instead of the platform accent (yellow on openframe/openmsp, pink only on flamingo/flamingo-teaser).

- **`MediaCarousel`** active pagination dot: `bg-ods-flamingo-pink` → `bg-ods-accent`
- **`CircularProgress`** `accent` variant: `--ods-flamingo-cyan-base` → `--ods-accent` (its sibling variants `success`/`warning`/`error` already use their semantic tokens; `accent` was the odd one out)

Comments documenting the old "always pink" intent were updated to say "platform accent".

## Why

`ods-flamingo-pink` / `ods-flamingo-cyan` are theme-independent **brand** tokens. Themed controls and state indicators should consume `--ods-accent` / `--color-accent-primary`, which `ods-colors.css` overrides per `[data-app-type]`. The reported bug was the carousel controls always showing Flamingo pink regardless of platform; this fixes that class of issue at the shared-component level.

## Reviewer notes

- Nav arrows were already correct (`bg-black/50` + `text-ods-text-on-dark`) — untouched.
- The MuxPlayer controls in the same carousel already read `--ods-accent`, so the dot now matches them.
- Consumed in the hub via `who-am-i`, `openframe-features-section`, and `vendor-detail-content`. Needs the usual lib release → hub pin bump to reach production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated media carousel pagination to use the accent color for the active dot.
  * Updated circular progress indicators to use the accent color for progress rings.
  * Refined related styling documentation to reflect the updated color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->