### PR TITLE
fix(walkthrough): use an RFC 6265 valid dismissal cookie name

### DIFF
--- a/openframe-frontend-core/src/utils/dismissal-storage.ts
+++ b/openframe-frontend-core/src/utils/dismissal-storage.ts
@@ -14,11 +14,17 @@ import {
 /** Cookie-name stem. */
 export const WALKTHROUGH_VIDEO_DISMISS_KEY = 'walkthrough-video-dismissed';
 
-/** THE per-platform cookie name — the ONE home for the encoding, mirroring
- *  `announcementDismissCookieName`. Hosts must not rebuild it inline, or an SSR
- *  reader added later will restate the separator. */
+/** THE per-platform cookie name — the ONE home for the encoding. Shaped exactly
+ *  like `announcementDismissCookieName` (`<platform>-<name>-dismissed`): `:` is
+ *  not a `token` character under RFC 6265, so the old `…-dismissed:<platform>`
+ *  form was only working on browser leniency. Hosts must not rebuild this
+ *  inline, or an SSR reader added later will restate the separator.
+ *
+ *  Renaming orphans existing cookies, so anyone who had dismissed the card sees
+ *  it once more. Deliberate and one-time: the alternative is reading both names
+ *  forever to save a single re-dismissal. */
 export function walkthroughDismissCookieName(platform: string): string {
-  return `${WALKTHROUGH_VIDEO_DISMISS_KEY}:${platform}`;
+  return `${platform}-${WALKTHROUGH_VIDEO_DISMISS_KEY}`;
 }
 
 /** Client-side dismissal check (id-match). Reads a cookie, so call it from an


### PR DESCRIPTION
Follow-up to #1561.

`walkthroughDismissCookieName` built the per-platform cookie as `walkthrough-video-dismissed:<platform>`. `:` is not a `token` character under RFC 6265, so that name was only working on browser leniency.

Reshaped to match the sibling `announcementDismissCookieName` exactly:

```
before  walkthrough-video-dismissed:openframe
after   openframe-walkthrough-video-dismissed
```

## Scope

One function. `WALKTHROUGH_VIDEO_DISMISS_KEY` is unchanged, and the only consumer (the hub's `GlobalWalkthroughVideoClient`) calls the function rather than rebuilding the key, so nothing else has to move.

## Behaviour change

Renaming orphans existing cookies: anyone who had dismissed the card sees it once more, then it stays dismissed. Deliberate — the alternative is reading both names forever to save a single re-dismissal.

## Verification

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated walkthrough dismissal cookie handling to use a standards-compliant, platform-specific name format.
  * Improved compatibility for migrating existing walkthrough dismissal settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->