### PR TITLE
feat(gateway-service-core): Tenant Gateway - route to the shared Fleet service

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/prop/FleetMultiTenancyProperties.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/config/prop/FleetMultiTenancyProperties.java
@@ -23,6 +23,13 @@ import java.util.List;
  *       allowed-endpoints:
  *         - "GET /api/{v}/fleet/hosts"
  *         - "DELETE /api/{v}/fleet/labels/id/{id}"
+ *       upstream:
+ *         api:
+ *           url: http://fleet.fleet-shared.svc.cluster.local
+ *           port: "8080"
+ *         websocket:
+ *           url: ws://fleet.fleet-shared.svc.cluster.local
+ *           port: "8080"
  * </pre>
  */
 @Data
@@ -31,7 +38,8 @@ import java.util.List;
 public class FleetMultiTenancyProperties {
 
     /**
-     * Master switch for Fleet multi-tenancy behavior at the gateway (the endpoint allowlist).
+     * Master switch for Fleet multi-tenancy behavior at the gateway (the endpoint allowlist and the
+     * shared-Fleet upstream routing).
      */
     private boolean enabled = false;
 
@@ -41,4 +49,19 @@ public class FleetMultiTenancyProperties {
      * when {@link #enabled} is true.
      */
     private List<String> allowedEndpoints = new ArrayList<>();
+
+    private Upstream upstream = new Upstream();
+
+    @Data
+    public static class Upstream {
+        private Endpoint api = new Endpoint();
+        private Endpoint websocket = new Endpoint();
+    }
+
+    @Data
+    public static class Endpoint {
+        private String url;
+        private String port;
+    }
+
 }

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/upstream/fleet/FleetUpstreamResolver.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/upstream/fleet/FleetUpstreamResolver.java
@@ -1,0 +1,81 @@
+package com.openframe.gateway.upstream.fleet;
+
+import com.openframe.core.service.ProxyUrlResolver;
+import com.openframe.data.document.tool.IntegratedTool;
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import com.openframe.gateway.upstream.DefaultToolUpstreamResolver;
+import com.openframe.gateway.upstream.ToolUpstreamResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Fleet MDM routing strategy for shared-DB multi-tenancy.
+ *
+ * <p>Target topology: <b>one shared Fleet server per cluster</b> serving all of that cluster's
+ * tenants against one shared MySQL — tenant isolation happens inside Fleet (per-request team pin
+ * from {@code X-Tenant-Id} / host / enroll secret), not by deployment. The gateway's job is only to
+ * send every tenant's {@code fleetmdm-server} traffic to that one shared Fleet.
+ *
+ * <p>When {@code openframe.fleet.multi-tenancy.enabled=true} AND the matching upstream URL is
+ * configured, the request routes to the configured shared Fleet — a single URL per gateway (each
+ * cluster's gateway hop owns this route). REST (browser proxy {@code /tools} and agent proxy
+ * {@code /tools/agent}) is gated on {@code openframe.fleet.multi-tenancy.upstream.api.url}; the
+ * WebSocket plane is gated independently on
+ * {@code openframe.fleet.multi-tenancy.upstream.websocket.url}. Whichever URL is missing — flag off,
+ * or the allowlist-only rollout phase — delegates that plane to the {@link DefaultToolUpstreamResolver},
+ * i.e. the per-tenant URL stored in the tenant's {@link IntegratedTool} document, byte-identical to
+ * today (a blank URL is never passed to the proxy resolver).
+ *
+ * <p>Config is shaped like {@code openframe.tools.meshcentral} for consistency: separate
+ * {@code api} and {@code websocket} endpoints. Fleet serves both on one listener, so they are
+ * typically the same host:port differing only by scheme ({@code http} vs {@code ws}).
+ */
+@Component
+@RequiredArgsConstructor
+public class FleetUpstreamResolver implements ToolUpstreamResolver {
+
+    public static final String TOOL_ID = "fleetmdm-server";
+
+    private final FleetMultiTenancyProperties multiTenancyProperties;
+    private final ProxyUrlResolver proxyUrlResolver;
+    private final DefaultToolUpstreamResolver defaultResolver;
+
+    @Override
+    public Optional<String> supportsToolId() {
+        return Optional.of(TOOL_ID);
+    }
+
+    @Override
+    public URI resolveRest(IntegratedTool tool, ServerHttpRequest request, String stripPrefix) {
+        FleetMultiTenancyProperties.Endpoint api = multiTenancyProperties.getUpstream().getApi();
+        if (sharedRoutingEnabled(api)) {
+            return proxyUrlResolver.resolve(TOOL_ID, api.getUrl(), api.getPort(), request.getURI(), stripPrefix);
+        }
+        return defaultResolver.resolveRest(tool, request, stripPrefix);
+    }
+
+    @Override
+    public URI resolveWs(IntegratedTool tool, ServerHttpRequest request, String stripPrefix) {
+        FleetMultiTenancyProperties.Endpoint ws = multiTenancyProperties.getUpstream().getWebsocket();
+        if (sharedRoutingEnabled(ws)) {
+            return proxyUrlResolver.resolve(TOOL_ID, ws.getUrl(), ws.getPort(), request.getURI(), stripPrefix);
+        }
+        return defaultResolver.resolveWs(tool, request, stripPrefix);
+    }
+
+    /**
+     * Shared-Fleet routing for a given plane engages only when multi-tenancy is on AND that plane's
+     * upstream URL is configured. Each plane (api / websocket) is gated on its own URL so an
+     * api-only configuration keeps per-tenant WebSocket routing rather than passing a blank URL to
+     * the proxy resolver.
+     */
+    private boolean sharedRoutingEnabled(FleetMultiTenancyProperties.Endpoint endpoint) {
+        return multiTenancyProperties.isEnabled() && isNotBlank(endpoint.getUrl());
+    }
+}

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/upstream/fleet/FleetUpstreamResolverTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/upstream/fleet/FleetUpstreamResolverTest.java
@@ -1,0 +1,148 @@
+package com.openframe.gateway.upstream.fleet;
+
+import com.openframe.core.service.ProxyUrlResolver;
+import com.openframe.data.document.tool.IntegratedTool;
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import com.openframe.gateway.upstream.DefaultToolUpstreamResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class FleetUpstreamResolverTest {
+
+    private static final String API_URL = "http://fleet.fleet-shared.svc.cluster.local";
+    private static final String WS_URL = "ws://fleet.fleet-shared.svc.cluster.local";
+    private static final String PORT = "8080";
+
+    private ProxyUrlResolver proxyUrlResolver;
+    private DefaultToolUpstreamResolver defaultResolver;
+    private FleetMultiTenancyProperties properties;
+    private FleetUpstreamResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        proxyUrlResolver = mock(ProxyUrlResolver.class);
+        defaultResolver = mock(DefaultToolUpstreamResolver.class);
+        properties = new FleetMultiTenancyProperties();
+        resolver = new FleetUpstreamResolver(properties, proxyUrlResolver, defaultResolver);
+    }
+
+    private static ServerHttpRequest request(String path) {
+        return MockServerHttpRequest.get(path).build();
+    }
+
+    private void configureSharedUpstream() {
+        properties.setEnabled(true);
+        properties.getUpstream().getApi().setUrl(API_URL);
+        properties.getUpstream().getApi().setPort(PORT);
+        properties.getUpstream().getWebsocket().setUrl(WS_URL);
+        properties.getUpstream().getWebsocket().setPort(PORT);
+    }
+
+    @Test
+    void routesRestToSharedFleetApiWhenEnabledAndConfigured() {
+        configureSharedUpstream();
+        URI expected = URI.create(API_URL + ":8080/api/latest/fleet/hosts");
+        when(proxyUrlResolver.resolve(anyString(), anyString(), anyString(), any(), anyString())).thenReturn(expected);
+
+        URI uri = resolver.resolveRest(mock(IntegratedTool.class),
+                request("/tools/fleetmdm-server/api/latest/fleet/hosts"), "/tools");
+
+        assertThat(uri).isEqualTo(expected);
+        verify(proxyUrlResolver).resolve(eq(FleetUpstreamResolver.TOOL_ID), eq(API_URL), eq(PORT), any(), eq("/tools"));
+        verifyNoInteractions(defaultResolver);
+    }
+
+    @Test
+    void agentPlaneRoutesToSharedFleetApiToo() {
+        configureSharedUpstream();
+        when(proxyUrlResolver.resolve(anyString(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(URI.create(API_URL + ":8080/api/osquery/enroll"));
+
+        resolver.resolveRest(mock(IntegratedTool.class),
+                request("/tools/agent/fleetmdm-server/api/osquery/enroll"), "/tools/agent");
+
+        verify(proxyUrlResolver).resolve(eq(FleetUpstreamResolver.TOOL_ID), eq(API_URL), eq(PORT), any(), eq("/tools/agent"));
+        verifyNoInteractions(defaultResolver);
+    }
+
+    @Test
+    void routesWsToSharedFleetWebsocketEndpoint() {
+        configureSharedUpstream();
+        when(proxyUrlResolver.resolve(anyString(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(URI.create(WS_URL + ":8080/api/v1/fleet/results/websocket"));
+
+        resolver.resolveWs(mock(IntegratedTool.class),
+                request("/ws/tools/fleetmdm-server/api/v1/fleet/results/websocket"), "/tools");
+
+        verify(proxyUrlResolver).resolve(eq(FleetUpstreamResolver.TOOL_ID), eq(WS_URL), eq(PORT), any(), eq("/tools"));
+        verifyNoInteractions(defaultResolver);
+    }
+
+    @Test
+    void flagOffDelegatesToPerTenantDocRouting() {
+        // enabled=false (default) — even with a URL configured, per-tenant routing stays.
+        properties.getUpstream().getApi().setUrl(API_URL);
+        IntegratedTool tool = mock(IntegratedTool.class);
+        ServerHttpRequest req = request("/tools/fleetmdm-server/api/latest/fleet/hosts");
+        URI perTenant = URI.create("http://fleet-service.tenant-0.svc.cluster.local:8080/api/latest/fleet/hosts");
+        when(defaultResolver.resolveRest(tool, req, "/tools")).thenReturn(perTenant);
+
+        URI uri = resolver.resolveRest(tool, req, "/tools");
+
+        assertThat(uri).isEqualTo(perTenant);
+        verifyNoInteractions(proxyUrlResolver);
+    }
+
+    @Test
+    void apiConfiguredButWebsocketMissingDelegatesWsToPerTenant() {
+        // Regression: api set, websocket URL blank — WS must delegate per-tenant, not pass a blank
+        // URL to the proxy resolver (which would fail URI parsing).
+        properties.setEnabled(true);
+        properties.getUpstream().getApi().setUrl(API_URL);
+        properties.getUpstream().getApi().setPort(PORT);
+        // websocket left unset
+
+        IntegratedTool tool = mock(IntegratedTool.class);
+        ServerHttpRequest wsReq = request("/ws/tools/fleetmdm-server/api/v1/fleet/results/websocket");
+        URI perTenantWs = URI.create("ws://fleet-service.tenant-0.svc.cluster.local:8080/api/v1/fleet/results/websocket");
+        when(defaultResolver.resolveWs(tool, wsReq, "/tools")).thenReturn(perTenantWs);
+
+        // WS delegates per-tenant...
+        assertThat(resolver.resolveWs(tool, wsReq, "/tools")).isEqualTo(perTenantWs);
+
+        // ...while REST still routes to the shared api endpoint.
+        ServerHttpRequest restReq = request("/tools/fleetmdm-server/api/latest/fleet/hosts");
+        when(proxyUrlResolver.resolve(anyString(), anyString(), anyString(), any(), anyString()))
+                .thenReturn(URI.create(API_URL + ":8080/api/latest/fleet/hosts"));
+        resolver.resolveRest(tool, restReq, "/tools");
+        verify(proxyUrlResolver).resolve(eq(FleetUpstreamResolver.TOOL_ID), eq(API_URL), eq(PORT), any(), eq("/tools"));
+    }
+
+    @Test
+    void enabledWithoutApiUrlDelegatesToPerTenantDocRouting() {
+        // The allowlist-only rollout phase: flag on, no shared upstream configured yet.
+        properties.setEnabled(true);
+        IntegratedTool tool = mock(IntegratedTool.class);
+        ServerHttpRequest req = request("/ws/tools/fleetmdm-server/x");
+        URI perTenant = URI.create("ws://fleet-service.tenant-0.svc.cluster.local:8080/x");
+        when(defaultResolver.resolveWs(tool, req, "/tools")).thenReturn(perTenant);
+
+        URI uri = resolver.resolveWs(tool, req, "/tools");
+
+        assertThat(uri).isEqualTo(perTenant);
+        verifyNoInteractions(proxyUrlResolver);
+    }
+}


### PR DESCRIPTION
## Description

Under Fleet shared-DB multi-tenancy the target topology is **one shared Fleet server per cluster** serving all of that cluster's tenants against one shared MySQL — tenant isolation happens inside Fleet (per-request team pin from `X-Tenant-Id` / host / enroll secret), not by deployment. But the gateway still resolves the Fleet upstream from each tenant's own `IntegratedTool` Mongo document (`toolUrls[type=API].url` → `fleet-service.<tenant-ns>`), i.e. the one-Fleet-per-tenant URL. This adds the routing that sends `fleetmdm-server` traffic to the shared Fleet instead, so the datastore fences + `X-Tenant-Id` forwarding already shipped actually have a shared Fleet to run against.

Ticket: https://app.clickup.com/t/9013925967/86ajnf4ur

## Improvements
- **`FleetUpstreamResolver`** — new `ToolUpstreamResolver` for `fleetmdm-server`, modeled on `MeshCentralUpstreamResolver`. When multi-tenancy is enabled **and** a shared upstream URL is configured, the browser proxy (`/tools`), the agent proxy (`/tools/agent`) and the live-query WebSocket (`resolveWs`) all route to the configured shared Fleet. Otherwise — flag off, **or** flag on with no URL (today's allowlist-only phase) — it **delegates to `DefaultToolUpstreamResolver`** (per-tenant tool-doc URL), byte-identical to current behavior.
- **`FleetMultiTenancyProperties.upstream`** — new config, shaped like `openframe.tools.meshcentral` for consistency: separate `api` and `websocket` endpoints (`{url, port}` each). Fleet serves both on one listener, so they are typically the same host:port differing only by scheme.

```yaml
openframe:
  fleet:
    multi-tenancy:
      enabled: true
      allowed-endpoints: [ ... ]      # existing
      upstream:
        api:       { url: http://fleet.fleet-shared.svc.cluster.local, port: "8080" }
        websocket: { url: ws://fleet.fleet-shared.svc.cluster.local,   port: "8080" }
```

## Behavior / rollout knob

| `enabled` | `upstream.api.url` | Effect |
|---|---|---|
| false (default) | — | per-tenant Fleet routing (unchanged) |
| true | empty | per-tenant routing (allowlist-only phase) |
| true | set | all Fleet traffic → cluster-shared Fleet |

Instant rollback: unset the URL → back to per-tenant routing.

## Notes
- Single URL per gateway (each cluster's gateway hop owns this route). If a central gateway ever needs to reach multiple clusters' Fleets, the property can grow into a cluster→URL map without breaking config.
- **Credentials unchanged**: `apiKeyHeadersResolver` still reads the per-tenant tool-doc bearer token (each tenant logs into the shared Fleet and stores a valid token — no code change needed here).
- `ToolUrlType.DASHBOARD` in the tool doc is unaffected — nothing routes on it (stored-but-unused for Fleet).
- No new endpoints, no DB changes.

## Tests
`FleetUpstreamResolverTest` — REST + agent plane → shared api endpoint; WS → shared websocket endpoint; flag-off and flag-on-without-URL both delegate to per-tenant routing. Full gateway module: 51 tests green.

## Depends on
Merged gateway allowlist / `X-Tenant-Id` forwarding (oss-lib #1453, #1467) and the fleetmdm shared-DB multi-tenancy feature (fleetmdm #76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable shared Fleet upstream routing for REST and WebSocket requests.
  * Fleet requests can now route to shared API and WebSocket endpoints when multi-tenancy routing is enabled.
  * Existing per-tenant routing remains available when shared upstream routing is disabled or not configured.

* **Tests**
  * Added coverage for shared upstream routing and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->