### PR TITLE
fix(): nats ws recovery watcher

### DIFF
--- a/openframe-frontend-core/src/components/chat/hooks/.use-jetstream-dialog-subscription.md
+++ b/openframe-frontend-core/src/components/chat/hooks/.use-jetstream-dialog-subscription.md
@@ -1,4 +1,4 @@
-<!-- source-hash: 82efaf1b62d0b5740b96c9d4e6160b6a -->
+<!-- source-hash: 5580bec3b68cb904d2a18151c969360c -->
 React hook that manages a JetStream ephemeral OrderedConsumer subscription for a chat dialog stream, handling connection lifecycle, reconnection with sequence resumption, and NATS client sharing.
 
 ## Key Components
@@ -13,12 +13,13 @@ The single exported hook. Accepts `UseJetStreamDialogSubscriptionOptions` and re
 |---|---|
 | `isConnected` | Whether the NATS WebSocket connection is live |
 | `isSubscribed` | Whether the JetStream consumer is active |
-| `reconnectionCount` | Increments on each successful reconnect |
+| `reconnectionCount` | Increments whenever the live tail is re-established: a NATS reconnect, a JetStream ordered-consumer recreation, or a resync after the page was hidden. Callers refetch persisted history on every increment |
 | `currentStreamSeq` | Highest stream sequence number observed |
 
 **Internal refs (stable across renders):**
 
 - `clientRef` — shared `NatsClient` instance
+- `lastRecoveryReportRef` — timestamp floor so a flapping consumer cannot storm callers with refetches
 - `subscriptionRef` — active `JetStreamSubscriptionHandle`
 - `highestStreamSeqRef` — tracks max stream sequence for gap-free resume
 
@@ -26,7 +27,8 @@ The single exported hook. Accepts `UseJetStreamDialogSubscriptionOptions` and re
 
 1. **Connection effect** — acquires/releases the shared NATS client when `enabled` or `wsUrl` changes; drives the `startConnectionLifecycle` which emits status events.
 2. **Dialog reset effect** — resets `highestStreamSeqRef` when `dialogId` changes so a new dialog never inherits a stale start sequence.
-3. **Subscription effect** — creates or recreates the ephemeral consumer when `isConnected`, `dialogId`, `topic`, `streamName`, or `reconnectionCount` change.
+3. **Visibility effect** — after the page has been hidden longer than `RESYNC_AFTER_HIDDEN_MS`, returning to view bumps the counter: a hidden page can stop receiving without the socket ever closing, and nothing else reports that.
+4. **Subscription effect** — creates or recreates the ephemeral consumer when `isConnected`, `dialogId`, `topic`, `streamName`, or the reconnect counter change.
 
 **Deliver policy logic:**
 
@@ -69,6 +71,8 @@ function ChatPane({ dialogId }: { dialogId: string }) {
 ## Reconnection Behavior
 
 On reconnect the consumer is **not** recreated from `optStartSeq`; instead it resumes from `highestStreamSeqRef.current + 1`, guaranteeing no chunk is replayed or skipped. Only a `dialogId` change resets that pointer back to `optStartSeq` (or live-tail).
+
+Consumer recreations reported by the client (`onRecovered`) are counted separately from connection reconnects and do **not** re-run the subscription effect — nats.ws has already rebuilt the consumer by then, so recreating ours would be churn that can feed itself. Both counts surface to callers summed as `reconnectionCount`, throttled by `RECOVERY_REPORT_FLOOR_MS`.
 
 The hook retries only on `closed` / `disconnected` NATS status events. Protocol-level `-ERR` events (e.g. permission violations on `CONSUMER.CREATE`) are logged as warnings without triggering the reconnection loop.
 

--- a/openframe-frontend-core/src/components/chat/hooks/use-jetstream-dialog-subscription.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-jetstream-dialog-subscription.ts
@@ -14,8 +14,21 @@ import {
   type UseJetStreamDialogSubscriptionReturn,
 } from '../types'
 
-const DEFAULT_INACTIVE_THRESHOLD_MS = 5 * 60_000
 const DEFAULT_STREAM_NAME = 'CHAT_CHUNKS'
+/**
+ * How long the page must have been out of sight before coming back counts as an
+ * absence worth resyncing for. Alt-tabbing must not churn the consumer; a
+ * window that sat in the tray must not come back showing a stale conversation.
+ */
+const RESYNC_AFTER_HIDDEN_MS = 10_000
+/**
+ * Floor between two reported recoveries. Every recovery costs the caller a
+ * history refetch, and a consumer that cannot hold its sequence — gap, reset,
+ * gap — would otherwise turn a server-side fault into a refetch storm from
+ * every open client. Recoveries are a repair signal, not a data feed: one per
+ * window is enough to close the gap.
+ */
+const RECOVERY_REPORT_FLOOR_MS = 5_000
 
 /**
  * Subscribe to a chat dialog stream via a JetStream **ephemeral OrderedConsumer**.
@@ -26,8 +39,11 @@ const DEFAULT_STREAM_NAME = 'CHAT_CHUNKS'
  *   (`DeliverPolicy.New`).
  * - On reconnect, the consumer is recreated starting from the highest stream
  *   sequence we've already observed + 1, so no chunk is replayed or skipped.
- * - Consumer is ephemeral with `AckPolicy.None` and a 5-minute inactivity
- *   threshold (overridable via `inactiveThresholdMs`).
+ * - Consumer is ephemeral with `AckPolicy.None` and the client's default
+ *   inactivity threshold (overridable via `inactiveThresholdMs`).
+ * - `reconnectionCount` also counts consumer recreations and post-absence
+ *   resyncs, not just NATS reconnects — see the counter's docs. Callers refetch
+ *   persisted history whenever it moves.
  */
 export function useJetStreamDialogSubscription({
   enabled,
@@ -48,8 +64,15 @@ export function useJetStreamDialogSubscription({
   const [isConnected, setIsConnected] = useState(false)
   const [isSubscribed, setIsSubscribed] = useState(false)
   const [reconnectionCount, setReconnectionCount] = useState(0)
+  // Kept apart from reconnectionCount because only the latter drives the
+  // subscription effect: nats.ws has already rebuilt the consumer by the time
+  // it reports a recovery, so tearing ours down and recreating it would be
+  // churn — and churn that can feed itself, since each new consumer can report
+  // its own recoveries. Callers see the two summed (see the return).
+  const [recoveryCount, setRecoveryCount] = useState(0)
   const [currentStreamSeq, setCurrentStreamSeq] = useState<number | null>(null)
 
+  const lastRecoveryReportRef = useRef(0)
   const clientRef = useRef<NatsClient | null>(null)
   const subscriptionRef = useRef<JetStreamSubscriptionHandle | null>(null)
   const highestStreamSeqRef = useRef<number | null>(null)
@@ -225,6 +248,36 @@ export function useJetStreamDialogSubscription({
     setCurrentStreamSeq(null)
   }, [dialogId])
 
+  // Coming back into view after a real absence is treated exactly like a
+  // reconnect, because the page cannot tell the difference from the inside.
+  // While it was hidden — a tray-hidden desktop window, a background tab, a
+  // sleeping machine — delivery may have stopped without the socket ever
+  // closing and without any consumer event to show for it. Nothing else will
+  // report that: the tail simply stays quiet, and the conversation on screen
+  // stays frozen at whatever was there when the window went away (the user's
+  // manual fix is a page refresh, which is exactly the history refetch this
+  // triggers). Bumping the counter rebuilds the consumer from the last sequence
+  // seen AND tells callers to refetch history.
+  useEffect(() => {
+    if (!enabled) return
+    let hiddenSince = document.visibilityState === 'hidden' ? Date.now() : 0
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        hiddenSince = Date.now()
+        return
+      }
+      const awayMs = hiddenSince === 0 ? 0 : Date.now() - hiddenSince
+      hiddenSince = 0
+      if (awayMs >= RESYNC_AFTER_HIDDEN_MS) {
+        setReconnectionCount((c) => c + 1)
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange)
+  }, [enabled])
+
   // Subscription lifecycle: (re)create the ephemeral JetStream consumer whenever
   // we transition into a connected state for a dialog, and whenever the dialog
   // changes. On reconnect we resume from highestStreamSeq + 1.
@@ -288,8 +341,17 @@ export function useJetStreamDialogSubscription({
             filterSubject,
             deliverPolicy: startSeq != null ? 'byStartSequence' : 'new',
             optStartSeq: startSeq,
-            inactiveThresholdMs: inactiveThresholdRef.current ?? DEFAULT_INACTIVE_THRESHOLD_MS,
+            // Undefined when the caller did not set one: the client owns the default,
+            // so it is not spelled out a second time here.
+            inactiveThresholdMs: inactiveThresholdRef.current,
             signal: abortController.signal,
+            onRecovered: () => {
+              if (cancelled) return
+              const now = Date.now()
+              if (now - lastRecoveryReportRef.current < RECOVERY_REPORT_FLOOR_MS) return
+              lastRecoveryReportRef.current = now
+              setRecoveryCount((c) => c + 1)
+            },
           },
         )
 
@@ -327,5 +389,15 @@ export function useJetStreamDialogSubscription({
     }
   }, [enabled, dialogId, isConnected, streamName, topic, reconnectionCount])
 
-  return { isConnected, isSubscribed, reconnectionCount, currentStreamSeq }
+  // One counter for every way the tail comes back — reconnect, consumer
+  // recreation, post-absence resync — because callers do the same thing for all
+  // of them: refetch persisted history, since the gap may predate what the
+  // stream still holds. The last two are the quiet ones; no connection event
+  // fires for either.
+  return {
+    isConnected,
+    isSubscribed,
+    reconnectionCount: reconnectionCount + recoveryCount,
+    currentStreamSeq,
+  }
 }

--- a/openframe-frontend-core/src/components/chat/types/api.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/api.types.ts
@@ -128,14 +128,21 @@ export interface UseJetStreamDialogSubscriptionOptions {
     maxDelayMs?: number
     multiplier?: number
   }
-  /** Consumer inactivity threshold in ms before NATS auto-cleans it. Default: 5 minutes. */
+  /** Consumer inactivity threshold in ms before NATS auto-cleans it. Defaults to the
+   *  client's, and applies only to the first consumer — recreations use nats.ws's. */
   inactiveThresholdMs?: number
 }
 
 export interface UseJetStreamDialogSubscriptionReturn {
   isConnected: boolean
   isSubscribed: boolean
-  /** Incremented each time the underlying NATS connection reconnects. Starts at 0. */
+  /**
+   * Incremented each time the live tail is re-established: a NATS reconnect, a
+   * JetStream ordered-consumer recreation, or the page returning to view after
+   * being hidden long enough to have missed something. All three mean the same
+   * thing to the caller — the tail may have skipped messages, so persisted
+   * history has to be refetched. Starts at 0.
+   */
   reconnectionCount: number
   /** Highest JetStream stream sequence observed so far (null before first delivery). */
   currentStreamSeq: number | null

--- a/openframe-frontend-core/src/nats/.nats.md
+++ b/openframe-frontend-core/src/nats/.nats.md
@@ -1,4 +1,4 @@
-<!-- source-hash: 67f40ff2bcded544220309f5fd1f87ad -->
+<!-- source-hash: ba650275f2095934d2e10402f745ef2c -->
 Browser/Tauri-compatible NATS client factory built on `nats.ws`, providing typed publish, subscribe, request-reply, and JetStream ordered consumer support with connection lifecycle management.
 
 ## Key Components
@@ -11,7 +11,7 @@ Browser/Tauri-compatible NATS client factory built on `nats.ws`, providing typed
 | `NatsClientOptions` | Connection config including servers, auth, reconnect, and exponential backoff |
 | `NatsSubscribeOptions` | Per-subscription options: queue group, max messages, abort signal |
 | `NatsPublishOptions` / `NatsRequestOptions` | Optional headers and timeout for publish/request operations |
-| `JetStreamOrderedSubscribeOptions` | JetStream ephemeral consumer config with deliver policy and idle threshold |
+| `JetStreamOrderedSubscribeOptions` | JetStream ephemeral consumer config: deliver policy, idle threshold (milliseconds — nats.ws converts to nanos itself), and `onRecovered`, which fires when the ordered consumer had to be rebuilt and the tail may have skipped messages |
 | `NatsStatus` / `NatsStatusEvent` | Union type and event shape for connection lifecycle events |
 | `JetStreamDeliverPolicy` | `'new'` or `'byStartSequence'` for ordered consumer replay |
 

--- a/openframe-frontend-core/src/nats/nats.ts
+++ b/openframe-frontend-core/src/nats/nats.ts
@@ -1,6 +1,7 @@
 import type {
   ConnectionOptions,
   Consumer,
+  ConsumerEvents,
   ConsumerMessages,
   JsMsg,
   MsgHdrs as NatsHeaders,
@@ -19,10 +20,27 @@ export interface JetStreamOrderedSubscribeOptions {
   deliverPolicy: JetStreamDeliverPolicy
   /** Required when deliverPolicy === 'byStartSequence'. */
   optStartSeq?: number
-  /** Auto-cleanup the ephemeral consumer after this idle time. Default: 5 minutes. */
+  /**
+   * Auto-cleanup the ephemeral consumer after this idle time. Defaults to
+   * nats.ws's own. Applies to the consumer created first: nats.ws only reads it
+   * when the start sequence is the one it was built with, so every consumer it
+   * recreates afterwards reverts to the library default.
+   */
   inactiveThresholdMs?: number
   /** AbortSignal to tear down the consumer. */
   signal?: AbortSignal
+  /**
+   * The ordered consumer had to be rebuilt: the server dropped the ephemeral
+   * consumer (its inactivity threshold elapsed while the page was suspended or
+   * offline), heartbeats were missed, or a sequence gap was detected. nats.ws
+   * recreates it from the last delivered sequence, so this is NOT an error —
+   * but everything that aged out of the stream while it was gone is
+   * unrecoverable from the tail, and no connection event announces it (the
+   * WebSocket never dropped). Callers that keep persisted history alongside
+   * the live tail must refetch it here, or they keep showing a snapshot from
+   * before the gap.
+   */
+  onRecovered?: () => void
 }
 
 export interface JetStreamSubscriptionHandle {
@@ -268,6 +286,47 @@ function mapNatsTypeToStatus(type: unknown): NatsStatus | null {
   if (t.includes('error')) return 'error'
   if (t.includes('close')) return 'closed'
   return null
+}
+
+/**
+ * Report an ordered consumer rebuilding itself.
+ *
+ * nats.ws announces this on the message iterator's status channel and nowhere
+ * else — the iterator keeps yielding, the WebSocket never drops, and nothing
+ * consumes that channel unless someone asks for it. That silence is what lets a
+ * tail resume after a suspended page having permanently missed whatever expired
+ * from the stream meanwhile: the recreation resumes from the last delivered
+ * sequence, so the gap is invisible from the tail alone.
+ *
+ * `recreatedEvent` is nats.ws's own enum value rather than a literal of ours: a
+ * copy that drifted from the library would kill this signal silently, which is
+ * the failure mode the signal exists to prevent.
+ *
+ * The status channel is closed along with the iterator, which ends this loop.
+ */
+function watchForRecovery(
+  iter: ConsumerMessages,
+  recreatedEvent: ConsumerEvents.OrderedConsumerRecreated,
+  onRecovered?: () => void,
+): void {
+  if (!onRecovered) return
+  void (async () => {
+    try {
+      const status = await iter.status()
+      for await (const event of status) {
+        if (event.type !== recreatedEvent) continue
+        try {
+          onRecovered()
+        } catch (e) {
+          // A caller that throws must not take the watch down with it — this
+          // loop is the only thing reporting recoveries for this subscription.
+          console.warn('[nats] onRecovered threw:', e)
+        }
+      }
+    } catch {
+      // Status ends with the subscription — nothing left to report.
+    }
+  })()
 }
 
 export function createNatsClient(options: NatsClientOptions): NatsClient {
@@ -524,15 +583,20 @@ export function createNatsClient(options: NatsClientOptions): NatsClient {
       return { unsubscribe() {} }
     }
 
-    const inactiveThresholdNs =
-      (opts.inactiveThresholdMs ?? 5 * 60_000) * 1_000_000
-
     const js = conn.jetstream()
     const consumer: Consumer = await js.consumers.get(opts.streamName, {
       filterSubjects: opts.filterSubject,
       deliver_policy: nats.DeliverPolicy.StartSequence,
       opt_start_seq: opts.optStartSeq ?? 0,
-      inactive_threshold: inactiveThresholdNs,
+      // Milliseconds, NOT nanoseconds: nats.ws runs this through its own
+      // `nanos()` before it reaches the server. Pre-converting here multiplied
+      // it by 1e6 twice, putting the threshold ~9.5 years out — so the ephemeral
+      // consumer never expired. Two consequences, both silent: every reconnect
+      // and dialog switch orphaned a consumer server-side, and a client that
+      // stopped pulling never got the `consumer deleted` that drives the ordered
+      // consumer's self-repair. Undefined stays undefined so nats.ws applies its
+      // own default rather than a copy of it.
+      inactive_threshold: opts.inactiveThresholdMs,
     })
 
     const iterRef: { current: ConsumerMessages | null } = { current: null }
@@ -575,6 +639,7 @@ export function createNatsClient(options: NatsClientOptions): NatsClient {
           return
         }
         iterRef.current = iter
+        watchForRecovery(iter, nats.ConsumerEvents.OrderedConsumerRecreated, opts.onRecovered)
         for await (const msg of iter) {
           if (closed) break
           try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat stream recovery after connection interruptions, consumer recreation, and extended periods when the page is hidden.
  * Automatically prompts refreshed conversation history when missed messages may have occurred.
  * Added recovery handling for ordered message consumers.

* **Bug Fixes**
  * Reduced redundant history refreshes during repeated recovery events.
  * Improved inactive-consumer threshold handling for more reliable message continuity.

* **Documentation**
  * Clarified reconnection, recovery, visibility-resync, and history-refetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->