### PR TITLE
FE CORE: Mingo chat — owner avatars (list + header) and My/All Chats scope

### DIFF
--- a/openframe-frontend-core/src/components/chat/chat-panel-header.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-panel-header.tsx
@@ -14,6 +14,7 @@ import { ChatHeaderIconButton } from './chat-header-icon-button'
 import { ChatHeaderSearchField } from './chat-header-search-field'
 import { ActionsMenuDropdown, type ActionsMenuItem } from '../ui/actions-menu'
 import { ChatPanelHeaderMobile } from './chat-panel-header-mobile'
+import { SquareAvatar } from '../ui/square-avatar'
 
 export interface ChatPanelHeaderProps {
   /** Show the back-chevron + bold (h3) title. When false, the static list
@@ -24,6 +25,11 @@ export interface ChatPanelHeaderProps {
   /** Optional sub-line under the title (e.g. the signed-in user's name).
    *  Rendered muted (`h6`) beneath the title in every view that has one. */
   subtitle?: React.ReactNode
+  /** Person identity shown as a 32px round avatar at the right edge of the
+   *  title cell (Figma 113:63273): the dialog OWNER in a conversation, the
+   *  signed-in user on the New Chat compose view. Initials fall back from
+   *  `name` when `avatarUrl` is absent/failing. Omit to hide. */
+  avatar?: { name?: string | null; avatarUrl?: string | null }
   /** Accessible label for the back chevron. */
   backAriaLabel?: string
   /** The open conversation is an archived chat (read-only). */
@@ -70,6 +76,7 @@ export function ChatPanelHeader({
   showBack = false,
   title,
   subtitle,
+  avatar,
   backAriaLabel = 'Back',
   isArchivedView = false,
   onBack,
@@ -142,13 +149,26 @@ export function ChatPanelHeader({
             onCollapse={onToggleSearch}
           />
         ) : (
-          <div className="flex flex-1 min-w-0 items-center px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)]">
+          <div className="flex flex-1 min-w-0 items-center gap-[var(--spacing-system-m)] px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)]">
             <div className="flex min-w-0 flex-col">
               <p className="truncate text-h3 leading-tight text-ods-text-primary">{title}</p>
               {subtitle && (
                 <p className="truncate text-h6 leading-tight text-ods-text-secondary">{subtitle}</p>
               )}
             </div>
+            {avatar && (avatar.name || avatar.avatarUrl) ? (
+              // Owner avatar at the title cell's right edge (Figma 113:63273).
+              <SquareAvatar
+                variant="round"
+                sizePx={32}
+                className="ml-auto"
+                src={avatar.avatarUrl || undefined}
+                alt={avatar.name || undefined}
+                fallback={avatar.name || undefined}
+                initialsClassName="text-[11px] text-ods-text-secondary"
+                title={avatar.name || undefined}
+              />
+            ) : null}
           </div>
         )}
 

--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -54,6 +54,7 @@ import { accentFromIdentityIcon, getAgentAccent } from './quick-action-chip'
 import { GuideModeBanner } from './guide-mode-banner'
 import { PortalContainerContext } from '../ui/portal-container'
 import { ChatPanelHeader, type ChatPanelHeaderProps } from './chat-panel-header'
+import { SquareAvatar } from '../ui/square-avatar'
 import { ChatHeaderIconButton } from './chat-header-icon-button'
 import { ChatHeaderSearchField } from './chat-header-search-field'
 import { ActionsMenuDropdown, type ActionsMenuItem } from '../ui/actions-menu'
@@ -295,6 +296,15 @@ export interface EmbeddableChatProps {
    * route omits it). Empty/undefined → the header renders the title alone.
    */
   userDisplayName?: string
+
+  /**
+   * Avatar URL of the signed-in user — the header-avatar counterpart of
+   * `userDisplayName`. Used for the New Chat compose view (and as the
+   * fallback when an open conversation's dialog carries no owner info).
+   * The server-resolved identity avatar wins when present; absent both →
+   * initials derived from the display name.
+   */
+  userAvatarUrl?: string
 
   /**
    * Content overrides for the default (Mingo-mode) empty state
@@ -900,6 +910,7 @@ function EmbeddableChatInner({
   defaultActiveMode,
   shell = 'drawer',
   userDisplayName,
+  userAvatarUrl,
   mingoWelcome,
   guideWelcome,
   contextPicker,
@@ -1206,6 +1217,8 @@ function EmbeddableChatInner({
     isMessagesLoading,
     hasMoreDialogs,
     loadMoreDialogs,
+    dialogScope,
+    setDialogScope,
     hasMoreMessages,
     loadMoreMessages,
   } = useUnifiedChat({ modes: effectiveModes, activeMode, mingoStateOverride: mingoState })
@@ -1898,6 +1911,21 @@ function EmbeddableChatInner({
       : undefined
   const headerOnOpenArchive = fetchArchivedDialogs ? openArchive : undefined
 
+  // Header person (sub-line + 32px avatar, Figma 113:63273): the dialog OWNER
+  // for an open conversation — with "All Chats" scope that can be another
+  // admin; the signed-in user otherwise (New Chat compose — they will own it).
+  // An owner without an avatar URL still wins the slot: initials of the OWNER,
+  // not the viewer's photo.
+  const headerOwner = hasConversation ? activeDialog?.owner : undefined
+  const headerPersonName = headerOwner?.name?.trim() || headerUserName
+  const headerPersonAvatarUrl = headerOwner
+    ? headerOwner.avatarUrl?.trim() || undefined
+    : identityUser?.avatarUrl?.trim() || userAvatarUrl?.trim() || undefined
+  const headerAvatar =
+    headerPersonName || headerPersonAvatarUrl
+      ? { name: headerPersonName, avatarUrl: headerPersonAvatarUrl }
+      : undefined
+
   // "Start New Chat" (rail button) — reset to the new-chat welcome. Uses the
   // dedicated reset (not `handleBack`, which would reopen the archive when the
   // open conversation is archived) so it always lands on a fresh chat.
@@ -1922,6 +1950,7 @@ function EmbeddableChatInner({
           showBack: true,
           title: 'New Chat',
           subtitle: headerUserName,
+          avatar: headerAvatar,
           backAriaLabel: 'Back to chats',
           onBack: () => setComposeOpen(false),
           onClose: handleClose,
@@ -1941,7 +1970,8 @@ function EmbeddableChatInner({
     : {
         showBack: headerShowBack,
         title: headerTitle,
-        subtitle: headerUserName,
+        subtitle: headerPersonName,
+        avatar: headerAvatar,
         backAriaLabel: headerBackAriaLabel,
         isArchivedView: isViewingArchived,
         onBack: headerOnBack,
@@ -2102,17 +2132,30 @@ function EmbeddableChatInner({
                       {/* No back cell in the wide layout — the left rail (and
                           its collapse/expand toggle) already provides chat-list
                           navigation, so a back chevron would be redundant. */}
-                      <div className="flex flex-1 min-w-0 items-center px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)]">
+                      <div className="flex flex-1 min-w-0 items-center gap-[var(--spacing-system-m)] px-[var(--spacing-system-mf)] py-[var(--spacing-system-sf)]">
                         <div className="flex min-w-0 flex-col">
                           <p className="truncate text-h3 leading-tight text-ods-text-primary">
                             {headerShowBack ? headerTitle : 'New Chat'}
                           </p>
-                          {headerUserName && (
+                          {headerPersonName && (
                             <p className="truncate text-h6 leading-tight text-ods-text-secondary">
-                              {headerUserName}
+                              {headerPersonName}
                             </p>
                           )}
                         </div>
+                        {headerAvatar ? (
+                          // Owner avatar at the title cell's right edge (Figma 113:63273).
+                          <SquareAvatar
+                            variant="round"
+                            sizePx={32}
+                            className="ml-auto"
+                            src={headerAvatar.avatarUrl || undefined}
+                            alt={headerAvatar.name || undefined}
+                            fallback={headerAvatar.name || undefined}
+                            initialsClassName="text-[11px] text-ods-text-secondary"
+                            title={headerAvatar.name || undefined}
+                          />
+                        ) : null}
                       </div>
 
                       {isViewingArchived && headerOnRestore && (
@@ -2194,6 +2237,8 @@ function EmbeddableChatInner({
                         onNewChat={handleNewChat}
                         onRequestRename={mingoCaps.canRename ? setRenameTarget : undefined}
                         onRequestArchive={mingoCaps.canArchive ? setArchiveTarget : undefined}
+                        scope={dialogScope}
+                        onScopeChange={setDialogScope}
                         searchQuery={mingoCaps.searchQuery}
                         hasMore={hasMoreDialogs}
                         isLoadingMore={isDialogsLoading && dialogs.length > 0}
@@ -2221,6 +2266,8 @@ function EmbeddableChatInner({
                     newChatAlways
                     onRequestRename={mingoCaps.canRename ? setRenameTarget : undefined}
                     onRequestArchive={mingoCaps.canArchive ? setArchiveTarget : undefined}
+                    scope={dialogScope}
+                    onScopeChange={setDialogScope}
                     searchQuery={mingoCaps.searchQuery}
                     hasMore={hasMoreDialogs}
                     isLoadingMore={isDialogsLoading && dialogs.length > 0}

--- a/openframe-frontend-core/src/components/chat/hooks/use-unified-chat.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-unified-chat.ts
@@ -197,6 +197,10 @@ export function useUnifiedChat(
     () => activeStateRef.current.loadMoreDialogs(),
     [],
   )
+  const setDialogScope = useCallback(
+    (scope: 'my' | 'all') => activeStateRef.current.setDialogScope?.(scope),
+    [],
+  )
   const reloadDialogs = useCallback(
     () => activeStateRef.current.reloadDialogs(),
     [],
@@ -246,6 +250,10 @@ export function useUnifiedChat(
       isMessagesLoading: activeState.isMessagesLoading,
       hasMoreDialogs: activeState.hasMoreDialogs,
       loadMoreDialogs,
+      // Scope only surfaces when the active adapter exposes it — the forward
+      // is unconditionally stable, gating happens on `dialogScope` itself.
+      dialogScope: activeState.dialogScope,
+      setDialogScope,
       hasMoreMessages: activeState.hasMoreMessages,
       loadMoreMessages,
       // Approvals
@@ -268,6 +276,7 @@ export function useUnifiedChat(
       renameDialog,
       archiveDialog,
       loadMoreDialogs,
+      setDialogScope,
       reloadDialogs,
       loadMoreMessages,
       approveRequest,

--- a/openframe-frontend-core/src/components/chat/mingo-chat-history.tsx
+++ b/openframe-frontend-core/src/components/chat/mingo-chat-history.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/cn'
 import { ActionsMenuDropdown, type ActionsMenuItem } from '../ui/actions-menu'
 import { Button } from '../ui/button'
 import { ScrollFadeOverlay, useScrollFade } from '../ui/scroll-fade'
+import { SquareAvatar } from '../ui/square-avatar'
 import { Ellipsis01Icon, SearchXmarkIcon } from '../icons-v2-generated'
 import { ChatListEmptyState } from './chat-list-empty-state'
 import type { DialogItem } from './types/component.types'
@@ -107,6 +108,8 @@ function MingoChatHistoryRow({
   const title = dialog.title || 'Untitled Chat'
   const unread = dialog.unreadMessagesCount ?? 0
   const hasMenu = !!onRequestRename || !!onRequestArchive
+  const owner = dialog.owner
+  const hasAvatar = !!(owner?.name || owner?.avatarUrl)
   // Keep the `⋯` visible while its menu is open — once Radix moves focus into
   // the portalled content the row loses hover/focus-within.
   const [menuOpen, setMenuOpen] = React.useState(false)
@@ -173,46 +176,82 @@ function MingoChatHistoryRow({
           {title}
         </span>
       </div>
-      {hasMenu ? (
-        // Sibling of the padded content (not inside it): sits at the item's
-        // right edge, free of the content's left padding. Revealed on row
-        // hover/focus; kept visible while its menu is open. Hidden on mobile —
-        // it's a hover affordance (no hover on touch).
+      {hasMenu || hasAvatar ? (
+        // Trailing 48px cell (Figma 113:63224): the owner avatar sits centred
+        // by default; hovering the row (or opening the menu) swaps it for the
+        // `⋯` actions button IN PLACE, so the title never reflows. Without an
+        // avatar the cell exists only for the hover menu, so it collapses on
+        // mobile exactly like the old hover-only gutter (no hover on touch).
         <span
-          onClick={(e) => e.stopPropagation()}
           className={cn(
-            // `self-stretch` so the wrapper fills the row height — gives the
-            // button's `h-full` a definite parent to resolve against (under the
-            // row's `items-center` the wrapper would otherwise collapse to its
-            // content and `h-full` on the button would no-op).
-            'self-stretch shrink-0 transition-opacity max-md:hidden',
-            menuOpen
-              ? 'opacity-100'
-              : 'opacity-0 group-hover/row:opacity-100 focus-within:opacity-100',
+            'relative w-12 self-stretch shrink-0',
+            !hasAvatar && 'max-md:hidden',
           )}
         >
-          <ActionsMenuDropdown
-            triggerAriaLabel="Chat actions"
-            groups={[{ items: menuItems }]}
-            open={menuOpen}
-            onOpenChange={setMenuOpen}
-            // Don't return focus (and its ring) to the `⋯` trigger on close.
-            onCloseAutoFocus={(e) => e.preventDefault()}
-            customTrigger={
-              <Button
-                variant="transparent"
-                size="icon"
-                aria-label="Chat actions"
-                // Square, grey icon → white on hover. `h-full` matches the row
-                // height exactly (no breakpoint poke from `size="icon"`'s
-                // responsive `md:h-12`); `w-9` keeps it compact; `p-0` drops the
-                // icon-size padding. tailwind-merge so these win over defaults.
-                className="h-full md:h-full rounded-none p-0 text-ods-text-secondary hover:text-ods-text-primary"
-              >
-                <Ellipsis01Icon />
-              </Button>
-            }
-          />
+          {hasMenu ? (
+            // Revealed on row hover/its own focus; kept visible while the menu
+            // is open. Hidden on mobile — it's a hover affordance. `peer/menu`
+            // so the avatar layer (a later sibling) can fade when the trigger
+            // holds keyboard focus.
+            <span
+              onClick={(e) => e.stopPropagation()}
+              className={cn(
+                'peer/menu absolute inset-0 transition-opacity max-md:hidden',
+                menuOpen
+                  ? 'opacity-100'
+                  : 'opacity-0 group-hover/row:opacity-100 focus-within:opacity-100',
+              )}
+            >
+              <ActionsMenuDropdown
+                triggerAriaLabel="Chat actions"
+                groups={[{ items: menuItems }]}
+                open={menuOpen}
+                onOpenChange={setMenuOpen}
+                // Don't return focus (and its ring) to the `⋯` trigger on close.
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                customTrigger={
+                  <Button
+                    variant="transparent"
+                    size="icon"
+                    aria-label="Chat actions"
+                    // Square, grey icon → white on hover. `h-full`/`w-full` fill
+                    // the 48px cell exactly (no breakpoint poke from
+                    // `size="icon"`'s responsive `md:h-12`); `p-0` drops the
+                    // icon-size padding. tailwind-merge so these win over
+                    // defaults.
+                    className="h-full md:h-full w-full rounded-none p-0 text-ods-text-secondary hover:text-ods-text-primary"
+                  >
+                    <Ellipsis01Icon />
+                  </Button>
+                }
+              />
+            </span>
+          ) : null}
+          {hasAvatar ? (
+            // Avatar layer — clicks fall through to row selection (it covers
+            // the cell whenever the menu trigger is faded out). On desktop it
+            // fades for the menu swap; on mobile it's always shown.
+            <span
+              onClick={() => onSelect?.(dialog.id)}
+              title={owner?.name || undefined}
+              className={cn(
+                'absolute inset-0 flex cursor-pointer items-center justify-center transition-opacity',
+                hasMenu &&
+                  (menuOpen
+                    ? 'opacity-0 pointer-events-none'
+                    : 'md:group-hover/row:opacity-0 md:group-hover/row:pointer-events-none md:peer-[:focus-within]/menu:opacity-0 md:peer-[:focus-within]/menu:pointer-events-none'),
+              )}
+            >
+              <SquareAvatar
+                variant="round"
+                sizePx={24}
+                src={owner?.avatarUrl || undefined}
+                alt={owner?.name || undefined}
+                fallback={owner?.name || undefined}
+                initialsClassName="text-[10px] text-ods-text-secondary"
+              />
+            </span>
+          ) : null}
         </span>
       ) : null}
     </div>
@@ -316,6 +355,7 @@ export function MingoChatHistory({
   onLoadMoreRef.current = onLoadMore
   const isLoadingMoreRef = React.useRef(isLoadingMore)
   isLoadingMoreRef.current = isLoadingMore
+  const dialogCount = dialogs.length
   React.useEffect(() => {
     const root = scrollRef.current
     const sentinel = sentinelRef.current
@@ -331,7 +371,15 @@ export function MingoChatHistory({
     )
     io.observe(sentinel)
     return () => io.disconnect()
-  }, [hasMore])
+    // `dialogCount`/`isLoadingMore` deps re-arm the observer after every page
+    // lands: `observe()` re-reports the CURRENT intersection, so a sentinel
+    // that stays in view (short host-filtered list — e.g. the "My Chats"
+    // scope keeps a handful of rows out of a 20-row page) keeps chaining
+    // loads until the viewport fills or `hasMore` flips. A continuously
+    // visible sentinel never re-crosses the threshold, so the previous
+    // [hasMore]-only observer fired exactly once per mount and the list
+    // grew by a single page per drawer open.
+  }, [hasMore, isLoadingMore, dialogCount])
 
   return (
     <div className={cn('relative flex flex-1 min-h-0 flex-col gap-[var(--spacing-system-m)]', className)}>

--- a/openframe-frontend-core/src/components/chat/mingo-history-rail.tsx
+++ b/openframe-frontend-core/src/components/chat/mingo-history-rail.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react'
 import { cn } from '../../utils/cn'
 import { Button } from '../ui/button'
+import { TabSelector } from '../ui/tab-selector'
 import { ChatsIcon } from '../icons-v2-generated/communication/chats-icon'
 import { PlusCircleIcon } from '../icons-v2-generated/signs-and-symbols/plus-circle-icon'
 import { AlertCircleIcon, Refresh01RightIcon } from '../icons-v2-generated'
@@ -13,6 +14,10 @@ import type { DialogItem } from './types/component.types'
 // =============================================================================
 // Types
 // =============================================================================
+
+/** Ownership scope of the rail's dialog list — the current user's chats only,
+ *  or every admin's chats in the tenant. */
+export type MingoHistoryScope = 'my' | 'all'
 
 export interface MingoHistoryRailProps {
   /** Dialogs to list, assumed already sorted newest-first by the host. */
@@ -32,6 +37,13 @@ export interface MingoHistoryRailProps {
   onRequestRename?: (dialog: DialogItem) => void
   /** Request archive — enables the row "Archive chat" action. */
   onRequestArchive?: (dialog: DialogItem) => void
+  /** Ownership scope shown as a two-state "My Chats / All Chats" selector
+   *  between "Start New Chat" and the list. Rendered only when BOTH `scope`
+   *  and `onScopeChange` are provided; the host owns the state and refilters
+   *  the `dialogs` it passes in. */
+  scope?: MingoHistoryScope
+  /** Scope selector change handler — see `scope`. */
+  onScopeChange?: (scope: MingoHistoryScope) => void
   /** Current server-side search term. Drives the list's "No chats found"
    *  empty state; the search INPUT itself lives in the panel header now, not
    *  in the rail body. */
@@ -77,6 +89,8 @@ export function MingoHistoryRail({
   newChatAlways = false,
   onRequestRename,
   onRequestArchive,
+  scope,
+  onScopeChange,
   searchQuery,
   hasMore = false,
   isLoadingMore = false,
@@ -113,6 +127,23 @@ export function MingoHistoryRail({
           Start New Chat
         </Button>
       )}
+
+      {/* Two-state ownership scope — "My Chats" / "All Chats". Stays visible in
+          the empty state too: an empty "My Chats" list must still offer the
+          switch to "All Chats" (host filters, so the empty state can be
+          scope-induced). Hidden while the load failed — retry is the only
+          useful action there. */}
+      {scope && onScopeChange && !loadError ? (
+        <TabSelector
+          className="shrink-0"
+          value={scope}
+          onValueChange={(value) => onScopeChange(value as MingoHistoryScope)}
+          items={[
+            { id: 'my', label: 'My Chats' },
+            { id: 'all', label: 'All Chats' },
+          ]}
+        />
+      ) : null}
 
       {loadError ? (
         <div className="flex flex-1 min-h-0 flex-col items-center justify-center gap-[var(--spacing-system-m)] text-center">

--- a/openframe-frontend-core/src/components/chat/types/component.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/component.types.ts
@@ -608,6 +608,14 @@ export interface DialogItem {
   timestamp?: Date | string
   isActive?: boolean
   unreadMessagesCount?: number
+  /** Dialog owner (creator) — drives the trailing avatar in the chat-history
+   *  rows (Figma 113:63224). Omit to render the row without an avatar. */
+  owner?: {
+    /** Full display name — initials fallback + `title` tooltip. */
+    name?: string | null
+    /** Absolute avatar URL; falls back to initials when absent or failing. */
+    avatarUrl?: string | null
+  }
 }
 
 // ========== Chat Sidebar Props ==========

--- a/openframe-frontend-core/src/components/chat/types/unified-chat-state.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/unified-chat-state.types.ts
@@ -369,6 +369,15 @@ export interface UnifiedChatState {
   /** Fetch the next page of dialogs. No-op when `hasMoreDialogs` is false. */
   loadMoreDialogs: () => Promise<void>
 
+  /** Ownership scope of `dialogs` — `'my'` (current user's chats) or `'all'`
+   *  (every admin's). Optional: adapters without ownership data omit it and
+   *  the "My Chats / All Chats" selector stays hidden. The HOST owns the
+   *  filtering — `dialogs` must already reflect this scope. */
+  dialogScope?: 'my' | 'all'
+
+  /** Switch the ownership scope — see `dialogScope`. */
+  setDialogScope?: (scope: 'my' | 'all') => void
+
   /** Whether more historical messages remain in the active dialog. */
   hasMoreMessages: boolean
 

--- a/openframe-frontend-core/src/components/ui/tab-selector.tsx
+++ b/openframe-frontend-core/src/components/ui/tab-selector.tsx
@@ -67,15 +67,18 @@ export function TabSelector({
               onClick={() => onValueChange(item.id)}
               aria-label={!item.label ? item.ariaLabel : undefined}
               className={cn(
-                'flex flex-1 items-center justify-center gap-2 rounded-xs p-2 text-h4 transition-colors duration-200 whitespace-nowrap',
+                // Bold on BOTH states — a medium↔bold flip between the active
+                // and inactive tabs read as inconsistent weight (and nudged
+                // label widths on every switch).
+                'flex flex-1 items-center justify-center gap-2 rounded-xs p-2 text-h4 font-bold transition-colors duration-200 whitespace-nowrap',
                 isDisabled
                   ? isActive
-                    ? 'cursor-not-allowed bg-ods-bg-surface text-ods-text-secondary [font-weight:700]'
+                    ? 'cursor-not-allowed bg-ods-bg-surface text-ods-text-secondary'
                     : 'cursor-not-allowed bg-transparent text-ods-text-secondary'
                   : isActive
                     ? variant === 'primary'
-                      ? 'bg-ods-accent text-ods-text-on-accent cursor-default [font-weight:700]'
-                      : 'bg-ods-bg-surface text-ods-text-primary cursor-default [font-weight:700]'
+                      ? 'bg-ods-accent text-ods-text-on-accent cursor-default'
+                      : 'bg-ods-bg-surface text-ods-text-primary cursor-default'
                     : 'bg-transparent text-ods-text-primary hover:bg-ods-bg-hover cursor-pointer',
               )}
             >


### PR DESCRIPTION
## Summary

Mingo drawer chat updates per Figma [`openframe---mingo` 113:63224](https://www.figma.com/design/O4J4CjkN4eakOmbZz9fsaG/openframe---mingo?node-id=113-63224):

- **Owner avatars in the chat list** — `DialogItem` gains an optional `owner { name, avatarUrl }`; `MingoChatHistoryRow` renders a trailing 24px round avatar (initials fallback via `SquareAvatar`). Hovering a row swaps the avatar for the existing `⋯` actions menu **in place**, so the title never reflows; on touch the avatar always shows.
- **"My Chats / All Chats" scope selector** — new optional `scope`/`onScopeChange` on `MingoHistoryRail`, rendered as a `TabSelector` between "Start New Chat" and the list. Plumbed through the `UnifiedChatState` contract (`dialogScope`/`setDialogScope`, both optional) and `useUnifiedChat` to both rail render sites. The **host owns the filtering** (the openframe app passes `DialogFilterInput.scope: MY|ALL` server-side).
- **Owner in the conversation header** — `ChatPanelHeader` (and the wide split header) render a 32px round person avatar at the title cell's right edge: the dialog owner in a conversation (relevant with "All Chats"), the signed-in user on New Chat. New `EmbeddableChat.userAvatarUrl` host-fallback prop (counterpart of `userDisplayName`); the conversation sub-line now names the owner.

## Fixes

- **Infinite scroll loaded exactly one page per mount** — `MingoChatHistory`'s IntersectionObserver was keyed on `[hasMore]` only; a continuously visible sentinel (short host-filtered list) never re-crosses the threshold, so the list grew by a single page per drawer open. The observer now re-arms after every page (`isLoadingMore`/`dialogCount` deps) and keeps loading until the viewport fills.
- **TabSelector active/inactive weight mismatch** — the active tab stacked `[font-weight:700]` on the `text-h4` (500) base while inactive stayed medium; both states are now `font-bold`, which also stops label widths nudging on every switch.

## Compatibility

All new props/fields are optional — consumers that don't pass owner/scope data render exactly as before.

## Testing

- `tsc --noEmit` and Biome clean.
- Verified live in the openframe-frontend Mingo drawer via yalc (avatars, scope toggle, auto-fill after the pagination fix).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “My Chats” and “All Chats” filters to chat history.
  * Added avatars to chat headers and history entries, with initials fallback.
  * Added support for displaying the current conversation owner and user identity.
* **Bug Fixes**
  * Improved chat history loading when additional conversations are available.
  * Chat scope selection is now preserved and synchronized across layouts.
* **Style**
  * Standardized tab label typography across active, inactive, and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->