### PR TITLE
FE core: fix OverlayScrollbars padding/gap regressions (#1487 follow-up)

### DIFF
--- a/openframe-frontend-core/src/components/features/notifications/notification-drawer.tsx
+++ b/openframe-frontend-core/src/components/features/notifications/notification-drawer.tsx
@@ -192,8 +192,10 @@ function DrawerScrollList({
   return (
     <OverlayScrollArea
       viewportRef={scrollRef}
-      className="flex-1 min-h-0"
-      contentClassName="flex flex-col gap-[var(--spacing-system-xs)] px-[var(--spacing-system-m)]"
+      // Horizontal padding lives on the host: OverlayScrollbars zeroes viewport
+      // padding, so `px-*` on `contentClassName` would be silently dropped.
+      className="flex-1 min-h-0 px-[var(--spacing-system-m)]"
+      contentClassName="flex flex-col gap-[var(--spacing-system-xs)]"
     >
       {isEmpty && !isLoadingMore ? (
         <EmptyState />

--- a/openframe-frontend-core/src/components/features/time-tracker/time-tracker-panel.tsx
+++ b/openframe-frontend-core/src/components/features/time-tracker/time-tracker-panel.tsx
@@ -152,10 +152,16 @@ export function TimeTrackerPanel({
   return (
     <OverlayScrollArea
       className={cn(
-        'max-h-[calc(100vh-6rem)] w-full rounded-md border border-ods-border bg-ods-card',
+        // Padding lives on the host, NOT `contentClassName`: OverlayScrollbars
+        // forces `padding: 0` on the viewport, so padding on the scroller is
+        // silently dropped (see OverlayScrollArea docs).
+        'max-h-[calc(100vh-6rem)] w-full rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-m)]',
         className,
       )}
-      contentClassName="relative flex flex-col gap-[var(--spacing-system-l)] p-[var(--spacing-system-m)]"
+      // No `relative` here so the absolute close button anchors to the padded
+      // host (OverlayScrollArea's host is always relative) and keeps its inset
+      // from the card edge instead of from the padding box.
+      contentClassName="flex flex-col gap-[var(--spacing-system-l)]"
     >
       <Button
         variant="transparent"

--- a/openframe-frontend-core/src/components/layout/page-container.tsx
+++ b/openframe-frontend-core/src/components/layout/page-container.tsx
@@ -411,7 +411,11 @@ function renderAdvancedPageContainer({
 
       {variant === 'detail' ? (
         // The only scrolling variant — standardized overlay scrollbar.
-        <OverlayScrollArea className={getContentClasses()}>
+        // `contentClassName` is forwarded to BOTH layers: padding stays effective
+        // on the host, while layout (`flex flex-col gap-*`) reaches the scroller,
+        // the direct parent of the children (OverlayScrollbars zeroes viewport
+        // padding, so padding on the scroller alone would be dropped).
+        <OverlayScrollArea className={getContentClasses()} contentClassName={contentClassName}>
           {children}
         </OverlayScrollArea>
       ) : (

--- a/openframe-frontend-core/src/components/ui/modal-v2.tsx
+++ b/openframe-frontend-core/src/components/ui/modal-v2.tsx
@@ -132,9 +132,15 @@ Modal.displayName = "ModalV2"
 
 const ModalContent = React.forwardRef<HTMLDivElement, ModalContentProps>(
   ({ children, className }, ref) => (
+    // `className` goes to BOTH layers on purpose: historically it styled the
+    // single scrolling div that directly parented the children, so it may carry
+    // layout (`flex flex-col gap-*` — must reach the scroller/`contentClassName`,
+    // the direct parent of the children) OR padding (must stay on the host, since
+    // OverlayScrollbars zeroes viewport padding). Each class lands where it works.
     <OverlayScrollArea
       viewportRef={ref}
       className={cn("flex-1 min-h-0", className)}
+      contentClassName={className}
     >
       {children}
     </OverlayScrollArea>

--- a/openframe-frontend-core/src/components/ui/modal.tsx
+++ b/openframe-frontend-core/src/components/ui/modal.tsx
@@ -83,9 +83,12 @@ Modal.displayName = "Modal"
 /** @deprecated Use ModalV2Content from './modal-v2' instead. */
 const ModalContent = React.forwardRef<HTMLDivElement, ModalContentProps>(
   ({ children, className }, ref) => (
+    // See ModalV2Content: `className` may carry layout (must reach the scroller)
+    // or padding (must stay on the host), so it goes to both layers.
     <OverlayScrollArea
       viewportRef={ref}
       className={cn("min-h-0 flex-1", className)}
+      contentClassName={className}
     >
       {children}
     </OverlayScrollArea>


### PR DESCRIPTION
## Description

The OverlayScrollbars migration split scroll containers into a host and a viewport, but OverlayScrollbars zeroes viewport padding and the viewport is the direct parent of the children. Several components put padding on the viewport (dropped) or routed consumer layout classes to the host (so flex/gap never reached the children):

## Improvements
- time-tracker-panel: move padding to the host; drop `relative` from the content so the close button keeps its inset from the card edge.
- modal-v2 / modal (ModalV2Content, deprecated ModalContent): forward the consumer `className` to both layers so `flex flex-col gap-*` reaches the scroller (fixes gaps in every SimpleModal, e.g. Manual Entry) while padding stays effective on the host.
- notification-drawer: move horizontal padding to the host.
- page-container (detail variant): forward `contentClassName` to the scroller too so detail pages' layout classes gap their children.

Verified in Storybook (TimeTracker, ModalV2, NotificationDrawer, PageContainer).