### PR TITLE
fix(header): drop no-op backdrop-blur that flickered content on scroll

### DIFF
--- a/openframe-frontend-core/src/components/navigation/header.tsx
+++ b/openframe-frontend-core/src/components/navigation/header.tsx
@@ -277,7 +277,18 @@ export function Header({ config, platform }: HeaderProps) {
           // 72px = unified-header spec height (Figma 4033-90260); the right
           // cluster self-stretches so the Mingo launcher can sit flush.
           "w-full h-[72px] flex items-center justify-between",
-          "border-b border-ods-border backdrop-blur-sm",
+          // NOTE: no `backdrop-blur` here. Every platform ships an OPAQUE
+          // header background (`backgroundColor` below resolves to an opaque
+          // ODS token — bg-ods-bg / bg-ods-card), so a backdrop-filter would
+          // blur a backdrop that is then fully painted over: zero visual
+          // effect, but it still forces the browser to keep a backdrop-filter
+          // surface and re-rasterize the strip behind this sticky bar every
+          // scroll frame. That surface desyncs a frame against the scrolling
+          // content and makes content flicker as it passes under the header
+          // (most visible on large high-contrast headings, e.g. /pricing).
+          // If a consumer ever wants a translucent "glass" header, add the
+          // blur together with a translucent `backgroundColor` deliberately.
+          "border-b border-ods-border",
           "pl-6",
           !config.mingo?.enabled && "pr-6",
           // Background color (configurable via backgroundColor prop)


### PR DESCRIPTION
## Problem

Reported: a visible flicker when scrolling the flamingo **/pricing** page, worst as the large monospace headings (\`What's in OpenFrame:\`, \`One Dollar. One Device.\`) pass under the sticky header.

## Root cause

The flicker is **not** in the page content — that section is static on scroll (instrumented: 0 DOM mutations, no reveal/entrance animations, opacity 1, no transforms). It's a **compositor artifact from the shared sticky header**.

The header carried \`backdrop-blur-sm\`, but every platform ships an **opaque** header background (\`headerBackground: UNIFIED_HEADER_BG = 'bg-ods-bg'\`, live-computed \`srgb 0.086…\`, alpha 1; others use \`bg-ods-card\`). So the blur samples a backdrop that is then **fully painted over** — zero visual effect, but it still forces Chromium to:

- keep a \`backdrop-filter\` compositing surface on the sticky bar, and
- re-rasterize the strip *behind* it every scroll frame.

That backdrop snapshot desyncs by a frame against the scrolling content → content flickers as it passes under the header. It's worst on high-contrast large text (the pricing headings). Flamingo also has \`headerAutoHide: false\`, so the header never translates on scroll here — ruling out the show/hide transform and leaving the backdrop-filter as the sole culprit.

## Fix

Remove \`backdrop-blur-sm\` from the header, with a comment explaining why it must not return (and how to add a real translucent "glass" header deliberately if ever wanted). This is a **visual no-op on every platform** (all header backgrounds are opaque) and eliminates the flicker for all header-bearing platforms at once.

## Verification

- Header renders pixel-identical: \`backdropFilter: none\`, background/border unchanged.
- Confirmed on local dev that the scroll flicker is gone on /pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)