### PR TITLE
fix: raise dragged sortable row above siblings in TicketStatusConfigList

### DIFF
--- a/openframe-frontend-core/src/components/features/ticket-status-config-list/ticket-status-config-list.tsx
+++ b/openframe-frontend-core/src/components/features/ticket-status-config-list/ticket-status-config-list.tsx
@@ -83,6 +83,10 @@ function SortableRow({
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
+    // Raise the actively dragged row above its siblings — without this the
+    // stacking follows DOM order, so a row dragged DOWN slides UNDER the rows
+    // below it while a row dragged up correctly renders on top.
+    zIndex: isDragging ? 1 : undefined,
   }
 
   return (


### PR DESCRIPTION
## Summary
- SortableRow (the internal wrapper in TicketStatusConfigList) only set transform/transition from useSortable, so stacking followed DOM order during drag: a row dragged DOWN slid under the rows below it, while a row dragged up rendered on top.
- Sets zIndex: 1 on the wrapper while isDragging so the active row always stacks above its siblings.
- Benefits every consumer: the ticket-status config page, and the openframe-frontend AI settings quick actions editor (which currently carries a local :has()-based workaround that can be removed once this ships).