### PR TITLE
feat(ods): add the micro stamp type step, fix StatusBadge button variant

### DIFF
--- a/openframe-frontend-core/src/ODS_TOKEN_RULES.md
+++ b/openframe-frontend-core/src/ODS_TOKEN_RULES.md
@@ -86,6 +86,8 @@ mobile below):
 | `text-h5` | Azeret Mono | 500 (medium) | 14/20 | 14/20 | 12/16 | -0.02em | **uppercase** |
 | `text-h6` | DM Sans | 500 (medium) | 14/20 | 14/20 | 12/16 | 0 | none |
 | `text-code` | Azeret Mono | 500 (medium) | 14/20 | 14/20 | 12/16 | 0 | none |
+| `text-micro-label` | Azeret Mono | 500 (medium) | 10/12 | 10/12 | 10/12 | -0.02em | **uppercase** |
+| `text-micro` | DM Sans | 500 (medium) | 10/12 | 10/12 | 10/12 | 0 | none |
 
 The breakpoint scaling is built into the utilities via the responsive CSS variables
 (`--font-size-h*` / `--font-line-space-h*` in `src/styles/ods-responsive-tokens.css`) — never
@@ -100,6 +102,12 @@ Key distinctions:
 - `text-h1` vs `text-h2`: both Azeret Mono semibold — h1 is the page title, h2 a section sub-title.
 - `text-h3` vs `text-h4`: same size (18px) but h3 is **bold**, h4 is **medium** — h4 for stat values, h3 for bold headings.
 - `text-h5` vs `text-h6`: same size (14px) but h5 is **Azeret Mono uppercase** (section labels like "POLICY TESTING"), h6 is **DM Sans sentence case** (regular labels like "Started", "Duration").
+- `text-micro-label` / `text-micro`: the **stamp scale**, one step below the captions, mirroring the
+  same mono-uppercase vs DM-Sans-sentence-case split. **Badges and chips ONLY** — status badges,
+  count chips, table markers — never reading text. Unlike every other step these are **fixed across
+  breakpoints**: a stamp must stay subordinate to the row it sits in, and growing it on desktop is
+  what balloons badges. Reach for these instead of hardcoding `text-[10px]`; if the text is
+  something a user actually reads, it belongs on `text-h5`/`text-h6` or larger.
 
 ## General
 

--- a/openframe-frontend-core/src/components/ui/status-badge.tsx
+++ b/openframe-frontend-core/src/components/ui/status-badge.tsx
@@ -9,8 +9,15 @@ const statusBadgeVariants = cva(
   {
     variants: {
       variant: {
+        // The two variants are two DENSITIES, not one style at two paddings:
+        // `card` is the caption-scale badge that stands on its own (14/20),
+        // `button` is the dense inline stamp that must stay subordinate to
+        // the row it sits in (10/12, fixed). Both are Azeret Mono uppercase.
+        // Keep them on different type steps — collapsing `button` onto the
+        // caption step doubled every stamp's box height (its 20px line-height
+        // against the stamp's 10px), which is exactly what regressed here.
         card: "px-3 py-1.5 text-h5",
-        button: "px-2 py-0.5 text-h5",
+        button: "px-2 py-0.5 text-micro-label",
       },
       colorScheme: {
         cyan: "bg-[var(--ods-flamingo-cyan-base)] text-ods-text-on-accent",

--- a/openframe-frontend-core/src/styles/ods-responsive-tokens.css
+++ b/openframe-frontend-core/src/styles/ods-responsive-tokens.css
@@ -48,6 +48,18 @@
   --font-line-space-h5-caption: 1rem;         /* 16px */
   --font-line-space-h6-caption: 1rem;         /* 16px */
 
+  /* MICRO — the stamp scale, below the h5/h6 caption step. For badges and
+   * chips only: dense inline stamps whose box must stay short (status
+   * badges, count chips, table markers). NOT for reading text.
+   *
+   * Deliberately FIXED across breakpoints (no override in the tablet/desktop
+   * blocks below): a stamp's job is to stay visually subordinate to the row
+   * it sits in, and growing it on desktop is what made badges balloon when
+   * hardcoded 10px labels were migrated to the caption step. Same rationale
+   * as the `f` ("fixed") spacing variants. */
+  --font-size-micro: 0.625rem;                /* 10px */
+  --font-line-space-micro: 0.75rem;           /* 12px */
+
   /* =================================================== */
   /* RESPONSIVE ICON SYSTEM */
   /* =================================================== */

--- a/openframe-frontend-core/tailwind.config.ts
+++ b/openframe-frontend-core/tailwind.config.ts
@@ -55,6 +55,26 @@ const odsTypographyPlugin = plugin(({ addUtilities }) => {
       fontSize: 'var(--font-size-h6-caption)',
       lineHeight: 'var(--font-line-space-h6-caption)',
     },
+    // MICRO STAMP SCALE (10/12, fixed across breakpoints) — badges and chips
+    // ONLY, never reading text. Mirrors the h5/h6 split one step down:
+    // `.text-micro-label` is the Azeret Mono uppercase stamp (status badges,
+    // the h5 analog), `.text-micro` is the DM Sans sentence-case chip (count
+    // and marker chips, the h6 analog). Use these instead of hardcoding
+    // `text-[10px]`; anything a user reads belongs on h5/h6 or larger.
+    '.text-micro-label': {
+      fontFamily: 'var(--font-h5-family)',
+      fontWeight: 'var(--font-h5-weight)',
+      fontSize: 'var(--font-size-micro)',
+      lineHeight: 'var(--font-line-space-micro)',
+      textTransform: 'uppercase',
+      letterSpacing: '-0.02em',
+    },
+    '.text-micro': {
+      fontFamily: 'var(--font-h6-family)',
+      fontWeight: 'var(--font-h6-weight)',
+      fontSize: 'var(--font-size-micro)',
+      lineHeight: 'var(--font-line-space-micro)',
+    },
   })
 })
 


### PR DESCRIPTION
## The bug

#1469 migrated `StatusBadge`'s `button` variant from `text-[10px] leading-none` to **`text-h5`** — which is **14/20 on desktop**. Two things broke:

1. Both badge variants landed on the **same** type step, so `card` and `button` became typographically identical. They exist to be two densities.
2. Every inline stamp grew ~40% in text and roughly doubled in box height (the caption step's 20px line-height replacing a 10px `leading-none`).

Measured on the real markup for a two-word label like the cap table's "ESOP Available":

| | height | width | text |
|---|---|---|---|
| before #1469 | 24px | 57px | 10px |
| after #1469 | **44px** | 95px | 14px |
| with this PR (+ `singleLine` at the call site) | 16px | 104px | 10px |

Reported by the user in three places: the hub sliding-menu group chips, the cap-table share types, and the people-hub "Night Owl"/"Weekend Beast" badges.

## Root cause

**ODS had no type step below the 12/14px captions.** A migration converting deliberate 10px micro-labels had nowhere correct to send them, so it rounded all of them up to the smallest caption — here, and at 106 more call sites in the hub.

ODS's own rules already cover this case:

> If Figma uses a token that doesn't exist in ODS, flag it — don't silently hardcode a fallback.

That flag was never raised. This PR adds the missing step rather than reverting to hardcoded px.

## What this adds

| Class | Font | Weight | All breakpoints | Tracking | Transform |
|-------|------|--------|-----------------|----------|-----------|
| `text-micro-label` | Azeret Mono | 500 | 10/12 | -0.02em | uppercase |
| `text-micro` | DM Sans | 500 | 10/12 | 0 | none |

Backed by `--font-size-micro` / `--font-line-space-micro`. The pair mirrors the existing h5-vs-h6 split (mono uppercase label vs DM Sans sentence case) one step down.

**Deliberately fixed across breakpoints** — the only step in the scale that doesn't grow. A stamp's job is to stay subordinate to the row it sits in, and scaling it up on desktop is precisely what balloons badges. Same rationale as the `f` ("fixed") spacing variants.

Scope is documented in `ODS_TOKEN_RULES.md`: **badges and chips only**, never reading text. Anything a user actually reads belongs on `text-h5`/`text-h6` or larger.

`StatusBadge` `button` now uses `text-micro-label`; `card` stays on `text-h5`, so the variants are two densities again.

## Needs a Figma counterpart

This adds a type step that does **not** exist in the Figma design system yet. Flagging per the rule above rather than letting code and design drift: the stamp scale should be added to [Font Sizes Table](https://www.figma.com/design/NYUB1Xe0bJyIuL16aUE81Z/open-design-system?node-id=132-460) with this spec, or tell me the values design prefers and I'll match them.

## Verification

In a running hub with this build linked: `text-micro-label` computes to 10px/12px Azeret Mono 500 uppercase at -0.2px, `text-micro` to 10px/12px DM Sans 500 — against 14px/20px for both h5 and h6. `tsc --noEmit` clean.

## Companion

Hub call-site sweep: flamingo-stack/multi-platform-hub#907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
