### PR TITLE
feat(walkthrough-video): content-managed card side + host suppression

### DIFF
--- a/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
+++ b/openframe-frontend-core/src/components/features/floating-walkthrough-video.tsx
@@ -71,7 +71,14 @@ export interface WalkthroughVideoData {
   captionsUrl?: string | null;
   title?: string | null;
   presenterAvatarUrl?: string | null;
+  /** Which bottom corner the collapsed card pins to. Travels WITH the video so
+   *  the side is content-managed (the hub's admin picks it per platform, no
+   *  host deploy); the `side` prop still overrides it per mount. */
+  position?: WalkthroughVideoSide | null;
 }
+
+/** The two bottom corners the collapsed card can pin to. */
+export type WalkthroughVideoSide = 'left' | 'right';
 
 export interface FloatingWalkthroughVideoProps {
   video: WalkthroughVideoData | null | undefined;
@@ -87,6 +94,24 @@ export interface FloatingWalkthroughVideoProps {
   /** Route identity from the host (the lib can't observe navigation). Changing
    *  it re-queries the footer IO target. */
   pathname?: string;
+  /** Bottom corner to pin the collapsed card to. Host override; when omitted
+   *  the content's own `video.position` decides, defaulting to 'left'. Only the
+   *  CARD moves — the theater is centered either way. */
+  side?: WalkthroughVideoSide;
+  /**
+   * Host-driven "stand down": fade the card out and stop its audio while some
+   * surface the host owns is occupying the screen — an open side panel, a
+   * takeover, a step-through tour.
+   *
+   * Why a prop and not another `hideNearSelector`: that one resolves its target
+   * ONCE via `document.querySelector` (re-queried only on `pathname`), so it
+   * cannot observe a panel that mounts when it opens. And why fade rather than
+   * letting the host unmount us: unmounting replays the whole appear-delay, so
+   * the card blinks back in like it's new every time the panel closes.
+   *
+   * Same visual treatment as the footer fade — see the `hidden` derivation.
+   */
+  suppressed?: boolean;
   className?: string;
 }
 
@@ -112,8 +137,13 @@ export function FloatingWalkthroughVideo({
   dismissal = {},
   hideNearSelector = 'footer',
   pathname,
+  side,
+  suppressed = false,
   className,
 }: FloatingWalkthroughVideoProps): React.ReactElement | null {
+  // Host prop wins over the content's own preference; 'left' is the historical
+  // corner, so an unset value renders exactly as it did before this prop.
+  const resolvedSide: WalkthroughVideoSide = side ?? video?.position ?? 'left';
   const dismissEnabled = dismissal !== false;
   const storageKey = (dismissEnabled && dismissal.storageKey) || WALKTHROUGH_VIDEO_DISMISS_KEY;
   // id-match dismissal key: a new video (new id) re-shows the card. No id
@@ -190,6 +220,12 @@ export function FloatingWalkthroughVideo({
   const [suspended, setSuspended] = useState(false);
   const [theaterStart, setTheaterStart] = useState<{ time: number; muted: boolean }>({ time: 0, muted: false });
   const [footerHidden, setFooterHidden] = useState(false);
+  // THE single "card is on screen but must stand down" flag. Both inputs mean
+  // the same thing to every consumer below (fade out, go pointer-inert, stop
+  // audio), so they collapse here rather than being threaded separately — the
+  // component's own state-model note warns against parallel booleans that can
+  // contradict each other.
+  const hidden = footerHidden || suppressed;
   const [cardFallback, setCardFallback] = useState<VideoMutedFallbackState>({ muted: false, blocked: false });
   // Card-player transport state, driving the persistent mute/play TOGGLES.
   // Separate from `cardFallback` (which is the autoplay-blocked prompt).
@@ -243,21 +279,21 @@ export function FloatingWalkthroughVideo({
     return () => document.removeEventListener('visibilitychange', onVis);
   }, [resumeMode]);
 
-  // Faded out behind the footer: stop audio. The card is `pointer-events-none`
-  // while hidden, so a still-playing player would be unreachable — the same
-  // reason the tab-hidden handler exists.
+  // Faded out (behind the footer, or stood down for a host surface): stop
+  // audio. The card is `pointer-events-none` while hidden, so a still-playing
+  // player would be unreachable — the same reason the tab-hidden handler exists.
   // Depends on cardMode too: a player that MOUNTS while the card is already
   // hidden (e.g. the footer scrolled into view during the theater) would
   // otherwise autoplay behind an invisible, pointer-inert card.
   useEffect(() => {
-    if (!footerHidden) return;
+    if (!hidden) return;
     const h = resumeHandleRef.current ?? previewHandleRef.current;
     try { h?.pause(); } catch { /* ignore */ }
     setCardPaused(true);
     setHovered(false);
     // `resumeMode`/`hovered` (not the derived cardMode, declared below) are the
     // inputs that decide whether a player is mounted.
-  }, [footerHidden, resumeMode, hovered]);
+  }, [hidden, resumeMode, hovered]);
 
   // Render-synced mirror of the derived `cardMode`, which is declared BELOW
   // the callbacks that need it. Reading state declared later from a memoized
@@ -644,16 +680,21 @@ export function FloatingWalkthroughVideo({
         // a group inside it can never match :hover.
         'group/card pointer-events-auto relative overflow-hidden rounded-lg border border-ods-border bg-ods-card shadow-2xl',
         'aspect-video w-60 sm:w-80 transition-opacity duration-200',
-        footerHidden ? 'opacity-0 pointer-events-none' : 'opacity-100',
+        hidden ? 'opacity-0 pointer-events-none' : 'opacity-100',
         className,
       )}
       // `mouse` only: pointerenter also fires for touch, which started a
       // preview on every tap. Focus mirrors hover so keyboard users can reach
       // the transport controls at all.
-      onPointerEnter={e => { if (e.pointerType === 'mouse' && previewAllowed && !resumeMode) setHovered(true); }}
+      // Every hover entry point is gated on `!hidden` as well: while faded out
+      // the card is `pointer-events-none`, but FOCUS still reaches it — a host
+      // panel (or any dialog) restores focus to whatever held it before opening,
+      // and if that was this card, the restore landed as keyboard intent and
+      // started an unmuted preview inside an invisible card.
+      onPointerEnter={e => { if (e.pointerType === 'mouse' && previewAllowed && !resumeMode && !hidden) setHovered(true); }}
       onPointerLeave={e => { if (e.pointerType === 'mouse') setHovered(false); }}
       // Re-arm hover after a close that left the pointer parked on the card.
-      onPointerMove={e => { if (e.pointerType === 'mouse' && previewAllowed && !resumeMode && !hovered) setHovered(true); }}
+      onPointerMove={e => { if (e.pointerType === 'mouse' && previewAllowed && !resumeMode && !hovered && !hidden) setHovered(true); }}
       // Keyboard intent only. Chrome focuses buttons on click, so a raw focus
       // mirror autostarted an unmuted preview with the pointer nowhere near
       // the card. `:focus-visible` alone is NOT enough: Radix restores focus
@@ -677,7 +718,7 @@ export function FloatingWalkthroughVideo({
           }
           return;
         }
-        if (previewAllowed && !resumeMode && keyboard) setHovered(true);
+        if (previewAllowed && !resumeMode && keyboard && !hidden) setHovered(true);
       }}
       onBlurCapture={e => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setHovered(false); }}
     >
@@ -706,10 +747,20 @@ export function FloatingWalkthroughVideo({
           previewHandleRef={cardMode === 'resume' ? resumeHandleRef : previewHandleRef}
           mutedIntent={userMuted}
           continuation={cardMode === 'resume'}
-          // `!footerHidden`: mounting with autoplay and pausing in an effect
+          // `!hidden`: mounting with autoplay and pausing in an effect
           // loses to MuxPlayer re-issuing play when media is ready, which left
           // audio running behind an invisible, pointer-inert card.
-          autoPlay={cardMode === 'resume' && handoff?.playing !== false && !footerHidden}
+          //
+          // `!cardPaused` is what makes hiding SURVIVABLE. `hidden` is not a
+          // one-way door — the footer scrolls back out of view, a suppressing
+          // host panel closes — and on the way back this prop flipped false →
+          // true again, which restarts playback (with sound, since the resume
+          // seed carries the theater's mute state). The hide path already
+          // records the stop as `cardPaused`, so honouring it here means the
+          // card comes back exactly as it left: same frame, still paused, Play
+          // showing. It cannot suppress a legitimate resume — closing a PLAYING
+          // theater seeds `cardPaused` false (see the resumeMode effect).
+          autoPlay={cardMode === 'resume' && handoff?.playing !== false && !hidden && !cardPaused}
           startTime={cardMode === 'resume' ? handoff!.time : undefined}
           startMuted={cardMode === 'resume' ? handoff!.muted : false}
           onEnded={cardMode === 'resume' ? () => setHandoff(null) : () => setCardPaused(true)}
@@ -816,7 +867,17 @@ export function FloatingWalkthroughVideo({
   return (
     <>
       {showCard && (
-        <div className={cn('pointer-events-none fixed bottom-0 left-0 p-[var(--spacing-system-mf)]', WALKTHROUGH_Z)} style={{ paddingBottom: 'max(var(--spacing-system-mf), env(safe-area-inset-bottom))' }}>
+        // Only ONE inset edge is set, so the corner swap can't leave both pinned
+        // (which would stretch this box across the viewport and make the card's
+        // own `className` margins push it off-centre).
+        <div
+          className={cn(
+            'pointer-events-none fixed bottom-0 p-[var(--spacing-system-mf)]',
+            resolvedSide === 'right' ? 'right-0' : 'left-0',
+            WALKTHROUGH_Z,
+          )}
+          style={{ paddingBottom: 'max(var(--spacing-system-mf), env(safe-area-inset-bottom))' }}
+        >
           {collapsed}
         </div>
       )}

--- a/openframe-frontend-core/src/types/supabase.ts
+++ b/openframe-frontend-core/src/types/supabase.ts
@@ -395,6 +395,10 @@ export type Database = {
           platform_id: string
           title: string
           status: string
+          /** Bottom corner the floating card pins to: 'left' | 'right'
+           *  (NOT NULL, DEFAULT 'left', CHECK-constrained in the DB). Named
+           *  `card_position` because bare `position` is an SQL keyword. */
+          card_position: string
           youtube_url: string | null
           main_video_url: string | null
           main_video_thumbnail: string | null
@@ -418,6 +422,7 @@ export type Database = {
           platform_id: string
           title: string
           status?: string
+          card_position?: string
           youtube_url?: string | null
           main_video_url?: string | null
           main_video_thumbnail?: string | null
@@ -441,6 +446,7 @@ export type Database = {
           platform_id?: string
           title?: string
           status?: string
+          card_position?: string
           youtube_url?: string | null
           main_video_url?: string | null
           main_video_thumbnail?: string | null


### PR DESCRIPTION
## What

Two new props on `<FloatingWalkthroughVideo>` plus two playback fixes, so the floating demo card can live on either side of the screen and get out of the way of a host's own surfaces.

### `position` / `side` — which corner the card pins to

`WalkthroughVideoData.position` travels **with the video row**, so the hub's Walkthrough Videos admin can move the card per platform without a release of every embedding site. The `side` prop overrides it per mount.

Unset resolves to `'left'` — rendering is byte-identical for every current consumer.

The positioner now sets only ONE horizontal edge. Pinning both stretched the container across the viewport, which threw off the card's own `className` margins.

### `suppressed` — stand down for a host surface

Fades the card out (and stops its audio) while a panel/takeover/tour the host owns is on screen.

- **A prop, not another `hideNearSelector`:** that one resolves its target once through `querySelector` (re-queried only on `pathname`), so it cannot observe a panel that mounts when it opens.
- **A fade, not "let the host unmount it":** unmounting replays the whole appear delay, so the card blinks back in like it is new every time the panel closes.

It collapses with `footerHidden` into one derived `hidden` rather than becoming a second parallel boolean — the file's own state-model note warns that exactly those contradict each other.

## Fixes

**Resume playback restarted after unhiding, with sound.** `autoPlay` was gated on `!hidden` alone, but `hidden` is not a one-way door — the footer scrolls back out of view, a suppressing panel closes — so the prop flipped `false → true` again and the player restarted. Since the resume seed carries the theater's mute state, it came back audible. It now also honours the `cardPaused` that the hide path already records, so the card returns on the same frame, still paused, with Play showing. A legitimate resume is unaffected: closing a *playing* theater seeds `cardPaused` false.

This one predates `suppressed` — it is reachable today by scrolling to the footer and back. The new prop just made it easy to hit.

**Focus reached the faded-out card.** While hidden the card is `pointer-events-none`, but focus still lands on it: a closing dialog restores focus to whatever held it before opening. That read as keyboard intent and started an unmuted preview inside an invisible card. Every hover entry point — pointer-enter, pointer-move, focus — is now gated on `!hidden`.

## Also

`walkthrough_videos.card_position` added to the Supabase types. Named `card_position` because a bare `position` is an SQL keyword (`POSITION(x IN y)`) that would need quoting in every hand-written predicate, including its own CHECK constraint.

## Testing

- `tsc --noEmit` and `npm run build` clean.
- Consumers type-checked and built against this branch via yalc: openframe-oss-frontend (`type-check` + `next build` green) and multi-platform-hub (no errors in the touched files).
- `npm run lint:biome` not run — `biome` is not installed in this package's environment.

## Consumers

Both sides of the feature are prepared and waiting on this release:

- **multi-platform-hub** — `card_position` column, write schema, public read mapping, and the admin **Card Position** picker.
- **openframe-oss-frontend** — mounts the widget app-wide, passes `suppressed` while the Mingo chat / notifications drawer is open, and clears the nav sidebar only on the left.

No action needed from other platforms: without `position` in their payload and without the new props, they keep rendering exactly as they do today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Walkthrough videos can now appear in either bottom corner.
  * Hosts can temporarily suppress the minimized walkthrough video.
  * Added support for storing and configuring walkthrough card position.

* **Bug Fixes**
  * Prevented hidden walkthrough videos from starting playback through hover or keyboard focus.
  * Improved audio stopping and resume behavior when videos are hidden or paused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->