### PR TITLE
Fix client tool-connection re-publish

### DIFF
--- a/clients/openframe-client/src/services/tool_connection_processing_manager.rs
+++ b/clients/openframe-client/src/services/tool_connection_processing_manager.rs
@@ -70,19 +70,11 @@ impl ToolConnectionProcessingManager {
             return Ok(());
         }
 
+        // Always re-resolve and re-publish every tool connection on startup. The server
+        // deduplicates (no-op when the id is unchanged), and this is what heals a stale
+        // agentToolId after the tool's server reassigns ids (e.g. Fleet MySQL recreated
+        // during a migration) or after an agent reinstall marked connections DISCONNECTED.
         for tool in tools {
-            if self
-                .tool_connection_service
-                .exists_by_tool_agent_id(&tool.tool_agent_id)
-                .await?
-            {
-                info!(
-                    "Tool connection for tool {} already exists - skipping",
-                    tool.tool_id
-                );
-                return Ok(());
-            }
-
             if self.try_mark_running(&tool.tool_id).await {
                 info!("Processing tool connection for {}", tool.tool_id);
                 self.process_tool(tool).await?;

--- a/clients/openframe-client/src/services/tool_installation_service.rs
+++ b/clients/openframe-client/src/services/tool_installation_service.rs
@@ -116,6 +116,19 @@ impl ToolInstallationService {
         let run_args_clone = tool_installation_message.run_command_args.clone();
         let reinstall = tool_installation_message.reinstall;
         let mut reinstall_dir_cleared = false;
+
+        // On reinstall, always drop the local tool connection record — even when the tool
+        // is missing from installed_tools.json — so run_new_tool re-resolves and
+        // re-publishes the connection instead of skipping on the stale entry.
+        if reinstall {
+            if let Err(e) = self
+                .tool_connection_service
+                .delete_by_tool_agent_id(tool_agent_id)
+                .await
+            {
+                warn!("Failed to remove tool connection: {:#}", e);
+            }
+        }
         // Create tool-specific directory
         let base_folder_path = self.directory_manager.app_support_dir();
         let tool_folder_path = base_folder_path.join(tool_agent_id);
@@ -267,14 +280,6 @@ impl ToolInstallationService {
                 reinstall_dir_cleared = true;
 
                 tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-
-                if let Err(e) = self
-                    .tool_connection_service
-                    .delete_by_tool_agent_id(tool_agent_id)
-                    .await
-                {
-                    warn!("Failed to remove tool connection: {:#}", e);
-                }
 
                 self.tool_connection_processing_manager
                     .clear_running_tool(&installed_tool.tool_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool connections are now consistently refreshed and republished when the application starts.
  * Reinstalling a tool now properly removes outdated connection information, including when installation records are missing.
  * Existing tool execution tracking is preserved during reinstalls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->