### PR TITLE
UI. flex-safe TruncateText trigger, span trigger, Tag/Autocomplete truncation tooltips

### DIFF
--- a/openframe-frontend-core/src/components/ui/autocomplete.tsx
+++ b/openframe-frontend-core/src/components/ui/autocomplete.tsx
@@ -25,6 +25,7 @@ import { Chevron02DownIcon } from "../icons-v2-generated/arrows/chevron-02-down-
 
 import { Loader2 } from "lucide-react"
 import { cn } from "../../utils/cn"
+import { TruncateText } from "./truncate-text"
 import { useAutoLimitTags } from "../../hooks/ui/use-auto-limit-tags"
 import { FieldWrapper } from "./field-wrapper"
 import { HiddenTagsPopup } from "./hidden-tags-popup"
@@ -601,7 +602,8 @@ function AutocompleteInner<T = string>(
                       )}
                       onClick={handleCreate}
                     >
-                      <span className="truncate" title={`+ Create "${inputValue.trim()}"`}>+ Create &quot;{inputValue.trim()}&quot;</span>
+                      {/* text-current: the row owns the typography/color (accent), not the TruncateText defaults. */}
+                      <TruncateText className="text-current">{`+ Create "${inputValue.trim()}"`}</TruncateText>
                     </div>
                   )
                 ) : (
@@ -635,7 +637,8 @@ function AutocompleteInner<T = string>(
                     >
                       {renderOption ? renderOption(option, isSelected) : (
                         <div className="flex items-center justify-between gap-[var(--spacing-system-xsf)] w-full min-w-0">
-                          <span className="truncate" title={option.label}>{option.label}</span>
+                          {/* text-current: selection state colors the row (accent vs primary); inherit it. */}
+                          <TruncateText className="text-current">{option.label}</TruncateText>
                           <div className="flex items-center gap-[var(--spacing-system-xsf)] shrink-0">
                             {isSelected && (
                               <CheckIcon className="text-ods-accent" size={20} />

--- a/openframe-frontend-core/src/components/ui/floating-tooltip.tsx
+++ b/openframe-frontend-core/src/components/ui/floating-tooltip.tsx
@@ -27,12 +27,17 @@ interface FloatingTooltipProps {
   /** Disable the tooltip without unmounting the trigger wrapper. */
   disabled?: boolean
   /**
-   * Classes for the trigger wrapper — the `div` this component puts around
-   * `children` to anchor the tooltip. That div becomes the flex/grid item in the
-   * caller's layout, so anything the child needed there (`min-w-0`, `flex-1`)
+   * Classes for the trigger wrapper — the element this component puts around
+   * `children` to anchor the tooltip. That element becomes the flex/grid item in
+   * the caller's layout, so anything the child needed there (`min-w-0`, `flex-1`)
    * must move onto it. Omit it and the wrapper carries no class, exactly as before.
    */
   triggerClassName?: string
+  /**
+   * Trigger wrapper element. Default `'div'`. Use `'span'` where a block element
+   * is invalid HTML — inside a `<p>`, a heading, or another `<span>`.
+   */
+  as?: 'div' | 'span'
 }
 
 // Parse colored text markup like [YELLOW]text[/YELLOW] into JSX
@@ -93,6 +98,7 @@ export function FloatingTooltip({
   delayDuration = 0,
   disabled = false,
   triggerClassName,
+  as: TriggerTag = 'div',
 }: FloatingTooltipProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   const arrowRef = React.useRef<HTMLDivElement>(null)
@@ -159,9 +165,9 @@ export function FloatingTooltip({
 
   return (
     <>
-      <div ref={refs.setReference} className={triggerClassName} {...getReferenceProps()}>
+      <TriggerTag ref={refs.setReference} className={triggerClassName} {...getReferenceProps()}>
         {children}
-      </div>
+      </TriggerTag>
       <FloatingPortal>
         {isOpen && (
           <div

--- a/openframe-frontend-core/src/components/ui/service-card.tsx
+++ b/openframe-frontend-core/src/components/ui/service-card.tsx
@@ -8,6 +8,9 @@ import { CheckIcon } from '../icons-v2-generated/signs-and-symbols'
 import { ExternalLink } from 'lucide-react'
 import { OpenFrameLogo } from '../..'
 import { useCopyToClipboard } from '../../hooks/use-copy-to-clipboard'
+import { useIsTruncated } from '../../hooks/ui/use-is-truncated'
+import { FloatingTooltip } from './floating-tooltip'
+import { TruncateText } from './truncate-text'
 
 export type ServiceCardRowAction = {
   copy?: boolean
@@ -61,9 +64,11 @@ export function ServiceCard({ title, subtitle, icon, tag, rows, className }: Ser
             {resolvedIcon}
           </div>
           <div className="min-w-0">
-            <div className="text-h3 text-ods-text-primary truncate" title={title}>{title}</div>
+            <TruncateText variant="h3">{title}</TruncateText>
             {subtitle && (
-              <div className="text-h6 text-ods-text-secondary truncate" title={subtitle}>{subtitle}</div>
+              <TruncateText variant="h6" tone="secondary">
+                {subtitle}
+              </TruncateText>
             )}
           </div>
         </div>
@@ -87,6 +92,7 @@ export function ServiceCard({ title, subtitle, icon, tag, rows, className }: Ser
 function ServiceCardRowItem({ row }: { row: ServiceCardRow }) {
   const [revealed, setRevealed] = useState(false)
   const { copy, copied } = useCopyToClipboard()
+  const { ref: valueRef, isTruncated: valueTruncated } = useIsTruncated<HTMLDivElement>(row.value)
   const actions = useMemo<ServiceCardRowAction>(() => ({ copy: true, open: !!row.href, reveal: !!row.isSecret, ...row.actions }), [row])
 
   const displayValue = row.isSecret ? <MaskedValue value={row.value} isRevealed={revealed} /> : <span>{row.value}</span>
@@ -104,7 +110,16 @@ function ServiceCardRowItem({ row }: { row: ServiceCardRow }) {
         <div className="w-20 md:w-24 shrink-0 text-h6 text-ods-text-primary">{row.label}</div>
       )}
       <div className={cn('flex-1 h-12 rounded-md border border-ods-border bg-ods-bg px-3 md:px-4 flex items-center justify-between min-w-0', row.monospace ? 'font-mono' : '')}>
-        <div className="truncate text-ods-text-primary min-w-0" title={typeof row.value === 'string' ? row.value : undefined}>{displayValue}</div>
+        {/* No tooltip while a secret is masked — the old native `title` leaked the raw value on hover. */}
+        <FloatingTooltip
+          content={row.value}
+          side="top"
+          disabled={!valueTruncated || (row.isSecret && !revealed)}
+          triggerClassName="min-w-0"
+          className="max-w-xs [overflow-wrap:anywhere]"
+        >
+          <div ref={valueRef} className="truncate text-ods-text-primary">{displayValue}</div>
+        </FloatingTooltip>
         <div className="flex items-center gap-2 pl-3 flex-shrink-0">
           {actions.reveal && (
             <button

--- a/openframe-frontend-core/src/components/ui/tag.tsx
+++ b/openframe-frontend-core/src/components/ui/tag.tsx
@@ -4,6 +4,8 @@ import React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { XmarkCircleIcon } from "../icons-v2-generated/signs-and-symbols/xmark-circle-icon"
 import { cn } from "../../utils/cn"
+import { useIsTruncated } from "../../hooks/ui/use-is-truncated"
+import { FloatingTooltip } from "./floating-tooltip"
 
 const tagVariants = cva(
   [
@@ -107,6 +109,37 @@ export interface TagProps
   as?: 'div' | 'span'
 }
 
+/**
+ * The tag's label slot. String labels get a `FloatingTooltip` with the full
+ * value when (and only when) the text is actually clipped — replacing the old
+ * native `title`, which showed with the OS delay, unstyled, and even when
+ * nothing was truncated. Node labels render exactly as before: the caller owns
+ * their content (and any tooltip), so none is added here.
+ * The trigger is a `span` so the tag stays valid phrasing content (`as="span"`
+ * exists precisely for tags inside a `<p>`).
+ */
+function TagLabel({ label, labelClassName }: { label: React.ReactNode; labelClassName?: string }) {
+  const isString = typeof label === 'string'
+  const { ref, isTruncated } = useIsTruncated<HTMLSpanElement>(isString ? label : null)
+
+  if (!isString) {
+    return <span className={cn("truncate", labelClassName)}>{label}</span>
+  }
+
+  return (
+    <FloatingTooltip
+      content={label}
+      side="top"
+      disabled={!isTruncated}
+      as="span"
+      triggerClassName="min-w-0 max-w-full"
+      className="max-w-xs whitespace-pre-line [overflow-wrap:anywhere]"
+    >
+      <span ref={ref} className={cn("truncate block", labelClassName)}>{label}</span>
+    </FloatingTooltip>
+  )
+}
+
 function Tag({
   label,
   variant,
@@ -134,7 +167,7 @@ function Tag({
           {icon}
         </span>
       )}
-      <span className={cn("truncate", labelClassName)} title={typeof label === 'string' ? label : undefined}>{label}</span>
+      <TagLabel label={label} labelClassName={labelClassName} />
       {onClose && (
         <button
           type="button"

--- a/openframe-frontend-core/src/components/ui/truncate-text.tsx
+++ b/openframe-frontend-core/src/components/ui/truncate-text.tsx
@@ -26,6 +26,19 @@ export interface TruncateTextProps {
   tone?: TruncateTextTone
   /** Force the monospace (heading) font family — preserves the variant's size while swapping family. */
   mono?: boolean
+  /**
+   * Extra classes for the tooltip trigger wrapper — the element that becomes the
+   * flex/grid item in the caller's layout (e.g. `flex-1`). Merged after the
+   * built-in `min-w-0 max-w-full`, which is what lets the trigger shrink inside
+   * flex rows so the text ellipsizes instead of clipping.
+   */
+  triggerClassName?: string
+  /**
+   * Trigger wrapper element. Default `'div'`. Use `'span'` where a block element
+   * is invalid HTML — inside a `<p>`, a heading, or another `<span>`; the span
+   * trigger is `inline-block` so the inner truncation still measures.
+   */
+  as?: 'div' | 'span'
 }
 
 const VARIANT_CLASS: Record<TruncateTextVariant, string> = {
@@ -69,6 +82,8 @@ export function TruncateText({
   variant = 'h4',
   tone = 'primary',
   mono = false,
+  triggerClassName,
+  as = 'div',
 }: TruncateTextProps) {
   const isMultiLine = lines > 1
   const { ref, isTruncated } = useIsTruncated<HTMLSpanElement>(children, { multiline: isMultiLine })
@@ -83,6 +98,11 @@ export function TruncateText({
       side={side}
       disabled={!isTruncated}
       className="max-w-xs whitespace-pre-line [overflow-wrap:anywhere]"
+      as={as}
+      // min-w-0: a flex/grid item's automatic minimum size is content-based when
+      // overflow is visible, so without this the trigger refuses to shrink and the
+      // text clips with no ellipsis and no tooltip.
+      triggerClassName={cn('min-w-0 max-w-full', as === 'span' && 'inline-block align-bottom', triggerClassName)}
     >
       <span
         ref={ref}


### PR DESCRIPTION
## Summary

Systemic truncation-tooltip fixes in `openframe-frontend-core`, follow-up to the FE truncation sweep (flamingo-stack/openframe-oss-frontend#125, ClickUp https://app.clickup.com/t/86aju1y70). Four files, all in `components/ui`.

- **FloatingTooltip**: new `as?: 'div' | 'span'` prop for the trigger wrapper. A span trigger keeps the tooltip valid phrasing content inside `<p>`, headings, or another `<span>` (mingo mention chips, page titles).
- **TruncateText**: the trigger now always carries `min-w-0 max-w-full`. Root cause fix: a flex/grid item with visible overflow has a content-based automatic minimum size, so the bare trigger div refused to shrink and text clipped with no ellipsis and no tooltip (e.g. the FE knowledge-base name cell). With this, TruncateText works as a direct flex child - no per-site `min-w-0` wrappers needed (existing wrappers stay harmless). Also exposes `as` and `triggerClassName` pass-throughs.
- **Tag**: string labels get a `FloatingTooltip` with the full value shown only when the text is actually clipped (`useIsTruncated`), replacing the native `title` - which was unstyled, OS-delayed, and shown even for fully visible labels. Node labels render exactly as before (callers own their content and tooltips). Inherited by every `<Tag>` across consumers (~73 call sites in openframe-frontend alone).
- **Autocomplete**: the default option row and the `+ Create "..."` row use `TruncateText` with `text-current`, so the row's selection-state color (accent vs primary) keeps inheriting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tag tooltips now intelligently appear only when label text is actually truncated, reducing visual clutter and improving usability.
  * Enhanced text truncation handling in autocomplete and search components.
  * Increased component flexibility for customizing text display and tooltip behavior across the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
