### PR TITLE
fix(cn): register text-code and text-badge so tailwind-merge stops dropping them

### DIFF
--- a/openframe-frontend-core/src/utils/cn.ts
+++ b/openframe-frontend-core/src/utils/cn.ts
@@ -6,10 +6,36 @@ import { extendTailwindMerge } from "tailwind-merge"
 // dev-localhost + Vercel-self-origin branches, and delegates its platform branch.
 import { getPlatformProductionUrl } from "../platform-domains"
 
+/**
+ * EVERY custom `text-*` utility we add in `tailwind.config.ts` MUST be listed here.
+ *
+ * tailwind-merge has no knowledge of our utilities, and `text-<word>` is
+ * indistinguishable from a text COLOUR to it. So an unlisted `text-badge` gets
+ * filed in tailwind-merge's `text-color` group, where it and any real colour
+ * class silently annihilate each other — last one wins, the other is dropped
+ * from the output entirely:
+ *
+ *   cn('text-badge', 'text-ods-text-on-accent')  -> 'text-ods-text-on-accent'  (size lost)
+ *   cn('text-[--some-colour]', 'text-badge')     -> 'text-badge'               (colour lost)
+ *
+ * Listing them in their own group makes them non-conflicting with colours, so
+ * both survive. This is why `text-h1`…`text-h6` are here; `text-code` and
+ * `text-badge` were added to the config later and missing them shipped exactly
+ * the two failures above (huge badges, and badge text losing its colour).
+ */
 const twMerge = extendTailwindMerge<'ods-typography'>({
   extend: {
     classGroups: {
-      'ods-typography': ['text-h1', 'text-h2', 'text-h3', 'text-h4', 'text-h5', 'text-h6'],
+      'ods-typography': [
+        'text-h1',
+        'text-h2',
+        'text-h3',
+        'text-h4',
+        'text-h5',
+        'text-h6',
+        'text-code',
+        'text-badge',
+      ],
     },
   },
 })


### PR DESCRIPTION
Fixes both live regressions from #1542. **One root cause, and it is not in the badge code — it is in `cn()`.**

## What broke

#1542 added the `.text-badge` utility but never registered it with `cn()`'s `extendTailwindMerge` class group.

tailwind-merge has no knowledge of our custom utilities, and `text-<word>` is indistinguishable from a text **colour** to it. So `text-badge` got filed in tailwind-merge's `text-color` group — where it and any real colour class silently annihilate each other, last one wins and the other is **dropped from the output entirely**:

```
cn('text-badge', 'text-ods-text-on-accent')            -> 'text-ods-text-on-accent'   size lost
cn('text-[--ods-attention-yellow-warning]','text-badge') -> 'text-badge'              colour lost
```

That is exactly the two symptoms:

| Symptom | Mechanism |
|---|---|
| Sidebar group chips render huge | `StatusBadge`'s `text-badge` dropped by the call site's `text-ods-text-on-accent` → no `font-size` → inherits |
| People-hub "Night Owl" / "Weekend Beast" lose their colour | the call site's colour dropped by `text-badge` → renders white |

Nothing was wrong with the token, the utility, or the call sites — all three compile correctly. The classes were being deleted before they ever reached the DOM.

## Fix

Register `text-badge` in the `ods-typography` class group, so it is non-conflicting with colours and both survive. `text-code` had the same latent bug since it was added and is fixed here too. The group now carries a comment stating the rule: **every custom `text-*` utility added to `tailwind.config.ts` must be listed here.**

## Verification

Against the real class list from the edited source, not a mock:

```
PASS  sidebar StatusBadge   size=true colour=true
PASS  Night Owl             size=true colour=true
PASS  Weekend Beast         size=true colour=true
3/3 pass
```

Also confirmed ordering: Tailwind emits `.text-badge` (line 31) after `.text-xs` (line 5), so at equal specificity the 10px still wins inside `Badge`, which sets `text-xs` on its base.

`tsc --noEmit` clean.

## Follow-up

Needs a release; the hub then only needs a pin bump — no hub source change, its `text-badge` call sites were always correct.
