### PR TITLE
Tenant-scope the KB image id lookup

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/KnowledgeBaseImageService.java
@@ -68,7 +68,7 @@ public class KnowledgeBaseImageService {
     }
 
     public String generateDownloadUrl(String imageId) {
-        KnowledgeBaseImage image = imageRepository.findById(imageId)
+        KnowledgeBaseImage image = imageRepository.findOneById(imageId)
                 .orElseThrow(() -> new NotFoundException("Image not found: " + imageId));
 
         return gcsPresignedUrlService.generateDownloadUrl(

--- a/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
+++ b/openframe-api-lib/src/test/java/com/openframe/api/service/KnowledgeBaseImageServiceTest.java
@@ -170,7 +170,7 @@ class KnowledgeBaseImageServiceTest {
     @Test
     @DisplayName("generateDownloadUrl signs with the longer download expiration, not the upload one")
     void generateDownloadUrl_happyPath() {
-        when(repository.findById("img-1")).thenReturn(Optional.of(KnowledgeBaseImage.builder()
+        when(repository.findOneById("img-1")).thenReturn(Optional.of(KnowledgeBaseImage.builder()
                 .id("img-1")
                 .storagePath("kb-images/abc.png")
                 .build()));
@@ -185,7 +185,7 @@ class KnowledgeBaseImageServiceTest {
     @Test
     @DisplayName("generateDownloadUrl throws NotFoundException for an unknown image id")
     void generateDownloadUrl_unknownId() {
-        when(repository.findById("missing")).thenReturn(Optional.empty());
+        when(repository.findOneById("missing")).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.generateDownloadUrl("missing"))
                 .isInstanceOf(NotFoundException.class);

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/KnowledgeBaseImageRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/KnowledgeBaseImageRepository.java
@@ -3,5 +3,16 @@ package com.openframe.data.repository.knowledgebase;
 import com.openframe.data.document.knowledgebase.KnowledgeBaseImage;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.Optional;
+
 public interface KnowledgeBaseImageRepository extends MongoRepository<KnowledgeBaseImage, String> {
+
+    /**
+     * Tenant-scoped id lookup. Deliberately a derived query rather than {@link #findById}:
+     * derived queries run through {@code TenantAwareMongoTemplate}'s {@code query()} proxy, which
+     * injects the {@code tenantId} criterion, while {@code findById} bypasses it. Image ids are
+     * embedded in article/ticket markdown, so on a shared database an unscoped lookup would serve
+     * another tenant's image to anyone holding its id.
+     */
+    Optional<KnowledgeBaseImage> findOneById(String id);
 }


### PR DESCRIPTION
## Description

`KnowledgeBaseImageService.generateDownloadUrl` resolved images with `findById`, which bypasses both tenant-isolation layers on the shared-database topology:

- **Layer 1** — `TenantAwareMongoTemplate` overrides `find`/`findOne`/`count`/the fluent `query()` entry point, but not `findById`: `SimpleMongoRepository.findById` goes straight to `MongoTemplate.findById`, so no `tenantId` criterion is injected.
- **Layer 2** — `TenantScopedRepositoryImpl` would cover `findById`, but it is not wired as `repositoryBaseClass` in `TenantAwareSyncConfig` yet.

Since image ids are embedded in article/ticket markdown as `/knowledge-base/images/{id}` and circulate by design, an id lifted from one tenant's content would resolve from another tenant's pod once tenants share the `openframe` database (already the case in dev).

## Fix

Replace `findById` with a derived `findOneById` query. Derived queries execute through `operations.query(type).matching(...)`, which `TenantAwareMongoTemplate` proxies to inject `tenantId` — per the MongoDB Multi-Tenant Architecture developer guide, derived queries are Layer 1-scoped. The lookup stays correct on the per-tenant-database topology (flag off → plain `_id` lookup, isolated by database separation) and becomes double-covered when Layer 2 lands.

Follow-up (out of scope): `KnowledgeBaseAttachmentService.generateDownloadUrl` has the same pre-existing `findById` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)