### PR TITLE
FE CORE: Mingo rail — keep "Start New Chat" visible with no chats

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -2263,7 +2263,6 @@ function EmbeddableChatInner({
                     activeDialogId={activeDialogId ?? undefined}
                     onSelectDialog={handleSelectDialog}
                     onNewChat={() => setComposeOpen(true)}
-                    newChatAlways
                     onRequestRename={mingoCaps.canRename ? setRenameTarget : undefined}
                     onRequestArchive={mingoCaps.canArchive ? setArchiveTarget : undefined}
                     scope={dialogScope}

--- a/openframe-frontend-core/src/components/chat/mingo-history-rail.tsx
+++ b/openframe-frontend-core/src/components/chat/mingo-history-rail.tsx
@@ -27,12 +27,9 @@ export interface MingoHistoryRailProps {
   /** Open a dialog. */
   onSelectDialog?: (id: string) => void
   /** Start a fresh chat — clears the open conversation so the chat block shows
-   *  the welcome. Rendered as the pinned "Start New Chat" button above the list. */
+   *  the welcome. Rendered as the pinned "Start New Chat" button above the list,
+   *  in every state (including the no-chats empty state). */
   onNewChat?: () => void
-  /** Show the "Start New Chat" button even when there are no chats yet. Needed
-   *  for the narrow single-column list, where there's no composer to fall back
-   *  on; the wide rail leaves it off (the chat block already has a composer). */
-  newChatAlways?: boolean
   /** Request rename — enables the row "Rename chat" action. */
   onRequestRename?: (dialog: DialogItem) => void
   /** Request archive — enables the row "Archive chat" action. */
@@ -76,17 +73,17 @@ export interface MingoHistoryRailProps {
  *
  * The dialog history that the stacked layout renders inline in the Mingo empty
  * state is hoisted here into a fixed-width rail beside the chat block. On top
- * sits a pinned "Start New Chat" button (shown once the user has chats); below
- * it the grouped Today / Yesterday / Older list (`MingoChatHistory`). With no
- * chats it collapses to a centred empty state; loading / error states mirror
- * the stacked empty state so the two layouts stay consistent.
+ * sits a pinned "Start New Chat" button (always shown when `onNewChat` is
+ * given); below it the grouped Today / Yesterday / Older list
+ * (`MingoChatHistory`). With no chats the list area collapses to a centred
+ * empty state; loading / error states mirror the stacked empty state so the
+ * two layouts stay consistent.
  */
 export function MingoHistoryRail({
   dialogs,
   activeDialogId,
   onSelectDialog,
   onNewChat,
-  newChatAlways = false,
   onRequestRename,
   onRequestArchive,
   scope,
@@ -113,10 +110,12 @@ export function MingoHistoryRail({
         className,
       )}
     >
-      {/* Pinned "Start New Chat". In the wide rail it's offered only once the
-          user has chats (the chat block's composer is the empty-state entry);
-          the narrow list forces it on (`newChatAlways`) since it has no composer. */}
-      {onNewChat && (hasList || newChatAlways) && (
+      {/* Pinned "Start New Chat" — always on top, in every state. It used to be
+          hidden in the wide rail while the user had no chats (the chat block's
+          composer being the empty-state entry), but that made the rail's primary
+          action vanish exactly when it's most needed, and shifted the layout the
+          moment the first chat appeared. */}
+      {onNewChat && (
         <Button
           variant="outline"
           fullWidth


### PR DESCRIPTION
## Problem

`MingoHistoryRail` hid its pinned **Start New Chat** button whenever the dialog list came back empty:

```tsx
{onNewChat && (hasList || newChatAlways) && ( … )}
```

The wide (split) rail never passed `newChatAlways`, so the button vanished in the no-chats state — including the common case where **My Chats** is empty while the tenant's chats sit under **All Chats**. The narrow single-column list had to opt back in via the prop.

Two problems with that:
- the rail's primary action disappears exactly when it is most needed (fresh tenant, empty scope);
- the column shifts down as soon as the first chat lands, since the button appears above the scope selector.

## Change

- Render **Start New Chat** in every state whenever `onNewChat` is given.
- Drop the now-redundant `newChatAlways` prop and its single call site in `embeddable-chat.tsx`.

No other consumer in the stack passed `newChatAlways` (grepped across the OpenFrame/hub repos), so removing it is not a breaking change in practice.

## Test plan

- Wide Mingo drawer, tenant with no chats → empty state shows **Start New Chat** above the "No Current Chats" block.
- Switch **All Chats → My Chats** with an empty personal scope → button stays put, no layout jump.
- Narrow single-column list → unchanged (it already forced the button on).
- `npm run type-check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Start New Chat” is now available in every chat list state, including when there are no existing chats or an active search.
  * Selecting “Start New Chat” opens the compose view directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->