### PR TITLE
fix(video): floating walkthrough card shows the video title, not the generic label

### DIFF
--- a/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
+++ b/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
@@ -738,7 +738,9 @@ export function FloatingWalkthroughVideo({
         ) : (
           <VideoPlayBadge size="sm" className="h-5 w-5 shrink-0" />
         )}
-        <span className="truncate">{label}</span>
+        {/* The video's OWN title is the point of the pill; `label` is only the
+            generic fallback for a video that carries no title. */}
+        <span className="truncate">{summaryTitle || label}</span>
       </span>
 
       {/* BIG centred glyph — the muted-fallback prompt (bite grammar). It IS


### PR DESCRIPTION
## Problem

The floating walkthrough video card's title pill always read **"Play Demo Video"** — the component's generic `label` default — instead of the video's own title.

## Cause

`floating-walkthrough-video.tsx` already computed `summaryTitle` (`video?.title`), but only used it for the theater dialog's `sr-only` title. The visible pill rendered `{label}` unconditionally, so the title never reached the screen even though the hub's DAL selects and passes `title` through the whole wire shape.

## Fix

The pill renders `{summaryTitle || label}` — the video's own title, with `label` (`"Play Demo Video"`) as the fallback for a video that carries no title. One-line change; no data-path or prop-contract change (hosts still pass no `label`, the hit layer's aria-label already combined both).

## Verification

Read-path traced end to end: `loadPublishedWalkthroughVideoForPlatform` selects `title` → `PublicWalkthroughVideo` → `/api/walkthrough-video` → `GlobalWalkthroughVideoClient` → widget. Visual check on the running dev server is worth a glance once yalc:watch republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video walkthrough cards now display the video’s title when available, with a generic label shown only when no title is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->