### PR TITLE
Quick Action component (QuickActionWall): measure real chip width for the adaptive pad target

### DIFF
--- a/openframe-frontend-core/src/components/chat/quick-action-wall.tsx
+++ b/openframe-frontend-core/src/components/chat/quick-action-wall.tsx
@@ -38,24 +38,27 @@ export function interleave<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>): T[] {
   return out
 }
 
-// Brick-mode padding fallback: ~14 columns of chips per row (~3200px) — one
-// row copy overflows any sensible container, so the loop always engages. Used
-// as the row-count reference and until the container width has been measured;
-// once measured, the per-row pad target adapts to that width (see MIN_CHIP_PX).
+// Brick-mode padding fallback: ~14 columns of chips per row — one row copy
+// overflows any sensible container, so the loop always engages. Used as the
+// row-count reference, and as the pad target until the container and chip
+// widths have been measured (then the per-row target adapts — see chipWidth).
 const DEFAULT_MIN_CHIPS_PER_ROW = 14
 
-// Conservative floor for one chip's on-track footprint in px (icon + a short
-// mono label + Tag padding + the copy gap). The adaptive pad target divides the
-// measured container width by this, so it must stay AT OR BELOW the narrowest
-// real chip — an over-estimate would under-pad and the row could stop scrolling
-// on a wide surface. Realistic quick-action labels are far wider, so the padded
-// copy overflows comfortably; the `+ADAPTIVE_PAD_MARGIN` covers the worst case.
-const MIN_CHIP_PX = 72
+// The adaptive pad target is derived from the MEASURED narrowest chip, not a
+// guessed width: repeats = ceil(containerWidth / measuredChipWidth) + margin.
+// Measuring (rather than assuming ~72px) is what makes it correct for a tiny
+// one-word chip AND a wide multi-word one — a guess that overshoots the real
+// chip under-pads and the row silently stops scrolling.
 const ADAPTIVE_PAD_MARGIN = 2
-// The adaptive target is clamped to [MIN_ADAPTIVE_PAD, DEFAULT_MIN_CHIPS_PER_ROW]:
-// it only ever REDUCES padding below the fixed default (for narrow composers) —
-// never above it, so no wide surface pads more than it does today.
+// Divide-by-near-zero guard ONLY: floors a glitched sub-pixel measurement, but
+// stays BELOW the narrowest real chip (padding alone is wider), so a genuinely
+// tiny one-glyph chip keeps its true measured width and still gets enough
+// repeats to overflow. MAX_ADAPTIVE_PAD bounds the count if the measurement is
+// ever degenerate.
+const MIN_MEASURED_CHIP_PX = 12
+// Sanity bounds on the resulting count.
 const MIN_ADAPTIVE_PAD = 4
+const MAX_ADAPTIVE_PAD = 60
 
 // Chat-agent walls (fae/mingo) cap the brick stack at 2 rows so the quick
 // actions never crowd the composer; every other surface keeps the caller's
@@ -187,22 +190,39 @@ export function QuickActionWall({
   contentClassName,
   sync,
 }: QuickActionWallProps) {
-  // Measure the brick container so the per-row pad target can adapt to its
-  // width (see MIN_CHIP_PX): a narrow chat composer needs only a handful of
-  // repeats to overflow, a wide wall needs many. Pre-measure / SSR falls back
-  // to the fixed default, which always overflows. Only used in brick mode.
+  // Adapt the per-row pad target to the actual geometry (brick mode only): a
+  // narrow chat composer needs only a handful of repeats to overflow, a wide
+  // wall needs many, and a tiny chip needs more repeats than a wide one. We
+  // measure BOTH the container width and the narrowest rendered chip, then pad
+  // to ceil(width / chip) + margin. Pre-measure / SSR falls back to the fixed
+  // default, which overflows any width.
   const brickRef = React.useRef<HTMLDivElement>(null)
   const [brickWidth, setBrickWidth] = React.useState(0)
+  const [chipWidth, setChipWidth] = React.useState(0)
   React.useEffect(() => {
     const el = brickRef.current
-    if (!el || typeof ResizeObserver === 'undefined') return
-    const ro = new ResizeObserver(entries => {
-      const w = entries[0]?.contentRect.width ?? 0
-      if (w > 0) setBrickWidth(w)
-    })
+    if (!el) return
+    // Read both widths straight off the laid-out DOM (offsetWidth is synchronous
+    // and reliable — a ResizeObserver initial callback can be throttled or never
+    // fire in a backgrounded/offscreen tab, which would strand the target on its
+    // fallback). Chips render as buttons on interactive walls — the only case
+    // that pads short sets; decorative walls keep the fallback. Converges in one
+    // pass: the widths don't depend on how many repeats we then draw.
+    const measure = () => {
+      const w = el.offsetWidth
+      if (w > 0) setBrickWidth(prev => (prev === w ? prev : w))
+      const chips = [...el.querySelectorAll('button')].map(b => (b as HTMLElement).offsetWidth).filter(x => x > 0)
+      if (chips.length > 0) {
+        const min = Math.max(Math.min(...chips), MIN_MEASURED_CHIP_PX)
+        setChipWidth(prev => (prev === min ? prev : min))
+      }
+    }
+    measure()
+    if (typeof ResizeObserver === 'undefined') return
+    const ro = new ResizeObserver(measure)
     ro.observe(el)
     return () => ro.disconnect()
-  }, [])
+  }, [chips])
 
   // Repeat-pad the track (stable suffixed keys; repeats keep the full chip —
   // identical selected/interactive state, so every visible instance behaves
@@ -266,10 +286,10 @@ export function QuickActionWall({
     // duplicates); before the first measure (or SSR) fall back to the fixed
     // default, which overflows any width.
     const adaptivePerRow =
-      brickWidth > 0
+      brickWidth > 0 && chipWidth > 0
         ? Math.min(
-            Math.max(Math.ceil(brickWidth / MIN_CHIP_PX) + ADAPTIVE_PAD_MARGIN, MIN_ADAPTIVE_PAD),
-            DEFAULT_MIN_CHIPS_PER_ROW,
+            Math.max(Math.ceil(brickWidth / chipWidth) + ADAPTIVE_PAD_MARGIN, MIN_ADAPTIVE_PAD),
+            MAX_ADAPTIVE_PAD,
           )
         : DEFAULT_MIN_CHIPS_PER_ROW
     const perRowTarget = minChips ? Math.ceil(minChips / stackRows) : adaptivePerRow

--- a/openframe-frontend-core/src/stories/QuickActionWall.stories.tsx
+++ b/openframe-frontend-core/src/stories/QuickActionWall.stories.tsx
@@ -200,6 +200,29 @@ export const BrickNarrowComposer: Story = {
   ),
 }
 
+/** Brick, single short chip: one tiny one-word action ("ONE") in a ~412px
+ *  composer. The pad target is measured from the ACTUAL chip width, so a narrow
+ *  chip is repeated enough times to overflow and scroll — a width guess that
+ *  overshot the real chip would under-pad and the row would sit static. */
+export const BrickSingleShortChip: Story = {
+  render: () => (
+    <div className="w-[412px] max-w-full rounded-md border border-ods-border bg-ods-card p-[var(--spacing-system-mf)]">
+      <QuickActionWall
+        chips={[{ id: 'one', label: 'ONE', theme: FAE_THEME, onSelect: () => console.log('one') }]}
+        agentSlug="mingo"
+        rows={4}
+        pauseOnHover
+        dragScroll
+        fade={['left', 'right']}
+        fadeSize={{ left: 32 }}
+        fadeColor="var(--color-bg-card)"
+        copyGap="var(--spacing-system-xxs)"
+        className="max-h-44"
+      />
+    </div>
+  ),
+}
+
 /** Brick, non-agent (no `agentSlug`): keeps exactly `rows` rows (marketing /
  *  onboarding walls are sized for their design), still getting the even split
  *  so a row is never filled with only one repeated chip. */


### PR DESCRIPTION
## Description
The adaptive pad target divided the container width by a GUESSED chip width (72px). A chip narrower than the guess (e.g. a one-word "ONE" ~40px) then got too few repeats: the row didn't overflow and the marquee sat static instead of scrolling.

Measure the narrowest rendered chip and the container width off the laid-out DOM (offsetWidth - synchronous and reliable; a ResizeObserver initial callback can be throttled/never fire in a backgrounded tab and strand the fallback), then pad to ceil(containerWidth / chipWidth) + margin. Correct for a tiny one-word chip AND a wide multi-word one; ResizeObserver still re-measures on resize. Falls back to the fixed default before measurement.
 
 ## Task
 [Quick action component (QuickActionWall): fix brick-row distribution, cap agent rows, adapt pad to width](https://app.clickup.com/t/9013925967/86ajmqt67)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quick Action Wall brick layouts to adapt chip repetition to the available container width.
  * Added safeguards for narrow layouts and pre-measurement states to prevent incorrect spacing or excessive repetition.

* **Tests**
  * Added coverage for brick layouts containing a single short chip in a constrained-width container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->