### PR TITLE
Added trigger enum for script schedule

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/CreateScriptScheduleInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/CreateScriptScheduleInput.java
@@ -1,8 +1,10 @@
 package com.openframe.api.dto.rmm.schedule;
 
 import com.openframe.data.document.rmm.ScriptPlatform;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.time.Instant;
@@ -24,6 +26,9 @@ public class CreateScriptScheduleInput {
     private List<ScriptPlatform> supportedPlatforms;
 
     private List<String> scriptIds;
+
+    @NotNull
+    private ScriptScheduleTrigger trigger;
 
     /**
      * First scheduled run as an absolute UTC instant (the dashboard converts the

--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleResponse.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleResponse.java
@@ -22,6 +22,8 @@ public class ScriptScheduleResponse {
 
     private List<String> scriptIds;
 
+    private String trigger;
+
     private Instant startAt;
     private Long repeat;
     private Instant nextRunAt;

--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/UpdateScriptScheduleInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/UpdateScriptScheduleInput.java
@@ -1,8 +1,10 @@
 package com.openframe.api.dto.rmm.schedule;
 
 import com.openframe.data.document.rmm.ScriptPlatform;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 import java.time.Instant;
@@ -27,6 +29,9 @@ public class UpdateScriptScheduleInput {
     private List<ScriptPlatform> supportedPlatforms;
 
     private List<String> scriptIds;
+
+    @NotNull
+    private ScriptScheduleTrigger trigger;
 
     /**
      * First scheduled run as an absolute UTC instant. PUT semantics: null clears

--- a/openframe-api-lib/src/main/java/com/openframe/api/mapper/ScriptScheduleMapper.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/mapper/ScriptScheduleMapper.java
@@ -5,6 +5,7 @@ import com.openframe.api.dto.rmm.schedule.ScriptScheduleResponse;
 import com.openframe.api.dto.rmm.schedule.UpdateScriptScheduleInput;
 import com.openframe.data.document.rmm.ScriptPlatform;
 import com.openframe.data.document.rmm.ScriptSchedule;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import com.openframe.data.document.rmm.ScriptStatus;
 import org.springframework.stereotype.Component;
 
@@ -25,6 +26,7 @@ public class ScriptScheduleMapper {
                 .description(input.getDescription())
                 .supportedPlatforms(input.getSupportedPlatforms())
                 .scriptIds(input.getScriptIds())
+                .trigger(defaultTrigger(input.getTrigger()))
                 .startAt(input.getStartAt())
                 .repeat(input.getRepeat())
                 .build();
@@ -35,8 +37,13 @@ public class ScriptScheduleMapper {
         existing.setDescription(input.getDescription());
         existing.setSupportedPlatforms(input.getSupportedPlatforms());
         existing.setScriptIds(input.getScriptIds());
+        existing.setTrigger(defaultTrigger(input.getTrigger()));
         existing.setStartAt(input.getStartAt());
         existing.setRepeat(input.getRepeat());
+    }
+
+    private static ScriptScheduleTrigger defaultTrigger(ScriptScheduleTrigger trigger) {
+        return trigger != null ? trigger : ScriptScheduleTrigger.DATE_TIME;
     }
 
     public ScriptScheduleResponse toResponse(ScriptSchedule entity) {
@@ -46,6 +53,7 @@ public class ScriptScheduleMapper {
                 .description(entity.getDescription())
                 .supportedPlatforms(mapPlatformsToResponse(entity.getSupportedPlatforms()))
                 .scriptIds(entity.getScriptIds())
+                .trigger(defaultTrigger(entity.getTrigger()).name())
                 .startAt(entity.getStartAt())
                 .repeat(entity.getRepeat())
                 .nextRunAt(entity.getNextRunAt())

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
@@ -15,6 +15,7 @@ import com.openframe.core.exception.BadRequestException;
 import com.openframe.core.exception.ConflictException;
 import com.openframe.core.exception.NotFoundException;
 import com.openframe.data.document.rmm.ScriptSchedule;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import com.openframe.data.document.rmm.ScriptStatus;
 import com.openframe.data.document.rmm.filter.ScriptScheduleQueryFilter;
 import com.openframe.data.repository.rmm.ScriptScheduleRepository;
@@ -68,11 +69,12 @@ public class ScriptScheduleService {
             throw new ConflictException("Script schedule with name '" + input.getName() + "' already exists");
         }
 
-        validateGrid(input.getStartAt(), input.getRepeat());
+        ScriptScheduleTrigger trigger = defaultTrigger(input.getTrigger());
+        validateTiming(trigger, input.getStartAt(), input.getRepeat());
 
         ScriptSchedule entity = scheduleMapper.toEntity(tenantId, input);
         entity.setCreatedBy(createdBy);
-        entity.setNextRunAt(entity.getStartAt());
+        entity.setNextRunAt(trigger == ScriptScheduleTrigger.DATE_TIME ? entity.getStartAt() : null);
         ScriptSchedule saved = scheduleRepository.save(entity);
         log.info("Created script schedule id={} name='{}' tenantId={}", saved.getId(), saved.getName(), tenantId);
         return scheduleMapper.toResponse(saved);
@@ -190,12 +192,17 @@ public class ScriptScheduleService {
             throw new ConflictException("Script schedule with name '" + input.getName() + "' already exists");
         }
 
-        validateGrid(input.getStartAt(), input.getRepeat());
+        ScriptScheduleTrigger trigger = defaultTrigger(input.getTrigger());
+        validateTiming(trigger, input.getStartAt(), input.getRepeat());
 
         Instant priorStartAt = existing.getStartAt();
         scheduleMapper.updateEntity(existing, input);
-        if (!Objects.equals(priorStartAt, existing.getStartAt())) {
-            existing.setNextRunAt(existing.getStartAt());
+        if (trigger == ScriptScheduleTrigger.DATE_TIME) {
+            if (!Objects.equals(priorStartAt, existing.getStartAt())) {
+                existing.setNextRunAt(existing.getStartAt());
+            }
+        } else {
+            existing.setNextRunAt(null);   // event-driven: never on the timer grid
         }
         ScriptSchedule saved = scheduleRepository.save(existing);
         log.info("Updated script schedule id={} tenantId={}", saved.getId(), tenantId);
@@ -249,6 +256,21 @@ public class ScriptScheduleService {
         ScriptSchedule saved = scheduleRepository.save(existing);
         log.info("Script schedule id={} tenantId={} status changed to {}", id, tenantId, target);
         return scheduleMapper.toResponse(saved);
+    }
+
+    private static ScriptScheduleTrigger defaultTrigger(ScriptScheduleTrigger trigger) {
+        return trigger != null ? trigger : ScriptScheduleTrigger.DATE_TIME;
+    }
+
+    private static void validateTiming(ScriptScheduleTrigger trigger, Instant startAt, Long repeatSeconds) {
+        if (trigger == ScriptScheduleTrigger.DEVICE_ONLINE) {
+            if (startAt != null || repeatSeconds != null) {
+                throw new BadRequestException(
+                        "A DEVICE_ONLINE schedule is event-triggered and must not set startAt or repeat");
+            }
+            return;
+        }
+        validateGrid(startAt, repeatSeconds);
     }
 
     private static void validateGrid(Instant startAt, Long repeatSeconds) {

--- a/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
@@ -58,7 +58,9 @@ type ScriptSchedule implements Node {
     name: String!
     description: String
     supportedPlatforms: [ScriptPlatform!]
-    """First scheduled run as an absolute UTC instant (the dashboard's Date + Time). Null if the schedule has no timing set."""
+    """What fires this schedule: DATE_TIME (time-driven, uses startAt/repeat) or DEVICE_ONLINE (event-driven, fires when an assigned device comes online). Never null."""
+    trigger: ScriptScheduleTrigger!
+    """First scheduled run as an absolute UTC instant (the dashboard's Date + Time). Null if the schedule has no timing set (always null for DEVICE_ONLINE)."""
     startAt: Instant
     """Recurrence interval in seconds. Null for a one-shot schedule that fires once at startAt."""
     repeat: Long
@@ -79,6 +81,11 @@ type ScriptSchedule implements Node {
     updatedAt: Instant
     """The creating user (resolved from the internal createdBy id via the user DataLoader)."""
     author: User
+}
+
+enum ScriptScheduleTrigger {
+    DATE_TIME
+    DEVICE_ONLINE
 }
 
 type ScriptScheduleConnection {
@@ -105,6 +112,7 @@ input CreateScriptScheduleInput {
     supportedPlatforms: [ScriptPlatform!]
     "Ids of existing Scripts to run, in run order."
     scriptIds: [ID!]
+    trigger: ScriptScheduleTrigger!
     "First scheduled run as an absolute UTC instant. Must fall on a 30-minute boundary (xx:00 or xx:30). Optional; a schedule with no startAt is never run until one is set."
     startAt: Instant
     "Recurrence interval in seconds. Must be a whole number of 30-minute slots (1800, 3600, 5400, …); the runner ticks on that grid. Null means run once at startAt."
@@ -121,6 +129,7 @@ input UpdateScriptScheduleInput {
     description: String
     supportedPlatforms: [ScriptPlatform!]
     scriptIds: [ID!]
+    trigger: ScriptScheduleTrigger!
     "First scheduled run (absolute UTC instant). Must fall on a 30-minute boundary (xx:00 or xx:30). PUT semantics: null clears the timing; changing it reschedules the next run."
     startAt: Instant
     "Recurrence interval in seconds. Must be a whole number of 30-minute slots (1800, 3600, 5400, …). Null clears recurrence (one-shot)."

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
@@ -15,6 +15,7 @@ import com.openframe.core.exception.ConflictException;
 import com.openframe.core.exception.NotFoundException;
 import com.openframe.data.document.rmm.ScriptPlatform;
 import com.openframe.data.document.rmm.ScriptSchedule;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import com.openframe.data.document.rmm.ScriptStatus;
 import com.openframe.data.document.rmm.filter.ScriptScheduleQueryFilter;
 import com.openframe.data.repository.rmm.ScriptScheduleRepository;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.Sort;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -429,6 +429,80 @@ class ScriptScheduleServiceTest {
             createInput.setRepeat(repeat);
             assertThat(scheduleService.create(createInput, "user-1").getRepeat()).isEqualTo(repeat);
         }
+    }
+
+    @Test
+    @DisplayName("create: a null trigger defaults to DATE_TIME")
+    void create_nullTrigger_defaultsToDateTime() {
+        when(scheduleRepository.existsByTenantIdAndNameAndStatusIn(any(), any(), any())).thenReturn(false);
+        when(scheduleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        assertThat(scheduleService.create(createInput, "user-1").getTrigger()).isEqualTo("DATE_TIME");
+    }
+
+    @Test
+    @DisplayName("create: DEVICE_ONLINE with no timing → saved with the trigger and a null nextRunAt (never on the timer grid)")
+    void create_deviceOnline_noTiming() {
+        createInput.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);
+        when(scheduleRepository.existsByTenantIdAndNameAndStatusIn(any(), any(), any())).thenReturn(false);
+        when(scheduleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        ScriptScheduleResponse result = scheduleService.create(createInput, "user-1");
+
+        assertThat(result.getTrigger()).isEqualTo("DEVICE_ONLINE");
+        ArgumentCaptor<ScriptSchedule> saved = ArgumentCaptor.forClass(ScriptSchedule.class);
+        verify(scheduleRepository).save(saved.capture());
+        assertThat(saved.getValue().getTrigger()).isEqualTo(ScriptScheduleTrigger.DEVICE_ONLINE);
+        assertThat(saved.getValue().getNextRunAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("create: DEVICE_ONLINE that also sets startAt is rejected — event-triggered schedules carry no timing")
+    void create_deviceOnline_withStartAt_rejected() {
+        createInput.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);
+        createInput.setStartAt(Instant.parse("2026-09-15T02:00:00Z"));
+        when(scheduleRepository.existsByTenantIdAndNameAndStatusIn(any(), any(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> scheduleService.create(createInput, "user-1"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("DEVICE_ONLINE");
+        verify(scheduleRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("create: DEVICE_ONLINE that also sets repeat is rejected")
+    void create_deviceOnline_withRepeat_rejected() {
+        createInput.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);
+        createInput.setRepeat(1800L);
+        when(scheduleRepository.existsByTenantIdAndNameAndStatusIn(any(), any(), any())).thenReturn(false);
+
+        assertThatThrownBy(() -> scheduleService.create(createInput, "user-1"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("DEVICE_ONLINE");
+        verify(scheduleRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("update: switching a DATE_TIME schedule to DEVICE_ONLINE clears nextRunAt and stores the trigger")
+    void update_toDeviceOnline_clearsNextRun() {
+        ScriptSchedule existing = active();
+        existing.setName("Nightly Maintenance");
+        existing.setTrigger(ScriptScheduleTrigger.DATE_TIME);
+        existing.setStartAt(Instant.parse("2026-09-15T02:00:00Z"));
+        existing.setNextRunAt(Instant.parse("2026-09-15T02:00:00Z"));
+        when(scheduleRepository.findByTenantIdAndId(TENANT_ID, SCHEDULE_ID)).thenReturn(Optional.of(existing));
+        when(scheduleRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        UpdateScriptScheduleInput input = new UpdateScriptScheduleInput();
+        input.setId(SCHEDULE_ID);
+        input.setName("Nightly Maintenance");
+        input.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);   // no startAt/repeat
+
+        ScriptScheduleResponse result = scheduleService.update(input);
+
+        assertThat(result.getTrigger()).isEqualTo("DEVICE_ONLINE");
+        assertThat(existing.getTrigger()).isEqualTo(ScriptScheduleTrigger.DEVICE_ONLINE);
+        assertThat(existing.getNextRunAt()).isNull();
     }
 
 

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptSchedule.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptSchedule.java
@@ -46,6 +46,9 @@ public class ScriptSchedule implements TenantScoped {
     private List<ScriptPlatform> supportedPlatforms;
     private List<String> scriptIds;
 
+    @Builder.Default
+    private ScriptScheduleTrigger trigger = ScriptScheduleTrigger.DATE_TIME;
+
     private Instant startAt;
 
     private Long repeat;

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptScheduleTrigger.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptScheduleTrigger.java
@@ -1,19 +1,5 @@
 package com.openframe.data.document.rmm;
 
-/**
- * What causes a {@link ScriptSchedule} to fire.
- *
- * <ul>
- *   <li>{@link #DATE_TIME} — time-driven: the management runner fires it on the
- *       half-hour grid from {@code startAt} + {@code repeat} (via {@code nextRunAt}).</li>
- *   <li>{@link #DEVICE_ONLINE} — event-driven: fires when an assigned device comes
- *       online. It has no timing ({@code startAt}/{@code repeat}/{@code nextRunAt} stay
- *       null) so the time-driven runner never picks it up.</li>
- * </ul>
- *
- * <p>A {@code null} trigger on a stored document is treated as {@link #DATE_TIME}
- * (backward compatibility with schedules created before this field existed).
- */
 public enum ScriptScheduleTrigger {
     DATE_TIME,
     DEVICE_ONLINE

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptScheduleTrigger.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptScheduleTrigger.java
@@ -1,0 +1,20 @@
+package com.openframe.data.document.rmm;
+
+/**
+ * What causes a {@link ScriptSchedule} to fire.
+ *
+ * <ul>
+ *   <li>{@link #DATE_TIME} — time-driven: the management runner fires it on the
+ *       half-hour grid from {@code startAt} + {@code repeat} (via {@code nextRunAt}).</li>
+ *   <li>{@link #DEVICE_ONLINE} — event-driven: fires when an assigned device comes
+ *       online. It has no timing ({@code startAt}/{@code repeat}/{@code nextRunAt} stay
+ *       null) so the time-driven runner never picks it up.</li>
+ * </ul>
+ *
+ * <p>A {@code null} trigger on a stored document is treated as {@link #DATE_TIME}
+ * (backward compatibility with schedules created before this field existed).
+ */
+public enum ScriptScheduleTrigger {
+    DATE_TIME,
+    DEVICE_ONLINE
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for time-based and device-online script schedule triggers.
  * Schedule responses now show the selected trigger type.
  * Device-online schedules can run without a start time or recurrence.
  * Time-based schedules continue to support start times and recurrence settings.

* **Bug Fixes**
  * Invalid trigger and timing combinations are now rejected.
  * Missing triggers default to time-based scheduling where applicable.
  * Updating a schedule to device-online clears its next scheduled run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->