### PR TITLE
fix(navigation): drop the Suspense boundary around AppLayout children

### DIFF
--- a/openframe-frontend-core/src/components/navigation/.app-layout.md
+++ b/openframe-frontend-core/src/components/navigation/.app-layout.md
@@ -18,7 +18,6 @@ The root shell component that composes the full application chrome — sidebar, 
 | `topBar` | `ReactNode` | Optional full-width banner pinned above sidebar and header |
 | `drawer` | `ReactNode` | Slot for an `AppLayoutDrawer` that portals into the main area |
 | `disabled` | `boolean` | Freezes nav/header chrome while keeping `children` interactive |
-| `loadingFallback` | `ReactNode` | `Suspense` fallback rendered inside `<main>` |
 
 ## Usage Example
 

--- a/openframe-frontend-core/src/components/navigation/app-layout.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useCallback, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { NavigationSidebarConfig } from '../../types/navigation'
 import { cn } from '../../utils'
 import { NotificationDrawer } from '../features/notifications/notification-drawer'
@@ -21,7 +21,6 @@ export interface AppLayoutProps {
   children: React.ReactNode
   sidebarConfig: NavigationSidebarConfig
   headerProps: Omit<AppHeaderProps, 'isMobileMenuOpen' | 'onToggleMobileMenu' | 'disabled'>
-  loadingFallback?: React.ReactNode
   mainClassName?: string
   className?: string
   mobileBurgerMenuProps: Omit<MobileBurgerMenuProps, 'isOpen' | 'onClose' | 'config' | 'disabled'>
@@ -52,7 +51,6 @@ export function AppLayout({
   children,
   sidebarConfig,
   headerProps,
-  loadingFallback,
   mainClassName,
   className,
   mobileBurgerMenuProps,
@@ -139,9 +137,7 @@ export function AppLayout({
             className="flex-1 flex flex-col relative overflow-hidden"
           >
             <main className={cn("flex-1 overflow-y-auto", mainClassName)}>
-              <Suspense fallback={loadingFallback ?? null}>
-                {children}
-              </Suspense>
+              {children}
             </main>
             {/* `drawer` slot — rendered here so it sits inside the
                 AppLayoutDrawerContainerContext and can portal into this exact

--- a/openframe-frontend-core/src/stories/.AppLayout.stories.md
+++ b/openframe-frontend-core/src/stories/.AppLayout.stories.md
@@ -6,7 +6,6 @@ Storybook stories for the `AppLayout` component, showcasing layout configuration
 - **`Default`** — Standard layout with sidebar, header, and active navigation tracking via `useState`
 - **`WithHeaderUserOnly`** — Layout using only `headerProps` for user identity
 - **`WithSearchAndOrganizations`** — Header with search bar and org selector enabled
-- **`WithLoadingFallback`** — Custom Suspense fallback spinner injected via `loadingFallback` prop
 - **`WithCustomMainClassName`** — Overrides main content area background styling
 - **`MinimizedSidebar`** — Starts with sidebar collapsed to icon-only mode
 - **`Interactive`** — Fully interactive story with live navigation state and current route display

--- a/openframe-frontend-core/src/stories/AppLayout.stories.tsx
+++ b/openframe-frontend-core/src/stories/AppLayout.stories.tsx
@@ -218,33 +218,6 @@ export const WithSearchAndOrganizations: Story = {
 }
 
 /**
- * Layout with custom loading fallback for Suspense.
- */
-export const WithLoadingFallback: Story = {
-  args: {
-    mobileBurgerMenuProps: {
-      user: {
-        userName: 'Alex Developer',
-        userEmail: 'alex@openframe.dev',
-        userAvatarUrl: 'https://github.com/shadcn.png',
-        userRole: 'Admin',
-      },
-    },
-    loadingFallback: (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-ods-accent" />
-      </div>
-    ),
-    children: (
-      <div className="p-4">
-        <h1 className="text-2xl font-semibold text-ods-text-primary mb-4">Content Loaded</h1>
-        <p className="text-ods-text-secondary">The loading spinner appears during Suspense.</p>
-      </div>
-    ),
-  },
-}
-
-/**
  * Layout with custom main content styling.
  */
 export const WithCustomMainClassName: Story = {


### PR DESCRIPTION
## Problem

`AppLayout` wrapped `<main>`'s children in a `Suspense` boundary whose fallback came from an optional `loadingFallback` prop:

```tsx
<main className={cn("flex-1 overflow-y-auto", mainClassName)}>
  <Suspense fallback={loadingFallback ?? null}>
    {children}
  </Suspense>
</main>
```

Any page subtree that suspends — most commonly `useSearchParams()` during client-side navigation — blanked the entire main area and remounted the page subtree, losing local state. With no `loadingFallback` passed (the usual case) the fallback was `null`, so the content simply flashed empty.

## Change

- Render `children` directly inside `<main>`. Pages that genuinely need a fallback own their own `Suspense` boundary, scoped to the part that actually suspends.
- Remove the now-purposeless `loadingFallback` prop from `AppLayoutProps`, together with the `WithLoadingFallback` story and the doc rows referencing it.

## Breaking change

`loadingFallback` is gone from `AppLayoutProps`. Nothing in this repo passed it (only the story did). Consumers still passing it will get a type error and should move the boundary into their own page.

## Verification

- `npm run type-check` — clean.
- `npm run test:run` — 298 passed / 24 failed; all 24 failures are in `src/utils/__tests__/first-touch-attribution.test.ts` and reproduce unchanged on `main`, unrelated to this diff.