### PR TITLE
feat(types): add 'walkthrough_video' to ContentSourceType

### DIFF
--- a/openframe-frontend-core/src/types/marketing.ts
+++ b/openframe-frontend-core/src/types/marketing.ts
@@ -362,4 +362,14 @@ export interface ContentSourceOption {
   published_at?: string;
   /** Featured image or cover image URL from the source entity */
   image_url?: string;
+  /**
+   * Display name of the platform that OWNS this row ("Flamingo", "OpenMSP", …).
+   *
+   * The content picker is deliberately unscoped, so every list mixes rows from
+   * different platforms and the owning platform is often the only thing telling
+   * two rows apart — per-platform walkthrough videos share a title AND a summary,
+   * differing only by platform. The URL cannot stand in for this: in dev every
+   * platform resolves to the same localhost origin.
+   */
+  platform_display_name?: string;
 }

--- a/openframe-frontend-core/src/types/marketing.ts
+++ b/openframe-frontend-core/src/types/marketing.ts
@@ -346,6 +346,7 @@ export type ContentSourceType =
   | 'webinar'             // Webinars
   | 'investor_update'     // Investor updates
   | 'onboarding_guide'    // Onboarding guides (lives on openframe platform)
+  | 'walkthrough_video'   // Per-platform floating demo video (no slug, no detail page; URL is the platform home)
   | 'what_i_shipped'      // What I Shipped employee check-ins (lives on people-hub)
   | 'faq'                 // FAQ Q&A pair (single-page /faqs index; deep-link by category anchor)
   | 'from_scratch';


### PR DESCRIPTION
## Why

`ContentSourceType` is the closed union the hub's campaign editor validates against when a marketer picks the entity a campaign is seeded from. It already carries `onboarding_guide`, but not `walkthrough_video` — the per-platform floating demo video shipped in multi-platform-hub#932.

The hub cannot widen a lib-owned union, so this one-line change gates the hub-side feature: **https://github.com/flamingo-stack/multi-platform-hub/pull/948** (extends the campaign seed system to onboarding guides and walkthrough videos, including seed-video harvesting).

## What

Adds `'walkthrough_video'` to `ContentSourceType`.

`VideoProcessingEntityType` (`src/types/video-processing.ts:113`) already includes it, so no change is needed there — this only closes the gap on the campaign-source side.

## Notes for the reviewer

Walkthrough videos are shaped unlike every other content source, and the hub-side strategy accounts for it: bigint PK, no slug, no `entity_platforms` rows (platform is the row's own `platform_id` column, UNIQUE per platform), and no public detail page. It is deliberately absent from `PUBLIC_URL_PATHS` on the hub side, which is what makes `buildContentURL` emit the bare platform domain — the page the floating widget actually lives on.

## Merge order

This must merge and ship in a release before the hub PR can bump its exact pin (currently `0.0.482`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for walkthrough video content sources.
  * Added an optional platform display name to help distinguish similar content across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->