### PR TITLE
Top-navigation size axis (small 56 / big 72) + Button font axis

### DIFF
--- a/openframe-frontend-core/src/components/features/time-tracker/time-tracker-header-button.tsx
+++ b/openframe-frontend-core/src/components/features/time-tracker/time-tracker-header-button.tsx
@@ -93,7 +93,7 @@ export function TimeTrackerHeaderButton({ className, disabled }: TimeTrackerHead
             <>
               <ClockHistoryIcon
                 className={cn(
-                  'h-4 w-4 md:h-6 md:w-6',
+                  'h-6 w-6',
                   isPaused ? 'text-ods-text-secondary' : isActive && 'text-ods-accent',
                 )}
               />

--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -169,7 +169,7 @@ export const AppHeader = React.memo(function AppHeader({
           <HeaderButton
             onClick={onToggleMobileMenu}
             isActive={isMobileMenuOpen}
-            icon={isMobileMenuOpen ? <XmarkIcon className="w-4 h-4" /> : <Menu01Icon className="w-4 h-4" />}
+            icon={isMobileMenuOpen ? <XmarkIcon className="w-6 h-6" /> : <Menu01Icon className="w-6 h-6" />}
             aria-label={isMobileMenuOpen ? 'Close menu' : 'Open menu'}
             aria-expanded={isMobileMenuOpen}
             className="border-r border-ods-border"
@@ -195,7 +195,7 @@ export const AppHeader = React.memo(function AppHeader({
           {/* Mobile: Search button */}
           {showSearch && (
             <HeaderButton
-              icon={<SearchIcon className="w-4 h-4 md:w-6 md:h-6" />}
+              icon={<SearchIcon className="w-6 h-6" />}
               aria-label="Search"
               className={cn('md:hidden', cellDivider, dimmedClass)}
               disabled={disabled}
@@ -324,9 +324,9 @@ function NotificationsHeaderButton({ fallbackUnreadCount, disabled, dimmedClass 
     <HeaderButton
       icon={
         isActive ? (
-          <XmarkIcon className="w-4 h-4 md:w-6 md:h-6" />
+          <XmarkIcon className="w-6 h-6" />
         ) : (
-          <div className="relative w-4 h-4 md:w-6 md:h-6">
+          <div className="relative w-6 h-6">
             <BellIcon className="w-full h-full" />
             {hasUnread && (
               <span className="absolute top-0 right-0 bg-ods-warning rounded-full w-1.5 h-1.5 md:w-2 md:h-2" />
@@ -357,11 +357,11 @@ function HeaderCellSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'flex h-full w-12 shrink-0 items-center justify-center border-l border-ods-border md:w-14',
+        'flex h-full w-14 shrink-0 items-center justify-center border-l border-ods-border',
         className,
       )}
     >
-      <div className="h-4 w-4 animate-pulse rounded bg-ods-border md:h-6 md:w-6" />
+      <div className="h-6 w-6 animate-pulse rounded bg-ods-border" />
     </div>
   );
 }
@@ -376,8 +376,8 @@ function HeaderCellSkeleton({ className }: { className?: string }) {
  */
 function HeaderWideCellSkeleton() {
   return (
-    <div className="flex h-full w-12 shrink-0 items-center justify-center gap-2 border-l border-ods-border md:w-[140px] md:px-4">
-      <div className="h-4 w-4 shrink-0 animate-pulse rounded bg-ods-border md:h-6 md:w-6" />
+    <div className="flex h-full w-14 shrink-0 items-center justify-center gap-2 border-l border-ods-border md:w-[140px] md:px-4">
+      <div className="h-6 w-6 shrink-0 animate-pulse rounded bg-ods-border" />
       <div className="hidden h-5 animate-pulse rounded bg-ods-border md:block md:w-[72px]" />
     </div>
   );
@@ -411,7 +411,7 @@ function AppHeaderSkeleton({
       aria-busy="true"
       leading={
         // Burger cell: mobile only, in CSS.
-        <div className="flex h-full w-12 shrink-0 items-center justify-center border-r border-ods-border md:hidden">
+        <div className="flex h-full w-14 shrink-0 items-center justify-center border-r border-ods-border md:hidden">
           <div className="h-4 w-4 animate-pulse rounded bg-ods-border" />
         </div>
       }

--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -412,7 +412,7 @@ function AppHeaderSkeleton({
       leading={
         // Burger cell: mobile only, in CSS.
         <div className="flex h-full w-14 shrink-0 items-center justify-center border-r border-ods-border md:hidden">
-          <div className="h-4 w-4 animate-pulse rounded bg-ods-border" />
+          <div className="h-6 w-6 animate-pulse rounded bg-ods-border" />
         </div>
       }
       logo={

--- a/openframe-frontend-core/src/components/navigation/header-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/header-button.tsx
@@ -23,7 +23,10 @@ export function HeaderButton({
       className={cn(
         "flex items-center justify-center shrink-0",
         "transition-colors duration-200",
-        "w-12 h-full md:w-14",
+        // Square cell width follows the TopNavigation size (56px small /
+        // 72px big) via the shell's --top-nav-cell var; 56px fallback for
+        // standalone use.
+        "w-[var(--top-nav-cell,3.5rem)] h-full",
         isActive
           ? "text-ods-text-primary bg-ods-bg-active"
           : // Transparent at rest so the cell inherits the bar's background

--- a/openframe-frontend-core/src/components/navigation/header-mingo-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/header-mingo-button.tsx
@@ -57,7 +57,7 @@ export function HeaderMingoButton({
         // Mobile, drawer open: the icon-only button doubles as the close
         // affordance, so swap the Mingo logo for an X. Match the other header
         // icons (e.g. notifications): secondary color, w-4 h-4 → md:w-6 h-6.
-        <XmarkIcon className="w-4 h-4 md:w-6 md:h-6 shrink-0 text-ods-text-secondary" />
+        <XmarkIcon className="w-6 h-6 shrink-0 text-ods-text-secondary" />
       ) : (
         // Outer frame follows the button's text color (currentColor); the eyes
         // and corner block are ODS cyan.
@@ -65,7 +65,7 @@ export function HeaderMingoButton({
           color="currentColor"
           eyesColor="var(--ods-flamingo-cyan-base)"
           cornerColor="var(--ods-flamingo-cyan-base)"
-          className="w-4 h-4 md:w-6 md:h-6 shrink-0"
+          className="w-6 h-6 shrink-0"
         />
       )}
       {!iconOnly && (

--- a/openframe-frontend-core/src/components/navigation/header-skeleton.tsx
+++ b/openframe-frontend-core/src/components/navigation/header-skeleton.tsx
@@ -21,20 +21,20 @@ export function HeaderSkeleton({ config }: HeaderSkeletonProps) {
     <div className="sticky top-0 z-[50] w-full">
       <header
         className={cn(
-          'flex h-12 w-full items-center border-b border-t border-ods-border md:h-14 md:border-t-0',
+          'flex h-[72px] w-full items-center border-b border-t border-ods-border md:border-t-0',
           config?.backgroundColor || 'bg-ods-card',
           config?.className,
         )}
       >
         {/* Leading cells: admin toggle / burger */}
         {showLeftActions && (
-          <div className="flex h-full w-12 items-center justify-center border-r border-ods-border md:w-14">
+          <div className="flex h-full w-[72px] items-center justify-center border-r border-ods-border">
             <div className="h-6 w-6 animate-pulse rounded bg-ods-border" />
           </div>
         )}
         {showMobileMenu && (
-          <div className="flex h-full w-12 items-center justify-center border-r border-ods-border md:w-14 lg:hidden">
-            <div className="h-4 w-4 animate-pulse rounded bg-ods-border md:h-6 md:w-6" />
+          <div className="flex h-full w-[72px] items-center justify-center border-r border-ods-border lg:hidden">
+            <div className="h-6 w-6 animate-pulse rounded bg-ods-border" />
           </div>
         )}
 

--- a/openframe-frontend-core/src/components/navigation/header.tsx
+++ b/openframe-frontend-core/src/components/navigation/header.tsx
@@ -135,11 +135,12 @@ export function Header({ config, platform }: HeaderProps) {
                 [item.id]: !prev[item.id],
               }));
             }}
-            size="small-legacy"
+            size="default"
+            font="regular"
             className={cn(
-              // Top-level nav links: h3 bold per the ODS top-navigation spec
-              // (Figma 2797-5978); dropdown children stay on the h6 step.
-              'text-h3 font-bold tracking-[-0.36px]',
+              // Top-level nav links: the default-size button with the h4
+              // (DM Sans 500) `font="regular"` label — Figma 133-740, added
+              // for navigation; dropdown children stay on the h6 step.
               item.isActive && 'bg-ods-bg-hover', // Active items get subtle gray background
               isOpen && 'bg-ods-bg-hover', // Open dropdowns get gray background
               item.className,
@@ -227,9 +228,9 @@ export function Header({ config, platform }: HeaderProps) {
           onClick={item.onClick} // Only for non-navigation actions
           leftIcon={item.icon}
           rightIcon={item.badge}
-          size="small-legacy"
+          size="default"
+          font="regular"
           className={cn(
-            'text-h3 font-bold tracking-[-0.36px]',
             'hover:bg-ods-bg-hover focus:bg-ods-bg-hover',
             'whitespace-nowrap',
             'text-ods-text-primary', // All items use primary text color
@@ -251,9 +252,9 @@ export function Header({ config, platform }: HeaderProps) {
         onClick={item.onClick}
         leftIcon={item.icon}
         rightIcon={item.badge}
-        size="small-legacy"
+        size="default"
+        font="regular"
         className={cn(
-          'text-h3 font-bold tracking-[-0.36px]',
           'hover:bg-ods-bg-hover focus:bg-ods-bg-hover',
           'whitespace-nowrap',
           'text-ods-text-primary', // All items use primary text color
@@ -301,15 +302,16 @@ export function Header({ config, platform }: HeaderProps) {
         style={config.style}
         backgroundClassName={config.backgroundColor}
         centerBreakpoint="lg"
+        size="big"
         leading={
           <>
             {/* Length-guarded: platform configs often pass `left: []`, and an
                 empty array is truthy — without the guard the cell would render
                 as a bare divider + padding. */}
+            {/* No padding on the wrapper: leading cells (HeaderButton-based
+                admin toggles) size themselves to the bar's square cell. */}
             {!!config.actions?.left?.length && (
-              <div className="flex h-full items-center border-r border-ods-border px-[var(--spacing-system-xs)]">
-                {config.actions.left}
-              </div>
+              <div className="flex h-full items-center border-r border-ods-border">{config.actions.left}</div>
             )}
             {/* Mobile/tablet menu toggle — a leading cell per the ODS spec
               (banded with the nav breakpoint `lg` so the desktop nav and the
@@ -328,8 +330,8 @@ export function Header({ config, platform }: HeaderProps) {
                 aria-controls={config.mobile?.isOpen ? MOBILE_NAV_PANEL_ID : undefined}
                 icon={
                   config.mobile?.isOpen
-                    ? config.mobile?.closeIcon || <XmarkIcon className="w-4 h-4 md:w-6 md:h-6" />
-                    : config.mobile?.menuIcon || <Menu01Icon className="w-4 h-4 md:w-6 md:h-6" />
+                    ? config.mobile?.closeIcon || <XmarkIcon className="w-6 h-6" />
+                    : config.mobile?.menuIcon || <Menu01Icon className="w-6 h-6" />
                 }
               />
             )}
@@ -340,7 +342,11 @@ export function Header({ config, platform }: HeaderProps) {
             {config.logo.element}
           </Link>
         }
-        logoClassName={hasLeftCells ? 'lg:pl-[var(--spacing-system-l)]' : undefined}
+        // Logo inset for the hub sites: 12px on mobile (the shell's base p-m),
+        // 16px on tablet (mf token; the shell default is pl-l = 24px there),
+        // desktop unchanged — pl-xxl, collapsed to pl-l when an always-visible
+        // leading cell sits before the logo.
+        logoClassName={cn('md:pl-[var(--spacing-system-mf)]', hasLeftCells && 'lg:pl-[var(--spacing-system-l)]')}
         center={
           hasNav ? (
             <nav

--- a/openframe-frontend-core/src/components/navigation/mingo-ai-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/mingo-ai-button.tsx
@@ -1,20 +1,20 @@
-'use client'
+'use client';
 
-import React from 'react'
-import { MingoIcon } from '../icons'
-import { cn } from '../../utils'
+import React from 'react';
+import { cn } from '../../utils';
+import { MingoIcon } from '../icons';
 
 export interface MingoAiButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  source?: string
+  source?: string;
   /** The platform's Mingo identity glyph — pass the SAME server-configured
    *  icon the chat panel renders (host-side: `EntityIcon` fed by the admin
    *  `assistantIcon`), so the launcher and the panel can never diverge.
    *  Falls back to the packaged Mingo mark when the server has none. */
-  icon?: React.ReactNode
+  icon?: React.ReactNode;
   /** The launcher's wordmark + aria-label — pass the server-configured
    *  assistant name (same `assistantName` the chat panel shows) so the
    *  launcher never hardcodes an identity the admin has renamed. */
-  label?: string
+  label?: string;
 }
 
 /**
@@ -32,7 +32,7 @@ export interface MingoAiButtonProps extends React.ButtonHTMLAttributes<HTMLButto
  * icon-only collapse that `Button` cannot express (same precedent as
  * `header-mingo-button.tsx`).
  */
-const MINGO_ACCENT = 'var(--ods-flamingo-cyan-base)'
+const MINGO_ACCENT = 'var(--ods-flamingo-cyan-base)';
 
 export function MingoAiButton({ source, icon, label = 'Mingo AI', className, onClick, ...props }: MingoAiButtonProps) {
   return (
@@ -40,12 +40,12 @@ export function MingoAiButton({ source, icon, label = 'Mingo AI', className, onC
       {...props}
       type="button"
       aria-label={label}
-      onClick={(e) => {
+      onClick={e => {
         // Coalesce to '' so a source-less mount still matches EmbeddableChat's
         // own `runtime.source ?? ''` comparison (undefined !== '' would make
         // the panel silently ignore the event).
-        window.dispatchEvent(new CustomEvent('ask-ai:open', { detail: { source: source ?? '' } }))
-        onClick?.(e)
+        window.dispatchEvent(new CustomEvent('ask-ai:open', { detail: { source: source ?? '' } }));
+        onClick?.(e);
       }}
       className={cn(
         // Unified ODS top-navigation cell (Figma 2797-6808 desktop /
@@ -58,11 +58,11 @@ export function MingoAiButton({ source, icon, label = 'Mingo AI', className, onC
         className,
       )}
     >
-      {/* Inner box = 1:1 twin of the header CTA's `size="small"` Button
-          geometry (rounded-md, h-6 md:h-8) so the animated ring traces
-          exactly where a normal small-button border would sit inside the
-          48/56px cell. */}
-      <span className="relative flex h-6 items-center gap-[var(--spacing-system-xsf)] rounded-md px-[var(--spacing-system-xsf)] md:h-8">
+      {/* Inner box = 1:1 twin of the DEFAULT-size Button geometry (rounded-md,
+          h-11 md:h-12, px-m) — the same footprint as the header's "Try for
+          Free" CTA — so the animated ring traces exactly where a full button
+          border would sit inside the 72px bar. */}
+      <span className="relative flex h-11 items-center gap-[var(--spacing-system-xsf)] rounded-md px-[var(--spacing-system-m)] md:h-12">
         {/* AI edge light (Apple-Intelligence-style): a rotating accent-
             gradient arc clipped to a 3px ring on the box outline via CSS
             mask (.mingo-edge-frame) — NO opaque cover, so the launcher
@@ -92,13 +92,14 @@ export function MingoAiButton({ source, icon, label = 'Mingo AI', className, onC
           />
         )}
         {/* Wordmark collapses below md — the mobile cell is icon-only per
-            spec. `text-code` (sentence-case mono caption, matching the small
-            CTA next to it) by product decision — the Figma wordmark is h3
-            bold; flagged for the designer. */}
-        <span className="relative hidden whitespace-nowrap text-code text-ods-text-primary md:inline">{label}</span>
+            spec. h3 bold, matching the default-size CTA label next to it
+            (Figma 2936-6825). */}
+        {/* Bare `text-h3` — the exact composite the default-size Button label
+            uses (bold 700 and -0.02em tracking are built into the utility). */}
+        <span className="relative hidden whitespace-nowrap text-h3 text-ods-text-primary md:inline">{label}</span>
       </span>
     </button>
-  )
+  );
 }
 
-export default MingoAiButton
+export default MingoAiButton;

--- a/openframe-frontend-core/src/components/navigation/mobile-burger-menu.tsx
+++ b/openframe-frontend-core/src/components/navigation/mobile-burger-menu.tsx
@@ -9,8 +9,8 @@ import { Logout02Icon, PenEditIcon, UserSearchIcon } from '../icons-v2-generated
 import { Button, SquareAvatar } from '../ui'
 import { OVERLAY_BACKDROP_CLASS } from '../ui/drawer'
 
-// Header height constant (h-12 = 48px)
-const HEADER_HEIGHT = 48
+// Header height constant — the unified top-navigation `small` bar (56px on all screens)
+const HEADER_HEIGHT = 56
 
 export interface MobileBurgerMenuProps {
   /** Whether the menu is open */
@@ -188,7 +188,7 @@ export const MobileBurgerMenu = React.memo(function MobileBurgerMenu({
                 fallback={user.userName}
                 size="lg"
                 variant="round"
-                className="w-12 h-12 shrink-0"
+                className="w-14 h-14 shrink-0"
               />
 
               {/* User Info */}

--- a/openframe-frontend-core/src/components/navigation/top-navigation.tsx
+++ b/openframe-frontend-core/src/components/navigation/top-navigation.tsx
@@ -5,6 +5,17 @@ import { cn } from '../../utils/cn';
 
 export type TopNavigationCenterBreakpoint = 'md' | 'lg';
 
+export type TopNavigationSize = 'small' | 'big';
+
+// Bar height + square-cell width per size (Figma 2797-5978 `size` axis).
+// Heights are FIXED across breakpoints. `--top-nav-cell` is consumed by
+// `HeaderButton` (and any custom cell) so cell widths follow the size without
+// each cell knowing about it.
+const SIZE_CLASSES: Record<TopNavigationSize, string> = {
+  small: 'h-14 [--top-nav-cell:3.5rem]',
+  big: 'h-[72px] [--top-nav-cell:4.5rem]',
+};
+
 // Literal class maps — Tailwind's scanner needs the full class strings.
 const CENTER_VISIBILITY: Record<TopNavigationCenterBreakpoint, string> = {
   md: 'hidden md:flex',
@@ -52,6 +63,9 @@ export interface TopNavigationProps extends React.HTMLAttributes<HTMLElement> {
   backgroundClassName?: string;
   /** Top border on mobile (the ODS spec bar shows it below md). Default true. */
   mobileTopBorder?: boolean;
+  /** Bar size (Figma 2797-5978 `size` axis): `small` = 56px (console),
+   *  `big` = 72px (marketing/hub sites). Fixed across breakpoints. */
+  size?: TopNavigationSize;
 }
 
 const hasContent = (node: React.ReactNode): boolean => node !== null && node !== undefined && node !== false;
@@ -80,6 +94,7 @@ export function TopNavigation({
   sideActions,
   backgroundClassName,
   mobileTopBorder = true,
+  size = 'small',
   className,
   children,
   ...props
@@ -87,7 +102,8 @@ export function TopNavigation({
   return (
     <header
       className={cn(
-        'flex h-12 w-full items-center border-b border-ods-border md:h-14',
+        'flex w-full items-center border-b border-ods-border',
+        SIZE_CLASSES[size],
         mobileTopBorder && 'border-t md:border-t-0',
         backgroundClassName ?? 'bg-ods-card',
         className,

--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -1,22 +1,27 @@
-"use client"
+'use client';
 
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
-import Link from "../../../embed-shims/next-link"
-import React from "react"
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import React from 'react';
+import Link from '../../../embed-shims/next-link';
 
-import { cn } from "../../../utils/cn"
-import { buttonSurfaceClasses, outlineBorderClasses, splitDividerColorClasses, splitGlyphSizeClasses } from "./button-styles"
+import { cn } from '../../../utils/cn';
+import {
+  buttonSurfaceClasses,
+  outlineBorderClasses,
+  splitDividerColorClasses,
+  splitGlyphSizeClasses,
+} from './button-styles';
 
 // Default layout: centered single content area, padding/gap on the button itself.
 const buttonVariants = cva(
   [
-    "relative inline-flex items-center justify-center gap-[var(--spacing-system-xsf)]",
-    "rounded-md whitespace-nowrap",
-    "transition-colors duration-200",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ods-focus",
-    "disabled:pointer-events-none",
-    "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:h-5 [&_svg]:w-5",
+    'relative inline-flex items-center justify-center gap-[var(--spacing-system-xsf)]',
+    'rounded-md whitespace-nowrap',
+    'transition-colors duration-200',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ods-focus',
+    'disabled:pointer-events-none',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg]:h-5 [&_svg]:w-5',
   ],
   {
     variants: {
@@ -30,9 +35,9 @@ const buttonVariants = cva(
         overlay: buttonSurfaceClasses.overlay,
       },
       size: {
-        default: "py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-11",
-        small: "p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8",
-        "small-legacy": "py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold", // Temporary alias for "small" — deprecated; grep size="small-legacy" (lib + hub) and migrate the remaining consumers before removal
+        default: 'py-[var(--spacing-system-sf)] px-[var(--spacing-system-m)] text-h3 md:h-12 h-11',
+        small: 'p-[var(--spacing-system-xs)] text-h5 h-6 md:h-8',
+        'small-legacy': 'py-[var(--spacing-system-xs)] px-[var(--spacing-system-m)] h-10 text-[14px] font-bold', // Temporary alias for "small" — deprecated; grep size="small-legacy" (lib + hub) and migrate the remaining consumers before removal
         // 24px pill for slim strips (announcement/promo bars, inline banner
         // actions — Primer banner / Polaris banner / Vercel-bar convention).
         // The label matches the strip's MESSAGE type ramp exactly (DM Sans
@@ -42,47 +47,59 @@ const buttonVariants = cva(
         // mono-uppercase control style of "small" nor a heavier weight.
         // Pinned h-6 across breakpoints (24px = the WCAG 2.5.8 target-size
         // floor) with horizontal-dominant padding and a 14px glyph.
-        compact: "py-0 px-[var(--spacing-system-sf)] text-h6 font-normal h-6 [&_svg]:h-3.5 [&_svg]:w-3.5",
-        icon: "p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6",
+        compact: 'py-0 px-[var(--spacing-system-sf)] text-h6 font-normal h-6 [&_svg]:h-3.5 [&_svg]:w-3.5',
+        icon: 'p-[var(--spacing-system-sf)] h-11 w-11 md:h-12 md:w-12 [&_svg]:h-4 [&_svg]:w-4 md:[&_svg]:h-6 md:[&_svg]:w-6',
         // Quiet 32px icon target with a 16px glyph, fixed across breakpoints
         // (Carbon ghost sm / Primer medium / shadcn icon-sm all pin 32px;
         // ≥ the 24px WCAG 2.5.8 target floor). For icon actions that read as
         // metadata rather than CTAs — author-page social rows, share rows.
         // Pair with variant="transparent" for the ghost treatment.
-        "icon-sm": "p-[var(--spacing-system-xxs)] h-8 w-8 [&_svg]:h-4 [&_svg]:w-4",
+        'icon-sm': 'p-[var(--spacing-system-xxs)] h-8 w-8 [&_svg]:h-4 [&_svg]:w-4',
         // Bare 56px media glyph (play / unmute over video). A size variant so
         // hosts stop re-implementing a <button> to escape the 20px svg cap.
-        "icon-glyph": "p-0 h-14 w-14 [&_svg]:h-14 [&_svg]:w-14",
+        'icon-glyph': 'p-0 h-14 w-14 [&_svg]:h-14 [&_svg]:w-14',
+      },
+      // Label typography axis (Figma 133-740). `bold` is the classic h3-bold
+      // label; `regular` swaps the DEFAULT size's label to the h4 step
+      // (DM Sans 500, neutral tracking) — added for navigation buttons.
+      // `small` keeps its mono-uppercase h5 label on both fonts per the spec.
+      font: {
+        bold: '',
+        regular: '',
       },
       fullWidth: {
-        true: "w-full",
-        false: "",
+        true: 'w-full',
+        false: '',
       },
       noPaddingX: {
-        true: "px-0",
-        false: "",
+        true: 'px-0',
+        false: '',
       },
     },
     compoundVariants: [
-      { size: "small", class: "[&_svg]:h-4 [&_svg]:w-4" },
+      { size: 'small', class: '[&_svg]:h-4 [&_svg]:w-4' },
+      // Comes after the size classes, so cn()'s tailwind-merge resolves the
+      // ods-typography group in favour of text-h4.
+      { size: 'default', font: 'regular', class: 'text-h4' },
     ],
     defaultVariants: {
-      variant: "accent",
-      size: "default",
+      variant: 'accent',
+      size: 'default',
+      font: 'bold',
       fullWidth: false,
       noPaddingX: false,
     },
-  }
-)
+  },
+);
 
 // Split layout (used when `splitIcon` is provided): outer button has no padding;
 // inner slots own padding/gap so the divider can span full button height.
 const splitShellVariants = cva(
   [
-    "group relative inline-flex items-stretch overflow-hidden rounded-md whitespace-nowrap",
-    "transition-colors duration-200",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ods-focus",
-    "disabled:pointer-events-none",
+    'group relative inline-flex items-stretch overflow-hidden rounded-md whitespace-nowrap',
+    'transition-colors duration-200',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ods-focus',
+    'disabled:pointer-events-none',
   ],
   {
     variants: {
@@ -94,65 +111,79 @@ const splitShellVariants = cva(
         warning: buttonSurfaceClasses.warning,
       },
       size: {
-        default: "h-12 text-h3",
-        small: "h-6 md:h-8 text-h5",
+        default: 'h-12 text-h3',
+        small: 'h-6 md:h-8 text-h5',
       },
-      fullWidth: { true: "w-full", false: "" },
+      fullWidth: { true: 'w-full', false: '' },
     },
-    defaultVariants: { variant: "accent", size: "default", fullWidth: false },
-  }
-)
+    defaultVariants: { variant: 'accent', size: 'default', fullWidth: false },
+  },
+);
 
 const splitSlotVariants = cva(
   // Glyph size lives per-size, not in the base: cva concatenates base + variant
   // without tailwind-merge, so a base `[&_svg]:h-5` and a variant `[&_svg]:h-4`
   // would both ship and the winner would come down to stylesheet order.
-  ["inline-flex items-center justify-center", "[&_svg]:shrink-0"],
+  ['inline-flex items-center justify-center', '[&_svg]:shrink-0'],
   {
     variants: {
       slot: {
-        main: "gap-[var(--spacing-system-xsf)]",
-        icon: "border-l",
+        main: 'gap-[var(--spacing-system-xsf)]',
+        icon: 'border-l',
       },
-      size: { default: splitGlyphSizeClasses, small: "[&_svg]:h-4 [&_svg]:w-4" },
-      variant: { accent: "", outline: "", transparent: "", destructive: "", warning: "" },
+      size: { default: splitGlyphSizeClasses, small: '[&_svg]:h-4 [&_svg]:w-4' },
+      variant: { accent: '', outline: '', transparent: '', destructive: '', warning: '' },
     },
     compoundVariants: [
-      { slot: "main", size: "default", class: "px-[var(--spacing-system-m)] py-[var(--spacing-system-sf)]" },
-      { slot: "main", size: "small", class: "px-[var(--spacing-system-xs)]" },
-      { slot: "icon", size: "default", class: "w-10" },
-      { slot: "icon", size: "small", class: "w-6 md:w-8" },
-      { slot: "icon", variant: "accent", class: cn(
-        splitDividerColorClasses.accent,
-        "group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled",
-      ) },
-      { slot: "icon", variant: "outline", class: splitDividerColorClasses.outline },
-      { slot: "icon", variant: "transparent", class: splitDividerColorClasses.transparent },
-      { slot: "icon", variant: "destructive", class: cn(
-        splitDividerColorClasses.destructive,
-        "group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled",
-      ) },
-      { slot: "icon", variant: "warning", class: cn(
-        splitDividerColorClasses.warning,
-        "group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled",
-      ) },
+      { slot: 'main', size: 'default', class: 'px-[var(--spacing-system-m)] py-[var(--spacing-system-sf)]' },
+      { slot: 'main', size: 'small', class: 'px-[var(--spacing-system-xs)]' },
+      { slot: 'icon', size: 'default', class: 'w-10' },
+      { slot: 'icon', size: 'small', class: 'w-6 md:w-8' },
+      {
+        slot: 'icon',
+        variant: 'accent',
+        class: cn(
+          splitDividerColorClasses.accent,
+          'group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled',
+        ),
+      },
+      { slot: 'icon', variant: 'outline', class: splitDividerColorClasses.outline },
+      { slot: 'icon', variant: 'transparent', class: splitDividerColorClasses.transparent },
+      {
+        slot: 'icon',
+        variant: 'destructive',
+        class: cn(
+          splitDividerColorClasses.destructive,
+          'group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled',
+        ),
+      },
+      {
+        slot: 'icon',
+        variant: 'warning',
+        class: cn(
+          splitDividerColorClasses.warning,
+          'group-disabled:border-ods-disabled group-aria-disabled:border-ods-disabled',
+        ),
+      },
     ],
-    defaultVariants: { slot: "main", size: "default", variant: "accent" },
-  }
-)
+    defaultVariants: { slot: 'main', size: 'default', variant: 'accent' },
+  },
+);
 
 /** @deprecated Use `size="small"` instead. Temporary alias kept for backward compatibility; will be removed in the future. */
-type DeprecatedButtonSize = "small-legacy"
+type DeprecatedButtonSize = 'small-legacy';
 
-type ButtonSize = Exclude<VariantProps<typeof buttonVariants>["size"], "small-legacy" | null | undefined> | DeprecatedButtonSize
+type ButtonSize =
+  | Exclude<VariantProps<typeof buttonVariants>['size'], 'small-legacy' | null | undefined>
+  | DeprecatedButtonSize;
 
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    Omit<VariantProps<typeof buttonVariants>, "size"> {
-  asChild?: boolean
-  href?: string
-  openInNewTab?: boolean
-  prefetch?: boolean
+    Omit<VariantProps<typeof buttonVariants>, 'size'> {
+  asChild?: boolean;
+  href?: string;
+  openInNewTab?: boolean;
+  prefetch?: boolean;
   /**
    * Pre-resolved anchor bundle (from `useNavLink({ href, targetPlatform })`).
    * When set, renders the Button as `<Link>` with `href` / `target` / `rel`
@@ -161,22 +192,22 @@ interface ButtonProps
    * gymnastics. Wins over the separate `href` / `openInNewTab` props.
    */
   linkProps?: {
-    href: string
-    target?: '_blank'
-    rel?: 'noopener noreferrer'
-    onClick?: React.MouseEventHandler<HTMLAnchorElement>
-  } | null
-  leftIcon?: React.ReactNode
-  rightIcon?: React.ReactNode
+    href: string;
+    target?: '_blank';
+    rel?: 'noopener noreferrer';
+    onClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  } | null;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
   /**
    * Renders a vertical divider and trailing icon area inside the button.
    * The whole button stays a single click target — the icon is decorative
    * (`aria-hidden`). For two independent click targets, use `<SplitButton>`.
    * Only honored when `size` is `"default"` or `"small"`.
    */
-  splitIcon?: React.ReactNode
-  loading?: boolean
-  size?: ButtonSize
+  splitIcon?: React.ReactNode;
+  loading?: boolean;
+  size?: ButtonSize;
 }
 
 const Spinner = () => (
@@ -188,13 +219,14 @@ const Spinner = () => (
       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
     />
   </svg>
-)
+);
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
     className,
     variant,
     size,
+    font,
     fullWidth,
     noPaddingX,
     asChild,
@@ -213,25 +245,22 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   },
   ref,
 ) {
-  const isDisabled = disabled || loading
+  const isDisabled = disabled || loading;
 
   // splitIcon is only supported for default/small sizes. With other sizes
   // (icon, small-legacy) we silently fall back to the normal layout.
-  const useSplitLayout = !!splitIcon && (size === "default" || size === "small" || size === undefined)
+  const useSplitLayout = !!splitIcon && (size === 'default' || size === 'small' || size === undefined);
 
   if (useSplitLayout) {
-    const safeSize = (size ?? "default") as "default" | "small"
-    const safeVariant = (variant ?? "accent") as "accent" | "outline" | "transparent" | "destructive" | "warning"
-    const shellClasses = cn(
-      splitShellVariants({ variant: safeVariant, size: safeSize, fullWidth }),
-      className,
-    )
-    const mainSlotClass = splitSlotVariants({ slot: "main", size: safeSize, variant: safeVariant })
-    const iconSlotClass = splitSlotVariants({ slot: "icon", size: safeSize, variant: safeVariant })
+    const safeSize = (size ?? 'default') as 'default' | 'small';
+    const safeVariant = (variant ?? 'accent') as 'accent' | 'outline' | 'transparent' | 'destructive' | 'warning';
+    const shellClasses = cn(splitShellVariants({ variant: safeVariant, size: safeSize, fullWidth }), className);
+    const mainSlotClass = splitSlotVariants({ slot: 'main', size: safeSize, variant: safeVariant });
+    const iconSlotClass = splitSlotVariants({ slot: 'icon', size: safeSize, variant: safeVariant });
 
     const splitContent = (
       <>
-        <span className={cn("contents", loading && "invisible")}>
+        <span className={cn('contents', loading && 'invisible')}>
           <span className={mainSlotClass}>
             {leftIcon && <span className="inline-flex items-center">{leftIcon}</span>}
             {children}
@@ -247,17 +276,21 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
           </span>
         )}
       </>
-    )
+    );
 
     // `linkProps` (the pre-resolved bundle from `useNavLink({ href, targetPlatform })`)
     // wins over the legacy `href` + `openInNewTab` props so callers can thread
     // the unified nav decision directly. Either path produces the same `<Link>`.
-    const splitAnchor = linkProps ?? (href ? {
-      href,
-      target: openInNewTab ? '_blank' as const : undefined,
-      rel: openInNewTab ? 'noopener noreferrer' as const : undefined,
-      onClick: onClick as unknown as React.MouseEventHandler<HTMLAnchorElement> | undefined,
-    } : null)
+    const splitAnchor =
+      linkProps ??
+      (href
+        ? {
+            href,
+            target: openInNewTab ? ('_blank' as const) : undefined,
+            rel: openInNewTab ? ('noopener noreferrer' as const) : undefined,
+            onClick: onClick as unknown as React.MouseEventHandler<HTMLAnchorElement> | undefined,
+          }
+        : null);
     if (splitAnchor) {
       return (
         <Link
@@ -271,28 +304,22 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
           aria-label={props['aria-label']}
           aria-disabled={isDisabled || undefined}
           tabIndex={isDisabled ? -1 : undefined}
-          className={cn(shellClasses, isDisabled && "pointer-events-none")}
+          className={cn(shellClasses, isDisabled && 'pointer-events-none')}
           onClick={splitAnchor.onClick}
         >
           {splitContent}
         </Link>
-      )
+      );
     }
 
     return (
-      <button
-        ref={ref}
-        className={shellClasses}
-        disabled={isDisabled}
-        onClick={onClick}
-        {...props}
-      >
+      <button ref={ref} className={shellClasses} disabled={isDisabled} onClick={onClick} {...props}>
         {splitContent}
       </button>
-    )
+    );
   }
 
-  const classes = cn(buttonVariants({ variant, size, fullWidth, noPaddingX }), className)
+  const classes = cn(buttonVariants({ variant, size, font, fullWidth, noPaddingX }), className);
 
   // asChild: consumer fully controls the rendered element; we just stamp our classes.
   if (asChild) {
@@ -300,14 +327,14 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       <Slot ref={ref} className={classes} {...props}>
         {children}
       </Slot>
-    )
+    );
   }
 
   // Real content stays in layout (preserving width) but goes invisible while loading.
   // The spinner is absolutely positioned so it never shifts the button's size.
   const content = (
     <>
-      <span className={cn("contents", loading && "invisible")}>
+      <span className={cn('contents', loading && 'invisible')}>
         {leftIcon && <span className="inline-flex items-center">{leftIcon}</span>}
         {children}
         {rightIcon && <span className="inline-flex items-center">{rightIcon}</span>}
@@ -318,15 +345,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
         </span>
       )}
     </>
-  )
+  );
 
   // Same `linkProps`-wins-over-href resolution as the splitIcon branch.
-  const anchor = linkProps ?? (href ? {
-    href,
-    target: openInNewTab ? '_blank' as const : undefined,
-    rel: openInNewTab ? 'noopener noreferrer' as const : undefined,
-    onClick: onClick as unknown as React.MouseEventHandler<HTMLAnchorElement> | undefined,
-  } : null)
+  const anchor =
+    linkProps ??
+    (href
+      ? {
+          href,
+          target: openInNewTab ? ('_blank' as const) : undefined,
+          rel: openInNewTab ? ('noopener noreferrer' as const) : undefined,
+          onClick: onClick as unknown as React.MouseEventHandler<HTMLAnchorElement> | undefined,
+        }
+      : null);
   if (anchor) {
     return (
       <Link
@@ -339,25 +370,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
         aria-label={props['aria-label']}
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
-        className={cn(classes, isDisabled && "pointer-events-none")}
+        className={cn(classes, isDisabled && 'pointer-events-none')}
         onClick={anchor.onClick}
       >
         {content}
       </Link>
-    )
+    );
   }
 
   return (
-    <button
-      ref={ref}
-      className={classes}
-      disabled={isDisabled}
-      onClick={onClick}
-      {...props}
-    >
+    <button ref={ref} className={classes} disabled={isDisabled} onClick={onClick} {...props}>
       {content}
     </button>
-  )
-})
+  );
+});
 
-export { Button, buttonVariants, type ButtonProps }
+export { Button, buttonVariants, type ButtonProps };

--- a/openframe-frontend-core/src/components/ui/button/button.tsx
+++ b/openframe-frontend-core/src/components/ui/button/button.tsx
@@ -111,12 +111,19 @@ const splitShellVariants = cva(
         warning: buttonSurfaceClasses.warning,
       },
       size: {
-        default: 'h-12 text-h3',
+        default: 'h-12',
         small: 'h-6 md:h-8 text-h5',
       },
+      // Same label-typography axis as the normal layout — `regular` swaps the
+      // default size's h3-bold label for the h4 (DM Sans 500) step.
+      font: { bold: '', regular: '' },
       fullWidth: { true: 'w-full', false: '' },
     },
-    defaultVariants: { variant: 'accent', size: 'default', fullWidth: false },
+    compoundVariants: [
+      { size: 'default', font: 'bold', class: 'text-h3' },
+      { size: 'default', font: 'regular', class: 'text-h4' },
+    ],
+    defaultVariants: { variant: 'accent', size: 'default', font: 'bold', fullWidth: false },
   },
 );
 
@@ -254,7 +261,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   if (useSplitLayout) {
     const safeSize = (size ?? 'default') as 'default' | 'small';
     const safeVariant = (variant ?? 'accent') as 'accent' | 'outline' | 'transparent' | 'destructive' | 'warning';
-    const shellClasses = cn(splitShellVariants({ variant: safeVariant, size: safeSize, fullWidth }), className);
+    const shellClasses = cn(splitShellVariants({ variant: safeVariant, size: safeSize, font, fullWidth }), className);
     const mainSlotClass = splitSlotVariants({ slot: 'main', size: safeSize, variant: safeVariant });
     const iconSlotClass = splitSlotVariants({ slot: 'icon', size: safeSize, variant: safeVariant });
 

--- a/openframe-frontend-core/src/hooks/ui/use-header-height.ts
+++ b/openframe-frontend-core/src/hooks/ui/use-header-height.ts
@@ -9,7 +9,9 @@ import { useEffect, useState } from 'react'
  * overlap the header.
  */
 export function useHeaderHeight(
-  defaultHeight = 64,
+  // First-paint fallback = the unified top-navigation `big` bar (72px), the
+  // size every hub/marketing site renders; replaced by the live measurement.
+  defaultHeight = 72,
   options: {
     /**
      * When false, no observers are attached and the default height is

--- a/openframe-frontend-core/src/stories/TopNavigation.stories.tsx
+++ b/openframe-frontend-core/src/stories/TopNavigation.stories.tsx
@@ -23,7 +23,7 @@ const logo = (
 const navLinks = (
   <nav className="flex items-center gap-2" aria-label="Main navigation">
     {['OpenFrame', 'OpenMSP', 'Resources', 'Pricing'].map(label => (
-      <Button key={label} variant="transparent" size="small-legacy" className="text-h3 font-bold tracking-[-0.36px]">
+      <Button key={label} variant="transparent" size="default" font="regular">
         {label}
       </Button>
     ))}
@@ -79,6 +79,7 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     centerBreakpoint: { control: 'radio', options: ['md', 'lg'] },
+    size: { control: 'radio', options: ['small', 'big'] },
     backgroundClassName: { control: 'text' },
     mobileTopBorder: { control: 'boolean' },
   },
@@ -112,6 +113,24 @@ export const MarketingFull: Story = {
       </Button>
     ),
     sideActions: sideActionCells,
+  },
+};
+
+/**
+ * The `big` (72px) bar every hub/marketing site renders — same zones, taller
+ * bar and 72px cells (Figma 2936-6812). `small` (56px) is the console size.
+ */
+export const MarketingBig: Story = {
+  args: {
+    ...MarketingFull.args,
+    size: 'big',
+    // Big bar carries the full default-size CTA (Figma 2936-6812), not the
+    // 32px mono control.
+    cta: (
+      <Button variant="accent" onClick={fn()}>
+        Try for Free
+      </Button>
+    ),
   },
 };
 


### PR DESCRIPTION
## Summary

- **TopNavigation `size` axis** (Figma 2797-5978): `small` = 56px (console), `big` = 72px (hub/marketing). Heights fixed across breakpoints; square cell width flows to `HeaderButton` via the `--top-nav-cell` var. Marketing `Header` renders `size="big"`; `AppHeader` stays small — **console mobile grows 48 → 56px** per the updated spec.
- **Button `font` axis** (Figma 133-740): `font="regular"` swaps the default size's h3-bold label for the h4 (DM Sans 500) step. Header nav links moved to `size="default" font="regular"` (two `small-legacy` call sites retired).
- Header cell icons unified at 24px on every breakpoint (were 16px below md).
- `MingoAiButton` restored to the full default-Button footprint (ring box h-11 md:h-12, `text-h3` wordmark) beside the default-size CTA.
- Hub logo insets: 12px mobile / 16px tablet / desktop unchanged (80px, collapsed to 24px next to an always-visible leading cell).
- Leading-cells wrapper unpadded — admin toggles are square `HeaderButton` cells.
- `MobileBurgerMenu` offset 48 → 56, `useHeaderHeight` default 64 → 72, skeletons synced; Storybook: `MarketingBig` story + `size` control.

## Consumer notes

- Hub companion PR: flamingo-stack/multi-platform-hub#… (32px logos, HeaderButton admin toggles, drawer backgrounds, default-size CTAs) — needs the release from this PR.
- FE bump will need its `app-shell-skeleton` synced to the 56px mobile bar.

## Testing

- `tsc` + build clean; Storybook verified; live-reviewed via yalc on flamingo/people-hub/product-hub.

ClickUp: https://app.clickup.com/t/86ajqwpd3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated header and navigation layouts with larger, more consistent spacing and 24px icons.
  * Improved mobile header sizing and menu alignment.
  * Standardized loading placeholders and navigation cell dimensions.
  * Refined button typography and added regular/bold font options.
* **New Features**
  * Added small and large navigation size variants.
  * Added an example showcasing the larger navigation layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->