### PR TITLE
Set id to Relay format

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/rmm/ScriptExecutionDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/rmm/ScriptExecutionDataFetcher.java
@@ -31,6 +31,7 @@ import org.dataloader.DataLoader;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
 
 /**
  * GraphQL resolver for the Execution History tab — the same handler backs both the
@@ -53,6 +54,7 @@ import java.util.concurrent.CompletableFuture;
 public class ScriptExecutionDataFetcher {
 
     private static final Relay RELAY = new Relay();
+    private static final Pattern RAW_MONGO_OBJECT_ID = Pattern.compile("^[0-9a-fA-F]{24}$");
 
     private final ScriptExecutionService scriptExecutionService;
     private final ScriptExecutionFilterService scriptExecutionFilterService;
@@ -139,8 +141,14 @@ public class ScriptExecutionDataFetcher {
         return filters;
     }
 
-    private static String decodeId(String globalId) {
-        return globalId == null ? null : RELAY.fromGlobalId(globalId).getId();
+    private static String decodeId(String id) {
+        if (id == null) {
+            return null;
+        }
+        if (RAW_MONGO_OBJECT_ID.matcher(id).matches()) {
+            return id;
+        }
+        return RELAY.fromGlobalId(id).getId();
     }
 
     private static List<String> decodeIds(List<String> globalIds) {

--- a/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcherTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/ScriptExecutionDataFetcherTest.java
@@ -108,6 +108,54 @@ class ScriptExecutionDataFetcherTest {
     }
 
     @Test
+    @DisplayName("scheduleExecutions: accepts a raw Mongo ObjectId (24 hex) as scheduleId — deep-link URLs like /schedules/{id}/executions don't Relay-encode")
+    void scheduleExecutions_acceptsRawMongoObjectId() {
+        String rawScheduleId = "6a681dba27c56915cbcaac2d";   // 24 hex, real Mongo ObjectId shape
+        SortInput sort = SortInput.builder().build();
+        CursorPaginationCriteria pagination = CursorPaginationCriteria.builder().build();
+        CountedGenericQueryResult<ScriptExecutionResponse> result = CountedGenericQueryResult.<ScriptExecutionResponse>builder().build();
+        CountedGenericConnection<GenericEdge<ScriptExecutionResponse>> connection =
+                CountedGenericConnection.<GenericEdge<ScriptExecutionResponse>>builder().build();
+        when(executionMapper.toCursorPaginationCriteria(any(ConnectionArgs.class))).thenReturn(pagination);
+        when(scriptExecutionService.list(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null, sort, pagination)).thenReturn(result);
+        when(executionMapper.toConnection(result)).thenReturn(connection);
+
+        assertThat(dataFetcher.scheduleExecutions(rawScheduleId, null, null, sort, 10, null, null, null))
+                .isSameAs(connection);
+        verify(scriptExecutionService).list(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null, sort, pagination);
+    }
+
+    @Test
+    @DisplayName("scheduleExecutions: still accepts a Relay-encoded scheduleId — Node-navigated callers keep working")
+    void scheduleExecutions_acceptsRelayGlobalId() {
+        String rawScheduleId = "sch-1";
+        String globalScheduleId = new Relay().toGlobalId("ScriptSchedule", rawScheduleId);
+        SortInput sort = SortInput.builder().build();
+        CursorPaginationCriteria pagination = CursorPaginationCriteria.builder().build();
+        CountedGenericQueryResult<ScriptExecutionResponse> result = CountedGenericQueryResult.<ScriptExecutionResponse>builder().build();
+        CountedGenericConnection<GenericEdge<ScriptExecutionResponse>> connection =
+                CountedGenericConnection.<GenericEdge<ScriptExecutionResponse>>builder().build();
+        when(executionMapper.toCursorPaginationCriteria(any(ConnectionArgs.class))).thenReturn(pagination);
+        when(scriptExecutionService.list(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null, sort, pagination)).thenReturn(result);
+        when(executionMapper.toConnection(result)).thenReturn(connection);
+
+        assertThat(dataFetcher.scheduleExecutions(globalScheduleId, null, null, sort, 10, null, null, null))
+                .isSameAs(connection);
+        verify(scriptExecutionService).list(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null, sort, pagination);
+    }
+
+    @Test
+    @DisplayName("scheduleExecutionFilters: raw Mongo ObjectId scheduleId is accepted — same permissive decode as scheduleExecutions")
+    void scheduleExecutionFilters_acceptsRawMongoObjectId() {
+        String rawScheduleId = "6a681dba27c56915cbcaac2d";
+        ScriptExecutionFilters filters = ScriptExecutionFilters.builder().filteredCount(0).build();
+        when(scriptExecutionFilterService.getExecutionFilters(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null)).thenReturn(filters);
+
+        assertThat(dataFetcher.scheduleExecutionFilters(rawScheduleId, null, null)).isSameAs(filters);
+        verify(scriptExecutionFilterService).getExecutionFilters(ExecutionOwnerScope.forSchedule(rawScheduleId), null, null);
+    }
+
+    @Test
     @DisplayName("ScriptExecution.id resolver returns the Relay global id (Base64 \"ScriptExecution:<rawId>\") — the opaque node handle, not the raw Mongo id")
     void scriptExecutionNodeId_returnsGlobalId() {
         DgsDataFetchingEnvironment dfe = mock(DgsDataFetchingEnvironment.class);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved script and schedule execution queries to accept both standard Relay IDs and raw MongoDB ObjectIds.
  * Added safer handling for missing IDs.

* **Tests**
  * Added coverage confirming schedule execution queries and filters work with both supported ID formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->