### PR TITLE
FE CORE: restore right edge padding when the bar has no endAdornment

### DIFF
--- a/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
+++ b/openframe-frontend-core/src/components/ui/announcement-bar-view.tsx
@@ -103,6 +103,11 @@ export function AnnouncementBarView({
       <div
         className={cn(
           'flex min-w-0 flex-1 flex-row items-center gap-[var(--spacing-system-s)] py-[var(--spacing-system-xs)] pl-[var(--spacing-system-l)]',
+          // The strip's right inset normally comes from the endAdornment
+          // wrapper's `mr`; without a trailing slot nothing padded the right
+          // edge and the CTA/text sat flush against it. Mirror the `l` edge
+          // padding in that case.
+          !endAdornment && 'pr-[var(--spacing-system-l)]',
           contentClassName,
         )}
         onClick={handleContentClick}
@@ -128,7 +133,7 @@ export function AnnouncementBarView({
         {actionBlock && (
           <div
             className="ml-[var(--spacing-system-m)] sr-only shrink-0 focus-within:not-sr-only md:not-sr-only md:flex"
-            onClick={(e) => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
           >
             {actionBlock}
           </div>


### PR DESCRIPTION
The strip's right inset came exclusively from the endAdornment wrapper's mr — with no trailing slot (e.g. bars without a dismiss button, or dismissible={false}) the CTA/text sat flush against the right edge. The content row now mirrors the left `l` edge padding when endAdornment is absent. Layout with a trailing slot is byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved announcement bar spacing when no trailing content is present, preventing text and calls to action from appearing too close to the right edge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->