### PR TITLE
fix(select): reset native button center alignment so selected values left-align

### DIFF
--- a/openframe-frontend-core/src/components/ui/select.tsx
+++ b/openframe-frontend-core/src/components/ui/select.tsx
@@ -31,7 +31,10 @@ const SelectTrigger = React.forwardRef<
       data-invalid={isInvalid || undefined}
       className={cn(
         // Layout & spacing - match Input
-        "flex w-full items-center justify-between gap-2 rounded-[6px] border px-3 h-11 md:h-12 outline-none",
+        // text-left resets the <button> UA default text-align:center, which the
+        // SelectValue span inherits and would otherwise center short values,
+        // reading as spurious left indentation on the selected value.
+        "flex w-full items-center justify-between gap-2 rounded-[6px] border px-3 h-11 md:h-12 outline-none text-left",
         // Typography - match Input exactly
         "text-h4",
         // Theme palette - match Input exactly


### PR DESCRIPTION
## What

Reset the native `<button>` center alignment on the shared `SelectTrigger` so selected values left-align.

## Why

`SelectTrigger` renders a native `<button>`, whose user-agent default `text-align: center` is inherited by the `SelectValue` span. Any selected value shorter than the trigger was centered, which reads as a large, arbitrary left indentation on the value. Placeholders and icon-bearing values were unaffected (they either fill the trigger or carry a real leading icon), which is why it looked like a per-dropdown bug.

## Fix

One declaration — `text-left` on the trigger className (`src/components/ui/select.tsx`). Because there is a single `SelectTrigger` SSOT feeding every consumer, all 28+ call sites in the hub inherit the fix uniformly; no per-dropdown patching.

## Verification

Measured live in the browser: plain-text triggers corrected (dependency-type 60px → 13px, external-repo-type 22px → 13px); icon-bearing triggers (model/provider/branch) kept their legitimate 37px leading-icon offset; placeholders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed select controls so short selected values are consistently aligned to the left.
  * Prevented browser default button alignment from causing selected text to appear indented or centered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->