### PR TITLE
fix(docs-nav): README chip contrast in knowledge-base sidebar

### DIFF
--- a/openframe-frontend-core/src/components/navigation/multi-level-navigation.tsx
+++ b/openframe-frontend-core/src/components/navigation/multi-level-navigation.tsx
@@ -175,7 +175,7 @@ function NavigationItem({
                 {node.name.endsWith('.md') ? node.name.replace('.md', '') : node.name}
               </span>
               {node.type === 'folder' && node.hasReadme && (
-                <span className="text-h6 bg-ods-bg-surface text-ods-text-tertiary px-1.5 py-0.5 rounded mr-2">
+                <span className="text-h6 bg-ods-bg-surface text-ods-text-secondary px-1.5 py-0.5 rounded mr-2">
                   README
                 </span>
               )}
@@ -307,7 +307,7 @@ function MobileNavigationItem({
                 {node.name.endsWith('.md') ? node.name.replace('.md', '') : node.name}
               </span>
               {node.type === 'folder' && node.hasReadme && (
-                <span className="text-h6 bg-ods-bg-surface text-ods-text-tertiary px-1.5 py-0.5 rounded mr-2">
+                <span className="text-h6 bg-ods-bg-surface text-ods-text-secondary px-1.5 py-0.5 rounded mr-2">
                   README
                 </span>
               )}


### PR DESCRIPTION
## Problem
On knowledge-base doc sidebars (e.g. https://www.flamingo.run/knowledge-base/openframe-oss-tenant), the `README` chips on folder rows are nearly invisible — dark grey text on a dark grey pill.

## Root cause
The chip in `MultiLevelNavigation` / `MobileNavigationDropdown` uses `text-ods-text-tertiary` on `bg-ods-bg-surface`. `--color-text-tertiary` maps to `soft-grey-hover` (#444444 dark / #dddddd light) while `--color-bg-surface` is `soft-grey` (#3a3a3a dark / #e7e7e7 light) — ~1.07:1 contrast in **both** themes.

## Fix
Switch the chip text to `text-ods-text-secondary`, the established pill pattern on surface backgrounds in the lib (filter-chip unselected state, sonner toasts). Menu item titles (`text-h6 text-ods-text-primary`) are fine and untouched.

Note: the `--color-text-tertiary` → `soft-grey-hover` mapping itself looks questionable (a hover-background grey used as a text color; ~15 more usages in the lib share this dimness) — left as-is here to keep the change scoped; worth a design review separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)