### PR TITLE
fix(rmm): schedule device assignment — platform matching and the missing #1556 migration

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/service/DeviceService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/DeviceService.java
@@ -11,6 +11,7 @@ import com.openframe.api.exception.DeviceNotFoundException;
 import com.openframe.data.document.device.DeviceStatus;
 import com.openframe.data.document.device.Machine;
 import com.openframe.data.document.device.filter.MachineQueryFilter;
+import com.openframe.data.document.rmm.ScriptPlatform;
 import com.openframe.data.document.tag.Tag;
 import com.openframe.data.document.tag.TagAssignment;
 import com.openframe.data.document.tag.TagEntityType;
@@ -121,8 +122,9 @@ public class DeviceService {
         // null-keyed criteria (InvalidMongoDbApiUsage). Keying it under "$or" ANDs cleanly at top level.
         List<org.bson.Document> perPlatform = platformNames.stream()
                 .filter(Objects::nonNull)
-                // Pattern.quote so a platform value with regex metacharacters is matched literally.
-                .map(name -> Criteria.where("osType").regex("^" + java.util.regex.Pattern.quote(name) + "$", "i").getCriteriaObject())
+                // One regex per platform, spelling out every osType the agents actually report for
+                // it — a platform name is not an osType, so matching the name alone finds nothing.
+                .map(name -> Criteria.where("osType").regex(ScriptPlatform.osTypeRegex(name), "i").getCriteriaObject())
                 .toList();
         if (!perPlatform.isEmpty()) {
             query.addCriteria(Criteria.where("$or").is(perPlatform));

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleDeviceService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleDeviceService.java
@@ -236,10 +236,12 @@ public class ScriptScheduleDeviceService {
      *       matching docs, so an unknown or cross-tenant id would otherwise be silently persisted as
      *       a {@link ScriptScheduleMachineAssigned} row; here it is rejected instead.</li>
      *   <li><b>Platform compatibility</b> (only when the schedule declares platforms) — each device's
-     *       {@code Machine.osType} (e.g. "windows"/"macos") must match one of the schedule's
-     *       {@code supportedPlatforms}, case-insensitively (osType is lowercase, {@link ScriptPlatform}
-     *       names are upper). A device with no known osType is allowed (can't determine). Prevents e.g.
-     *       assigning a Windows device to a macOS schedule.</li>
+     *       {@code Machine.osType} must denote one of the schedule's {@code supportedPlatforms},
+     *       decided by {@link ScriptPlatform#matches}. The stored value is whatever the agent
+     *       reported ({@code "MAC_OS"}, {@code "WINDOWS"}), not a platform name, so it is matched
+     *       through that enum's aliases instead of being compared to the name directly. A device
+     *       with no known osType is allowed (can't determine). Prevents e.g. assigning a Windows
+     *       device to a macOS schedule.</li>
      * </ol>
      * No-op when nothing is being assigned.
      */
@@ -269,7 +271,8 @@ public class ScriptScheduleDeviceService {
         List<String> incompatible = machines.stream()
                 .filter(m -> {
                     String os = m.getOsType();
-                    return os != null && !os.isBlank() && !allowed.contains(os.trim().toUpperCase());
+                    return os != null && !os.isBlank()
+                            && schedulePlatforms.stream().noneMatch(platform -> platform.matches(os));
                 })
                 .map(m -> m.getHostname() != null ? m.getHostname() : m.getMachineId())
                 .toList();

--- a/openframe-api-service-core/src/test/java/com/openframe/data/document/rmm/ScriptPlatformTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/data/document/rmm/ScriptPlatformTest.java
@@ -1,0 +1,103 @@
+package com.openframe.data.document.rmm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The platform ↔ {@code osType} vocabulary gap these aliases exist to close: the Rust agent
+ * registers Macs as {@code "MAC_OS"}, so every comparison that read a platform NAME as if it were
+ * an osType silently resolved to zero Macs — schedules offered no Mac in Available Devices,
+ * rejected one added by hand, and dispatched to none.
+ */
+class ScriptPlatformTest {
+
+    @ParameterizedTest
+    @DisplayName("the spellings agents actually register Macs under all resolve to MACOS")
+    @ValueSource(strings = {"MAC_OS", "mac_os", "MACOS", "macos", "Mac-OS", "mac os", "Darwin", "OSX", "Mac OS X"})
+    void macSpellingsResolveToMacos(String osType) {
+        assertThat(ScriptPlatform.fromOsType(osType)).contains(ScriptPlatform.MACOS);
+        assertThat(ScriptPlatform.MACOS.matches(osType)).isTrue();
+    }
+
+    @Test
+    @DisplayName("MAC_OS is not any other platform — the fix must not widen what a Mac matches")
+    void macOsIsNotWindowsOrLinux() {
+        assertThat(ScriptPlatform.WINDOWS.matches("MAC_OS")).isFalse();
+        assertThat(ScriptPlatform.LINUX.matches("MAC_OS")).isFalse();
+    }
+
+    @ParameterizedTest
+    @DisplayName("Windows and Linux keep resolving as they did")
+    @ValueSource(strings = {"WINDOWS", "windows", "win32"})
+    void windowsSpellings(String osType) {
+        assertThat(ScriptPlatform.fromOsType(osType)).contains(ScriptPlatform.WINDOWS);
+    }
+
+    @Test
+    @DisplayName("'darwin' is a Mac, not a Windows box — the 'win' alias must not match inside it")
+    void darwinIsNotWindows() {
+        assertThat(ScriptPlatform.WINDOWS.matches("darwin")).isFalse();
+        assertThat(ScriptPlatform.fromOsType("darwin")).contains(ScriptPlatform.MACOS);
+    }
+
+    @Test
+    @DisplayName("an unrecognised osType resolves to no platform and matches none")
+    void unknownOsType() {
+        assertThat(ScriptPlatform.fromOsType("plan9")).isEmpty();
+        assertThat(ScriptPlatform.fromOsType(null)).isEmpty();
+        assertThat(ScriptPlatform.fromOsType("  ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("osTypeMatches: a platform name matches a device's stored osType across the spelling gap")
+    void osTypeMatchesAcrossSpellings() {
+        assertThat(ScriptPlatform.osTypeMatches("MACOS", "MAC_OS")).isTrue();
+        assertThat(ScriptPlatform.osTypeMatches("MACOS", "WINDOWS")).isFalse();
+        assertThat(ScriptPlatform.osTypeMatches("WINDOWS", "WINDOWS")).isTrue();
+    }
+
+    @Test
+    @DisplayName("osTypeMatches: a name denoting no known platform still matches itself")
+    void osTypeMatchesFallsBackToSelfComparison() {
+        assertThat(ScriptPlatform.osTypeMatches("plan9", "PLAN9")).isTrue();
+        assertThat(ScriptPlatform.osTypeMatches("plan9", "haiku")).isFalse();
+        assertThat(ScriptPlatform.osTypeMatches(null, "MAC_OS")).isFalse();
+        assertThat(ScriptPlatform.osTypeMatches("MACOS", null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("osTypeRegex: matches every stored Mac spelling, and nothing else")
+    void osTypeRegexCoversStoredSpellings() {
+        Pattern pattern = Pattern.compile(ScriptPlatform.osTypeRegex("MACOS"), Pattern.CASE_INSENSITIVE);
+
+        assertThat(pattern.matcher("MAC_OS").matches()).isTrue();
+        assertThat(pattern.matcher("macos").matches()).isTrue();
+        assertThat(pattern.matcher("Darwin").matches()).isTrue();
+        assertThat(pattern.matcher("WINDOWS").matches()).isFalse();
+    }
+
+    @Test
+    @DisplayName("osTypeRegex: anchored, so a platform is never matched as a substring of another osType")
+    void osTypeRegexIsAnchored() {
+        Pattern windows = Pattern.compile(ScriptPlatform.osTypeRegex("WINDOWS"), Pattern.CASE_INSENSITIVE);
+
+        assertThat(windows.matcher("darwin").matches()).isFalse();     // contains "win"
+        assertThat(windows.matcher("windows 11").matches()).isFalse();
+        assertThat(windows.matcher("WINDOWS").matches()).isTrue();
+    }
+
+    @Test
+    @DisplayName("osTypeRegex: an unknown platform name is matched literally, metacharacters and all")
+    void osTypeRegexQuotesUnknownNames() {
+        Pattern pattern = Pattern.compile(ScriptPlatform.osTypeRegex("plan.9"), Pattern.CASE_INSENSITIVE);
+
+        assertThat(pattern.matcher("plan.9").matches()).isTrue();
+        assertThat(pattern.matcher("planX9").matches()).isFalse();     // '.' is not a wildcard here
+    }
+}

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptPlatform.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/ScriptPlatform.java
@@ -1,14 +1,96 @@
 package com.openframe.data.document.rmm;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 /**
  * Operating-system platform on which a {@link Script} is supported.
  *
  * <p>The set is intentionally minimal; finer-grained distinctions (e.g.
  * specific Windows or distro versions) are expressed in the script body or
  * via execution-time arguments rather than as separate platform values.
+ *
+ * <p><b>Platform name vs stored {@code osType}.</b> These are two different
+ * vocabularies and must never be compared directly. A platform is an enum
+ * constant ({@code MACOS}); {@code Machine.osType} is whatever the agent
+ * reported at registration and is persisted verbatim — the Rust agent sends
+ * {@code "WINDOWS"} and {@code "MAC_OS"}, so a plain
+ * {@code "MACOS".equalsIgnoreCase(osType)} silently excludes every Mac. Each
+ * constant therefore carries the {@code osType} spellings that mean it, and all
+ * comparisons go through {@link #matches}, {@link #osTypeMatches} or
+ * {@link #osTypeRegex}.
+ *
+ * <p>Aliases are compared on a canonical form (lower-cased, separators removed),
+ * so an unlisted spelling like {@code "Mac-OS"} still resolves. The alias list
+ * additionally spells out the separator variants because {@link #osTypeRegex}
+ * matches stored values as they are, without canonicalising them first.
  */
 public enum ScriptPlatform {
-    WINDOWS,
-    LINUX,
-    MACOS
+    WINDOWS("windows", "win", "win32", "win64"),
+    LINUX("linux", "ubuntu", "debian", "centos", "rhel", "red hat", "redhat", "fedora", "arch", "alpine"),
+    MACOS("macos", "mac_os", "mac-os", "mac os", "macosx", "mac_os_x", "mac os x", "osx", "os x", "darwin");
+
+    private final List<String> osTypeAliases;
+
+    ScriptPlatform(String... osTypeAliases) {
+        this.osTypeAliases = List.of(osTypeAliases);
+    }
+
+    /** Every {@code osType} spelling that means this platform. */
+    public List<String> osTypeAliases() {
+        return osTypeAliases;
+    }
+
+    /** Is a device reporting {@code osType} running this platform? */
+    public boolean matches(String osType) {
+        String canonical = canonical(osType);
+        return canonical != null && osTypeAliases.stream().anyMatch(alias -> canonical.equals(canonical(alias)));
+    }
+
+    /** The platform a reported {@code osType} denotes, empty when it denotes none of them. */
+    public static Optional<ScriptPlatform> fromOsType(String osType) {
+        return Arrays.stream(values()).filter(platform -> platform.matches(osType)).findFirst();
+    }
+
+    /**
+     * Does {@code platformName} describe a device running {@code osType}? {@code platformName} is
+     * either a {@link ScriptPlatform} name or a raw osType coming from a saved device criteria;
+     * one that denotes no known platform falls back to a direct case-insensitive comparison, so a
+     * value this enum has never heard of still matches itself.
+     */
+    public static boolean osTypeMatches(String platformName, String osType) {
+        if (platformName == null || osType == null) {
+            return false;
+        }
+        return fromOsType(platformName)
+                .map(platform -> platform.matches(osType))
+                .orElseGet(() -> platformName.equalsIgnoreCase(osType));
+    }
+
+    /**
+     * Anchored regex matching every stored spelling of {@code platformName} — for querying the
+     * {@code osType} field, which holds the agent's spelling rather than a platform name. Intended
+     * to be used with the case-insensitive flag. Anchoring is what keeps {@code "win"} from
+     * matching {@code "darwin"}, and each alternative is quoted so a value carrying regex
+     * metacharacters is matched literally.
+     */
+    public static String osTypeRegex(String platformName) {
+        List<String> alternatives = fromOsType(platformName)
+                .map(ScriptPlatform::osTypeAliases)
+                .orElseGet(() -> List.of(platformName));
+        return alternatives.stream()
+                .map(Pattern::quote)
+                .collect(Collectors.joining("|", "^(?:", ")$"));
+    }
+
+    private static String canonical(String value) {
+        if (value == null) {
+            return null;
+        }
+        String stripped = value.trim().toLowerCase().replaceAll("[\\s_-]", "");
+        return stripped.isEmpty() ? null : stripped;
+    }
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/device/CustomMachineRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/device/CustomMachineRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.openframe.data.repository.device;
 
 import com.openframe.data.document.device.Machine;
 import com.openframe.data.document.device.filter.MachineQueryFilter;
+import com.openframe.data.document.rmm.ScriptPlatform;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.bson.types.ObjectId;
@@ -13,7 +14,6 @@ import org.springframework.data.mongodb.core.query.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Pattern;
 
 @Slf4j
 public class CustomMachineRepositoryImpl implements CustomMachineRepository {
@@ -141,10 +141,10 @@ public class CustomMachineRepositoryImpl implements CustomMachineRepository {
 
         if (osTypeScope != null) {
             // Keyed "$or" (not keyless orOperator): buildDeviceQuery may already have added a keyless
-            // "$and", and Query rejects a second null-keyed criteria (InvalidMongoDbApiUsage). osType is
-            // stored lowercase, platform names are upper → anchored case-insensitive regex per platform.
+            // "$and", and Query rejects a second null-keyed criteria (InvalidMongoDbApiUsage). One
+            // anchored case-insensitive regex per platform, covering every osType spelling it has.
             List<Document> perPlatform = osTypeScope.stream()
-                    .map(name -> Criteria.where("osType").regex("^" + Pattern.quote(name) + "$", "i").getCriteriaObject())
+                    .map(name -> Criteria.where("osType").regex(ScriptPlatform.osTypeRegex(name), "i").getCriteriaObject())
                     .toList();
             query.addCriteria(Criteria.where("$or").is(perPlatform));
         }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/rmm/ScheduleDeviceTargetResolver.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/rmm/ScheduleDeviceTargetResolver.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Single source of truth for "which machines does this schedule target right now". Shared by the
@@ -31,8 +30,9 @@ import java.util.stream.Collectors;
  * </ul>
  *
  * <p>Criteria OS is always intersected with the schedule's {@code supportedPlatforms}, so a criteria
- * target is guaranteed platform-compatible. Matching on {@code osType} is case-insensitive (osType is
- * stored lowercase; {@link ScriptPlatform} names are upper).
+ * target is guaranteed platform-compatible. A stored {@code osType} is the agent's own spelling
+ * ({@code "MAC_OS"}, {@code "WINDOWS"}) and never a platform name, so both the intersection and the
+ * per-machine check go through {@link ScriptPlatform}'s alias matching rather than comparing strings.
  */
 @Component
 @RequiredArgsConstructor
@@ -77,7 +77,7 @@ public class ScheduleDeviceTargetResolver {
         List<String> platformScope = platformScope(schedule);
         if (platformScope != null) {                       // an OS constraint applies
             String osType = machine.getOsType();
-            if (osType == null || platformScope.stream().noneMatch(osType::equalsIgnoreCase)) {
+            if (osType == null || platformScope.stream().noneMatch(name -> ScriptPlatform.osTypeMatches(name, osType))) {
                 return false;
             }
         }
@@ -120,22 +120,25 @@ public class ScheduleDeviceTargetResolver {
     private List<String> platformScope(ScriptSchedule schedule) {
         ScheduleDeviceCriteria criteria = schedule.getDeviceCriteria();
         List<String> osTypes = criteria == null ? null : criteria.getOsTypes();
-        List<String> supported = schedule.getSupportedPlatforms() == null ? List.of()
-                : schedule.getSupportedPlatforms().stream().map(Enum::name).toList();
+        List<ScriptPlatform> supported = schedule.getSupportedPlatforms() == null ? List.of()
+                : schedule.getSupportedPlatforms();
 
         boolean hasOs = isNotEmpty(osTypes);
         if (!hasOs && supported.isEmpty()) {
             return null;                                    // unconstrained
         }
         if (!hasOs) {
-            return supported;                               // schedule platforms only
+            return supported.stream().map(Enum::name).toList();   // schedule platforms only
         }
         if (supported.isEmpty()) {
             return osTypes;                                 // criteria OS only
         }
-        Set<String> supportedUpper = supported.stream().map(String::toUpperCase).collect(Collectors.toSet());
+        // Intersected on the platform each side DENOTES, not on its spelling: a criteria osType of
+        // "MAC_OS" and a supportedPlatform of MACOS are the same constraint, and comparing the two
+        // strings would read them as disjoint and resolve the schedule to nothing.
+        Set<ScriptPlatform> supportedSet = Set.copyOf(supported);
         return osTypes.stream()
-                .filter(os -> supportedUpper.contains(os.toUpperCase()))
+                .filter(os -> ScriptPlatform.fromOsType(os).map(supportedSet::contains).orElse(false))
                 .toList();                                  // possibly empty → contradictory
     }
 

--- a/openframe-management-service-core/src/main/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnit.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnit.java
@@ -1,0 +1,150 @@
+package com.openframe.management.migration;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Finishes the schema change that turned a schedule's device assignment from one document holding a
+ * {@code machineIds} array into one row per (schedule, machine) pair.
+ *
+ * <p>That change altered the mapping but left the database as it was, and two things outlive it:
+ *
+ * <ol>
+ *   <li><b>The old unique index</b> {@code (tenantId, scriptScheduleId)}. Spring Data's
+ *       auto-index-creation only ever creates indexes — it never drops one that disappeared from the
+ *       annotations — so every database provisioned before that commit still enforces
+ *       one-row-per-schedule. The first device added to a schedule succeeds and the second fails with
+ *       {@code E11000}, which is how this surfaced.</li>
+ *   <li><b>Documents still in the old shape.</b> The current model has no {@code machineIds} field,
+ *       so those documents map to a row with a null {@code machineId} and are skipped by every
+ *       reader: the assignments they hold are invisible, and the schedules that owned them look
+ *       empty. They are read here as raw {@link Document}s for exactly that reason — mapping them to
+ *       the entity would silently drop the very field being migrated.</li>
+ * </ol>
+ *
+ * <p>The two steps are ordered, not independent: the stale index permits a single row per schedule,
+ * so the split rows cannot be written while it still exists.
+ *
+ * <p>Both steps are idempotent and safe on a fresh install — a missing collection, a missing index
+ * and an absence of legacy documents are each a no-op, and the rows are upserted on their natural
+ * key so a partially-migrated collection converges rather than conflicting.
+ */
+@Slf4j
+@ChangeUnit(id = "repair-schedule-device-assignments", order = "009", author = "openframe")
+public class RepairScheduleDeviceAssignmentsChangeUnit {
+
+    private static final String COLLECTION = "script_schedules_machines_assigned";
+    private static final String LEGACY_INDEX = "tenant_scriptScheduleId";
+
+    private static final String ID_FIELD = "_id";
+    private static final String TENANT_ID_FIELD = "tenantId";
+    private static final String SCHEDULE_ID_FIELD = "scriptScheduleId";
+    private static final String MACHINE_ID_FIELD = "machineId";
+    private static final String LEGACY_MACHINE_IDS_FIELD = "machineIds";
+    private static final String CREATED_BY_FIELD = "createdBy";
+    private static final String CREATED_AT_FIELD = "createdAt";
+
+    @Execution
+    public void execution(MongoTemplate mongoTemplate) {
+        if (!mongoTemplate.collectionExists(COLLECTION)) {
+            log.info("Repair schedule device assignments: collection {} does not exist; skipping", COLLECTION);
+            return;
+        }
+        dropLegacyIndex(mongoTemplate);
+        splitLegacyDocuments(mongoTemplate);
+    }
+
+    /**
+     * Intentionally empty. Re-creating the unique {@code (tenantId, scriptScheduleId)} index would
+     * restore the defect this removes, and it would now fail outright against any schedule that has
+     * more than one device. The split rows are valid under the current model, so leaving them in
+     * place is the correct rollback state.
+     */
+    @RollbackExecution
+    public void rollback() {
+    }
+
+    private void dropLegacyIndex(MongoTemplate mongoTemplate) {
+        IndexOperations indexOps = mongoTemplate.indexOps(COLLECTION);
+        boolean present = indexOps.getIndexInfo().stream()
+                .anyMatch(index -> LEGACY_INDEX.equals(index.getName()));
+        if (!present) {
+            log.info("Legacy index {}.{} is absent; nothing to drop", COLLECTION, LEGACY_INDEX);
+            return;
+        }
+        indexOps.dropIndex(LEGACY_INDEX);
+        log.info("Dropped legacy unique index {}.{} — a schedule may now hold more than one device",
+                COLLECTION, LEGACY_INDEX);
+    }
+
+    private void splitLegacyDocuments(MongoTemplate mongoTemplate) {
+        Query legacy = new Query(Criteria.where(LEGACY_MACHINE_IDS_FIELD).exists(true));
+        List<Document> documents = mongoTemplate.find(legacy, Document.class, COLLECTION);
+        if (documents.isEmpty()) {
+            log.info("No legacy {} documents to split", COLLECTION);
+            return;
+        }
+
+        int rows = 0;
+        for (Document document : documents) {
+            rows += splitDocument(mongoTemplate, document);
+            mongoTemplate.remove(new Query(Criteria.where(ID_FIELD).is(document.get(ID_FIELD))), COLLECTION);
+        }
+        log.info("Split {} legacy assignment document(s) into {} row(s)", documents.size(), rows);
+    }
+
+    private int splitDocument(MongoTemplate mongoTemplate, Document document) {
+        List<String> machineIds = document.getList(LEGACY_MACHINE_IDS_FIELD, String.class);
+        if (machineIds == null || machineIds.isEmpty()) {
+            return 0;
+        }
+        String tenantId = document.getString(TENANT_ID_FIELD);
+        String scheduleId = document.getString(SCHEDULE_ID_FIELD);
+        if (tenantId == null || scheduleId == null) {
+            log.warn("Skipping legacy assignment document {} — missing tenantId or scriptScheduleId",
+                    document.get(ID_FIELD));
+            return 0;
+        }
+
+        int written = 0;
+        for (String machineId : machineIds.stream().filter(Objects::nonNull).distinct().toList()) {
+            upsertRow(mongoTemplate, tenantId, scheduleId, machineId, document);
+            written++;
+        }
+        return written;
+    }
+
+    private void upsertRow(MongoTemplate mongoTemplate, String tenantId, String scheduleId,
+                           String machineId, Document source) {
+        // The natural key is the query, so an upsert converges: a row already written in the new
+        // shape keeps its own audit fields rather than being overwritten with the legacy document's.
+        // tenantId/scriptScheduleId/machineId are not repeated in the update — Mongo builds an
+        // inserted document from the query's equality terms, and restating them here would be a
+        // conflicting path.
+        Query row = new Query(Criteria.where(TENANT_ID_FIELD).is(tenantId)
+                .and(SCHEDULE_ID_FIELD).is(scheduleId)
+                .and(MACHINE_ID_FIELD).is(machineId));
+        Update update = new Update()
+                .setOnInsert(CREATED_BY_FIELD, source.getString(CREATED_BY_FIELD))
+                .setOnInsert(CREATED_AT_FIELD, createdAt(source));
+        mongoTemplate.upsert(row, update, COLLECTION);
+    }
+
+    private Date createdAt(Document source) {
+        Object createdAt = source.get(CREATED_AT_FIELD);
+        return createdAt instanceof Date date ? date : Date.from(Instant.now());
+    }
+}

--- a/openframe-management-service-core/src/test/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnitTest.java
+++ b/openframe-management-service-core/src/test/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnitTest.java
@@ -1,0 +1,195 @@
+package com.openframe.management.migration;
+
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The defect this guards: adding a second device to a schedule failed with E11000, because the
+ * pre-split unique index still enforced one assignment row per schedule.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RepairScheduleDeviceAssignmentsChangeUnitTest {
+
+    private static final String COLLECTION = "script_schedules_machines_assigned";
+    private static final String LEGACY_INDEX = "tenant_scriptScheduleId";
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+    @Mock
+    private IndexOperations indexOps;
+
+    private final RepairScheduleDeviceAssignmentsChangeUnit changeUnit =
+            new RepairScheduleDeviceAssignmentsChangeUnit();
+
+    private void collectionExists() {
+        when(mongoTemplate.collectionExists(COLLECTION)).thenReturn(true);
+        when(mongoTemplate.indexOps(COLLECTION)).thenReturn(indexOps);
+    }
+
+    private void indexes(String... names) {
+        when(indexOps.getIndexInfo()).thenReturn(Arrays.stream(names).map(name -> {
+            IndexInfo info = mock(IndexInfo.class);
+            when(info.getName()).thenReturn(name);
+            return info;
+        }).toList());
+    }
+
+    private void legacyDocuments(Document... documents) {
+        when(mongoTemplate.find(any(Query.class), eq(Document.class), eq(COLLECTION)))
+                .thenReturn(List.of(documents));
+    }
+
+    private Document legacyDocument(String scheduleId, List<String> machineIds) {
+        return new Document("_id", "legacy-" + scheduleId)
+                .append("tenantId", "tenant-1")
+                .append("scriptScheduleId", scheduleId)
+                .append("machineIds", machineIds)
+                .append("createdBy", "user-1")
+                .append("createdAt", new Date(0));
+    }
+
+    @Test
+    @DisplayName("drops the stale unique index that allowed only one device per schedule")
+    void dropsStaleIndex() {
+        collectionExists();
+        indexes("_id_", LEGACY_INDEX, "tenant_scriptScheduleId_machineId");
+        legacyDocuments();
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(indexOps).dropIndex(LEGACY_INDEX);
+    }
+
+    @Test
+    @DisplayName("a database that never had the stale index is left alone")
+    void freshDatabaseIsNoOp() {
+        collectionExists();
+        indexes("_id_", "tenant_scriptScheduleId_machineId");
+        legacyDocuments();
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(indexOps, never()).dropIndex(any());
+    }
+
+    @Test
+    @DisplayName("a fresh install with no collection yet does nothing at all")
+    void missingCollectionIsNoOp() {
+        when(mongoTemplate.collectionExists(COLLECTION)).thenReturn(false);
+
+        changeUnit.execution(mongoTemplate);
+
+        verifyNoInteractions(indexOps);
+        verify(mongoTemplate, never()).upsert(any(), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("a legacy machineIds array becomes one row per machine, and the old document is removed")
+    void splitsLegacyDocument() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1", "m-2", "m-3")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, times(3)).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+        verify(mongoTemplate).remove(any(Query.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("the index is dropped BEFORE rows are written — it would otherwise reject the second one")
+    void dropsIndexBeforeWritingRows() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1", "m-2")));
+
+        changeUnit.execution(mongoTemplate);
+
+        InOrder ordered = inOrder(indexOps, mongoTemplate);
+        ordered.verify(indexOps).dropIndex(LEGACY_INDEX);
+        ordered.verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("duplicate and null machine ids in the legacy array collapse to one row each")
+    void deduplicatesMachineIds() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", Arrays.asList("m-1", "m-1", null, "m-2")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, times(2)).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("the natural key is the query and audit fields are set only on insert, so a re-run cannot overwrite")
+    void upsertsOnNaturalKeyWithoutOverwriting() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1")));
+
+        changeUnit.execution(mongoTemplate);
+
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+        verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(), eq(COLLECTION));
+
+        Document query = queryCaptor.getValue().getQueryObject();
+        assertThat(query.get("tenantId")).isEqualTo("tenant-1");
+        assertThat(query.get("scriptScheduleId")).isEqualTo("sched-1");
+        assertThat(query.get("machineId")).isEqualTo("m-1");
+
+        Document update = updateCaptor.getValue().getUpdateObject();
+        assertThat(update).containsOnlyKeys("$setOnInsert");
+        Document onInsert = (Document) update.get("$setOnInsert");
+        assertThat(onInsert.get("createdBy")).isEqualTo("user-1");
+        // The key fields are NOT restated — Mongo builds them from the query's equality terms,
+        // and repeating them in the update would be a conflicting path.
+        assertThat(onInsert).doesNotContainKeys("tenantId", "scriptScheduleId", "machineId");
+    }
+
+    @Test
+    @DisplayName("a legacy document missing its schedule id is skipped rather than written as a broken row")
+    void skipsMalformedLegacyDocument() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(new Document("_id", "legacy-broken")
+                .append("tenantId", "tenant-1")
+                .append("machineIds", List.of("m-1")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, never()).upsert(any(), any(Update.class), eq(COLLECTION));
+        verify(mongoTemplate).remove(any(Query.class), eq(COLLECTION));
+    }
+}


### PR DESCRIPTION
Two defects in script-schedule device assignment. They surfaced together, share the same code path, and neither is complete without the other: the first makes Macs selectable, the second makes a selection of more than one device persist.

---

# 1. macOS devices never appear in Available Devices

A schedule scopes devices by comparing `supportedPlatforms` to `Machine.osType`, but those are two different vocabularies:

- a platform is a `ScriptPlatform` enum name — `MACOS`
- `osType` is whatever the agent reported at registration, persisted verbatim — the Rust agent sends [`"MAC_OS"`](https://github.com/flamingo-stack/openframe-oss-tenant/blob/main/clients/openframe-client/src/services/device_data_fetcher.rs)

So `^MACOS$` never matched `MAC_OS`, and every Mac fell out of the query — missing from Available Devices, rejected when added by hand, never targeted by a criteria schedule. Windows only worked by coincidence: the agent happens to send the exact string `"WINDOWS"`.

Neither value ever changed — the two vocabularies were simply never the same one. The agent has reported `MAC_OS` since `osType` was introduced (openframe-oss-tenant@1042c8d2d, Oct 2025); `ScriptPlatform` was added eight months later for a different purpose (#1047); and #1580 was the first code to compare them directly, on the assumption that they matched.

Several comments in this code asserted "osType is stored lowercase; platform names are upper" — neither half was true, and that assumption is what the comparisons were built on. The test fixtures encoded the same assumption (`"macos"`, `"windows"`), which is why they stayed green. Both are corrected here.

### Fix

`ScriptPlatform` now owns the `osType` spellings that denote each platform and exposes the three comparisons the call sites need:

| | use |
|---|---|
| `matches(osType)` | in-memory check against a known platform |
| `osTypeMatches(name, osType)` | scope entry that may be a platform name *or* a raw criteria osType; an unknown name falls back to comparing with itself |
| `osTypeRegex(name)` | querying the `osType` field |

Aliases are compared canonically (lower-cased, separators stripped), so an unlisted spelling like `Mac-OS` still resolves. The query regex stays **anchored**, which is what keeps `win` from matching inside `darwin`.

**Why the read side and not normalisation on write.** Normalising `osType` at registration would only fix devices that re-register, and would need a data migration to help the ones already in the database. Matching on the read side repairs the existing fleet immediately and keeps working whichever spelling a given agent sends.

### Call sites moved onto it

- `DeviceService.applyPlatformScope` — backs `availableDevices` and `addAllDevicesToSchedule`
- `ScriptScheduleDeviceService.validateDevices` — add/set devices
- `ScheduleDeviceTargetResolver.matchesCriteria` — DEVICE_ONLINE trigger
- `ScheduleDeviceTargetResolver.platformScope` — the `criteria ∩ supportedPlatforms` intersection, which read `"MAC_OS"` and `MACOS` as disjoint and resolved the schedule to nothing
- `CustomMachineRepositoryImpl.buildCriteriaQuery` — criteria device query

---

# 2. Adding a second device fails with E11000

#1556 turned a schedule's device assignment from one document holding a `machineIds` array into one row per (schedule, machine) pair. It changed the mapping and left the database untouched, so two things outlived it:

**The old unique index `(tenantId, scriptScheduleId)`.** Spring Data's auto-index-creation only ever *creates* indexes — it never drops one that disappeared from the annotations. So every database provisioned before that commit still enforces one-assignment-row-per-schedule, which is exactly the invariant the split was meant to remove. The first device added to a schedule succeeds; the second fails with `E11000 duplicate key error, index: tenant_scriptScheduleId`.

**Documents still in the old shape.** The current model has no `machineIds` field, so they map to a row with a null `machineId` and are skipped by every reader — the assignments they hold are invisible, and the schedules that owned them look empty.

### Fix

A Mongock `@ChangeUnit` (`order = "009"`) that drops the stale index, then splits any legacy document into one row per machine. Legacy documents are read as raw `Document`s on purpose: mapping them to the entity would silently drop the very field being migrated.

**The order is load-bearing, not stylistic.** The stale index permits a single row per schedule, so the split rows cannot be written while it still exists. There is a test asserting that ordering specifically, because reversing it would fail on the second machine of the first schedule.

### Safety

- **Idempotent.** A missing collection, a missing index, and an absence of legacy documents are each a no-op — safe on a fresh install and safe to re-run.
- **Convergent.** Rows are upserted on their natural key `(tenantId, scriptScheduleId, machineId)` with audit fields under `$setOnInsert`, so a row already written in the new shape keeps its own `createdAt`/`createdBy` rather than being overwritten by the legacy document's.
- **Non-destructive to valid data.** Only documents carrying the legacy `machineIds` field are read, and each is removed only after its rows are written. A legacy document missing `tenantId`/`scriptScheduleId` is logged and skipped rather than written as a broken row.
- **Rollback is deliberately empty.** Re-creating the old unique index would restore the defect, and it would now fail outright against any schedule holding more than one device. The split rows are valid under the current model, so leaving them is the correct rollback state.

---

## Database impact

The platform matching (part 1) writes nothing — existing documents are matched as they are, and no migration is needed for it.

The change unit (part 2) does write, and it runs **at startup of the `openframe-management` service on the first deploy after this merges** — like every other change unit in `com.openframe.management.migration`. Nothing happens before then. Mongock journals it and will not repeat it.

## Tests

- `ScriptPlatformTest` — the spelling gap, the anchoring (`darwin` is not Windows), the unknown-name fallback, metacharacter quoting.
- `RepairScheduleDeviceAssignmentsChangeUnitTest` — index drop, fresh-database no-op, missing-collection no-op, the split, drop-before-write ordering, machine-id de-duplication, the upsert key / `$setOnInsert` shape, malformed-document skip.

Existing tests should be unaffected — the device query keeps its shape of one regex document per platform (`DeviceServiceTest` asserts `$or` has size 1), and the `macos` / `windows` fixtures in `ScriptScheduleDeviceServiceTest` and `ScheduleDeviceTargetResolverIT` resolve to the same platforms as before.

> ⚠️ **Not verified by a build.** No JDK or Maven was available where this was written, so nothing here has been compiled or run. Please let CI confirm before review.
