### PR TITLE
feat(api): add requireTenantId to CurrentPrincipalSupport

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/support/CurrentPrincipalSupport.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/support/CurrentPrincipalSupport.java
@@ -14,6 +14,15 @@ public final class CurrentPrincipalSupport {
     private CurrentPrincipalSupport() {
     }
 
+    /** @return the current tenantId; throws if the principal is absent or carries no tenant. */
+    public static String requireTenantId(AuthPrincipal principal) {
+        String tenantId = principal == null ? null : principal.getTenantId();
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new UnauthorizedException("No authenticated tenant in the request");
+        }
+        return tenantId;
+    }
+
     /** @return the current userId; throws if the principal is absent or carries no user id. */
     public static String requireUserId(AuthPrincipal principal) {
         String userId = principal == null ? null : principal.getId();


### PR DESCRIPTION
## What

Adds `requireTenantId(AuthPrincipal)` to the shared `com.openframe.api.support.CurrentPrincipalSupport` (added in #1549 with `requireUserId` / `requireHumanUserId`).

## Why

`openframe-saas-api` still carries its own `com.openframe.saas.api.support.CurrentPrincipalSupport` — a near-duplicate — only because the shared one lacked `requireTenantId`, which its onboarding fetchers use. This adds the missing method so the saas copy can be deleted and those fetchers switched onto the shared helper (follow-up tenant PR).

Purely additive — no existing behavior changes. Method is a verbatim lift of the saas copy's `requireTenantId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure requests have a valid tenant identifier.
  * Requests with missing or blank tenant information now receive an unauthorized response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->