### PR TITLE
FE CORE: AnnouncementBarView — stable 56px md+ strip, mockup-exact mobile layout, dismissible prop

### DIFF
--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -42,7 +42,12 @@ import { Button } from './ui/button';
  * storage reads happen ONLY in effects (a render-time read would desync
  * hydration in SSR mode).
  */
-export function AnnouncementBar({ initialAnnouncement, previewMode = false, className }: AnnouncementBarProps = {}) {
+export function AnnouncementBar({
+  initialAnnouncement,
+  previewMode = false,
+  dismissible = true,
+  className,
+}: AnnouncementBarProps = {}) {
   // Namespace for the dismissal cookie/legacy keys. Next hosts inline
   // NEXT_PUBLIC_APP_TYPE (matching the server's currentPlatform(), which the
   // hub layout uses for the SSR cookie read); platform-agnostic embeds get
@@ -274,18 +279,22 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
             /* Dismiss - the common Button in its ghost-icon treatment
                (size="icon-sm": 32px target, >= the 24px WCAG 2.5.8 AA floor,
                16px glyph) with the bar's quiet tint hover. Inert in
-               previewMode. */
-            <Button
-              onClick={handleDismiss}
-              variant="transparent"
-              size="icon-sm"
-              className={barButtonClasses}
-              aria-label="Dismiss announcement"
-              type="button"
-              tabIndex={expanded ? 0 : -1}
-            >
-              <X strokeWidth={2} />
-            </Button>
+               previewMode; omitted entirely when the host opts out via
+               `dismissible={false}` (the bar then only disappears by
+               deactivating the announcement). */
+            dismissible ? (
+              <Button
+                onClick={handleDismiss}
+                variant="transparent"
+                size="icon-sm"
+                className={barButtonClasses}
+                aria-label="Dismiss announcement"
+                type="button"
+                tabIndex={expanded ? 0 : -1}
+              >
+                <X strokeWidth={2} />
+              </Button>
+            ) : undefined
           }
         />
       </div>

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -184,9 +184,11 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
     >
       {/*
         Markup is the shared pure view (AnnouncementBarView), which carries the
-        bar's anatomy: ONE line of text inside a 44px strip, ONE compact CTA on
-        the right (hidden below `md`, where the content row is the tap target),
-        and a ghost-icon dismiss. Surface + content treatment stay here.
+        bar's anatomy: one 56px row from `md` up with the compact CTA inline;
+        below `md` a stacked layout with the CTA VISIBLE full-width on its own
+        row and the dismiss up in the content row (Figma 2862-8391 — this
+        replaced the old whole-bar mobile tap target). Surface + content
+        treatment stay here.
       */}
       <div
         className={`min-h-0 overflow-hidden ${themeScope}`}
@@ -194,8 +196,6 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
       >
         <AnnouncementBarView
           className="text-[color:var(--color-text-primary)]"
-          contentClassName={hasCta ? 'cursor-pointer md:cursor-default' : undefined}
-          onContentClick={hasCta ? handleCtaClick : undefined}
           startAdornment={
             /* ONE unified icon path (shared with the chat): uploaded image URL
                wins, else a library glyph by name (+ props), via <EntityIcon>. */
@@ -215,11 +215,13 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
             />
           }
           title={
-            /* Single-line message: bold title + regular description inline,
-               truncating as one unit, at the strip's caption scale (`text-h6`
-               = 13/14px — the same treatment string titles get from the view).
-               Separator is a middot (house rule: no en/em dashes in copy). */
-            <p className="min-w-0 max-w-full text-h6 truncate mb-0">
+            /* Bold title + regular description inline at the mockup's body
+               scale (`text-h4` = DM Sans 500, 14/20 below `md`, 18/24 from
+               `md` up) — wrapping below `md`, truncating as one unit from
+               `md` up (the same responsive pair string titles get from the
+               view). Separator is a middot (house rule: no en/em dashes in
+               copy). */
+            <p className="min-w-0 max-w-full break-words text-h4 md:truncate mb-0">
               <span className="font-[number:var(--font-weight-semibold)]">{displayAnnouncement.title}</span>
               {displayAnnouncement.description && (
                 <span className="hidden sm:inline opacity-80"> · {displayAnnouncement.description}</span>
@@ -233,9 +235,8 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
                announcement colors are data, not token surfaces). Inline
                styles win over the variant's hover classes on every state,
                so hover feedback is opacity (the bar's original treatment);
-               nothing can render dark-on-dark. The view CSS-hides it below
-               `md`, where the whole content row is the tap target — this
-               Button stays the keyboard/AT path (known tradeoff).
+               nothing can render dark-on-dark. The view renders it inline
+               from `md` up and as a visible full-width row below `md`.
 
                Geometry + type come from the design system's size="compact"
                (24px caption-scale pill for slim strips — rationale documented

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -238,15 +238,17 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
                nothing can render dark-on-dark. The view renders it inline
                from `md` up and as a visible full-width row below `md`.
 
-               Geometry + type come from the design system's size="compact"
-               (24px caption-scale pill for slim strips — rationale documented
-               on the variant in button.tsx). */
+               Geometry + type follow the mockup's "button-full" (Figma
+               9418-52494 / 2862-8391): the design system's size="small"
+               (uppercase text-h5 label, 16px glyph) pinned to h-8 — the
+               mockup keeps the 32px height on EVERY breakpoint, while
+               "small" alone drops to 24px below `md`. */
             hasCta && displayAnnouncement.cta_text ? (
               <Button
                 onClick={handleCtaClick}
                 variant="outline"
-                size="compact"
-                className="transition-opacity hover:opacity-90"
+                size="small"
+                className="h-8 transition-opacity hover:opacity-90"
                 style={{
                   backgroundColor:
                     displayAnnouncement.cta_button_background_color || ANNOUNCEMENT_CTA_DEFAULTS.background,
@@ -258,8 +260,8 @@ export function AnnouncementBar({ initialAnnouncement, previewMode = false, clas
                   displayAnnouncement.cta_show_icon && displayAnnouncement.cta_icon_name ? (
                     <EntityIcon
                       icon={{ name: displayAnnouncement.cta_icon_name, props: displayAnnouncement.cta_icon_props }}
-                      size={14}
-                      className="w-3.5 h-3.5"
+                      size={16}
+                      className="w-4 h-4"
                     />
                   ) : undefined
                 }

--- a/openframe-frontend-core/src/components/announcement-bar.tsx
+++ b/openframe-frontend-core/src/components/announcement-bar.tsx
@@ -12,6 +12,7 @@ import {
   isAnnouncementDismissed,
 } from '../utils/announcement-storage';
 import { getAppType } from '../utils/app-config';
+import { cn } from '../utils/cn';
 import { pickReadableTextColor } from '../utils/color-analysis';
 import { EntityIcon } from './icon-display';
 import { AnnouncementBarView } from './ui/announcement-bar-view';
@@ -211,12 +212,12 @@ export function AnnouncementBar({
                 props: displayAnnouncement.icon_props,
               }}
               size={24}
-              // 20px below `md`, 24px from `md` up. `!` is required: logo
-              // glyphs (LogoOpenframeIcon / sizedLogo in icon-library) drive
-              // their size via an inline style, which a plain class loses to.
-              // Not `--icon-size-icon-size` — that token is 16/24 and would
-              // shrink the mobile glyph.
-              className="relative !size-5 shrink-0 md:!size-6"
+              // 16px below `md` (the mockup's mobile glyph — it must not
+              // exceed the 20px title row, Figma 9418-52387 / 2862-8391),
+              // 24px from `md` up. `!` is required: logo glyphs
+              // (LogoOpenframeIcon / sizedLogo in icon-library) drive their
+              // size via an inline style, which a plain class loses to.
+              className="relative !size-4 shrink-0 md:!size-6"
             />
           }
           title={
@@ -276,18 +277,21 @@ export function AnnouncementBar({
             ) : undefined
           }
           endAdornment={
-            /* Dismiss - the common Button in its ghost-icon treatment
-               (size="icon-sm": 32px target, >= the 24px WCAG 2.5.8 AA floor,
-               16px glyph) with the bar's quiet tint hover. Inert in
-               previewMode; omitted entirely when the host opts out via
-               `dismissible={false}` (the bar then only disappears by
-               deactivating the announcement). */
+            /* Dismiss - the common Button in its ghost-icon treatment with
+               the bar's quiet tint hover. Below `md` the mockup pins the
+               close to a 20px box with a 16px glyph so the top row stays
+               20px tall and the stacked bar lands on 76px total (Figma
+               2862-8391 — a deliberate exception to the 24px WCAG 2.5.8
+               target floor); from `md` up it grows back to the standard
+               icon-sm 32px target. Inert in previewMode; omitted entirely
+               when the host opts out via `dismissible={false}` (the bar
+               then only disappears by deactivating the announcement). */
             dismissible ? (
               <Button
                 onClick={handleDismiss}
                 variant="transparent"
                 size="icon-sm"
-                className={barButtonClasses}
+                className={cn('h-5 w-5 p-0 md:h-8 md:w-8', barButtonClasses)}
                 aria-label="Dismiss announcement"
                 type="button"
                 tabIndex={expanded ? 0 : -1}

--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -3,44 +3,29 @@
 import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import { cn } from '../../utils/cn';
 
-/**
- * Mirrors `screens.md` in tailwind.config.ts (800px), which is also where the
- * ODS responsive tokens step up (ods-responsive-tokens.css). ONE breakpoint
- * for the whole bar: the `md:` variants below and the `onContentClick` guard
- * must never disagree (they did before — the guard read a stale 768px while
- * the CSS switched at 800px).
- */
-const MD_QUERY = '(min-width: 800px)';
-
 export interface AnnouncementBarViewProps {
   /**
    * Leading slot — typically an icon, at content width before the title. Size
-   * it in the slot: the bar's icon runs 20px below `md` and 24px from `md` up,
-   * and no ODS icon token carries that pair (`--icon-size-icon-size` is 16/24).
+   * it in the slot: the bar's icon runs 16-20px below `md` and 24px from `md`
+   * up (Figma boxes the mobile glyph at 16px inside a 20px frame).
    */
   startAdornment?: ReactNode;
   /**
-   * Bar message, always ONE line. A plain string gets the strip's text
-   * treatment (`text-h6`, truncating); pass a ReactElement to own the markup
-   * (e.g. bold title + inline description truncating as one unit).
+   * Bar message. A plain string gets the mockup's text treatment (`text-h4` =
+   * DM Sans 500, 14/20 below `md` and 18/24 from `md` up), wrapping below `md`
+   * and truncating to one line from `md` up. Pass a ReactElement to own the
+   * markup (e.g. bold title + inline description) — mirror that responsive
+   * wrap/truncate pair in your element.
    */
   title?: string | ReactElement;
   /**
-   * Primary CTA, at content width after the title. Hidden below `md`, where
-   * the content row becomes the tap target instead (`onContentClick`) — the
-   * banner pattern's touch-first tradeoff.
+   * Primary CTA. From `md` up it sits inline at content width between the
+   * title and `endAdornment`; below `md` it moves to its own full-width row
+   * under the content (Figma 2862-8391) and the bar's height grows to fit.
    */
   actionBlock?: ReactElement;
-  /** Trailing slot (e.g. a dismiss button). Outside the tap target, every breakpoint. */
+  /** Trailing slot (e.g. a dismiss button) — stays in the top/content row on every breakpoint. */
   endAdornment?: ReactElement;
-  /**
-   * Below `md` only: fires when the content row is tapped, standing in for the
-   * `actionBlock` that is CSS-hidden at that width. No-op from `md` up, where
-   * the CTA is visible and owns the interaction.
-   */
-  onContentClick?: () => void;
-  /** Extra classes for the padded content row (e.g. a cursor affordance). */
-  contentClassName?: string;
   /** Surface styling (background, text color, theme scope) is the consumer's — pass it here. */
   className?: string;
   style?: CSSProperties;
@@ -50,69 +35,53 @@ export interface AnnouncementBarViewProps {
  * Pure presentational announcement/notification bar. No data fetching,
  * storage, or navigation — consumers own state and pass content through slots.
  *
- * Anatomy follows the announcement-bar industry standard: ONE line of text at
- * 13-14px inside a slim strip (guides converge on 40-60px with a single
- * sentence; two stacked 18px rows blow past that) — 44px below `md`, 56px from
- * `md` up per Figma 9418-52494 (32px CTA + 12px vertical insets), STABLE with
- * or without the CTA (reserving the full strip means toggling the action never
- * resizes the bar on desktop/tablet) — ONE compact CTA on the right, and a
- * trailing dismiss slot. Spacing is the ODS responsive tokens,
- * which step at the same 800px as `md`: `l` = 16/24px edge padding, `s` =
- * 8/12px gap, `m` = CTA offset, `xs` = 4/8px.
+ * Layout (Figma 9418-52494 desktop/tablet, 2862-8391 mobile):
+ * - `md` (800px) and up: ONE row inside a strip FIXED at 56px (`md:min-h-14`,
+ *   32px CTA + 12px vertical insets) — reserved unconditionally, so toggling
+ *   or removing the action never resizes the bar on desktop/tablet. Title
+ *   truncates to one line.
+ * - Below `md`: the container stacks (`px` 16 / `py` 12 / gap 8). Top row =
+ *   `startAdornment` + wrapping title + `endAdornment`; when an `actionBlock`
+ *   is present it renders as a VISIBLE full-width button on its own second
+ *   row and the bar's height adapts to content (~84px with a single-line
+ *   title and CTA, 44px without one).
+ *
+ * The `actionBlock` element is mounted in both positions (inline `md`-up slot
+ * and the mobile full-width row); exactly one is `display:none` at any width,
+ * so keyboard/AT always reach exactly one control.
  */
 export function AnnouncementBarView({
   startAdornment,
   title,
   actionBlock,
   endAdornment,
-  onContentClick,
-  contentClassName,
   className,
   style,
 }: AnnouncementBarViewProps) {
-  const handleContentClick = onContentClick
-    ? () => {
-        if (!window.matchMedia(MD_QUERY).matches) onContentClick();
-      }
-    : undefined;
-
   return (
-    // From `md` up the strip is a fixed 56px (Figma 9418-52494: 32px CTA +
-    // 12px vertical insets) — reserved unconditionally so removing/hiding the
-    // action never changes the bar's height on desktop/tablet. Below `md` the
-    // CTA is hidden anyway, so the 44px strip stands.
-    <div className={cn('flex w-full max-w-full min-h-11 md:min-h-14 items-center', className)} style={style}>
-      {/* Content row — the tap target below `md`, where the CTA is hidden.
-          Its vertical padding never drives the height; the strip min-h does. */}
-      <div
-        className={cn(
-          'flex min-w-0 flex-1 flex-row items-center gap-[var(--spacing-system-s)] py-[var(--spacing-system-xs)] pl-[var(--spacing-system-l)]',
-          contentClassName,
-        )}
-        onClick={handleContentClick}
-      >
+    <div
+      className={cn(
+        'flex w-full max-w-full flex-col gap-[var(--spacing-system-s)] px-[var(--spacing-system-l)] py-[var(--spacing-system-sf)] md:min-h-14 md:flex-row md:items-center md:py-0',
+        className,
+      )}
+      style={style}
+    >
+      {/* Content row: leading icon + title (+ inline CTA from `md`) + trailing
+          slot. `items-start` below `md` keeps the adornments pinned to the
+          first text line when the title wraps; `md:items-center` re-centers
+          everything in the fixed strip. */}
+      <div className="flex w-full min-w-0 flex-1 items-start gap-[var(--spacing-system-s)] md:w-auto md:items-center">
         {startAdornment && <div className="flex shrink-0 items-center">{startAdornment}</div>}
         {typeof title === 'string' ? (
-          <p className="mb-0 min-w-0 max-w-full flex-1 truncate text-h6">{title}</p>
+          <p className="mb-0 min-w-0 max-w-full flex-1 break-words text-h4 md:truncate">{title}</p>
         ) : (
           title != null && <div className="min-w-0 max-w-full flex-1">{title}</div>
         )}
-        {/* Below `md` the CTA is visually replaced by the row-wide tap target,
-            but a `display:none` button is unreachable by keyboard and AT. So
-            it is only visually hidden there (`sr-only`) and reveals itself on
-            focus — the row stays the touch affordance while Tab still reaches
-            a real, labelled control. `md:` restores the normal inline CTA. */}
-        {actionBlock && (
-          <div className="ml-[var(--spacing-system-m)] sr-only shrink-0 focus-within:not-sr-only md:not-sr-only md:flex">
-            {actionBlock}
-          </div>
-        )}
+        {actionBlock && <div className="hidden shrink-0 md:flex">{actionBlock}</div>}
+        {endAdornment && <div className="flex shrink-0 items-center">{endAdornment}</div>}
       </div>
-      {/* Trailing slot. Its own 32px hit box optically re-centers the glyph
-          against the 16/24px left edge. */}
-      {endAdornment && (
-        <div className="ml-[var(--spacing-system-xs)] mr-[var(--spacing-system-m)] shrink-0">{endAdornment}</div>
-      )}
+      {/* Mobile-only action row — the CTA stretched to the bar's full width. */}
+      {actionBlock && <div className="flex w-full md:hidden [&>*]:w-full">{actionBlock}</div>}
     </div>
   );
 }

--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -51,9 +51,12 @@ export interface AnnouncementBarViewProps {
  * storage, or navigation — consumers own state and pass content through slots.
  *
  * Anatomy follows the announcement-bar industry standard: ONE line of text at
- * 13-14px inside a 44px-tall strip (guides converge on 40-60px with a single
- * sentence; two stacked 18px rows blow past that), ONE compact CTA on the
- * right, and a trailing dismiss slot. Spacing is the ODS responsive tokens,
+ * 13-14px inside a slim strip (guides converge on 40-60px with a single
+ * sentence; two stacked 18px rows blow past that) — 44px below `md`, 56px from
+ * `md` up per Figma 9418-52494 (32px CTA + 12px vertical insets), STABLE with
+ * or without the CTA (reserving the full strip means toggling the action never
+ * resizes the bar on desktop/tablet) — ONE compact CTA on the right, and a
+ * trailing dismiss slot. Spacing is the ODS responsive tokens,
  * which step at the same 800px as `md`: `l` = 16/24px edge padding, `s` =
  * 8/12px gap, `m` = CTA offset, `xs` = 4/8px.
  */
@@ -74,9 +77,13 @@ export function AnnouncementBarView({
     : undefined;
 
   return (
-    <div className={cn('flex w-full max-w-full min-h-11 items-center', className)} style={style}>
+    // From `md` up the strip is a fixed 56px (Figma 9418-52494: 32px CTA +
+    // 12px vertical insets) — reserved unconditionally so removing/hiding the
+    // action never changes the bar's height on desktop/tablet. Below `md` the
+    // CTA is hidden anyway, so the 44px strip stands.
+    <div className={cn('flex w-full max-w-full min-h-11 md:min-h-14 items-center', className)} style={style}>
       {/* Content row — the tap target below `md`, where the CTA is hidden.
-          Its vertical padding never drives the height; the 44px strip does. */}
+          Its vertical padding never drives the height; the strip min-h does. */}
       <div
         className={cn(
           'flex min-w-0 flex-1 flex-row items-center gap-[var(--spacing-system-s)] py-[var(--spacing-system-xs)] pl-[var(--spacing-system-l)]',

--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -36,10 +36,10 @@ export interface AnnouncementBarViewProps {
  * storage, or navigation — consumers own state and pass content through slots.
  *
  * Layout (Figma 9418-52494 desktop/tablet, 2862-8391 mobile):
- * - `md` (800px) and up: ONE row inside a strip FIXED at 56px (`md:min-h-14`,
- *   32px CTA + 12px vertical insets) — reserved unconditionally, so toggling
- *   or removing the action never resizes the bar on desktop/tablet. Title
- *   truncates to one line.
+ * - `md` (800px) and up: ONE row inside a strip with a RESERVED 56px minimum
+ *   height (`md:min-h-14`, the mockup's strip height) — held unconditionally,
+ *   so toggling or removing the action never resizes the bar on
+ *   desktop/tablet. Title truncates to one line.
  * - Below `md`: the container stacks (`px` 16 / `py` 8 / gap 8). Top row =
  *   `startAdornment` + wrapping title + `endAdornment`; when an `actionBlock`
  *   is present it renders as a VISIBLE full-width button on its own second

--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -6,8 +6,8 @@ import { cn } from '../../utils/cn';
 export interface AnnouncementBarViewProps {
   /**
    * Leading slot — typically an icon, at content width before the title. Size
-   * it in the slot: the bar's icon runs 16-20px below `md` and 24px from `md`
-   * up (Figma boxes the mobile glyph at 16px inside a 20px frame).
+   * it in the slot: the bar's icon is 16px below `md` (must not exceed the
+   * 20px title row, Figma 9418-52387) and 24px from `md` up.
    */
   startAdornment?: ReactNode;
   /**
@@ -40,11 +40,11 @@ export interface AnnouncementBarViewProps {
  *   32px CTA + 12px vertical insets) — reserved unconditionally, so toggling
  *   or removing the action never resizes the bar on desktop/tablet. Title
  *   truncates to one line.
- * - Below `md`: the container stacks (`px` 16 / `py` 12 / gap 8). Top row =
+ * - Below `md`: the container stacks (`px` 16 / `py` 8 / gap 8). Top row =
  *   `startAdornment` + wrapping title + `endAdornment`; when an `actionBlock`
  *   is present it renders as a VISIBLE full-width button on its own second
- *   row and the bar's height adapts to content (~84px with a single-line
- *   title and CTA, 44px without one).
+ *   row and the bar's height adapts to content (76px with a single-line
+ *   title and CTA per Figma 9418-52387: 8 + 20 + 8 + 32 + 8).
  *
  * The `actionBlock` element is mounted in both positions (inline `md`-up slot
  * and the mobile full-width row); exactly one is `display:none` at any width,
@@ -61,7 +61,7 @@ export function AnnouncementBarView({
   return (
     <div
       className={cn(
-        'flex w-full max-w-full flex-col gap-[var(--spacing-system-s)] px-[var(--spacing-system-l)] py-[var(--spacing-system-sf)] md:min-h-14 md:flex-row md:items-center md:py-0',
+        'flex w-full max-w-full flex-col gap-[var(--spacing-system-s)] px-[var(--spacing-system-l)] py-[var(--spacing-system-s)] md:min-h-14 md:flex-row md:items-center md:py-0',
         className,
       )}
       style={style}

--- a/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
+++ b/openframe-frontend-core/src/stories/AnnouncementBar.stories.tsx
@@ -84,6 +84,26 @@ export const WithCTA: Story = {
 }
 
 /**
+ * Non-dismissible announcement — `dismissible={false}` drops the close (X)
+ * button, so the bar only disappears when the announcement is deactivated.
+ */
+export const WithoutCloseButton: Story = {
+  args: {
+    dismissible: false,
+    initialAnnouncement: {
+      ...baseAnnouncement,
+      id: 'story-no-dismiss',
+      title: 'Mandatory Maintenance Notice',
+      description: 'This announcement cannot be dismissed by the user.',
+      cta_enabled: true,
+      cta_text: 'Learn More',
+      cta_url: 'https://example.com',
+      cta_target: '_blank',
+    },
+  },
+}
+
+/**
  * Announcement with a CTA button that opens in the same tab.
  */
 export const WithCTASameTab: Story = {

--- a/openframe-frontend-core/src/types/announcement.ts
+++ b/openframe-frontend-core/src/types/announcement.ts
@@ -238,6 +238,11 @@ export interface AnnouncementBarProps {
    * cookies or touches localStorage).
    */
   previewMode?: boolean;
+  /**
+   * When false, the dismiss (X) button is not rendered — the bar can only
+   * disappear by deactivating the announcement. Default true.
+   */
+  dismissible?: boolean;
   className?: string;
 }
 


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/86ajm41gn
Figma: desktop/tablet https://www.figma.com/design/YQttTEQP9lQIP92VGHBwvy/openframe---dashboard?node-id=9418-52494&m=dev · mobile https://www.figma.com/design/YQttTEQP9lQIP92VGHBwvy/openframe---dashboard?node-id=9418-52387&m=dev · DS mobile https://www.figma.com/design/NYUB1Xe0bJyIuL16aUE81Z/open-design-system?node-id=2862-8391&m=dev

## Summary
- **Stable md+ height**: the strip is a fixed 56px on `md`+ (`md:min-h-14`, per the 1280x56 Figma frame), reserved unconditionally — toggling/removing the `actionBlock` no longer resizes the bar on desktop/tablet.
- **Mobile redesign**: below `md` the `actionBlock` is a VISIBLE full-width 32px button on its own row, replacing the old sr-only CTA + whole-bar tap target (`onContentClick`/`contentClassName` removed — `AnnouncementBar` was their only consumer). Top row = `startAdornment` + wrapping title + `endAdornment`.
- **Mockup-exact mobile metrics (9418-52387)**: 76px total with CTA (8px vertical padding + 20px title row + 8px gap + 32px button); `AnnouncementBar` icon 16px below `md` (24px from `md`), dismiss pinned to a 20px box/16px glyph below `md` (deliberate exception to the 24px WCAG 2.5.8 floor, back to 32px `icon-sm` from `md`).
- **CTA geometry**: `size="small"` pinned to `h-8` (32px on every breakpoint, uppercase `text-h5` label, 16px glyph) instead of the old 24px `compact`.
- **Typography**: titles use `text-h4` (DM Sans 500, 14/20 mobile / 18/24 md+).
- **New `dismissible` prop** on `AnnouncementBar` (default `true`) — `false` drops the close button; covered by the new `WithoutCloseButton` story.

## Testing
- Storybook (`WithCTA`, 375px): bar 76px, icon 16x16, dismiss 20x20, title 14/20/500; 1280px: bar 56px, dismiss 32px, icon 24px, CTA 32px.
- Verified via yalc in openframe-frontend: md+ `offsetHeight` = 56/56 with/without action at 1280px and 820px.
- Biome + `tsc --noEmit` + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to hide the announcement bar’s close button.
  * Updated announcement bar layouts for responsive desktop, tablet, and mobile presentation.
  * Improved CTA placement, sizing, and mobile full-width behavior.
* **Bug Fixes**
  * Refined responsive title and description wrapping for improved readability.
* **Documentation**
  * Updated component property descriptions to reflect the revised responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->