### PR TITLE
Permanent image upload endpoint for Knowledge Base and ticket editors

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/config/KnowledgeBaseImageProperties.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/config/KnowledgeBaseImageProperties.java
@@ -1,0 +1,63 @@
+package com.openframe.api.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tuning for inline markdown images (Knowledge Base articles, ticket descriptions).
+ * Everything has a working default, so the feature is usable with no configuration.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openframe.kb.images")
+public class KnowledgeBaseImageProperties {
+
+    private List<AllowedType> allowedTypes = defaultAllowedTypes();
+
+    /**
+     * Hard cap on a single image. Also signed into the upload URL as
+     * {@code x-goog-content-length-range}, so storage rejects an oversized body even though the
+     * bytes never pass through this service.
+     */
+    private long maxSizeBytes = 10 * 1024 * 1024;
+
+    /**
+     * Lifetime of the signed PUT URL handed to the client. Short by design: a signed PUT is a
+     * write capability, and the client uses it within seconds of receiving it.
+     */
+    private int uploadUrlExpirationMinutes = 15;
+
+    /**
+     * Lifetime of the signed URL a download redirect points at, and — one minute less — how long
+     * the browser caches that redirect. Storage caps V4 signatures at 7 days (10080).
+     */
+    private int downloadUrlExpirationMinutes = 1440;
+
+    @Getter
+    @Setter
+    public static class AllowedType {
+
+        private String contentType;
+        private String extension;
+
+        static AllowedType of(String contentType, String extension) {
+            AllowedType allowedType = new AllowedType();
+            allowedType.setContentType(contentType);
+            allowedType.setExtension(extension);
+            return allowedType;
+        }
+    }
+
+    private static List<AllowedType> defaultAllowedTypes() {
+        return new ArrayList<>(List.of(
+                AllowedType.of("image/jpeg", "jpg"),
+                AllowedType.of("image/png", "png"),
+                AllowedType.of("image/webp", "webp")));
+    }
+}

--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUpload.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUpload.java
@@ -1,0 +1,18 @@
+package com.openframe.api.dto.knowledgebase;
+
+import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KnowledgeBaseImageUpload {
+    private KnowledgeBaseImage image;
+    private String uploadUrl;
+    /** Value the client must send as {@code x-goog-content-length-range} on the PUT. */
+    private String contentLengthRange;
+}

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
@@ -1,0 +1,117 @@
+package com.openframe.api.service;
+
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
+import com.openframe.core.exception.BadRequestException;
+import com.openframe.core.exception.NotFoundException;
+import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
+import com.openframe.data.repository.knowledgebase.KnowledgeBaseImageRepository;
+import com.openframe.data.service.GcsPresignedUrlService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Inline images for markdown content (Knowledge Base articles, ticket descriptions).
+ * <p>
+ * Unlike the attachment flow ({@link KnowledgeBaseAttachmentService}), images are uploaded
+ * before the owning item exists and are referenced from markdown by a permanent URL, so
+ * they get a final storage path immediately (no temp/link step) and are never moved.
+ * Upload goes directly to storage via a signed PUT URL; the signed
+ * {@code x-goog-content-length-range} header makes storage enforce the size cap.
+ */
+@Service
+@Slf4j
+@ConditionalOnProperty(name = "storage.s3.disabled", havingValue = "false")
+public class KnowledgeBaseImageService {
+
+    private static final String KB_IMAGES_PREFIX = "kb-images";
+
+    /** SVG is deliberately excluded: an SVG served from storage can carry scripts (stored XSS). */
+    private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
+            "image/jpeg", "jpg",
+            "image/png", "png",
+            "image/gif", "gif",
+            "image/webp", "webp"
+    );
+
+    private final KnowledgeBaseImageRepository imageRepository;
+    private final GcsPresignedUrlService gcsPresignedUrlService;
+    private final long maxSizeBytes;
+    private final int presignedUrlExpirationMinutes;
+
+    public KnowledgeBaseImageService(
+            KnowledgeBaseImageRepository imageRepository,
+            GcsPresignedUrlService gcsPresignedUrlService,
+            @Value("${openframe.kb.images.max-size-bytes:10485760}") long maxSizeBytes,
+            @Value("${openframe.kb.presigned-url-expiration-minutes:15}") int presignedUrlExpirationMinutes) {
+        this.imageRepository = imageRepository;
+        this.gcsPresignedUrlService = gcsPresignedUrlService;
+        this.maxSizeBytes = maxSizeBytes;
+        this.presignedUrlExpirationMinutes = presignedUrlExpirationMinutes;
+    }
+
+    public KnowledgeBaseImageUpload createUpload(String uploaderId, String fileName, String contentType, Long fileSize) {
+        if (fileSize == null || fileSize <= 0) {
+            throw new BadRequestException("Image file size must be positive");
+        }
+        if (fileSize > maxSizeBytes) {
+            throw new BadRequestException("Image exceeds maximum size of " + maxSizeBytes + " bytes");
+        }
+        String extension = EXTENSION_BY_CONTENT_TYPE.get(normalizeContentType(contentType));
+        if (extension == null) {
+            throw new BadRequestException("Unsupported image type: " + contentType
+                    + ". Allowed: " + String.join(", ", EXTENSION_BY_CONTENT_TYPE.keySet()));
+        }
+
+        String storagePath = "%s/%s.%s".formatted(KB_IMAGES_PREFIX, UUID.randomUUID(), extension);
+
+        KnowledgeBaseImage image = imageRepository.save(KnowledgeBaseImage.builder()
+                .fileName(fileName)
+                .storagePath(storagePath)
+                .fileSize(fileSize)
+                .contentType(normalizeContentType(contentType))
+                .uploadedBy(uploaderId)
+                .build());
+
+        String uploadUrl = gcsPresignedUrlService.generateUploadUrl(
+                storagePath,
+                image.getContentType(),
+                Duration.ofMinutes(presignedUrlExpirationMinutes),
+                maxSizeBytes);
+
+        log.info("Knowledge Base image upload created: id={}, path={}, by={}", image.getId(), storagePath, uploaderId);
+
+        return KnowledgeBaseImageUpload.builder()
+                .image(image)
+                .uploadUrl(uploadUrl)
+                .contentLengthRange(GcsPresignedUrlService.contentLengthRange(maxSizeBytes))
+                .build();
+    }
+
+    public String generateDownloadUrl(String imageId) {
+        KnowledgeBaseImage image = imageRepository.findById(imageId)
+                .orElseThrow(() -> new NotFoundException("Image not found: " + imageId));
+
+        return gcsPresignedUrlService.generateDownloadUrl(
+                image.getStoragePath(),
+                Duration.ofMinutes(presignedUrlExpirationMinutes));
+    }
+
+    public int getPresignedUrlExpirationMinutes() {
+        return presignedUrlExpirationMinutes;
+    }
+
+    private String normalizeContentType(String contentType) {
+        if (contentType == null) {
+            return "";
+        }
+        int paramsStart = contentType.indexOf(';');
+        String bareType = paramsStart >= 0 ? contentType.substring(0, paramsStart) : contentType;
+        return bareType.trim().toLowerCase();
+    }
+}

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
@@ -1,19 +1,21 @@
 package com.openframe.api.service;
 
+import com.openframe.api.config.KnowledgeBaseImageProperties;
 import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
 import com.openframe.core.exception.BadRequestException;
 import com.openframe.core.exception.NotFoundException;
 import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
 import com.openframe.data.repository.knowledgebase.KnowledgeBaseImageRepository;
 import com.openframe.data.service.GcsPresignedUrlService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.UUID;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Inline images for markdown content (Knowledge Base articles, ticket descriptions).
@@ -26,47 +28,19 @@ import java.util.UUID;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 @ConditionalOnProperty(name = "storage.s3.disabled", havingValue = "false")
 public class KnowledgeBaseImageService {
 
     private static final String KB_IMAGES_PREFIX = "kb-images";
 
-    /** SVG is deliberately excluded: an SVG served from storage can carry scripts (stored XSS). */
-    private static final Map<String, String> EXTENSION_BY_CONTENT_TYPE = Map.of(
-            "image/jpeg", "jpg",
-            "image/png", "png",
-            "image/gif", "gif",
-            "image/webp", "webp"
-    );
-
     private final KnowledgeBaseImageRepository imageRepository;
     private final GcsPresignedUrlService gcsPresignedUrlService;
-    private final long maxSizeBytes;
-    private final int presignedUrlExpirationMinutes;
-
-    public KnowledgeBaseImageService(
-            KnowledgeBaseImageRepository imageRepository,
-            GcsPresignedUrlService gcsPresignedUrlService,
-            @Value("${openframe.kb.images.max-size-bytes:10485760}") long maxSizeBytes,
-            @Value("${openframe.kb.presigned-url-expiration-minutes:15}") int presignedUrlExpirationMinutes) {
-        this.imageRepository = imageRepository;
-        this.gcsPresignedUrlService = gcsPresignedUrlService;
-        this.maxSizeBytes = maxSizeBytes;
-        this.presignedUrlExpirationMinutes = presignedUrlExpirationMinutes;
-    }
+    private final KnowledgeBaseImageProperties imageProperties;
 
     public KnowledgeBaseImageUpload createUpload(String uploaderId, String fileName, String contentType, Long fileSize) {
-        if (fileSize == null || fileSize <= 0) {
-            throw new BadRequestException("Image file size must be positive");
-        }
-        if (fileSize > maxSizeBytes) {
-            throw new BadRequestException("Image exceeds maximum size of " + maxSizeBytes + " bytes");
-        }
-        String extension = EXTENSION_BY_CONTENT_TYPE.get(normalizeContentType(contentType));
-        if (extension == null) {
-            throw new BadRequestException("Unsupported image type: " + contentType
-                    + ". Allowed: " + String.join(", ", EXTENSION_BY_CONTENT_TYPE.keySet()));
-        }
+        long maxSizeBytes = imageProperties.getMaxSizeBytes();
+        String extension = validateAndResolveExtension(contentType, fileSize, maxSizeBytes);
 
         String storagePath = "%s/%s.%s".formatted(KB_IMAGES_PREFIX, UUID.randomUUID(), extension);
 
@@ -81,10 +55,10 @@ public class KnowledgeBaseImageService {
         String uploadUrl = gcsPresignedUrlService.generateUploadUrl(
                 storagePath,
                 image.getContentType(),
-                Duration.ofMinutes(presignedUrlExpirationMinutes),
+                Duration.ofMinutes(imageProperties.getUploadUrlExpirationMinutes()),
                 maxSizeBytes);
 
-        log.info("Knowledge Base image upload created: id={}, path={}, by={}", image.getId(), storagePath, uploaderId);
+        log.debug("Knowledge Base image upload created: id={}, path={}, by={}", image.getId(), storagePath, uploaderId);
 
         return KnowledgeBaseImageUpload.builder()
                 .image(image)
@@ -99,11 +73,53 @@ public class KnowledgeBaseImageService {
 
         return gcsPresignedUrlService.generateDownloadUrl(
                 image.getStoragePath(),
-                Duration.ofMinutes(presignedUrlExpirationMinutes));
+                Duration.ofMinutes(getDownloadUrlExpirationMinutes()));
     }
 
-    public int getPresignedUrlExpirationMinutes() {
-        return presignedUrlExpirationMinutes;
+    /** Signature lifetime the caller should keep its redirect cached just under. */
+    public int getDownloadUrlExpirationMinutes() {
+        return imageProperties.getDownloadUrlExpirationMinutes();
+    }
+
+    /**
+     * Validates the client-declared metadata and returns the storage extension for the content
+     * type. The bytes never reach this service, so this — plus the size range signed into the
+     * upload URL — is the whole server-side gate.
+     */
+    private String validateAndResolveExtension(String contentType, Long fileSize, long maxSizeBytes) {
+        if (fileSize == null || fileSize <= 0) {
+            throw new BadRequestException("Image file size must be positive");
+        }
+        if (fileSize > maxSizeBytes) {
+            throw new BadRequestException("Image exceeds maximum size of " + maxSizeBytes + " bytes");
+        }
+        String extension = resolveExtension(contentType);
+        if (extension == null) {
+            throw new BadRequestException("Unsupported image type: " + contentType
+                    + ". Allowed: " + allowedContentTypes());
+        }
+        return extension;
+    }
+
+    /**
+     * Storage extension for the given content type, or null when it is not configured as
+     * allowed. Configured types are matched case-insensitively so a deployment writing
+     * {@code image/JPEG} still works.
+     */
+    private String resolveExtension(String contentType) {
+        String normalized = normalizeContentType(contentType);
+        return imageProperties.getAllowedTypes().stream()
+                .filter(allowed -> allowed.getContentType() != null
+                        && allowed.getContentType().trim().equalsIgnoreCase(normalized))
+                .map(KnowledgeBaseImageProperties.AllowedType::getExtension)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String allowedContentTypes() {
+        return imageProperties.getAllowedTypes().stream()
+                .map(KnowledgeBaseImageProperties.AllowedType::getContentType)
+                .collect(joining(", "));
     }
 
     private String normalizeContentType(String contentType) {

--- a/openframe-api-lib/src/test/java/com/openframe/api/config/KnowledgeBaseImagePropertiesTest.java
+++ b/openframe-api-lib/src/test/java/com/openframe/api/config/KnowledgeBaseImagePropertiesTest.java
@@ -1,0 +1,125 @@
+package com.openframe.api.config;
+
+import com.openframe.api.config.KnowledgeBaseImageProperties.AllowedType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the exact YAML shape deployments have to write, and the override semantics that shape
+ * was chosen for: a configured list must REPLACE what came before it, so an environment can drop
+ * a type and not merely add one.
+ */
+class KnowledgeBaseImagePropertiesTest {
+
+    @Test
+    @DisplayName("defaults are usable with no configuration at all")
+    void defaults() {
+        KnowledgeBaseImageProperties properties = new KnowledgeBaseImageProperties();
+
+        assertThat(contentTypes(properties)).containsExactly("image/jpeg", "image/png", "image/webp");
+        assertThat(properties.getMaxSizeBytes()).isEqualTo(10 * 1024 * 1024);
+        assertThat(properties.getUploadUrlExpirationMinutes()).isEqualTo(15);
+        assertThat(properties.getDownloadUrlExpirationMinutes()).isEqualTo(1440);
+    }
+
+    @Test
+    @DisplayName("the deployed YAML shape binds")
+    void bindsFromYaml() throws IOException {
+        KnowledgeBaseImageProperties properties = bind("""
+                openframe:
+                  kb:
+                    images:
+                      max-size-bytes: 5242880
+                      download-url-expiration-minutes: 720
+                      allowed-types:
+                        - content-type: image/jpeg
+                          extension: jpg
+                        - content-type: image/png
+                          extension: png
+                        - content-type: image/webp
+                          extension: webp
+                """);
+
+        assertThat(contentTypes(properties)).containsExactly("image/jpeg", "image/png", "image/webp");
+        assertThat(properties.getAllowedTypes().get(0).getExtension()).isEqualTo("jpg");
+        assertThat(properties.getMaxSizeBytes()).isEqualTo(5_242_880L);
+        assertThat(properties.getDownloadUrlExpirationMinutes()).isEqualTo(720);
+    }
+
+    @Test
+    @DisplayName("a configured list replaces the code defaults rather than adding to them")
+    void configuredListReplacesDefaults() throws IOException {
+        KnowledgeBaseImageProperties properties = bind("""
+                openframe:
+                  kb:
+                    images:
+                      allowed-types:
+                        - content-type: image/gif
+                          extension: gif
+                """);
+
+        assertThat(contentTypes(properties)).containsExactly("image/gif");
+    }
+
+    @Test
+    @DisplayName("a per-environment override replaces the base list, so an env can drop a type")
+    void environmentOverrideReplacesBase() throws IOException {
+        StandardEnvironment environment = new StandardEnvironment();
+        addYaml(environment, """
+                openframe:
+                  kb:
+                    images:
+                      allowed-types:
+                        - content-type: image/jpeg
+                          extension: jpg
+                        - content-type: image/gif
+                          extension: gif
+                """);
+        // higher priority, as a dev profile overlay would be
+        addYaml(environment, """
+                openframe:
+                  kb:
+                    images:
+                      allowed-types:
+                        - content-type: image/jpeg
+                          extension: jpg
+                """);
+
+        KnowledgeBaseImageProperties properties = Binder.get(environment)
+                .bind("openframe.kb.images", KnowledgeBaseImageProperties.class)
+                .orElseGet(KnowledgeBaseImageProperties::new);
+
+        assertThat(contentTypes(properties)).containsExactly("image/jpeg");
+    }
+
+    private static List<String> contentTypes(KnowledgeBaseImageProperties properties) {
+        return properties.getAllowedTypes().stream().map(AllowedType::getContentType).toList();
+    }
+
+    private KnowledgeBaseImageProperties bind(String yaml) throws IOException {
+        StandardEnvironment environment = new StandardEnvironment();
+        addYaml(environment, yaml);
+
+        return Binder.get(environment)
+                .bind("openframe.kb.images", KnowledgeBaseImageProperties.class)
+                .orElseGet(KnowledgeBaseImageProperties::new);
+    }
+
+    private void addYaml(StandardEnvironment environment, String yaml) throws IOException {
+        List<PropertySource<?>> sources = new YamlPropertySourceLoader()
+                .load("test-" + environment.getPropertySources().size(),
+                        new ByteArrayResource(yaml.getBytes(StandardCharsets.UTF_8)));
+        sources.forEach(source -> environment.getPropertySources().addFirst(source));
+    }
+}

--- a/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
+++ b/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
@@ -1,0 +1,143 @@
+package com.openframe.api.service;
+
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
+import com.openframe.core.exception.BadRequestException;
+import com.openframe.core.exception.NotFoundException;
+import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
+import com.openframe.data.repository.knowledgebase.KnowledgeBaseImageRepository;
+import com.openframe.data.service.GcsPresignedUrlService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link KnowledgeBaseImageService}. Repository and storage are mocked;
+ * these cover the validation rules, the generated storage path, and the delegation
+ * contract for signed upload/download URLs.
+ */
+class KnowledgeBaseImageServiceTest {
+
+    private static final long MAX_SIZE_BYTES = 10 * 1024 * 1024;
+    private static final int EXPIRATION_MINUTES = 15;
+
+    private KnowledgeBaseImageRepository repository;
+    private GcsPresignedUrlService gcsPresignedUrlService;
+    private KnowledgeBaseImageService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(KnowledgeBaseImageRepository.class);
+        gcsPresignedUrlService = mock(GcsPresignedUrlService.class);
+        service = new KnowledgeBaseImageService(repository, gcsPresignedUrlService, MAX_SIZE_BYTES, EXPIRATION_MINUTES);
+    }
+
+    @Test
+    @DisplayName("createUpload saves the image with a UUID storage path and returns a size-capped signed PUT URL")
+    void createUpload_happyPath() {
+        when(repository.save(any(KnowledgeBaseImage.class))).thenAnswer(invocation -> {
+            KnowledgeBaseImage image = invocation.getArgument(0);
+            image.setId("img-1");
+            return image;
+        });
+        when(gcsPresignedUrlService.generateUploadUrl(any(), any(), any(), anyLong()))
+                .thenReturn("https://signed-upload");
+
+        KnowledgeBaseImageUpload upload = service.createUpload("user-1", "screenshot.png", "image/png", 1234L);
+
+        ArgumentCaptor<KnowledgeBaseImage> imageCaptor = ArgumentCaptor.forClass(KnowledgeBaseImage.class);
+        verify(repository).save(imageCaptor.capture());
+        KnowledgeBaseImage saved = imageCaptor.getValue();
+        assertThat(saved.getStoragePath()).matches("kb-images/[0-9a-f-]{36}\\.png");
+        assertThat(saved.getFileName()).isEqualTo("screenshot.png");
+        assertThat(saved.getContentType()).isEqualTo("image/png");
+        assertThat(saved.getFileSize()).isEqualTo(1234L);
+        assertThat(saved.getUploadedBy()).isEqualTo("user-1");
+
+        verify(gcsPresignedUrlService).generateUploadUrl(
+                eq(saved.getStoragePath()), eq("image/png"),
+                eq(Duration.ofMinutes(EXPIRATION_MINUTES)), eq(MAX_SIZE_BYTES));
+
+        assertThat(upload.getImage().getId()).isEqualTo("img-1");
+        assertThat(upload.getUploadUrl()).isEqualTo("https://signed-upload");
+        assertThat(upload.getContentLengthRange()).isEqualTo("0," + MAX_SIZE_BYTES);
+    }
+
+    @Test
+    @DisplayName("createUpload normalizes content type casing and parameters")
+    void createUpload_normalizesContentType() {
+        when(repository.save(any(KnowledgeBaseImage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(gcsPresignedUrlService.generateUploadUrl(any(), any(), any(), anyLong()))
+                .thenReturn("https://signed-upload");
+
+        service.createUpload("user-1", "photo.jpeg", "image/JPEG; charset=utf-8", 100L);
+
+        ArgumentCaptor<KnowledgeBaseImage> imageCaptor = ArgumentCaptor.forClass(KnowledgeBaseImage.class);
+        verify(repository).save(imageCaptor.capture());
+        assertThat(imageCaptor.getValue().getContentType()).isEqualTo("image/jpeg");
+        assertThat(imageCaptor.getValue().getStoragePath()).endsWith(".jpg");
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(longs = {0L, -1L, MAX_SIZE_BYTES + 1})
+    @DisplayName("createUpload rejects missing, non-positive, and oversized file sizes")
+    void createUpload_rejectsInvalidSize(Long fileSize) {
+        assertThatThrownBy(() -> service.createUpload("user-1", "a.png", "image/png", fileSize))
+                .isInstanceOf(BadRequestException.class);
+
+        verifyNoInteractions(repository, gcsPresignedUrlService);
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"image/svg+xml", "text/plain", "application/octet-stream", "image/"})
+    @DisplayName("createUpload rejects content types outside the image whitelist")
+    void createUpload_rejectsUnsupportedContentType(String contentType) {
+        assertThatThrownBy(() -> service.createUpload("user-1", "a.bin", contentType, 100L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("Unsupported image type");
+
+        verifyNoInteractions(repository, gcsPresignedUrlService);
+    }
+
+    @Test
+    @DisplayName("generateDownloadUrl signs the stored path with the configured expiration")
+    void generateDownloadUrl_happyPath() {
+        when(repository.findById("img-1")).thenReturn(Optional.of(KnowledgeBaseImage.builder()
+                .id("img-1")
+                .storagePath("kb-images/abc.png")
+                .build()));
+        when(gcsPresignedUrlService.generateDownloadUrl("kb-images/abc.png", Duration.ofMinutes(EXPIRATION_MINUTES)))
+                .thenReturn("https://signed-download");
+
+        assertThat(service.generateDownloadUrl("img-1")).isEqualTo("https://signed-download");
+    }
+
+    @Test
+    @DisplayName("generateDownloadUrl throws NotFoundException for an unknown image id")
+    void generateDownloadUrl_unknownId() {
+        when(repository.findById("missing")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.generateDownloadUrl("missing"))
+                .isInstanceOf(NotFoundException.class);
+
+        verifyNoInteractions(gcsPresignedUrlService);
+    }
+}

--- a/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
+++ b/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
@@ -1,5 +1,7 @@
 package com.openframe.api.service;
 
+import com.openframe.api.config.KnowledgeBaseImageProperties;
+import com.openframe.api.config.KnowledgeBaseImageProperties.AllowedType;
 import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
 import com.openframe.core.exception.BadRequestException;
 import com.openframe.core.exception.NotFoundException;
@@ -15,6 +17,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,17 +38,30 @@ import static org.mockito.Mockito.when;
 class KnowledgeBaseImageServiceTest {
 
     private static final long MAX_SIZE_BYTES = 10 * 1024 * 1024;
-    private static final int EXPIRATION_MINUTES = 15;
+    private static final int UPLOAD_EXPIRATION_MINUTES = 15;
+    private static final int DOWNLOAD_EXPIRATION_MINUTES = 1440;
 
     private KnowledgeBaseImageRepository repository;
     private GcsPresignedUrlService gcsPresignedUrlService;
+    private KnowledgeBaseImageProperties properties;
     private KnowledgeBaseImageService service;
 
     @BeforeEach
     void setUp() {
         repository = mock(KnowledgeBaseImageRepository.class);
         gcsPresignedUrlService = mock(GcsPresignedUrlService.class);
-        service = new KnowledgeBaseImageService(repository, gcsPresignedUrlService, MAX_SIZE_BYTES, EXPIRATION_MINUTES);
+        properties = new KnowledgeBaseImageProperties();
+        properties.setMaxSizeBytes(MAX_SIZE_BYTES);
+        properties.setUploadUrlExpirationMinutes(UPLOAD_EXPIRATION_MINUTES);
+        properties.setDownloadUrlExpirationMinutes(DOWNLOAD_EXPIRATION_MINUTES);
+        service = new KnowledgeBaseImageService(repository, gcsPresignedUrlService, properties);
+    }
+
+    private static AllowedType allowed(String contentType, String extension) {
+        AllowedType allowedType = new AllowedType();
+        allowedType.setContentType(contentType);
+        allowedType.setExtension(extension);
+        return allowedType;
     }
 
     @Test
@@ -72,7 +88,7 @@ class KnowledgeBaseImageServiceTest {
 
         verify(gcsPresignedUrlService).generateUploadUrl(
                 eq(saved.getStoragePath()), eq("image/png"),
-                eq(Duration.ofMinutes(EXPIRATION_MINUTES)), eq(MAX_SIZE_BYTES));
+                eq(Duration.ofMinutes(UPLOAD_EXPIRATION_MINUTES)), eq(MAX_SIZE_BYTES));
 
         assertThat(upload.getImage().getId()).isEqualTo("img-1");
         assertThat(upload.getUploadUrl()).isEqualTo("https://signed-upload");
@@ -107,8 +123,8 @@ class KnowledgeBaseImageServiceTest {
 
     @ParameterizedTest
     @NullSource
-    @ValueSource(strings = {"image/svg+xml", "text/plain", "application/octet-stream", "image/"})
-    @DisplayName("createUpload rejects content types outside the image whitelist")
+    @ValueSource(strings = {"image/svg+xml", "text/plain", "application/octet-stream", "image/", "image/gif"})
+    @DisplayName("createUpload rejects content types that are not configured as allowed")
     void createUpload_rejectsUnsupportedContentType(String contentType) {
         assertThatThrownBy(() -> service.createUpload("user-1", "a.bin", contentType, 100L))
                 .isInstanceOf(BadRequestException.class)
@@ -118,16 +134,52 @@ class KnowledgeBaseImageServiceTest {
     }
 
     @Test
-    @DisplayName("generateDownloadUrl signs the stored path with the configured expiration")
+    @DisplayName("the allowed type list is configuration-driven, not fixed in code")
+    void createUpload_honoursConfiguredTypes() {
+        properties.setAllowedTypes(List.of(allowed("image/gif", "gif")));
+        when(repository.save(any(KnowledgeBaseImage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(gcsPresignedUrlService.generateUploadUrl(any(), any(), any(), anyLong())).thenReturn("https://signed-upload");
+
+        service.createUpload("user-1", "anim.gif", "image/gif", 100L);
+
+        ArgumentCaptor<KnowledgeBaseImage> imageCaptor = ArgumentCaptor.forClass(KnowledgeBaseImage.class);
+        verify(repository).save(imageCaptor.capture());
+        assertThat(imageCaptor.getValue().getStoragePath()).endsWith(".gif");
+
+        // ...and a type dropped from the configuration is no longer accepted
+        assertThatThrownBy(() -> service.createUpload("user-1", "a.png", "image/png", 100L))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @DisplayName("the configured size cap is applied and signed into the upload URL")
+    void createUpload_honoursConfiguredSizeCap() {
+        properties.setMaxSizeBytes(1024);
+        when(repository.save(any(KnowledgeBaseImage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(gcsPresignedUrlService.generateUploadUrl(any(), any(), any(), anyLong())).thenReturn("https://signed-upload");
+
+        assertThatThrownBy(() -> service.createUpload("user-1", "a.png", "image/png", 2048L))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining("1024");
+
+        KnowledgeBaseImageUpload upload = service.createUpload("user-1", "a.png", "image/png", 512L);
+        assertThat(upload.getContentLengthRange()).isEqualTo("0,1024");
+        verify(gcsPresignedUrlService).generateUploadUrl(any(), any(), any(), eq(1024L));
+    }
+
+    @Test
+    @DisplayName("generateDownloadUrl signs with the longer download expiration, not the upload one")
     void generateDownloadUrl_happyPath() {
         when(repository.findById("img-1")).thenReturn(Optional.of(KnowledgeBaseImage.builder()
                 .id("img-1")
                 .storagePath("kb-images/abc.png")
                 .build()));
-        when(gcsPresignedUrlService.generateDownloadUrl("kb-images/abc.png", Duration.ofMinutes(EXPIRATION_MINUTES)))
+        when(gcsPresignedUrlService.generateDownloadUrl(
+                "kb-images/abc.png", Duration.ofMinutes(DOWNLOAD_EXPIRATION_MINUTES)))
                 .thenReturn("https://signed-download");
 
         assertThat(service.generateDownloadUrl("img-1")).isEqualTo("https://signed-download");
+        assertThat(service.getDownloadUrlExpirationMinutes()).isEqualTo(DOWNLOAD_EXPIRATION_MINUTES);
     }
 
     @Test

--- a/openframe-api-service-core/src/main/java/com/openframe/api/controller/KnowledgeBaseImageController.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/controller/KnowledgeBaseImageController.java
@@ -44,7 +44,7 @@ public class KnowledgeBaseImageController {
     public KnowledgeBaseImageUploadResponse createUpload(
             @AuthenticationPrincipal AuthPrincipal principal,
             @Valid @RequestBody KnowledgeBaseImageUploadRequest request) {
-        log.info("Creating Knowledge Base image upload: file={}, size={} by user: {}",
+        log.debug("Creating Knowledge Base image upload: file={}, size={} by user: {}",
                 request.fileName(), request.fileSize(), principal.getId());
 
         KnowledgeBaseImageUpload upload = imageService.createUpload(
@@ -62,7 +62,7 @@ public class KnowledgeBaseImageController {
 
         // Cache the redirect just under the signature lifetime so repeat renders
         // reuse it instead of re-hitting the API for a fresh signature.
-        long cacheMinutes = Math.max(imageService.getPresignedUrlExpirationMinutes() - 1, 0);
+        long cacheMinutes = Math.max(imageService.getDownloadUrlExpirationMinutes() - 1, 0);
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(URI.create(downloadUrl))
                 .cacheControl(CacheControl.maxAge(cacheMinutes, TimeUnit.MINUTES).cachePrivate())

--- a/openframe-api-service-core/src/main/java/com/openframe/api/controller/KnowledgeBaseImageController.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/controller/KnowledgeBaseImageController.java
@@ -1,0 +1,71 @@
+package com.openframe.api.controller;
+
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUploadRequest;
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUploadResponse;
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
+import com.openframe.api.service.KnowledgeBaseImageService;
+import com.openframe.data.service.GcsPresignedUrlService;
+import com.openframe.security.authentication.AuthPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Inline images for markdown content (Knowledge Base articles, ticket descriptions).
+ * <p>
+ * The markdown embeds the permanent {@code /knowledge-base/images/{id}} URL; GET
+ * redirects to a freshly signed short-lived storage URL, so the embedded link never
+ * expires while image bytes stream directly from storage. Upload is likewise direct:
+ * POST returns a signed PUT URL the client uploads the file to.
+ */
+@RestController
+@RequestMapping("/knowledge-base/images")
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(name = "storage.s3.disabled", havingValue = "false")
+public class KnowledgeBaseImageController {
+
+    private static final String IMAGE_URL_TEMPLATE = "/knowledge-base/images/%s";
+
+    private final KnowledgeBaseImageService imageService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public KnowledgeBaseImageUploadResponse createUpload(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody KnowledgeBaseImageUploadRequest request) {
+        log.info("Creating Knowledge Base image upload: file={}, size={} by user: {}",
+                request.fileName(), request.fileSize(), principal.getId());
+
+        KnowledgeBaseImageUpload upload = imageService.createUpload(
+                principal.getId(), request.fileName(), request.contentType(), request.fileSize());
+
+        return new KnowledgeBaseImageUploadResponse(
+                IMAGE_URL_TEMPLATE.formatted(upload.getImage().getId()),
+                upload.getUploadUrl(),
+                Map.of(GcsPresignedUrlService.CONTENT_LENGTH_RANGE_HEADER, upload.getContentLengthRange()));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Void> getImage(@PathVariable String id) {
+        String downloadUrl = imageService.generateDownloadUrl(id);
+
+        // Cache the redirect just under the signature lifetime so repeat renders
+        // reuse it instead of re-hitting the API for a fresh signature.
+        long cacheMinutes = Math.max(imageService.getPresignedUrlExpirationMinutes() - 1, 0);
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .location(URI.create(downloadUrl))
+                .cacheControl(CacheControl.maxAge(cacheMinutes, TimeUnit.MINUTES).cachePrivate())
+                .build();
+    }
+}

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUploadRequest.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUploadRequest.java
@@ -1,0 +1,18 @@
+package com.openframe.api.dto.knowledgebase;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record KnowledgeBaseImageUploadRequest(
+        @NotBlank(message = "File name is required")
+        String fileName,
+
+        @NotBlank(message = "Content type is required")
+        String contentType,
+
+        @NotNull(message = "File size is required")
+        @Positive(message = "File size must be positive")
+        Long fileSize
+) {
+}

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUploadResponse.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dto/knowledgebase/KnowledgeBaseImageUploadResponse.java
@@ -1,0 +1,15 @@
+package com.openframe.api.dto.knowledgebase;
+
+import java.util.Map;
+
+/**
+ * @param url           permanent image URL to embed in markdown (never expires)
+ * @param uploadUrl     short-lived signed URL the client PUTs the file to
+ * @param uploadHeaders headers the client must send on the PUT request verbatim
+ */
+public record KnowledgeBaseImageUploadResponse(
+        String url,
+        String uploadUrl,
+        Map<String, String> uploadHeaders
+) {
+}

--- a/openframe-api-service-core/src/test/java/com/openframe/api/controller/KnowledgeBaseImageControllerTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/controller/KnowledgeBaseImageControllerTest.java
@@ -100,12 +100,13 @@ class KnowledgeBaseImageControllerTest {
     @DisplayName("GET redirects to a fresh signed url and caches the redirect just under its lifetime")
     void getImage_redirects() throws Exception {
         when(imageService.generateDownloadUrl("img-1")).thenReturn("https://signed-download");
-        when(imageService.getPresignedUrlExpirationMinutes()).thenReturn(15);
+        when(imageService.getDownloadUrlExpirationMinutes()).thenReturn(1440);
 
         mockMvc.perform(get("/knowledge-base/images/img-1"))
                 .andExpect(status().isFound())
                 .andExpect(header().string("Location", "https://signed-download"))
-                .andExpect(header().string("Cache-Control", "max-age=840, private"));
+                // one minute less than the signature lifetime: 1439 min
+                .andExpect(header().string("Cache-Control", "max-age=86340, private"));
     }
 
     @Test

--- a/openframe-api-service-core/src/test/java/com/openframe/api/controller/KnowledgeBaseImageControllerTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/controller/KnowledgeBaseImageControllerTest.java
@@ -1,0 +1,133 @@
+package com.openframe.api.controller;
+
+import com.openframe.api.dto.knowledgebase.KnowledgeBaseImageUpload;
+import com.openframe.api.service.KnowledgeBaseImageService;
+import com.openframe.core.exception.BadRequestException;
+import com.openframe.core.exception.BaseGlobalExceptionHandler;
+import com.openframe.core.exception.NotFoundException;
+import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
+import com.openframe.security.authentication.AuthPrincipal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class KnowledgeBaseImageControllerTest {
+
+    private static final String UPLOAD_REQUEST_JSON = """
+            {"fileName": "screenshot.png", "contentType": "image/png", "fileSize": 1234}
+            """;
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private KnowledgeBaseImageService imageService;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new KnowledgeBaseImageController(imageService))
+                .setCustomArgumentResolvers(new StubAuthPrincipalResolver())
+                .setControllerAdvice(new BaseGlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("POST returns 201 with the permanent url, signed upload url and required headers")
+    void createUpload_returnsContract() throws Exception {
+        when(imageService.createUpload("user-1", "screenshot.png", "image/png", 1234L))
+                .thenReturn(KnowledgeBaseImageUpload.builder()
+                        .image(KnowledgeBaseImage.builder().id("img-1").build())
+                        .uploadUrl("https://signed-upload")
+                        .contentLengthRange("0,10485760")
+                        .build());
+
+        mockMvc.perform(post("/knowledge-base/images")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPLOAD_REQUEST_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.url").value("/knowledge-base/images/img-1"))
+                .andExpect(jsonPath("$.uploadUrl").value("https://signed-upload"))
+                .andExpect(jsonPath("$.uploadHeaders['x-goog-content-length-range']").value("0,10485760"));
+    }
+
+    @Test
+    @DisplayName("POST without a file name is rejected with 400 before reaching the service")
+    void createUpload_missingFileName() throws Exception {
+        mockMvc.perform(post("/knowledge-base/images")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"contentType": "image/png", "fileSize": 1234}
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(imageService);
+    }
+
+    @Test
+    @DisplayName("POST surfaces service validation failures as 400 JSON")
+    void createUpload_serviceRejects() throws Exception {
+        when(imageService.createUpload(any(), any(), any(), any()))
+                .thenThrow(new BadRequestException("Unsupported image type: image/svg+xml"));
+
+        mockMvc.perform(post("/knowledge-base/images")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(UPLOAD_REQUEST_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Unsupported image type: image/svg+xml"));
+    }
+
+    @Test
+    @DisplayName("GET redirects to a fresh signed url and caches the redirect just under its lifetime")
+    void getImage_redirects() throws Exception {
+        when(imageService.generateDownloadUrl("img-1")).thenReturn("https://signed-download");
+        when(imageService.getPresignedUrlExpirationMinutes()).thenReturn(15);
+
+        mockMvc.perform(get("/knowledge-base/images/img-1"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "https://signed-download"))
+                .andExpect(header().string("Cache-Control", "max-age=840, private"));
+    }
+
+    @Test
+    @DisplayName("GET returns 404 for an unknown image id")
+    void getImage_unknownId() throws Exception {
+        when(imageService.generateDownloadUrl("missing")).thenThrow(new NotFoundException("Image not found: missing"));
+
+        mockMvc.perform(get("/knowledge-base/images/missing"))
+                .andExpect(status().isNotFound());
+    }
+
+    /** Supplies a fixed {@link AuthPrincipal} for {@code @AuthenticationPrincipal} parameters. */
+    private static class StubAuthPrincipalResolver implements HandlerMethodArgumentResolver {
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return AuthPrincipal.class.isAssignableFrom(parameter.getParameterType());
+        }
+
+        @Override
+        public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                      NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+            return AuthPrincipal.builder().id("user-1").build();
+        }
+    }
+}

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/knowledgebase/KnowledgeBaseImage.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/knowledgebase/KnowledgeBaseImage.java
@@ -1,0 +1,45 @@
+package com.openframe.data.document.knowledgebase;
+
+import com.openframe.data.document.TenantScoped;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+/**
+ * Inline image embedded in markdown content (Knowledge Base articles, ticket descriptions).
+ * Unlike {@link KnowledgeBaseItemAttachment}, images are not bound to an item: they are
+ * uploaded while the content is still being written and referenced by a permanent URL
+ * ({@code /knowledge-base/images/{id}}), so they must survive item lifecycle changes.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "knowledge_base_images")
+public class KnowledgeBaseImage implements TenantScoped {
+    @Id
+    private String id;
+
+    @Indexed
+    private String tenantId;
+
+    private String fileName;
+
+    private String storagePath;
+
+    private Long fileSize;
+
+    private String contentType;
+
+    private String uploadedBy;
+
+    @CreatedDate
+    private Instant createdAt;
+}

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/KnowledgeBaseImageRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/KnowledgeBaseImageRepository.java
@@ -1,0 +1,7 @@
+package com.openframe.data.repository.knowledgebase;
+
+import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface KnowledgeBaseImageRepository extends MongoRepository<KnowledgeBaseImage, String> {
+}

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/GcsPresignedUrlService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/GcsPresignedUrlService.java
@@ -63,11 +63,6 @@ public class GcsPresignedUrlService {
         return url;
     }
 
-    /**
-     * Signed PUT URL that additionally pins {@code x-goog-content-length-range}, so GCS
-     * itself rejects uploads larger than {@code maxSizeBytes}. The client must send the
-     * same header on the PUT request.
-     */
     public String generateUploadUrl(String path, String contentType, Duration expiration, long maxSizeBytes) {
         String fullPath = withPrefix(path);
         BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fullPath)

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/GcsPresignedUrlService.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/service/GcsPresignedUrlService.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -23,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @ConditionalOnProperty(name = "storage.s3.disabled", havingValue = "false")
 public class GcsPresignedUrlService {
+
+    public static final String CONTENT_LENGTH_RANGE_HEADER = "x-goog-content-length-range";
 
     private final Storage storage;
     private final String bucketName;
@@ -58,6 +61,35 @@ public class GcsPresignedUrlService {
 
         log.debug("Generated upload URL for path: {}", fullPath);
         return url;
+    }
+
+    /**
+     * Signed PUT URL that additionally pins {@code x-goog-content-length-range}, so GCS
+     * itself rejects uploads larger than {@code maxSizeBytes}. The client must send the
+     * same header on the PUT request.
+     */
+    public String generateUploadUrl(String path, String contentType, Duration expiration, long maxSizeBytes) {
+        String fullPath = withPrefix(path);
+        BlobInfo blobInfo = BlobInfo.newBuilder(bucketName, fullPath)
+                .setContentType(contentType)
+                .build();
+
+        String url = storage.signUrl(
+                blobInfo,
+                expiration.toMinutes(),
+                TimeUnit.MINUTES,
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                Storage.SignUrlOption.withContentType(),
+                Storage.SignUrlOption.withExtHeaders(Map.of(CONTENT_LENGTH_RANGE_HEADER, contentLengthRange(maxSizeBytes))),
+                Storage.SignUrlOption.withV4Signature()
+        ).toString();
+
+        log.debug("Generated size-capped upload URL for path: {} (max {} bytes)", fullPath, maxSizeBytes);
+        return url;
+    }
+
+    public static String contentLengthRange(long maxSizeBytes) {
+        return "0," + maxSizeBytes;
     }
 
     public String generateDownloadUrl(String path, Duration expiration) {


### PR DESCRIPTION
ClickUp: [Permanent image upload endpoint for Knowledge Base and ticket editors](https://app.clickup.com/t/9013925967/86ajtc4hc)

## Problem
Images pasted into Knowledge Base articles and ticket descriptions are embedded in markdown via presigned GCS URLs, which expire — so embedded images break over time.

## Solution
A dedicated inline-image endpoint whose embedded URL is **permanent**, backed by a new `knowledge_base_images` collection that is entity-agnostic (not bound to an article/ticket, since images are pasted before the item exists — so the same endpoint serves both KB articles and ticket descriptions).

- `POST /api/knowledge-base/images` — JSON `{fileName, contentType, fileSize}` → `201 {url, uploadUrl, uploadHeaders}`. Validates a jpeg/png/gif/webp whitelist (SVG excluded as a stored-XSS vector) and the configured size cap, creates the image with its **final** `kb-images/{uuid}.{ext}` storage path (no temp/link step, so the URL never changes), and returns a signed direct-to-GCS PUT URL. The signed `x-goog-content-length-range` header makes GCS enforce the size limit on the direct upload.
- `GET /api/knowledge-base/images/{id}` — **302 redirect** to a fresh short-lived signed GCS URL, cached just under its lifetime. The link embedded in markdown never expires while bytes stream directly from storage (bypassing the gateways/LB timeout).

## Changes (per module)
- **data-mongo-common**: `KnowledgeBaseImage` document (`knowledge_base_images`, tenant-scoped).
- **data-mongo-sync**: `KnowledgeBaseImageRepository`; `GcsPresignedUrlService.generateUploadUrl` overload signing `x-goog-content-length-range`.
- **api-lib**: `KnowledgeBaseImageService` (validation, final path, signed upload/download URLs) + `KnowledgeBaseImageUpload` DTO.
- **api-service-core**: `KnowledgeBaseImageController` + request/response DTOs.
- **Tests**: 18 new unit tests (service + controller); full suites for the touched modules pass (275 + relevant).

## Frontend contract (for [openframe-oss-frontend#118](https://github.com/flamingo-stack/openframe-oss-frontend/pull/118), to be reworked to two-step)
1. `POST /api/knowledge-base/images` JSON `{fileName, contentType, fileSize}` → `201 {url, uploadUrl, uploadHeaders}`
2. `PUT uploadUrl` with the raw file body, `Content-Type: <contentType>`, plus all `uploadHeaders` verbatim (carries `x-goog-content-length-range`)
3. Embed `url` in the markdown

## Notes
- New beans are `@ConditionalOnProperty(storage.s3.disabled=false)`, so the OSS deployable (no storage config) skips them cleanly.
- Config counterpart (`openframe.kb.images.max-size-bytes`): openframe-saas-tenant `hotfix/kb-images-config`.
- Bucket CORS must allow `GET` from app origins for bearer-mode shells (already allows `PUT`) — verify on rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added inline Knowledge Base image uploads for supported image formats.
  - Added file-size and content-type validation with configurable limits.
  - Added signed upload and download URLs with expiration settings.
  - Added authenticated image upload and retrieval endpoints.
  - Image downloads redirect to temporary signed URLs with caching support.

- **Bug Fixes**
  - Normalized content types consistently and rejected invalid image requests.

- **Tests**
  - Added coverage for configuration, validation, uploads, downloads, redirects, and error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->