### PR TITLE
fix(announcement-bar): restore the 44px single-line strip in the shared view

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -183,13 +183,10 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
       style={{ gridTemplateRows: expanded ? '1fr' : '0fr' }}
     >
       {/*
-        Markup is the shared pure view (AnnouncementBarView, Figma
-        9364-40603 / 9418-43969 / 9418-44006): one row from `md` (800px) up,
-        stacked below it with the CTA stretched full-width next to the
-        content-width dismiss. The CTA Button is now rendered on EVERY
-        breakpoint (it replaced the old whole-bar mobile tap target, which
-        also retires the 768px window.innerWidth check that disagreed with
-        the md:800px breakpoint).
+        Markup is the shared pure view (AnnouncementBarView), which carries the
+        bar's anatomy: ONE line of text inside a 44px strip, ONE compact CTA on
+        the right (hidden below `md`, where the content row is the tap target),
+        and a ghost-icon dismiss. Surface + content treatment stay here.
       */}
       <div
         className={`min-h-0 overflow-hidden ${themeScope}`}
@@ -197,6 +194,8 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
       >
         <AnnouncementBarView
           className="text-[color:var(--color-text-primary)]"
+          contentClassName={hasCta ? 'cursor-pointer md:cursor-default' : undefined}
+          onContentClick={hasCta ? handleCtaClick : undefined}
           startAdornment={
             /* ONE unified icon path (shared with the chat): uploaded image URL
                wins, else a library glyph by name (+ props), via <EntityIcon>. */
@@ -207,23 +206,21 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
                 props: displayAnnouncement.icon_props,
               }}
               size={24}
-              // `!` is required: logo glyphs (LogoOpenframeIcon / sizedLogo in
-              // icon-library) drive their size via an inline style, which beats
-              // a plain class — author !important beats the inline style, so
-              // the responsive token (16px < md, 24px from md) wins everywhere.
-              className="relative !size-[var(--icon-size-icon-size)] shrink-0"
+              // 20px below `md`, 24px from `md` up. `!` is required: logo
+              // glyphs (LogoOpenframeIcon / sizedLogo in icon-library) drive
+              // their size via an inline style, which a plain class loses to.
+              // Not `--icon-size-icon-size` — that token is 16/24 and would
+              // shrink the mobile glyph.
+              className="relative !size-5 shrink-0 md:!size-6"
             />
           }
           title={
-            /* Single-line message: title + description inline, truncating as
-               one unit. Type per the ODS mockup (2862-8391): the "h3 body @
-               500" Figma style maps to the code's `.text-h4` utility (the
-               `.text-h3` utility is 700; h3/h4 body share the same size
-               tokens) — the same treatment string titles get from the view.
-               Description keeps opacity-80 for hierarchy. Separator is a
-               middot (house rule: no en/em dashes in copy). */
-            <p className="min-w-0 max-w-full text-h4 truncate mb-0">
-              <span>{displayAnnouncement.title}</span>
+            /* Single-line message: bold title + regular description inline,
+               truncating as one unit, at the strip's caption scale (`text-h6`
+               = 13/14px — the same treatment string titles get from the view).
+               Separator is a middot (house rule: no en/em dashes in copy). */
+            <p className="min-w-0 max-w-full text-h6 truncate mb-0">
+              <span className="font-semibold">{displayAnnouncement.title}</span>
               {displayAnnouncement.description && (
                 <span className="hidden sm:inline opacity-80"> · {displayAnnouncement.description}</span>
               )}
@@ -236,7 +233,9 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
                announcement colors are data, not token surfaces). Inline
                styles win over the variant's hover classes on every state,
                so hover feedback is opacity (the bar's original treatment);
-               nothing can render dark-on-dark.
+               nothing can render dark-on-dark. The view CSS-hides it below
+               `md`, where the whole content row is the tap target — this
+               Button stays the keyboard/AT path (known tradeoff).
 
                Geometry + type come from the design system's size="compact"
                (24px caption-scale pill for slim strips — rationale documented

--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -3,92 +3,99 @@
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { cn } from '../../utils/cn';
 
+/**
+ * Mirrors `screens.md` in tailwind.config.ts (800px), which is also where the
+ * ODS responsive tokens step up (ods-responsive-tokens.css). ONE breakpoint
+ * for the whole bar: the `md:` variants below and the `onContentClick` guard
+ * must never disagree (they did before — the guard read a stale 768px while
+ * the CSS switched at 800px).
+ */
+const MD_QUERY = '(min-width: 800px)';
+
 export interface AnnouncementBarViewProps {
   /**
-   * Leading slot — typically an icon. Rendered before the title. Per the
-   * mockup icons are 16px below `md` and 24px from `md` up — size them with
-   * the responsive token: `size-[var(--icon-size-icon-size)]`.
+   * Leading slot — typically an icon, at content width before the title. Size
+   * it in the slot: the bar's icon runs 20px below `md` and 24px from `md` up,
+   * and no ODS icon token carries that pair (`--icon-size-icon-size` is 16/24).
    */
   startAdornment?: ReactNode;
   /**
-   * Bar message. A plain string gets the mockup's text treatment (`text-h4`,
-   * single line from `md` up, wrapping below); pass a ReactElement to fully
-   * own the markup/typography (e.g. bold title + inline description).
+   * Bar message, always ONE line. A plain string gets the strip's text
+   * treatment (`text-h6`, truncating); pass a ReactElement to own the markup
+   * (e.g. bold title + inline description truncating as one unit).
    */
   title?: string | ReactElement;
   /**
-   * Primary CTA. From `md` up it sits at content width in one trailing
-   * container with `endAdornment`; below `md` it drops to its own
-   * full-width second row (Figma ODS 2862-8391). Omit it entirely to
-   * collapse that row — the bar height then follows the remaining content.
+   * Primary CTA, at content width after the title. Hidden below `md`, where
+   * the content row becomes the tap target instead (`onContentClick`) — the
+   * banner pattern's touch-first tradeoff.
    */
   actionBlock?: ReactElement;
-  /**
-   * Trailing slot (e.g. a dismiss button). Always keeps its content width:
-   * inline after the title below `md` (and on every breakpoint when there is
-   * no `actionBlock`), after the action from `md` up. NOTE: with an
-   * `actionBlock` present the element is mounted twice (one copy per
-   * breakpoint, the inactive one `display:none`) — keep it stateless.
-   */
+  /** Trailing slot (e.g. a dismiss button). Outside the tap target, every breakpoint. */
   endAdornment?: ReactElement;
+  /**
+   * Below `md` only: fires when the content row is tapped, standing in for the
+   * `actionBlock` that is CSS-hidden at that width. No-op from `md` up, where
+   * the CTA is visible and owns the interaction.
+   */
+  onContentClick?: () => void;
+  /** Extra classes for the padded content row (e.g. a cursor affordance). */
+  contentClassName?: string;
   /** Surface styling (background, text color, theme scope) is the consumer's — pass it here. */
   className?: string;
   style?: CSSProperties;
 }
 
 /**
- * Pure presentational announcement/notification bar (Figma 9364-40603 desktop,
- * 9418-43969 tablet, ODS 2862-8391 mobile). No data fetching, storage, or
- * navigation — consumers own state and pass content through slots.
+ * Pure presentational announcement/notification bar. No data fetching,
+ * storage, or navigation — consumers own state and pass content through slots.
  *
- * Layout: `md` (800px) and up is a single row — `startAdornment` + title
- * (flex-1, truncating) + trailing container (`actionBlock` + `endAdornment`)
- * at content width. Below `md`: `startAdornment` + wrapping title +
- * `endAdornment` share the first row (top-aligned so a two-line title keeps
- * the adornments on line one, each centered in a line-height box), and the
- * action alone stretches across its own second row. No action → no second
- * row; the bar height follows the content. Spacing/typography use responsive
- * ODS tokens, so paddings and font sizes track the breakpoint automatically.
+ * Anatomy follows the announcement-bar industry standard: ONE line of text at
+ * 13-14px inside a 44px-tall strip (guides converge on 40-60px with a single
+ * sentence; two stacked 18px rows blow past that), ONE compact CTA on the
+ * right, and a trailing dismiss slot. Spacing is the ODS responsive tokens,
+ * which step at the same 800px as `md`: `l` = 16/24px edge padding, `s` =
+ * 8/12px gap, `m` = CTA offset, `xs` = 4/8px.
  */
 export function AnnouncementBarView({
   startAdornment,
   title,
   actionBlock,
   endAdornment,
+  onContentClick,
+  contentClassName,
   className,
   style,
 }: AnnouncementBarViewProps) {
-  // Below `md` adornments center inside a box matching the title's first
-  // text line (20px), so `items-start` keeps them on line one of a wrapped
-  // title without hugging the row's top edge. From `md` up the row is
-  // single-line and center-aligned, so the boxes dissolve (`h-auto`).
-  const adornmentBox = 'flex h-5 shrink-0 items-center md:h-auto';
+  const handleContentClick = onContentClick
+    ? () => {
+        if (!window.matchMedia(MD_QUERY).matches) onContentClick();
+      }
+    : undefined;
 
   return (
-    <div
-      className={cn(
-        'flex w-full flex-col gap-[var(--spacing-system-s)] px-[var(--spacing-system-l)] py-[var(--spacing-system-sf)] md:flex-row md:items-center',
-        className,
-      )}
-      style={style}
-    >
-      <div className="flex min-w-0 flex-1 items-start gap-[var(--spacing-system-s)] md:items-center">
-        {startAdornment && <div className={adornmentBox}>{startAdornment}</div>}
-        {typeof title === 'string' ? (
-          <p className="min-w-0 flex-1 break-words text-h4 md:truncate">{title}</p>
-        ) : (
-          title != null && <div className="min-w-0 flex-1">{title}</div>
+    <div className={cn('flex w-full max-w-full min-h-11 items-center', className)} style={style}>
+      {/* Content row — the tap target below `md`, where the CTA is hidden.
+          Its vertical padding never drives the height; the 44px strip does. */}
+      <div
+        className={cn(
+          'flex min-w-0 flex-1 flex-row items-center gap-[var(--spacing-system-s)] py-[var(--spacing-system-xs)] pl-[var(--spacing-system-l)]',
+          contentClassName,
         )}
-        {/* Mobile home of the trailing adornment — and its only home when
-            there is no action row to share from `md` up. */}
-        {endAdornment && <div className={cn(adornmentBox, actionBlock && 'md:hidden')}>{endAdornment}</div>}
+        onClick={handleContentClick}
+      >
+        {startAdornment && <div className="flex shrink-0 items-center">{startAdornment}</div>}
+        {typeof title === 'string' ? (
+          <p className="mb-0 min-w-0 max-w-full flex-1 truncate text-h6">{title}</p>
+        ) : (
+          title != null && <div className="min-w-0 max-w-full flex-1">{title}</div>
+        )}
+        {actionBlock && <div className="ml-[var(--spacing-system-m)] hidden shrink-0 md:flex">{actionBlock}</div>}
       </div>
-      {actionBlock && (
-        <div className="flex w-full shrink-0 items-center gap-[var(--spacing-system-s)] md:w-auto">
-          <div className="flex min-w-0 flex-1 md:flex-none [&>*]:w-full md:[&>*]:w-auto">{actionBlock}</div>
-          {endAdornment && <div className="hidden shrink-0 md:flex">{endAdornment}</div>}
-        </div>
-      )}
+      {/* Trailing slot. The right edge runs 8/16px — no ODS spacing token
+          carries that pair, and the slot's own 32px hit box optically
+          re-centers it against the 16/24px left edge. */}
+      {endAdornment && <div className="ml-[var(--spacing-system-xs)] mr-2 shrink-0 md:mr-4">{endAdornment}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## What

#1529 extracted `AnnouncementBarView` (good) but rebuilt the bar to a Figma mockup, which changed the shipped design. This keeps the extraction and restores the bar's anatomy.

| | after #1529 | this PR |
|---|---|---|
| Strip | 56px, stacked below `md` | **44px `min-h-11`, one row at every breakpoint** |
| Title | `text-h4`, plain weight | **`text-h6`, bold title + inline description** |
| CTA | full-width second row on mobile | **compact pill on the right, `hidden md:flex`** |
| Mobile | CTA button | **content row is the tap target** |
| Icon | 16px → 24px | **20px → 24px** |

The anatomy follows the announcement-bar industry standard: one line of text at 13-14px inside a 44px strip (guides converge on 40-60px with a single sentence), one compact CTA, one ghost-icon dismiss. That now lives *in the shared view*, so the pattern is what gets reused rather than a one-off mockup.

## Geometry is token-driven

The ODS responsive tokens land exactly on the original values, so there are no hand-written breakpoint classes for spacing:

| Original | px (mobile → md) | Token |
|---|---|---|
| `pl-4 md:pl-6` | 16 → 24 | `--spacing-system-l` |
| `gap-2 md:gap-3` | 8 → 12 | `--spacing-system-s` |
| `md:ml-4` (CTA) | 16 | `--spacing-system-m` |
| `ml-1 md:ml-2` (dismiss) | 4 → 8 | `--spacing-system-xs` |

Two pairs have no matching token and stay explicit, each with a comment saying why: the **20/24px icon** (`--icon-size-icon-size` is 16/24 and would shrink the mobile glyph) and the **8/16px right edge**.

## Kept from #1529

- The `ods-colors.css` Tier-2 re-anchor, so the bar uses semantic `--color-*` aliases instead of reaching for Tier-1 primitives inside its theme island.
- The author-`!important` icon size class — logo glyphs (`LogoOpenframeIcon` / `sizedLogo`) set their size via an inline style that a plain class loses to.
- The 768-vs-800 breakpoint fix. The old whole-bar tap guard read `window.innerWidth < 768` while the CSS switched at `md` = 800px. There is now one `MD_QUERY` constant in the view owning both.

## Verification

Live on a hub dev server against the real active announcement, measured in-page:

| | 799px | 1280px | original |
|---|---|---|---|
| Strip height | 44px | 44px | 44px |
| Title | 12px, weight 600, 1 line | 14px, weight 600, truncates | matches |
| Icon | 20x20 | 24x24 | matches |
| Edge padding / gap | 16 / 8 | 24 / 12 | matches |
| CTA | hidden, row is tap target | 24px pill, 16px from title | matches |
| Dismiss | 32px, 8px right edge | 32px, 16px right edge | matches |

Breakpoint agreement checked at 799 and 801: the JS tap guard and the `md:` variants flip together. `tsc --noEmit` clean.

## Note, not addressed here

Mobile title type is **12px**, not the 13px the bar shipped with. That came from #1469 swapping `text-[13px] md:text-sm` for `text-h6`, whose mobile token is 12px, and it is left alone as part of the sanctioned ODS wave. Desktop is unchanged at 14px.

## Follow-up

Hub needs the matching SSR height-seed revert plus a pin bump once this is released: flamingo-stack/multi-platform-hub#906

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Announcement CTAs can now be activated by tapping the announcement content on smaller screens.
  * Announcement bars use a streamlined single-row layout with improved responsive behavior.
  * CTA buttons remain available on larger screens and for keyboard and assistive technology users.

* **Style**
  * Updated announcement title typography, icon sizing, spacing, and responsive presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->