### PR TITLE
Table row and header heights match the designed 68/80 and 48px

### DIFF
--- a/openframe-frontend-core/src/components/ui/data-table/.data-table-skeleton.md
+++ b/openframe-frontend-core/src/components/ui/data-table/.data-table-skeleton.md
@@ -7,8 +7,8 @@ Renders animated skeleton placeholder rows for a `DataTable` during loading stat
 |--------|------|-------------|
 | `DataTableSkeleton` | Component | Animated pulse skeleton rows mirroring visible table columns |
 | `DataTableSkeletonProps` | Interface | Props: `rows` (count), `className`, `rowClassName` |
-| `ROW_HEIGHT_DESKTOP` | Constant | Shared row height class for desktop (`h-[68px] md:h-[80px]`) |
-| `ROW_HEIGHT_MOBILE` | Constant | Shared row height class for mobile (`h-[68px]`) |
+| `ROW_HEIGHT_DESKTOP` | Constant | Shared row height class for desktop (`h-[66px] md:h-[78px]` (inner; +2px border = 68/80 total)) |
+| `ROW_HEIGHT_MOBILE` | Constant | Shared row height class for mobile (`h-[66px]` (inner)) |
 
 ## Usage Example
 

--- a/openframe-frontend-core/src/components/ui/data-table/data-table-header.tsx
+++ b/openframe-frontend-core/src/components/ui/data-table/data-table-header.tsx
@@ -156,7 +156,9 @@ function HeaderCell({ header, isLgUp, sort, onSortChange }: HeaderCellProps) {
       ) : (
         <div
           className={cn(
-            'flex w-full items-center gap-[var(--spacing-system-xsf)] py-[var(--spacing-system-sf)] rounded-sm select-none transition-colors duration-200',
+            // Fixed 48px header height per design (20px label centered inside)
+            // instead of the padding-driven 44px.
+            'flex w-full items-center gap-[var(--spacing-system-xsf)] h-12 rounded-sm select-none transition-colors duration-200',
             isLgUp && alignJustify(align),
             canSort && 'group cursor-pointer',
           )}

--- a/openframe-frontend-core/src/components/ui/data-table/data-table-row.tsx
+++ b/openframe-frontend-core/src/components/ui/data-table/data-table-row.tsx
@@ -110,7 +110,7 @@ function DataTableRowImpl<T>({
         compact
           ? 'py-[var(--spacing-system-xsf)]'
           : autoHeight
-            ? 'py-[var(--spacing-system-sf)] min-h-[68px] md:min-h-[80px]'
+            ? 'py-[var(--spacing-system-sf)] min-h-[66px] md:min-h-[78px]'
             : `py-0 ${ROW_HEIGHT_DESKTOP}`,
         hasSubRow && 'border-b border-ods-border',
       )}

--- a/openframe-frontend-core/src/components/ui/data-table/data-table-skeleton.tsx
+++ b/openframe-frontend-core/src/components/ui/data-table/data-table-skeleton.tsx
@@ -3,9 +3,13 @@
 import { cn } from '../../../utils/cn'
 import { useDataTableContext } from './data-table'
 
-/** Consistent row heights — identical to legacy `Table`. */
-export const ROW_HEIGHT_DESKTOP = 'h-[68px] md:h-[80px]'
-export const ROW_HEIGHT_MOBILE = 'h-[68px]'
+/**
+ * Consistent INNER row heights. The row card wraps these in a 1px border on
+ * each side, so the outer block lands on the designed 68px / 80px total —
+ * hence the 66/78 values here.
+ */
+export const ROW_HEIGHT_DESKTOP = 'h-[66px] md:h-[78px]'
+export const ROW_HEIGHT_MOBILE = 'h-[66px]'
 
 export interface DataTableSkeletonProps {
   rows?: number

--- a/openframe-frontend-core/src/components/ui/table/.table-skeleton.md
+++ b/openframe-frontend-core/src/components/ui/table/.table-skeleton.md
@@ -18,8 +18,8 @@ Main export. Renders `n` skeleton card rows with responsive desktop (`md:flex`) 
 | `rowClassName` | `string` | — | Extra classes on the inner flex row |
 
 ### Constants *(deprecated)*
-- `ROW_HEIGHT_DESKTOP` — `'h-[68px] md:h-[80px]'`
-- `ROW_HEIGHT_MOBILE` — `'h-[68px]'`
+- `ROW_HEIGHT_DESKTOP` — `'h-[66px] md:h-[78px]'` (inner; +2px border = 68/80 total)
+- `ROW_HEIGHT_MOBILE` — `'h-[66px]'` (inner)
 
 **Primary column detection:** The component automatically identifies the widest (`flex-1` or `flex-[n]`) column as "primary" and renders a second skeleton line on every other row to simulate multi-line content.
 

--- a/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
+++ b/openframe-frontend-core/src/components/ui/table/table-skeleton.tsx
@@ -4,8 +4,10 @@ import React from 'react'
 import { cn } from '../../../utils/cn'
 import type { TableCardSkeletonProps } from './types'
 
-const ROW_HEIGHT_DESKTOP = 'h-[68px] md:h-[80px]'
-const ROW_HEIGHT_MOBILE = 'h-[68px]'
+// INNER row heights: the bordered row card adds 1px top + bottom, so the
+// outer block totals the designed 68px / 80px.
+const ROW_HEIGHT_DESKTOP = 'h-[66px] md:h-[78px]'
+const ROW_HEIGHT_MOBILE = 'h-[66px]'
 
 /** @deprecated Use `DataTableSkeleton` from `data-table` instead. */
 export function TableCardSkeleton({


### PR DESCRIPTION
## Description
- DataTable and legacy Table row height constants become INNER heights (66px mobile / 78px desktop) so the bordered row card totals the designed 68px / 80px instead of 70/82
- autoHeight rows: min-h adjusted the same way
- DataTable header cell: fixed 48px height (h-12) with centered label instead of the padding-driven 44px

## Task
[Policy Testing — UI Update](https://app.clickup.com/t/9013925967/86ajphg37)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted data table and table skeleton row heights for more accurate sizing across desktop and mobile layouts.
  * Standardized header cell height to improve vertical alignment and consistency.
  * Preserved intended overall dimensions when borders are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->