### PR TITLE
ci: allow publishing a snapshot from any ref via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: ''
+      snapshot:
+        description: 'Publish a SNAPSHOT from the selected ref instead of a release (does not move the latest tag). Use this to test an unmerged branch live.'
+        required: false
+        type: boolean
+        default: false
 
 env:
   REGISTRY: "com.openframe.oss"
@@ -80,13 +85,13 @@ jobs:
           echo "Found old version: $OLD_VERSION"
 
       - name: Set Snapshot Version
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || inputs.snapshot
         run: |
           echo "NEW_VERSION=${{ env.OLD_VERSION }}-SNAPSHOT" >> $GITHUB_ENV
           echo "${{ env.OLD_VERSION }} → ${{ env.OLD_VERSION }}-SNAPSHOT"
 
       - name: Set Release Version
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && !inputs.snapshot
         env:
           NEW_VERSION: ${{ github.event.inputs.version }}
         run: |
@@ -188,12 +193,12 @@ jobs:
           echo "Found old version: $OLD_VERSION"
 
       - name: Set Snapshot Version
-        if: steps.should_run.outputs.run == 'true' && github.event_name == 'push'
+        if: steps.should_run.outputs.run == 'true' && (github.event_name == 'push' || inputs.snapshot)
         working-directory: ${{ matrix.path }}
         run: npm version "${{ env.OLD_VERSION }}-snapshot.$(date +%Y%m%d%H%M%S)" --no-git-tag-version
 
       - name: Set Release Version
-        if: steps.should_run.outputs.run == 'true' && github.event_name == 'workflow_dispatch'
+        if: steps.should_run.outputs.run == 'true' && github.event_name == 'workflow_dispatch' && !inputs.snapshot
         working-directory: ${{ matrix.path }}
         env:
           NEW_VERSION: ${{ github.event.inputs.version }}
@@ -218,20 +223,28 @@ jobs:
           npm version "$NEW_VERSION" --no-git-tag-version
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
+      # A snapshot must NEVER take the `latest` dist-tag: `latest` is what a bare
+      # `npm install` resolves to, and a snapshot can now come from an UNMERGED
+      # ref. Snapshots go to the `snapshot` tag; consumers pin the exact
+      # `x.y.z-snapshot.<ts>` string (a `^x.y.z` range does not match a
+      # prerelease, so a caret will not pick one up by accident).
       - name: Publish ${{ env.NEW_VERSION }}
         if: steps.should_run.outputs.run == 'true'
         working-directory: ${{ matrix.path }}
-        run: npm publish --tag latest --access public
+        run: npm publish --tag ${{ (github.event_name == 'push' || inputs.snapshot) && 'snapshot' || 'latest' }} --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 
+  # NOTE: rust has no snapshot path (it tags a git release rather than pushing to
+  # a registry), so `snapshot: true` is refused here rather than silently cutting
+  # a real release — a half-applied flag is worse than an unsupported one.
   release-rust:
     name: Release Rust
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'rust'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'rust' && !inputs.snapshot
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,10 +192,21 @@ jobs:
           echo "OLD_VERSION=$OLD_VERSION" >> $GITHUB_ENV
           echo "Found old version: $OLD_VERSION"
 
+      # Exports NEW_VERSION like the release path below does: the publish step is
+      # named `Publish ${{ env.NEW_VERSION }}`, so without this a snapshot run
+      # renders as a bare "Publish " in the Actions UI. OLD_VERSION is passed
+      # through `env:` rather than interpolated into the script, so the registry
+      # string is shell data and never expands as code.
       - name: Set Snapshot Version
         if: steps.should_run.outputs.run == 'true' && (github.event_name == 'push' || inputs.snapshot)
         working-directory: ${{ matrix.path }}
-        run: npm version "${{ env.OLD_VERSION }}-snapshot.$(date +%Y%m%d%H%M%S)" --no-git-tag-version
+        env:
+          OLD_VERSION: ${{ env.OLD_VERSION }}
+        run: |
+          NEW_VERSION="${OLD_VERSION}-snapshot.$(date +%Y%m%d%H%M%S)"
+          npm version "$NEW_VERSION" --no-git-tag-version
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "Snapshot version: $NEW_VERSION"
 
       - name: Set Release Version
         if: steps.should_run.outputs.run == 'true' && github.event_name == 'workflow_dispatch' && !inputs.snapshot


### PR DESCRIPTION
## Why

Snapshots already exist — npm has `0.0.454-snapshot.20260719120410`, `0.0.457-snapshot.20260720155037`, etc. But the snapshot step is gated `github.event_name == 'push'`, and `push` only fires on `main`. So there is **no way to test an unmerged branch against a real published build**: dispatching today runs the *release* path and would cut a real version from unmerged code.

Concretely this is blocking a live test of #1506 without merging it first.

## What

Adds a `snapshot` boolean input to `workflow_dispatch` that reuses the existing snapshot version path:

```bash
gh workflow run release.yml --ref <branch> -f target=node -f snapshot=true
```

→ publishes `<base>-snapshot.<timestamp>` built from that ref.

## Also: snapshots no longer take the `latest` dist-tag

`npm publish --tag latest` was unconditional, so **every snapshot moved `latest`** — what a bare `npm install` resolves to. That was already fragile (it self-corrected only because a real release usually followed), and it becomes unacceptable once a snapshot can come from an unmerged ref.

Snapshots now publish under a `snapshot` tag. Consumers pin the exact `x.y.z-snapshot.<ts>` string; a `^x.y.z` range cannot pick one up by accident, because semver ranges do not match prereleases.

## Notes

- Applied to **both** node and java, so the flag means the same thing for either target.
- **Rust refuses `snapshot: true`** rather than silently cutting a release — it tags a git release rather than pushing to a registry, so it has no snapshot path. A half-applied flag is worse than an unsupported one.
- Uses the `inputs.*` context (typed boolean) rather than `github.event.inputs.*` (always a string, so `!github.event.inputs.snapshot` would be wrong for `"false"`).
- `inputs.snapshot` is empty on a `push` event, so the existing main-push behaviour is unchanged apart from the dist-tag.
- No product code touched; the node matrix is static, so dispatch is not path-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release workflows now support manually publishing Java and Node snapshot versions from a selected source revision.
  * Node snapshot packages are published under the `snapshot` distribution tag, while standard releases continue using `latest`.
  * Rust releases remain limited to standard release workflows and are not available for snapshot publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->