### PR TITLE
deps(data-pinot): exclude Pinot/GCS/DGS dead-weight transitives at source

### DIFF
--- a/openframe-api-service-core/pom.xml
+++ b/openframe-api-service-core/pom.xml
@@ -50,6 +50,13 @@
             <groupId>com.netflix.graphql.dgs</groupId>
             <artifactId>graphql-dgs-spring-boot-starter</artifactId>
             <version>${netflix.dgs.version}</version>
+            <exclusions>
+                <!-- test-data generator pulled in by the DGS starter; unused at runtime -->
+                <exclusion>
+                    <groupId>com.netflix.graphql.dgs</groupId>
+                    <artifactId>graphql-dgs-mocking</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceToolAgentUpdateService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceToolAgentUpdateService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
-import static org.apache.zookeeper.common.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Service
 @RequiredArgsConstructor

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceToolInstallationService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceToolInstallationService.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
-import static org.apache.zookeeper.common.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Service
 @RequiredArgsConstructor

--- a/openframe-data-mongo-sync/pom.xml
+++ b/openframe-data-mongo-sync/pom.xml
@@ -73,6 +73,13 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
             <version>2.36.1</version>
+            <exclusions>
+                <!-- xDS control-plane stack; plain GCS calls never use it -->
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-xds</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/openframe-data-pinot/pom.xml
+++ b/openframe-data-pinot/pom.xml
@@ -34,6 +34,47 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-1.2-api</artifactId>
                 </exclusion>
+                <!-- Server-side transitives of pinot-common; the client sends SQL over HTTP,
+                     the broker parses it — none of these run client-side -->
+                <exclusion>
+                    <groupId>org.webjars</groupId>
+                    <artifactId>swagger-ui</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.containers</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.media</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.inject</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.ext</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.helix</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <!-- org.apache.calcite is NOT excluded: Connection.execute() resolves the
+                     table name by parsing the SQL client-side with the Calcite babel parser;
+                     without it every query dies with NoClassDefFoundError. -->
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/9013925967/86ajtc6gp

Source-side companion to flamingo-stack/openframe-saas-tenant#2345 — the same exclusions applied where the dependencies are declared, so every consumer benefits at the next release instead of repeating them per app repo.

## Changes

- **openframe-data-pinot**: exclude pinot-common's server-side transitives from `pinot-java-client` — `swagger-ui`, `org.glassfish.jersey.*` (5 groups), `helix`, `zookeeper`, `groovy-all`. The client sends SQL over HTTP; the broker parses it.
  - **Calcite is deliberately NOT excluded**: `Connection.execute()` resolves the table name by parsing the SQL client-side with the Calcite babel parser, and its catch block catches `Exception`, not `Error` — without Calcite every query dies with `NoClassDefFoundError`. Verified with real queries (count / select * / group-by) against the dev broker on the trimmed classpath; unit tests alone do not catch this.
- **openframe-data-mongo-sync**: exclude `io.grpc:grpc-xds` (12 MB) from `google-cloud-storage` — plain GCS calls never use the xDS control plane.
- **openframe-api-service-core**: exclude `graphql-dgs-mocking` (test-data generator, drags datafaker/rgxgen) from the DGS starter.
- **openframe-api-service-core (code)**: `ForceToolInstallationService` / `ForceToolAgentUpdateService` had accidental IDE auto-imports of `org.apache.zookeeper.common.StringUtils.isBlank` — replaced with the commons-lang3 equivalent already used in those files. These imports compile-coupled the API core to Pinot's zookeeper transitive and are the reason the tenant repo cannot exclude zookeeper until this releases.

## Verification

- Bytecode scan of all released 6.20.15/3.24.8 jars: the two misimports were the only references to any excluded package across the platform.
- `mvn install` + `mvn test` for the three changed modules: build green, 537/537 tests pass.
- Real broker query test through `pinot-java-client` on the trimmed classpath: `PINOT_SMOKE_OK` (connection, query send, response deserialization all working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency handling across data and API services.
  * Standardized blank-value checks for more consistent behavior.

* **Chores**
  * Removed unused transitive libraries to reduce unnecessary application components.
  * Retained required SQL parsing support while excluding unused server-side features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->