### PR TITLE
Unified top-navigation: post-merge review fixes

### DIFF
--- a/openframe-frontend-core/src/components/navigation/header.tsx
+++ b/openframe-frontend-core/src/components/navigation/header.tsx
@@ -129,8 +129,9 @@ export function Header({ config, platform }: HeaderProps) {
             leftIcon={item.icon}
             rightIcon={item.badge}
             onClick={() => {
+              // Single-open: opening a dropdown closes any other open one —
+              // only one nav dropdown may be expanded at a time.
               setOpenDropdowns(prev => ({
-                ...prev,
                 [item.id]: !prev[item.id],
               }));
             }}

--- a/openframe-frontend-core/src/components/navigation/mingo-ai-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/mingo-ai-button.tsx
@@ -51,7 +51,10 @@ export function MingoAiButton({ source, icon, label = 'Mingo AI', className, onC
         // Unified ODS top-navigation cell (Figma 2797-6808 desktop /
         // 2797-7275 mobile): full-height cell with a leading divider,
         // transparent at rest so it inherits the bar's background.
-        'group/mingo relative flex h-full shrink-0 items-center border-l border-ods-border bg-transparent px-[var(--spacing-system-m)] transition-colors duration-200 hover:bg-ods-bg-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-ods-accent',
+        // No hover background on the cell: the animated ring + shimmer are
+        // the ONLY hover treatment (a bg flip on top read as a double
+        // animation).
+        'group/mingo relative flex h-full shrink-0 items-center border-l border-ods-border bg-transparent px-[var(--spacing-system-m)] focus:outline-none focus-visible:ring-2 focus-visible:ring-ods-accent',
         className,
       )}
     >

--- a/openframe-frontend-core/src/components/navigation/mobile-nav-panel.tsx
+++ b/openframe-frontend-core/src/components/navigation/mobile-nav-panel.tsx
@@ -103,12 +103,12 @@ export function MobileNavPanel({ isOpen, config }: MobileNavPanelProps) {
         className={cn(
           "fixed z-[9999] rounded-lg shadow-xl",
           config.className ? "" : "bg-ods-card border border-ods-border",
-          // Responsive positioning and sizing — LEFT-anchored from md, under
-          // the burger cell that sits at the left edge of the unified
-          // top-navigation (it used to be right-anchored when the burger
-          // lived on the right).
+          // Responsive positioning and sizing — LEFT-anchored from md, flush
+          // under the burger cell at the left edge of the unified
+          // top-navigation (a larger inset read as a stray gap between the
+          // burger and its panel).
           "right-2 left-2 md:right-auto",
-          "md:left-6 md:w-[400px] md:max-w-[calc(100vw-3rem)]",
+          "md:left-2 md:w-[400px] md:max-w-[calc(100vw-1rem)]",
           // Small-viewport (svh) sizing anchored below the measured header —
           // 100vh overflowed under mobile browser chrome, leaving the bottom
           // entries and footer unreachable while the body was scroll-locked.


### PR DESCRIPTION
## Summary

Follow-up to #1591 addressing live-review feedback on the hub:

- **Nav dropdowns are single-open** - expanding one dropdown now closes any other (previously several could stay open at once).
- **Mingo launcher: single hover animation** - dropped the cell's hover background; the animated edge ring + shimmer are the only hover treatment.
- **MobileNavPanel flush under the burger** - `md:left-2` instead of `md:left-6`; the 24px inset next to the left-edge burger cell read as a stray gap.

Companion hub PR unifies the flamingo dropdown backgrounds.

ClickUp: https://app.clickup.com/t/86ajqwpd3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated navigation dropdowns so opening one automatically closes others.
  * Improved mobile navigation panel positioning and sizing at medium screen widths.

* **Style**
  * Refined hover behavior for the Mingo AI button to preserve its animated visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->