### PR TITLE
fix(push): set aps.sound=default so iOS notifications make a sound

### DIFF
--- a/openframe-notification-push/src/main/java/com/openframe/notification/push/FcmPushSender.java
+++ b/openframe-notification-push/src/main/java/com/openframe/notification/push/FcmPushSender.java
@@ -90,7 +90,6 @@ public class FcmPushSender implements NotificationChannel {
                         .setTitle(truncateToBytes(notification.getTitle(), properties.getMaxTitleBytes()))
                         .setBody(truncateToBytes(notification.getDescription(), properties.getMaxBodyBytes()))
                         .build())
-                // iOS plays no sound unless aps.sound is set; Android takes sound from the channel
                 .setApnsConfig(ApnsConfig.builder()
                         .setAps(Aps.builder().setSound("default").build())
                         .build())

--- a/openframe-notification-push/src/main/java/com/openframe/notification/push/FcmPushSender.java
+++ b/openframe-notification-push/src/main/java/com/openframe/notification/push/FcmPushSender.java
@@ -2,6 +2,8 @@ package com.openframe.notification.push;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
@@ -87,6 +89,10 @@ public class FcmPushSender implements NotificationChannel {
                 .setNotification(com.google.firebase.messaging.Notification.builder()
                         .setTitle(truncateToBytes(notification.getTitle(), properties.getMaxTitleBytes()))
                         .setBody(truncateToBytes(notification.getDescription(), properties.getMaxBodyBytes()))
+                        .build())
+                // iOS plays no sound unless aps.sound is set; Android takes sound from the channel
+                .setApnsConfig(ApnsConfig.builder()
+                        .setAps(Aps.builder().setSound("default").build())
                         .build())
                 .putAllData(data)
                 .build();

--- a/openframe-notification-push/src/test/java/com/openframe/notification/push/FcmPushSenderTest.java
+++ b/openframe-notification-push/src/test/java/com/openframe/notification/push/FcmPushSenderTest.java
@@ -177,7 +177,7 @@ class FcmPushSenderTest {
     @Test
     @DisplayName("Given any push, when it is sent, then the APNs payload carries aps.sound=default — iOS stays silent without it, while Android takes its sound from the notification channel")
     void ios_push_carries_default_sound() throws Exception {
-        when(deviceRepository.findByUserId("u1")).thenReturn(List.of(device("tok-a")));
+        when(deviceRepository.findByUserId("u1")).thenReturn(List.of(device("tok-a", PushPlatform.IOS)));
         BatchResponse delivered = batch(0, List.of(success()));
         when(firebaseMessaging.sendEachForMulticast(any())).thenReturn(delivered);
 
@@ -214,7 +214,11 @@ class FcmPushSenderTest {
     }
 
     private static PushDevice device(String token) {
-        return PushDevice.builder().token(token).userId("u1").platform(PushPlatform.ANDROID).build();
+        return device(token, PushPlatform.ANDROID);
+    }
+
+    private static PushDevice device(String token, PushPlatform platform) {
+        return PushDevice.builder().token(token).userId("u1").platform(platform).build();
     }
 
     private static BatchResponse batch(int failureCount, List<SendResponse> responses) {

--- a/openframe-notification-push/src/test/java/com/openframe/notification/push/FcmPushSenderTest.java
+++ b/openframe-notification-push/src/test/java/com/openframe/notification/push/FcmPushSenderTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -171,6 +172,35 @@ class FcmPushSenderTest {
         assertThat(data).doesNotContainKey("context");
         assertThat(data).containsEntry("notificationId", "notif-1")
                 .containsEntry("type", "TICKET_ASSIGNED");
+    }
+
+    @Test
+    @DisplayName("Given any push, when it is sent, then the APNs payload carries aps.sound=default — iOS stays silent without it, while Android takes its sound from the notification channel")
+    void ios_push_carries_default_sound() throws Exception {
+        when(deviceRepository.findByUserId("u1")).thenReturn(List.of(device("tok-a")));
+        BatchResponse delivered = batch(0, List.of(success()));
+        when(firebaseMessaging.sendEachForMulticast(any())).thenReturn(delivered);
+
+        sender.deliver("u1", notification(), NotificationCategory.TICKETS);
+
+        ArgumentCaptor<MulticastMessage> captor = ArgumentCaptor.forClass(MulticastMessage.class);
+        verify(firebaseMessaging).sendEachForMulticast(captor.capture());
+        assertThat(apsSound(captor.getValue())).isEqualTo("default");
+    }
+
+    // firebase-admin exposes no getters for ApnsConfig; reach into its internals (pinned 9.9.0).
+    // ApnsConfig renders the Aps into payload["aps"] as a plain map, so sound sits right there.
+    private static Object apsSound(MulticastMessage message) throws Exception {
+        Object apnsConfig = field(message, "apnsConfig");
+        assertThat(apnsConfig).as("apnsConfig must be set so iOS makes a sound").isNotNull();
+        Map<?, ?> aps = (Map<?, ?>) ((Map<?, ?>) field(apnsConfig, "payload")).get("aps");
+        return aps.get("sound");
+    }
+
+    private static Object field(Object target, String name) throws Exception {
+        Field f = target.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(target);
     }
 
     private static Notification notification() {


### PR DESCRIPTION
## Problem
iOS notifications arrive **silently** — banner shows, no sound. Android is fine.

## Cause
`FcmPushSender.sendChunk` builds the message with a top-level `notification` (title/body) + `data`, but no `ApnsConfig`. FCM relays the notification into APNs `aps.alert`, but does **not** set `aps.sound` on its own, so iOS plays nothing. Android takes its sound from the notification channel, so it was never affected.

## Fix
Attach `ApnsConfig` with `aps.sound = "default"` to the multicast. One insertion in `sendChunk`; Android behaviour unchanged; `badge` intentionally left out (v1 decision — needs an unread counter).

## Test
`FcmPushSenderTest.ios_push_carries_default_sound` captures the sent `MulticastMessage` and asserts the APNs payload carries `aps.sound=default` (firebase-admin has no getters, so it reads the pinned-9.9.0 internals). Full module suite green locally (18 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKdcCJmnHipDNZe1qYqp9H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * iOS push notifications now play the device’s default notification sound.
  * Added coverage to verify the sound setting is included in notification payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->