### PR TITLE
feat(walkthrough-video): admin-selectable bottom corner position

### DIFF
--- a/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
+++ b/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
@@ -2,7 +2,8 @@
 
 /**
  * <FloatingWalkthroughVideo> — THE generic, embeddable per-platform demo-video
- * widget. A collapsed card pinned bottom-left (bite-identical hover grammar via
+ * widget. A collapsed card pinned to a bottom corner — left unless the video
+ * data says `position: 'right'` — (bite-identical hover grammar via
  * <VideoHoverPreviewSurface>) that opens a large in-page theater (Radix Dialog
  * primitives, NOT native fullscreen) showing ONLY the video: a bare 16:9 stage
  * with the player's own controls + captions. No card chrome, no summary.
@@ -71,6 +72,9 @@ export interface WalkthroughVideoData {
   captionsUrl?: string | null;
   title?: string | null;
   presenterAvatarUrl?: string | null;
+  /** Which bottom corner the collapsed card pins to. Admin-controlled per
+   *  video; anything other than 'right' (including absent) means left. */
+  position?: 'left' | 'right' | null;
 }
 
 export interface FloatingWalkthroughVideoProps {
@@ -816,7 +820,14 @@ export function FloatingWalkthroughVideo({
   return (
     <>
       {showCard && (
-        <div className={cn('pointer-events-none fixed bottom-0 left-0 p-[var(--spacing-system-mf)]', WALKTHROUGH_Z)} style={{ paddingBottom: 'max(var(--spacing-system-mf), env(safe-area-inset-bottom))' }}>
+        <div
+          className={cn(
+            'pointer-events-none fixed bottom-0 p-[var(--spacing-system-mf)]',
+            video.position === 'right' ? 'right-0' : 'left-0',
+            WALKTHROUGH_Z,
+          )}
+          style={{ paddingBottom: 'max(var(--spacing-system-mf), env(safe-area-inset-bottom))' }}
+        >
           {collapsed}
         </div>
       )}

--- a/openframe-frontend-core/src/types/supabase.ts
+++ b/openframe-frontend-core/src/types/supabase.ts
@@ -410,7 +410,7 @@ export type Database = {
           highlight_video_thumbnail: string | null
           highlight_video_duration_ms: number | null
           author_id: string | null
-          position: string
+          position: 'left' | 'right'
           created_at: string
           updated_at: string
         }
@@ -419,7 +419,7 @@ export type Database = {
           platform_id: string
           title: string
           status?: string
-          position?: string
+          position?: 'left' | 'right'
           youtube_url?: string | null
           main_video_url?: string | null
           main_video_thumbnail?: string | null
@@ -458,7 +458,7 @@ export type Database = {
           highlight_video_thumbnail?: string | null
           highlight_video_duration_ms?: number | null
           author_id?: string | null
-          position?: string
+          position?: 'left' | 'right'
           created_at?: string
           updated_at?: string
         }

--- a/openframe-frontend-core/src/types/supabase.ts
+++ b/openframe-frontend-core/src/types/supabase.ts
@@ -410,6 +410,7 @@ export type Database = {
           highlight_video_thumbnail: string | null
           highlight_video_duration_ms: number | null
           author_id: string | null
+          position: string
           created_at: string
           updated_at: string
         }
@@ -418,6 +419,7 @@ export type Database = {
           platform_id: string
           title: string
           status?: string
+          position?: string
           youtube_url?: string | null
           main_video_url?: string | null
           main_video_thumbnail?: string | null
@@ -456,6 +458,7 @@ export type Database = {
           highlight_video_thumbnail?: string | null
           highlight_video_duration_ms?: number | null
           author_id?: string | null
+          position?: string
           created_at?: string
           updated_at?: string
         }


### PR DESCRIPTION
## Summary

Adds an admin-controlled screen position to the floating walkthrough-video widget.

- `WalkthroughVideoData` gains `position?: 'left' | 'right' | null` — the wire contract the hub DAL re-exports as `PublicWalkthroughVideo`.
- The collapsed card container pins `right-0` when `position === 'right'`, `left-0` otherwise (absent/null = left, preserving current behavior for every existing consumer).
- The hand-curated `walkthrough_videos` table in `types/supabase.ts` gains the `position` column (Row/Insert/Update).

The theater dialog is centered and unaffected. No new imports, no runtime deps.

## Companion PR

Hub side (admin modal Select, schemas, DAL, DB migration): flamingo-stack/multi-platform-hub#970. The hub picks this up at the next lib release + pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Walkthrough videos can now be pinned to either the left or right bottom corner.
  * Videos default to the left side unless a right-side position is specified.
  * Added support for saving and updating the walkthrough video position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->