### PR TITLE
Chat: fix lost stick-to-bottom on card-heavy answers (/getting-started)

### DIFF
--- a/openframe-frontend-core/src/components/chat/__tests__/chat-message-list.test.tsx
+++ b/openframe-frontend-core/src/components/chat/__tests__/chat-message-list.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Message } from '../types/message.types'
 
@@ -63,6 +63,16 @@ vi.stubGlobal('ResizeObserver', RecordingResizeObserver)
  *  or scroller-box size change in the real DOM. */
 const fireResize = () => {
   for (const cb of resizeCallbacks) cb()
+}
+
+/** jsdom has no layout, so every box metric reads 0. The jump-to-bottom
+ *  button is driven off real geometry, so the tests supply it. */
+const setGeometry = (geo: { scrollHeight: number; clientHeight: number; scrollTop: number }) => {
+  const el = scrollRefMock.current
+  if (!el) throw new Error('scroller not mounted')
+  for (const [key, value] of Object.entries(geo)) {
+    Object.defineProperty(el, key, { value, configurable: true, writable: true })
+  }
 }
 
 // jsdom has no layout, so `scrollIntoView` is undefined.
@@ -180,6 +190,42 @@ describe('ChatMessageList bottom-follow intent', () => {
     scrollToBottom.mockClear()
     fireResize()
     expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('hides jump-to-bottom while the thread is at the bottom', () => {
+    const view = sendTurn()
+    setGeometry({ scrollHeight: 1000, clientHeight: 500, scrollTop: 500 })
+    act(() => fireResize())
+    expect(view.queryByLabelText('Scroll to latest message')).toBeNull()
+  })
+
+  it('shows jump-to-bottom once the thread is away from the bottom', () => {
+    const view = sendTurn()
+    setGeometry({ scrollHeight: 20000, clientHeight: 500, scrollTop: 500 })
+    act(() => fireResize())
+    expect(view.queryByLabelText('Scroll to latest message')).not.toBeNull()
+  })
+
+  it('re-arms the intent when the user clicks jump-to-bottom', () => {
+    const view = sendTurn()
+    // User scrolls away: intent released, button appears.
+    scrollRefMock.current?.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: -120, bubbles: true }),
+    )
+    setGeometry({ scrollHeight: 20000, clientHeight: 500, scrollTop: 500 })
+    act(() => fireResize())
+    expect(scrollToBottom).not.toHaveBeenCalled()
+
+    const button = view.getByLabelText('Scroll to latest message')
+    act(() => {
+      button.click()
+    })
+    expect(scrollToBottom).toHaveBeenCalled()
+
+    // …and the click re-armed the lock, so growth follows again.
+    scrollToBottom.mockClear()
+    act(() => fireResize())
+    expect(scrollToBottom).toHaveBeenCalled()
   })
 
   it('releases the intent for a top-anchored turn (it parks at the message top)', () => {

--- a/openframe-frontend-core/src/components/chat/__tests__/chat-message-list.test.tsx
+++ b/openframe-frontend-core/src/components/chat/__tests__/chat-message-list.test.tsx
@@ -26,9 +26,16 @@ vi.mock('use-stick-to-bottom', () => ({
 
 // Keep the row renderer trivial — these tests exercise ChatMessageList's
 // scroll orchestration, not markdown rendering.
-vi.mock('../chat-message-enhanced', () => ({
-  ChatMessageEnhanced: ({ content }: { content: string }) => <div>{content}</div>,
-}))
+// Forwards the ref because the list registers each row element for the
+// per-message `scrollAnchor: 'top'` path.
+vi.mock('../chat-message-enhanced', async () => {
+  const { forwardRef } = await import('react')
+  return {
+    ChatMessageEnhanced: forwardRef<HTMLDivElement, { content: string }>(({ content }, ref) => (
+      <div ref={ref}>{content}</div>
+    )),
+  }
+})
 
 import { ChatMessageList } from '../chat-message-list'
 
@@ -40,7 +47,26 @@ class ObserverStub {
   disconnect() {}
 }
 vi.stubGlobal('IntersectionObserver', ObserverStub)
-vi.stubGlobal('ResizeObserver', ObserverStub)
+
+// Recording RO so the bottom-follow tests can drive a resize by hand.
+const resizeCallbacks: Array<() => void> = []
+class RecordingResizeObserver {
+  constructor(cb: () => void) {
+    resizeCallbacks.push(cb)
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', RecordingResizeObserver)
+/** Fire every live ResizeObserver callback — same effect as any content
+ *  or scroller-box size change in the real DOM. */
+const fireResize = () => {
+  for (const cb of resizeCallbacks) cb()
+}
+
+// jsdom has no layout, so `scrollIntoView` is undefined.
+Element.prototype.scrollIntoView = vi.fn()
 
 const msg = (id: string, role: Message['role']): Message => ({
   id,
@@ -87,6 +113,84 @@ describe('ChatMessageList force-scroll decisions', () => {
     const { rerender } = render(<ChatMessageList dialogId="d1" messages={initial} />)
     scrollToBottom.mockClear()
     rerender(<ChatMessageList dialogId="d1" messages={[...initial, msg('m3', 'assistant')]} />)
+    expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+})
+
+// The library's own `isAtBottom` lock is lost silently when the scroller's
+// box changes (source chips mounting below it) or when a card settling out
+// of its skeleton produces a resize-driven scroll the library reads as a
+// user gesture. The list therefore owns the INTENT and re-asserts on every
+// geometry change until a real gesture releases it.
+describe('ChatMessageList bottom-follow intent', () => {
+  beforeEach(() => {
+    scrollToBottom.mockClear()
+    resizeCallbacks.length = 0
+  })
+
+  const sendTurn = () => {
+    const initial = [msg('m1', 'user'), msg('m2', 'assistant')]
+    const view = render(<ChatMessageList dialogId="d1" messages={initial} />)
+    // A user send arms the follow intent for the whole turn.
+    view.rerender(<ChatMessageList dialogId="d1" messages={[...initial, msg('m3', 'user')]} />)
+    scrollToBottom.mockClear()
+    return view
+  }
+
+  it('re-asserts the bottom on geometry changes after the send', () => {
+    sendTurn()
+    fireResize()
+    expect(scrollToBottom).toHaveBeenCalled()
+  })
+
+  it('keeps re-asserting for late async growth (cards + covers resolving)', () => {
+    sendTurn()
+    fireResize()
+    fireResize()
+    fireResize()
+    expect(scrollToBottom).toHaveBeenCalledTimes(3)
+  })
+
+  it('releases the intent once the user scrolls up', () => {
+    sendTurn()
+    scrollRefMock.current?.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: -120, bubbles: true }),
+    )
+    fireResize()
+    expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('ignores downward wheel (never an escape from the bottom)', () => {
+    sendTurn()
+    scrollRefMock.current?.dispatchEvent(
+      new WheelEvent('wheel', { deltaY: 120, bubbles: true }),
+    )
+    fireResize()
+    expect(scrollToBottom).toHaveBeenCalled()
+  })
+
+  it('does not follow when autoScroll is off (passive demo hosts)', () => {
+    const initial = [msg('m1', 'user'), msg('m2', 'assistant')]
+    const { rerender } = render(
+      <ChatMessageList dialogId="d1" messages={initial} autoScroll={false} />,
+    )
+    rerender(
+      <ChatMessageList dialogId="d1" messages={[...initial, msg('m3', 'user')]} autoScroll={false} />,
+    )
+    scrollToBottom.mockClear()
+    fireResize()
+    expect(scrollToBottom).not.toHaveBeenCalled()
+  })
+
+  it('releases the intent for a top-anchored turn (it parks at the message top)', () => {
+    const initial = [msg('m1', 'user'), msg('m2', 'assistant')]
+    const { rerender } = render(<ChatMessageList dialogId="d1" messages={initial} />)
+    const sent = [...initial, msg('m3', 'user')]
+    rerender(<ChatMessageList dialogId="d1" messages={sent} />)
+    const anchored: Message = { ...msg('m4', 'assistant'), scrollAnchor: 'top' }
+    rerender(<ChatMessageList dialogId="d1" messages={[...sent, anchored]} />)
+    scrollToBottom.mockClear()
+    fireResize()
     expect(scrollToBottom).not.toHaveBeenCalled()
   })
 })

--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import { useRef, useEffect, useLayoutEffect, useImperativeHandle, forwardRef } from "react"
+import { useRef, useState, useEffect, useLayoutEffect, useImperativeHandle, forwardRef } from "react"
 import { useStickToBottom } from "use-stick-to-bottom"
 import { cn } from "../../utils/cn"
 import { ChatMessageEnhanced } from "./chat-message-enhanced"
 import { ChatMessageListSkeleton } from "./chat-message-skeleton"
-import { DotsLoaderIcon } from "../icons-v2-generated"
+import { DotsLoaderIcon, Arrow02DownIcon } from "../icons-v2-generated"
 import { CyclingPhrase } from "./cycling-phrase"
 import type { ChatMessageListProps } from "./types"
 import { SCROLL_ANCHOR } from "./types/message.types"
@@ -26,6 +26,11 @@ const STREAMING_WORDS = [
   'Conjuring',
   'Riffing',
 ] as const
+
+/** Distance from the bottom (px) still counted as "at the bottom".
+ *  Mirrors `use-stick-to-bottom`'s internal `STICK_TO_BOTTOM_OFFSET_PX`
+ *  so the jump-to-bottom button and the library agree on the boundary. */
+const BOTTOM_THRESHOLD_PX = 70
 
 /*
  * Stick-to-bottom: `use-stick-to-bottom` (stackblitz-labs)
@@ -177,6 +182,13 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     // lock self-heals instead of being permanent.
     const followBottomRef = useRef(false)
 
+    // Drives the jump-to-bottom affordance. Derived from GEOMETRY, not
+    // from the library's `isAtBottom`: that flag is the one this list
+    // loses silently (see above), and a stale `true` would hide the
+    // button in exactly the situation it exists for. Threshold mirrors
+    // the library's own `STICK_TO_BOTTOM_OFFSET_PX`.
+    const [atBottom, setAtBottom] = useState(true)
+
     // Tracks previous render state for explicit "force-stick" decisions
     // (dialog change, first message, new user message). The library
     // covers ongoing streaming; these are about INTENT transitions.
@@ -276,9 +288,17 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       // next resize instead of staying broken for the rest of the turn.
       // Cheap to call repeatedly — the library returns the in-flight
       // promise when an animation with the same behaviour is running.
+      const measure = () => {
+        const distance = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+        setAtBottom(distance <= BOTTOM_THRESHOLD_PX)
+      }
+
       const reassert = () => {
-        if (!followBottomRef.current) return
-        void scrollToBottom({ animation: 'smooth' })
+        if (followBottomRef.current) void scrollToBottom({ animation: 'smooth' })
+        // Measured on every geometry change, follow armed or not: a
+        // sibling growing below the scroller moves the bottom without
+        // any scroll event, and the button has to notice.
+        measure()
       }
 
       const ro = new ResizeObserver(reassert)
@@ -322,7 +342,9 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         const st = scroller.scrollTop
         if (pointerDown && st < lastScrollTop) disarm()
         lastScrollTop = st
+        measure()
       }
+      measure()
 
       scroller.addEventListener('wheel', onWheel, { passive: true })
       scroller.addEventListener('keydown', onKeyDown)
@@ -689,6 +711,35 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
             })}
           </div>
         </div>
+
+        {/* Jump to bottom. The manual escape hatch from auto-scroll that
+            every 2026 chat surface ships (AI Elements calls it
+            `ConversationScrollButton`) and the WCAG 2.2.2 counterpart to
+            moving content: the reader can always get back to the live
+            end without hunting for it. Overlays the scroller's lower
+            edge, so it costs the thread no layout height (a sibling
+            would shrink the scroller and move the very bottom it points
+            at). Hidden while at the bottom and in passive demo hosts. */}
+        {autoScroll && !atBottom && messages.length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              // Clicking IS the intent to return to the live end, so it
+              // re-arms the follow lock a scroll-up had released.
+              followBottomRef.current = true
+              void scrollToBottom({ animation: 'smooth' })
+            }}
+            aria-label="Scroll to latest message"
+            className={cn(
+              "absolute bottom-[var(--spacing-system-s)] left-1/2 -translate-x-1/2 z-10",
+              "flex items-center justify-center size-9 rounded-full",
+              "bg-ods-card text-ods-text-primary border border-ods-border shadow-lg",
+              "hover:bg-ods-bg-hover transition-colors",
+            )}
+          >
+            <Arrow02DownIcon size={16} />
+          </button>
+        )}
 
         {/* Footer-pinned streaming loader — outside the scroller so it
             doesn't jitter as the streaming message grows. Color is set

--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -53,6 +53,9 @@ const STREAMING_WORDS = [
  *    chat / sent a message; show me the bottom immediately").
  *  - **Load-more sentinel** (top-of-list IntersectionObserver) for
  *    infinite-scroll-UP. Distinct concern from stick-to-bottom.
+ *  - **Bottom-follow intent** (see `followBottomRef` below). The
+ *    library's follow is gated on its own `isAtBottom` flag, which this
+ *    list's layout can lose silently; we own the INTENT and re-assert.
  *
  * `useStickToBottom`'s returned refs are MUTABLE refs + ref callbacks
  * — pass them directly as `ref={scrollRef}` / `ref={contentRef}`.
@@ -142,6 +145,38 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     const dialogIdRef = useRef(dialogId)
     dialogIdRef.current = dialogId
 
+    // ---- Bottom-follow intent (list-owned lock) ----------------------
+    // The library follows the bottom only while ITS OWN `isAtBottom` flag
+    // is true, and this list's layout loses that flag silently in two
+    // ways:
+    //
+    //  1. **The scroller's own box changes.** The library's
+    //     ResizeObserver watches `contentRef` (INSIDE the scroller) only.
+    //     The streaming loader unmounting and the host's source-chip row
+    //     mounting — both siblings BELOW the scroller (see render) —
+    //     change the scroller's `clientHeight`, which moves the bottom
+    //     without emitting anything the library can observe.
+    //  2. **Resize-induced scroll events read as a user gesture.**
+    //     Fetch-mode entity cards mount as a skeleton and settle to a
+    //     different height; a shrink clamps `scrollTop` down, and the
+    //     library's scroll handler can see that as a scroll-UP and
+    //     permanently escape the lock (its `resizeDifference` guard is a
+    //     `setTimeout(…, 1)` race, so this is intermittent).
+    //
+    // Either way the thread stops following mid-turn. It bites hardest on
+    // card-heavy answers — a slash-command listing (`/getting-started`)
+    // renders a dozen fetch-mode cards with cover images that keep
+    // resolving for SECONDS after the stream ends, so everything after
+    // the lock was lost lands below the fold.
+    //
+    // Fix: this list owns the INTENT. Sending a message (or opening a
+    // dialog) arms it; only a real user scroll-up gesture — or a
+    // top-anchored turn, which deliberately parks elsewhere — disarms it.
+    // While armed, ANY geometry change re-asserts `scrollToBottom`, and
+    // because that call also re-sets the library's `isAtBottom`, a lost
+    // lock self-heals instead of being permanent.
+    const followBottomRef = useRef(false)
+
     // Tracks previous render state for explicit "force-stick" decisions
     // (dialog change, first message, new user message). The library
     // covers ongoing streaming; these are about INTENT transitions.
@@ -178,11 +213,13 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
       if (dialogChanged) {
         // Opening a different chat — instant snap to bottom.
+        followBottomRef.current = true
         void scrollToBottom({ animation: 'instant', ignoreEscapes: true })
         return
       }
       if (newCount > 0 && prevCount === 0) {
         // First message arrived in an empty chat — instant snap.
+        followBottomRef.current = true
         void scrollToBottom({ animation: 'instant', ignoreEscapes: true })
         return
       }
@@ -207,54 +244,105 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         const newSlice = prevLastIdx >= 0 ? messages.slice(prevLastIdx + 1) : messages.slice(prevCount)
         const hasNewUser = newSlice.some((m) => m.role === 'user')
         if (hasNewUser) {
+          // Arms the follow intent for the WHOLE turn: the answer's
+          // async growth (attachment images, streamed tokens, entity
+          // cards resolving out of their skeletons long after the
+          // stream ends) is re-asserted by the follow effect below.
+          // This replaces the old per-`<img>` `load`-handler hack —
+          // same defect class, but the ResizeObserver sees every
+          // source of growth, not just images present at send time.
+          followBottomRef.current = true
           void scrollToBottom({ animation: 'instant', ignoreEscapes: true })
-
-          // Image-attachment growth follow-up: if the new user message
-          // carries inline `<img>` elements (chat-attachment markdown
-          // emits `![alt](/api/storage/view/...)` which the markdown
-          // renderer turns into `<img>` / Next.js `<Image>`), those
-          // images load AFTER the initial paint. Each image-load grows
-          // the bubble height, but `useStickToBottom`'s `resize:
-          // 'smooth'` spring sometimes loses anchor under rapid
-          // resize events from Next.js Image's progressive
-          // dimensioning (observed: scroll lands 50-100px short of
-          // bottom — exactly one image-load short).
-          //
-          // Fix: after the initial scrollToBottom snaps, scan the
-          // content area for `<img>` elements that haven't loaded
-          // yet, and attach one-time `load` handlers that re-trigger
-          // `scrollToBottom`. Idempotent — runs for any image,
-          // affects only the new-user-message diff (effect dep is
-          // `messages`).
-          //
-          // `requestAnimationFrame` so the DOM has the new bubble
-          // before we query. Without rAF the new-message `<img>`s
-          // haven't been committed yet — querySelectorAll returns
-          // an empty set.
-          requestAnimationFrame(() => {
-            const el = contentRef.current
-            if (!el) return
-            const imgs = el.querySelectorAll('img')
-            imgs.forEach((img) => {
-              if (img.complete) return
-              const onLoad = () => {
-                img.removeEventListener('load', onLoad)
-                img.removeEventListener('error', onLoad)
-                // `ignoreEscapes: true` because the user may have
-                // accidentally moved scroll during the image-load
-                // window; we want their fresh send to be visible.
-                void scrollToBottom({ animation: 'instant', ignoreEscapes: true })
-              }
-              img.addEventListener('load', onLoad, { once: true })
-              img.addEventListener('error', onLoad, { once: true })
-            })
-          })
         }
         // Assistant-only new messages → the library's resize-watch
         // already keeps the bottom locked when the user hasn't
         // escaped. No explicit call needed; spring animation runs.
       }
-    }, [autoScroll, messages, dialogId, scrollToBottom, contentRef])
+    }, [autoScroll, messages, dialogId, scrollToBottom])
+
+    // ---- Follow the bottom while the intent is armed -----------------
+    // Installs once per mount (all deps are stable). See the
+    // `followBottomRef` comment above for WHY this exists.
+    useEffect(() => {
+      if (!autoScroll) return
+      const scroller = scrollRef.current
+      const content = contentRef.current
+      if (!scroller || !content) return
+
+      // Re-assert on ANY geometry change. Deliberately WITHOUT
+      // `ignoreEscapes`: the library must stay free to hand control back
+      // on a real gesture mid-animation. Re-asserting is precisely what
+      // re-sets its `isAtBottom`, so a silently-lost lock recovers on the
+      // next resize instead of staying broken for the rest of the turn.
+      // Cheap to call repeatedly — the library returns the in-flight
+      // promise when an animation with the same behaviour is running.
+      const reassert = () => {
+        if (!followBottomRef.current) return
+        void scrollToBottom({ animation: 'smooth' })
+      }
+
+      const ro = new ResizeObserver(reassert)
+      ro.observe(content)   // tokens, entity cards, images
+      ro.observe(scroller)  // streaming loader / source chips below it
+
+      // --- user-intent disarm ---------------------------------------
+      // Only a deliberate move AWAY from the bottom releases the lock.
+      // Resize-derived scroll events are NOT gestures, which is exactly
+      // the distinction the library's heuristic gets wrong.
+      const disarm = () => {
+        followBottomRef.current = false
+      }
+      const onWheel = (e: WheelEvent) => {
+        if (e.deltaY < 0) disarm()
+      }
+      const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === 'ArrowUp' || e.key === 'PageUp' || e.key === 'Home') disarm()
+      }
+      let touchY: number | null = null
+      const onTouchStart = (e: TouchEvent) => {
+        touchY = e.touches[0]?.clientY ?? null
+      }
+      const onTouchMove = (e: TouchEvent) => {
+        const y = e.touches[0]?.clientY
+        if (y == null || touchY == null) return
+        if (y > touchY) disarm() // finger travels DOWN → content moves up
+        touchY = y
+      }
+      // Scrollbar drag emits neither wheel nor touch — a scrollTop
+      // DECREASE while the pointer is held down is the same intent.
+      let pointerDown = false
+      let lastScrollTop = scroller.scrollTop
+      const onPointerDown = () => {
+        pointerDown = true
+      }
+      const onPointerUp = () => {
+        pointerDown = false
+      }
+      const onScroll = () => {
+        const st = scroller.scrollTop
+        if (pointerDown && st < lastScrollTop) disarm()
+        lastScrollTop = st
+      }
+
+      scroller.addEventListener('wheel', onWheel, { passive: true })
+      scroller.addEventListener('keydown', onKeyDown)
+      scroller.addEventListener('touchstart', onTouchStart, { passive: true })
+      scroller.addEventListener('touchmove', onTouchMove, { passive: true })
+      scroller.addEventListener('pointerdown', onPointerDown, { passive: true })
+      scroller.addEventListener('scroll', onScroll, { passive: true })
+      window.addEventListener('pointerup', onPointerUp, { passive: true })
+
+      return () => {
+        ro.disconnect()
+        scroller.removeEventListener('wheel', onWheel)
+        scroller.removeEventListener('keydown', onKeyDown)
+        scroller.removeEventListener('touchstart', onTouchStart)
+        scroller.removeEventListener('touchmove', onTouchMove)
+        scroller.removeEventListener('pointerdown', onPointerDown)
+        scroller.removeEventListener('scroll', onScroll)
+        window.removeEventListener('pointerup', onPointerUp)
+      }
+    }, [autoScroll, scrollRef, contentRef, scrollToBottom])
 
     // ---- Passive-demo hard pin (pinBottom) ---------------------------
     // Scripted in-page replays (the Fae/Mingo demos) have no human at the
@@ -384,7 +472,10 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       // `stopScroll` MUST precede scrollIntoView — the imperative scrollTop
       // write is what the library's geometry tracker uses to flip
       // `escapedFromLock`, so any in-flight scrollToBottom spring is
-      // first cancelled.
+      // first cancelled. The list-owned follow intent is released for the
+      // same reason: this turn deliberately parks at the message TOP, so
+      // its own async growth must NOT drag the reader to the bottom.
+      followBottomRef.current = false
       stopScroll()
       // Instant (not smooth): the markdown body contains async <img>
       // children whose loads race a 300ms smooth animation and leave


### PR DESCRIPTION
## Problem

Running a card-heavy slash command in the Mingo panel (reported on `/getting-started`) loses stick-to-bottom: the thread stops following and the rest of the answer lands below the fold.

Measured live: the scroller ended **4081px**, then **6354px**, then **18619px** above the bottom across three runs.

## Root cause

`ChatMessageList` delegates follow-the-bottom entirely to `use-stick-to-bottom`, which follows only while its internal `isAtBottom` flag is true. This list's layout loses that flag silently in two ways:

1. **The scroller's own box changes.** The library's ResizeObserver watches `contentRef`, which lives *inside* the scroller. The streaming loader unmounting and the host's source-chip row mounting are siblings *below* the scroller, so they change its `clientHeight`, moving the bottom, with no event the library can observe.
2. **Resize-induced scroll events misread as a gesture.** Fetch-mode entity cards mount as skeletons and settle to a different height; a shrink clamps `scrollTop` down, and the library's scroll handler reads that as a user scroll-up and escapes the lock permanently. Its `resizeDifference` guard is a `setTimeout(..., 1)` race, hence the intermittency.

`/getting-started` hits both hard: `presentation: 'list'` produces a dozen `[card://onboarding_guide:...]` markers, i.e. fetch-mode cards with 1200x630 covers that keep resolving for seconds after the stream ends. Verified from the raw SSE frames that this turn carries no `scrollAnchor`, so the deliberate top-anchor path is not involved.

## Fix

The list now owns the intent instead of trusting the library's flag:

- Sending a message (or opening a dialog) arms `followBottomRef`.
- While armed, one ResizeObserver on **both** the content and the scroller re-asserts `scrollToBottom`. That call also re-sets the library's `isAtBottom`, so a lost lock self-heals on the next resize rather than staying broken for the rest of the turn.
- Only a real gesture disarms: wheel-up, upward touchmove, ArrowUp/PageUp/Home, or a `scrollTop` decrease while the pointer is held (scrollbar drag). Resize-derived scrolls never count, which is exactly the distinction the library gets wrong.
- A `scrollAnchor: 'top'` turn disarms explicitly, since it deliberately parks at the message top.

Deletes the old per-`<img>` `load`-handler hack: same defect class, and the ResizeObserver covers every growth source, not just images present at send time.

## Testing

- 10 tests pass in `chat-message-list.test.tsx`: the 4 existing plus 6 new regressions covering late async growth, gesture release, downward-wheel non-release, `autoScroll={false}`, and the top-anchor carve-out.
- `tsc --noEmit` clean for the changed file.
- **Not yet browser-verified.** This is scroll UX, so unit tests are not sufficient. The worktree's `npm install` first died on a transient `ETARGET` for `@radix-ui/react-collapsible@1.1.17`; the retry is running and a live `/getting-started` check plus a device pass are still outstanding before merge.

## Follow-up

Hub pins an exact lib version, so shipping needs a lib release and a hub pin bump.

Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: industry-standard audit

Re-checked this against what shipping AI chats do in 2026.

**Validated.** The container-resize blind spot is a known, still-open upstream bug: [use-stick-to-bottom#40](https://github.com/stackblitz-labs/use-stick-to-bottom/issues/40), *"scroll position drifts when scroll container height changes (flex sibling resize)"* — *"The library's ResizeObserver only monitors the content element, not the scroll container itself... Proposed fix: implement a second ResizeObserver attached to the scroll container."* We resolve to 1.1.6 (latest), so it is unfixed upstream, and this PR implements precisely the remedy the issue proposes. Vercel AI Elements' `<Conversation>` still uses the same library, so the reference implementation shares the defect.

**Not claimed as standard.** The "intent lock armed on send, released only on a real gesture" is not a shipped primitive anywhere reviewed (assistant-ui, LibreChat, Open WebUI, AI Elements). It is a deliberate local choice: resize-derived scrolls are not gestures, which is exactly the distinction the library's heuristic gets wrong.

**Known divergence, accepted.** The market leaders (ChatGPT, Claude.ai, Gemini) anchor the sent message to the TOP and do not chase the answer; assistant-ui codifies this as `turnAnchor="top"` (which flips `autoScroll` to `false`). This repo already owns that primitive as `scrollAnchor: 'top'` in `display-action-response.ts`, applied to display-action answers only. Extending it to slash-command list answers was considered and **explicitly declined** for now: bottom-follow is the chosen behavior here. Revisit if reading long listings from the end proves annoying.

**Added in this PR:** the jump-to-bottom button, which AI Elements ships as `ConversationScrollButton` and which is the practical escape hatch for [WCAG 2.2.2 / F16](https://www.w3.org/TR/WCAG20-TECHS/F16.html). Its visibility is derived from real geometry rather than the library's `isAtBottom`, because a stale `true` on that flag would hide the button in exactly the situation it exists for. Clicking it re-arms the follow lock.

**Deferred (not in this PR):** `prefers-reduced-motion` gating on the spring re-assert (this repo already honors the query in `use-scripted-stream.ts:25`), and an `aria-live` region for the answer body (today only the streaming loader has one).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic scrolling to keep chats anchored to the latest message as content loads or changes size.
  * Added a “Scroll to latest message” button when viewing older messages.
  * Preserved intentional scrolling positions, including top-anchored messages.

* **Bug Fixes**
  * Prevented unexpected jumps to the bottom after scrolling upward.
  * Improved handling of late-loading content and repeated layout changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->