### PR TITLE
fix(rmm): finish the schedule device-assignment split with a migration

### DIFF
--- a/openframe-management-service-core/src/main/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnit.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnit.java
@@ -1,0 +1,150 @@
+package com.openframe.management.migration;
+
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Finishes the schema change that turned a schedule's device assignment from one document holding a
+ * {@code machineIds} array into one row per (schedule, machine) pair.
+ *
+ * <p>That change altered the mapping but left the database as it was, and two things outlive it:
+ *
+ * <ol>
+ *   <li><b>The old unique index</b> {@code (tenantId, scriptScheduleId)}. Spring Data's
+ *       auto-index-creation only ever creates indexes — it never drops one that disappeared from the
+ *       annotations — so every database provisioned before that commit still enforces
+ *       one-row-per-schedule. The first device added to a schedule succeeds and the second fails with
+ *       {@code E11000}, which is how this surfaced.</li>
+ *   <li><b>Documents still in the old shape.</b> The current model has no {@code machineIds} field,
+ *       so those documents map to a row with a null {@code machineId} and are skipped by every
+ *       reader: the assignments they hold are invisible, and the schedules that owned them look
+ *       empty. They are read here as raw {@link Document}s for exactly that reason — mapping them to
+ *       the entity would silently drop the very field being migrated.</li>
+ * </ol>
+ *
+ * <p>The two steps are ordered, not independent: the stale index permits a single row per schedule,
+ * so the split rows cannot be written while it still exists.
+ *
+ * <p>Both steps are idempotent and safe on a fresh install — a missing collection, a missing index
+ * and an absence of legacy documents are each a no-op, and the rows are upserted on their natural
+ * key so a partially-migrated collection converges rather than conflicting.
+ */
+@Slf4j
+@ChangeUnit(id = "repair-schedule-device-assignments", order = "009", author = "openframe")
+public class RepairScheduleDeviceAssignmentsChangeUnit {
+
+    private static final String COLLECTION = "script_schedules_machines_assigned";
+    private static final String LEGACY_INDEX = "tenant_scriptScheduleId";
+
+    private static final String ID_FIELD = "_id";
+    private static final String TENANT_ID_FIELD = "tenantId";
+    private static final String SCHEDULE_ID_FIELD = "scriptScheduleId";
+    private static final String MACHINE_ID_FIELD = "machineId";
+    private static final String LEGACY_MACHINE_IDS_FIELD = "machineIds";
+    private static final String CREATED_BY_FIELD = "createdBy";
+    private static final String CREATED_AT_FIELD = "createdAt";
+
+    @Execution
+    public void execution(MongoTemplate mongoTemplate) {
+        if (!mongoTemplate.collectionExists(COLLECTION)) {
+            log.info("Repair schedule device assignments: collection {} does not exist; skipping", COLLECTION);
+            return;
+        }
+        dropLegacyIndex(mongoTemplate);
+        splitLegacyDocuments(mongoTemplate);
+    }
+
+    /**
+     * Intentionally empty. Re-creating the unique {@code (tenantId, scriptScheduleId)} index would
+     * restore the defect this removes, and it would now fail outright against any schedule that has
+     * more than one device. The split rows are valid under the current model, so leaving them in
+     * place is the correct rollback state.
+     */
+    @RollbackExecution
+    public void rollback() {
+    }
+
+    private void dropLegacyIndex(MongoTemplate mongoTemplate) {
+        IndexOperations indexOps = mongoTemplate.indexOps(COLLECTION);
+        boolean present = indexOps.getIndexInfo().stream()
+                .anyMatch(index -> LEGACY_INDEX.equals(index.getName()));
+        if (!present) {
+            log.info("Legacy index {}.{} is absent; nothing to drop", COLLECTION, LEGACY_INDEX);
+            return;
+        }
+        indexOps.dropIndex(LEGACY_INDEX);
+        log.info("Dropped legacy unique index {}.{} — a schedule may now hold more than one device",
+                COLLECTION, LEGACY_INDEX);
+    }
+
+    private void splitLegacyDocuments(MongoTemplate mongoTemplate) {
+        Query legacy = new Query(Criteria.where(LEGACY_MACHINE_IDS_FIELD).exists(true));
+        List<Document> documents = mongoTemplate.find(legacy, Document.class, COLLECTION);
+        if (documents.isEmpty()) {
+            log.info("No legacy {} documents to split", COLLECTION);
+            return;
+        }
+
+        int rows = 0;
+        for (Document document : documents) {
+            rows += splitDocument(mongoTemplate, document);
+            mongoTemplate.remove(new Query(Criteria.where(ID_FIELD).is(document.get(ID_FIELD))), COLLECTION);
+        }
+        log.info("Split {} legacy assignment document(s) into {} row(s)", documents.size(), rows);
+    }
+
+    private int splitDocument(MongoTemplate mongoTemplate, Document document) {
+        List<String> machineIds = document.getList(LEGACY_MACHINE_IDS_FIELD, String.class);
+        if (machineIds == null || machineIds.isEmpty()) {
+            return 0;
+        }
+        String tenantId = document.getString(TENANT_ID_FIELD);
+        String scheduleId = document.getString(SCHEDULE_ID_FIELD);
+        if (tenantId == null || scheduleId == null) {
+            log.warn("Skipping legacy assignment document {} — missing tenantId or scriptScheduleId",
+                    document.get(ID_FIELD));
+            return 0;
+        }
+
+        int written = 0;
+        for (String machineId : machineIds.stream().filter(Objects::nonNull).distinct().toList()) {
+            upsertRow(mongoTemplate, tenantId, scheduleId, machineId, document);
+            written++;
+        }
+        return written;
+    }
+
+    private void upsertRow(MongoTemplate mongoTemplate, String tenantId, String scheduleId,
+                           String machineId, Document source) {
+        // The natural key is the query, so an upsert converges: a row already written in the new
+        // shape keeps its own audit fields rather than being overwritten with the legacy document's.
+        // tenantId/scriptScheduleId/machineId are not repeated in the update — Mongo builds an
+        // inserted document from the query's equality terms, and restating them here would be a
+        // conflicting path.
+        Query row = new Query(Criteria.where(TENANT_ID_FIELD).is(tenantId)
+                .and(SCHEDULE_ID_FIELD).is(scheduleId)
+                .and(MACHINE_ID_FIELD).is(machineId));
+        Update update = new Update()
+                .setOnInsert(CREATED_BY_FIELD, source.getString(CREATED_BY_FIELD))
+                .setOnInsert(CREATED_AT_FIELD, createdAt(source));
+        mongoTemplate.upsert(row, update, COLLECTION);
+    }
+
+    private Date createdAt(Document source) {
+        Object createdAt = source.get(CREATED_AT_FIELD);
+        return createdAt instanceof Date date ? date : Date.from(Instant.now());
+    }
+}

--- a/openframe-management-service-core/src/test/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnitTest.java
+++ b/openframe-management-service-core/src/test/java/com/openframe/management/migration/RepairScheduleDeviceAssignmentsChangeUnitTest.java
@@ -1,0 +1,195 @@
+package com.openframe.management.migration;
+
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * The defect this guards: adding a second device to a schedule failed with E11000, because the
+ * pre-split unique index still enforced one assignment row per schedule.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RepairScheduleDeviceAssignmentsChangeUnitTest {
+
+    private static final String COLLECTION = "script_schedules_machines_assigned";
+    private static final String LEGACY_INDEX = "tenant_scriptScheduleId";
+
+    @Mock
+    private MongoTemplate mongoTemplate;
+    @Mock
+    private IndexOperations indexOps;
+
+    private final RepairScheduleDeviceAssignmentsChangeUnit changeUnit =
+            new RepairScheduleDeviceAssignmentsChangeUnit();
+
+    private void collectionExists() {
+        when(mongoTemplate.collectionExists(COLLECTION)).thenReturn(true);
+        when(mongoTemplate.indexOps(COLLECTION)).thenReturn(indexOps);
+    }
+
+    private void indexes(String... names) {
+        when(indexOps.getIndexInfo()).thenReturn(Arrays.stream(names).map(name -> {
+            IndexInfo info = mock(IndexInfo.class);
+            when(info.getName()).thenReturn(name);
+            return info;
+        }).toList());
+    }
+
+    private void legacyDocuments(Document... documents) {
+        when(mongoTemplate.find(any(Query.class), eq(Document.class), eq(COLLECTION)))
+                .thenReturn(List.of(documents));
+    }
+
+    private Document legacyDocument(String scheduleId, List<String> machineIds) {
+        return new Document("_id", "legacy-" + scheduleId)
+                .append("tenantId", "tenant-1")
+                .append("scriptScheduleId", scheduleId)
+                .append("machineIds", machineIds)
+                .append("createdBy", "user-1")
+                .append("createdAt", new Date(0));
+    }
+
+    @Test
+    @DisplayName("drops the stale unique index that allowed only one device per schedule")
+    void dropsStaleIndex() {
+        collectionExists();
+        indexes("_id_", LEGACY_INDEX, "tenant_scriptScheduleId_machineId");
+        legacyDocuments();
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(indexOps).dropIndex(LEGACY_INDEX);
+    }
+
+    @Test
+    @DisplayName("a database that never had the stale index is left alone")
+    void freshDatabaseIsNoOp() {
+        collectionExists();
+        indexes("_id_", "tenant_scriptScheduleId_machineId");
+        legacyDocuments();
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(indexOps, never()).dropIndex(any());
+    }
+
+    @Test
+    @DisplayName("a fresh install with no collection yet does nothing at all")
+    void missingCollectionIsNoOp() {
+        when(mongoTemplate.collectionExists(COLLECTION)).thenReturn(false);
+
+        changeUnit.execution(mongoTemplate);
+
+        verifyNoInteractions(indexOps);
+        verify(mongoTemplate, never()).upsert(any(), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("a legacy machineIds array becomes one row per machine, and the old document is removed")
+    void splitsLegacyDocument() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1", "m-2", "m-3")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, times(3)).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+        verify(mongoTemplate).remove(any(Query.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("the index is dropped BEFORE rows are written — it would otherwise reject the second one")
+    void dropsIndexBeforeWritingRows() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1", "m-2")));
+
+        changeUnit.execution(mongoTemplate);
+
+        InOrder ordered = inOrder(indexOps, mongoTemplate);
+        ordered.verify(indexOps).dropIndex(LEGACY_INDEX);
+        ordered.verify(mongoTemplate).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("duplicate and null machine ids in the legacy array collapse to one row each")
+    void deduplicatesMachineIds() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", Arrays.asList("m-1", "m-1", null, "m-2")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, times(2)).upsert(any(Query.class), any(Update.class), eq(COLLECTION));
+    }
+
+    @Test
+    @DisplayName("the natural key is the query and audit fields are set only on insert, so a re-run cannot overwrite")
+    void upsertsOnNaturalKeyWithoutOverwriting() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(legacyDocument("sched-1", List.of("m-1")));
+
+        changeUnit.execution(mongoTemplate);
+
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+        verify(mongoTemplate).upsert(queryCaptor.capture(), updateCaptor.capture(), eq(COLLECTION));
+
+        Document query = queryCaptor.getValue().getQueryObject();
+        assertThat(query.get("tenantId")).isEqualTo("tenant-1");
+        assertThat(query.get("scriptScheduleId")).isEqualTo("sched-1");
+        assertThat(query.get("machineId")).isEqualTo("m-1");
+
+        Document update = updateCaptor.getValue().getUpdateObject();
+        assertThat(update).containsOnlyKeys("$setOnInsert");
+        Document onInsert = (Document) update.get("$setOnInsert");
+        assertThat(onInsert.get("createdBy")).isEqualTo("user-1");
+        // The key fields are NOT restated — Mongo builds them from the query's equality terms,
+        // and repeating them in the update would be a conflicting path.
+        assertThat(onInsert).doesNotContainKeys("tenantId", "scriptScheduleId", "machineId");
+    }
+
+    @Test
+    @DisplayName("a legacy document missing its schedule id is skipped rather than written as a broken row")
+    void skipsMalformedLegacyDocument() {
+        collectionExists();
+        indexes(LEGACY_INDEX);
+        legacyDocuments(new Document("_id", "legacy-broken")
+                .append("tenantId", "tenant-1")
+                .append("machineIds", List.of("m-1")));
+
+        changeUnit.execution(mongoTemplate);
+
+        verify(mongoTemplate, never()).upsert(any(), any(Update.class), eq(COLLECTION));
+        verify(mongoTemplate).remove(any(Query.class), eq(COLLECTION));
+    }
+}


### PR DESCRIPTION
## Problem

Adding a **second** device to a script schedule fails with `E11000 duplicate key error, index: tenant_scriptScheduleId`. The first one always works.

#1556 turned a schedule's device assignment from one document holding a `machineIds` array into one row per (schedule, machine) pair. It changed the mapping and left the database untouched, so two things outlived it:

**1. The old unique index `(tenantId, scriptScheduleId)`.** Spring Data's auto-index-creation only ever *creates* indexes — it never drops one that disappeared from the annotations. So every database provisioned before that commit still enforces one-assignment-row-per-schedule, which is exactly the invariant the split was meant to remove.

**2. Documents still in the old shape.** The current model has no `machineIds` field, so those documents map to a row with a null `machineId` and are skipped by every reader — the assignments they hold are invisible, and the schedules that owned them look empty. This migration reads them as raw `Document`s for that reason: mapping them to the entity would silently drop the very field being migrated.

## Fix

A Mongock `@ChangeUnit` (`order = "009"`) that drops the stale index, then splits any legacy document into one row per machine.

**The order is load-bearing, not stylistic.** The stale index permits a single row per schedule, so the split rows cannot be written while it still exists. There is a test asserting that ordering specifically, because reversing it would fail on the second machine of the first schedule.

## Safety

- **Idempotent.** A missing collection, a missing index, and an absence of legacy documents are each a no-op — safe on a fresh install and safe to re-run.
- **Convergent.** Rows are upserted on their natural key `(tenantId, scriptScheduleId, machineId)` with audit fields under `$setOnInsert`, so a row already written in the new shape keeps its own `createdAt`/`createdBy` rather than being overwritten by the legacy document's.
- **Non-destructive to valid data.** Only documents carrying the legacy `machineIds` field are read, and each is removed only after its rows are written. A legacy document missing `tenantId`/`scriptScheduleId` is logged and skipped rather than written as a broken row.
- **Rollback is deliberately empty.** Re-creating the old unique index would restore the defect, and it would now fail outright against any schedule holding more than one device. The split rows are valid under the current model, so leaving them is the correct rollback state.

## When this runs

At startup of the `openframe-management` service (Deployment, `replicas: 1`), like every other change unit in `com.openframe.management.migration` — so **on the first deploy after this merges**, not before. Mongock journals it and will not repeat it.

## Tests

`RepairScheduleDeviceAssignmentsChangeUnitTest` covers the index drop, the fresh-database no-op, the missing-collection no-op, the split, the drop-before-write ordering, machine-id de-duplication, the upsert key/`$setOnInsert` shape, and the malformed-document skip.

> ⚠️ **Not verified by a build.** No JDK or Maven was available where this was written, so nothing here has been compiled or run. Please let CI confirm before review.

## Related

#1596 fixes a separate defect in the same feature — platform names were compared directly to `Machine.osType`, so macOS devices never appeared in a schedule's Available Devices at all. That PR deliberately contains no database write; this one is the database half. They are independent and can land in either order.
