### PR TITLE
feat(tickets): live reply stream provider, common SSE client, unified header unread indication

### DIFF
--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -11,6 +11,7 @@ import { BellIcon } from '../icons-v2-generated/interface/bell-icon';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, SquareAvatar } from '../ui';
 import { HeaderButton } from './header-button';
 import { HeaderGlobalSearch } from './header-global-search';
+import { TicketAlertsButton } from './ticket-alerts-button';
 import { HeaderMingoButton } from './header-mingo-button';
 import { HeaderOrganizationFilter } from './header-organization-filter';
 import { TopNavigation } from './top-navigation';
@@ -24,6 +25,14 @@ export interface AppHeaderProps {
   onOrgChange?: (id: string) => void;
   showNotifications?: boolean;
   unreadCount?: number;
+  /** Render the support-ticket alerts cell (`TicketAlertsButton`).
+   *  Requires wrapping the app in `<TicketLiveProvider>` — without it
+   *  the cell renders nothing. */
+  showTicketAlerts?: boolean;
+  /** Navigation target for the tickets surface (e.g. '/help-center/tickets'). */
+  ticketAlertsHref?: string;
+  /** Host navigation for the tickets cell (router push). Wins over href. */
+  onTicketAlerts?: () => void;
   /** Render the time-tracker button + popup. Requires wrapping the app in `<TimeTrackerProvider>`. */
   showTimeTracker?: boolean;
   /** Render the "Mingo AI" launcher button (drawer-style trigger for an
@@ -110,6 +119,9 @@ export const AppHeader = React.memo(function AppHeader({
   onOrgChange,
   showNotifications,
   unreadCount = 0,
+  showTicketAlerts = false,
+  ticketAlertsHref,
+  onTicketAlerts,
   showTimeTracker = false,
   showMingoAI = false,
   onMingoAI,
@@ -145,6 +157,7 @@ export const AppHeader = React.memo(function AppHeader({
             showOrganizations && 'icon-lg',
             showTimeTracker && 'icon',
             showNotifications && 'icon',
+            showTicketAlerts && 'icon',
             showUser && 'icon-md',
             showMingoAI && 'wide',
           ].filter(Boolean) as HeaderLoadingCell[])
@@ -221,6 +234,17 @@ export const AppHeader = React.memo(function AppHeader({
               fallbackUnreadCount={unreadCount}
               disabled={disabled}
               dimmedClass={cn(cellDivider, dimmedClass)}
+            />
+          )}
+
+          {/* Support-ticket alerts (Help Center) — renders nothing when
+              no <TicketLiveProvider> is mounted. */}
+          {showTicketAlerts && (
+            <TicketAlertsButton
+              href={ticketAlertsHref}
+              onClick={onTicketAlerts}
+              disabled={disabled}
+              className={cn(cellDivider, dimmedClass)}
             />
           )}
 
@@ -322,18 +346,10 @@ function NotificationsHeaderButton({ fallbackUnreadCount, disabled, dimmedClass 
 
   return (
     <HeaderButton
-      icon={
-        isActive ? (
-          <XmarkIcon className="w-6 h-6" />
-        ) : (
-          <div className="relative w-6 h-6">
-            <BellIcon className="w-full h-full" />
-            {hasUnread && (
-              <span className="absolute top-0 right-0 bg-ods-warning rounded-full w-1.5 h-1.5 md:w-2 md:h-2" />
-            )}
-          </div>
-        )
-      }
+      icon={isActive ? <XmarkIcon className="w-6 h-6" /> : <BellIcon className="w-6 h-6" />}
+      // Shared dot primitive on the cell — same markup every indicator
+      // cell renders (see HeaderButton.showUnreadDot / <UnreadDot>).
+      showUnreadDot={!isActive && hasUnread}
       aria-label={isActive ? 'Close notifications' : 'Notifications'}
       onClick={onClick}
       isActive={isActive}

--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -26,13 +26,17 @@ export interface AppHeaderProps {
   showNotifications?: boolean;
   unreadCount?: number;
   /** Render the support-ticket alerts cell (`TicketAlertsButton`).
-   *  Requires wrapping the app in `<TicketLiveProvider>` — without it
-   *  the cell renders nothing. */
+   *  Attention-only: even when true it renders nothing unless a
+   *  `<TicketLiveProvider>` is mounted, the viewer is signed in, AND
+   *  there are unread support replies. */
   showTicketAlerts?: boolean;
-  /** Navigation target for the tickets surface (e.g. '/help-center/tickets'). */
+  /** BASE path of the tickets surface (e.g. '/help-center/tickets').
+   *  The cell appends `?ticket=<id>#ticket-<id>` for the newest-unread
+   *  ticket before navigating. */
   ticketAlertsHref?: string;
-  /** Host navigation for the tickets cell (router push). Wins over href. */
-  onTicketAlerts?: () => void;
+  /** Host navigation (router push) — receives the FULL computed href.
+   *  Defaults to `window.location.assign`. */
+  onTicketAlerts?: (href: string) => void;
   /** Render the time-tracker button + popup. Requires wrapping the app in `<TimeTrackerProvider>`. */
   showTimeTracker?: boolean;
   /** Render the "Mingo AI" launcher button (drawer-style trigger for an
@@ -237,12 +241,13 @@ export const AppHeader = React.memo(function AppHeader({
             />
           )}
 
-          {/* Support-ticket alerts (Help Center) — renders nothing when
-              no <TicketLiveProvider> is mounted. */}
+          {/* Support-ticket alerts (Help Center) — attention-only: renders
+              nothing unless there are unread replies (and a
+              <TicketLiveProvider> is mounted). */}
           {showTicketAlerts && (
             <TicketAlertsButton
-              href={ticketAlertsHref}
-              onClick={onTicketAlerts}
+              href={ticketAlertsHref ?? '/tickets'}
+              onNavigate={onTicketAlerts}
               disabled={disabled}
               className={cn(cellDivider, dimmedClass)}
             />

--- a/openframe-frontend-core/src/components/navigation/app-header.tsx
+++ b/openframe-frontend-core/src/components/navigation/app-header.tsx
@@ -30,8 +30,9 @@ export interface AppHeaderProps {
    *  `<TicketLiveProvider>` is mounted, the viewer is signed in, AND
    *  there are unread support replies. */
   showTicketAlerts?: boolean;
-  /** BASE path of the tickets surface (e.g. '/help-center/tickets').
-   *  The cell appends `?ticket=<id>#ticket-<id>` for the newest-unread
+  /** BASE path of the tickets surface (any nesting prefix allowed —
+   *  '/help-center/tickets', '/support/portal/tickets'). The cell builds
+   *  the SSOT deep link `<href>?ticket=<id>` for the newest-unread
    *  ticket before navigating. */
   ticketAlertsHref?: string;
   /** Host navigation (router push) — receives the FULL computed href.

--- a/openframe-frontend-core/src/components/navigation/header-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/header-button.tsx
@@ -2,12 +2,17 @@
 
 import React from 'react'
 import { cn } from '../../utils/cn'
+import { UnreadDot } from './unread-dot'
 
 export interface HeaderButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Whether the button is in active/pressed state */
   isActive?: boolean
   /** Icon to display in the button */
   icon: React.ReactNode
+  /** Render the shared `UnreadDot` at the icon's top-right (the
+   *  notifications-bell treatment, promoted to the cell primitive so
+   *  indicator cells never copy the dot markup). */
+  showUnreadDot?: boolean
   /** Additional class names */
   className?: string
 }
@@ -15,6 +20,7 @@ export interface HeaderButtonProps extends React.ButtonHTMLAttributes<HTMLButton
 export function HeaderButton({
   isActive = false,
   icon,
+  showUnreadDot = false,
   className,
   ...props
 }: HeaderButtonProps) {
@@ -36,7 +42,14 @@ export function HeaderButton({
       )}
       {...props}
     >
-      {icon}
+      {showUnreadDot ? (
+        <span className="relative inline-flex">
+          {icon}
+          <UnreadDot />
+        </span>
+      ) : (
+        icon
+      )}
     </button>
   )
 }

--- a/openframe-frontend-core/src/components/navigation/header.tsx
+++ b/openframe-frontend-core/src/components/navigation/header.tsx
@@ -8,6 +8,7 @@ import { Menu01Icon, XmarkIcon } from '../icons-v2-generated';
 import { Button } from '../ui/button';
 import { HeaderButton } from './header-button';
 import { MingoAiButton } from './mingo-ai-button';
+import { TicketAlertsButton } from './ticket-alerts-button';
 import { MOBILE_NAV_PANEL_ID } from './mobile-nav-panel';
 import { TopNavigation } from './top-navigation';
 
@@ -384,13 +385,26 @@ export function Header({ config, platform }: HeaderProps) {
         }
         ctaClassName="gap-3"
         sideActions={
-          config.mingo?.enabled ? (
-            <MingoAiButton
-              source={config.mingo.source}
-              icon={config.mingo.icon}
-              label={config.mingo.label}
-              className={config.mingo.className}
-            />
+          config.tickets || config.mingo?.enabled ? (
+            <>
+              {/* Support-ticket alerts cell — before Mingo, flush cell row.
+                  Renders nothing unless the host mounted <TicketLiveProvider>. */}
+              {config.tickets && (
+                <TicketAlertsButton
+                  href={config.tickets.href}
+                  onClick={config.tickets.onClick}
+                  className="border-l border-ods-border"
+                />
+              )}
+              {config.mingo?.enabled && (
+                <MingoAiButton
+                  source={config.mingo.source}
+                  icon={config.mingo.icon}
+                  label={config.mingo.label}
+                  className={config.mingo.className}
+                />
+              )}
+            </>
           ) : undefined
         }
       />

--- a/openframe-frontend-core/src/components/navigation/header.tsx
+++ b/openframe-frontend-core/src/components/navigation/header.tsx
@@ -388,11 +388,12 @@ export function Header({ config, platform }: HeaderProps) {
           config.tickets || config.mingo?.enabled ? (
             <>
               {/* Support-ticket alerts cell — before Mingo, flush cell row.
-                  Renders nothing unless the host mounted <TicketLiveProvider>. */}
+                  Attention-only: renders nothing unless there are unread
+                  replies (and the host mounted <TicketLiveProvider>). */}
               {config.tickets && (
                 <TicketAlertsButton
                   href={config.tickets.href}
-                  onClick={config.tickets.onClick}
+                  onNavigate={config.tickets.onClick}
                   className="border-l border-ods-border"
                 />
               )}

--- a/openframe-frontend-core/src/components/navigation/index.ts
+++ b/openframe-frontend-core/src/components/navigation/index.ts
@@ -49,6 +49,10 @@ export type { MobileBurgerMenuProps } from './mobile-burger-menu'
 
 export { HeaderButton } from './header-button'
 export type { HeaderButtonProps } from './header-button'
+export { UnreadDot } from './unread-dot'
+export type { UnreadDotProps } from './unread-dot'
+export { TicketAlertsButton } from './ticket-alerts-button'
+export type { TicketAlertsButtonProps } from './ticket-alerts-button'
 
 export { TopNavigation } from './top-navigation'
 export type { TopNavigationProps, TopNavigationCenterBreakpoint } from './top-navigation'

--- a/openframe-frontend-core/src/components/navigation/index.ts
+++ b/openframe-frontend-core/src/components/navigation/index.ts
@@ -49,8 +49,8 @@ export type { MobileBurgerMenuProps } from './mobile-burger-menu'
 
 export { HeaderButton } from './header-button'
 export type { HeaderButtonProps } from './header-button'
-export { UnreadDot } from './unread-dot'
-export type { UnreadDotProps } from './unread-dot'
+export { UnreadDot, UnreadCountBadge } from './unread-dot'
+export type { UnreadDotProps, UnreadCountBadgeProps } from './unread-dot'
 export { TicketAlertsButton } from './ticket-alerts-button'
 export type { TicketAlertsButtonProps } from './ticket-alerts-button'
 

--- a/openframe-frontend-core/src/components/navigation/navigation-sidebar-item.tsx
+++ b/openframe-frontend-core/src/components/navigation/navigation-sidebar-item.tsx
@@ -4,6 +4,7 @@ import { cloneElement, memo, type ReactElement, type ReactNode } from 'react'
 import Link from '../../embed-shims/next-link'
 import { NavigationSidebarItem } from '../../types/navigation'
 import { cn } from '../../utils'
+import { UnreadDot } from './unread-dot'
 
 interface IconProps {
   color?: string
@@ -82,9 +83,7 @@ export const NavigationSidebarItemButton = memo(function NavigationSidebarItemBu
         {cloneElement(item.icon as ReactElement<IconProps>, {
           color: isActive && !disabled ? "text-ods-accent" : "text-ods-text-secondary",
         })}
-        {hasUnread && !showLabel && (
-          <span className="absolute top-0 right-0 bg-ods-warning rounded-full w-2 h-2" />
-        )}
+        {hasUnread && !showLabel && <UnreadDot size="fixed" />}
       </div>
 
       <span

--- a/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+/**
+ * TicketAlertsButton — the unified header affordance for support-ticket
+ * unread indication. Mounted by BOTH header shells (hub `Header` via
+ * `HeaderConfig.tickets`, console `AppHeader` via `showTicketAlerts`).
+ *
+ * Design note: the console's NATS-backed notifications bell covers
+ * OpenFrame-internal events; Help Center replies come from the HubSpot
+ * mirror domain and must ALSO surface on the hub, which mounts no
+ * notifications system — so the affordance both hosts can share is this
+ * dedicated cell, not the bell. (Optional follow-up, out of scope:
+ * bridge ticket events into the console bell as well.)
+ *
+ * Renders nothing when no `TicketLiveProvider` is mounted (host didn't
+ * opt into ticket realtime) — the cell can be composed unconditionally.
+ * Unread state comes exclusively from the provider's single summary map.
+ */
+
+import React from 'react'
+import { cn } from '../../utils/cn'
+import { LifeBuoyIcon } from '../icons-v2-generated/interface/life-buoy-icon'
+import { useOptionalTicketLive } from '../tickets/ticket-live-provider'
+import { HeaderButton } from './header-button'
+
+export interface TicketAlertsButtonProps {
+  /** Navigation target for the host's tickets surface (hub `/tickets`,
+   *  console `/help-center/tickets`). Used when `onClick` is absent. */
+  href?: string
+  /** Host-provided navigation (e.g. router push). Wins over `href`. */
+  onClick?: () => void
+  disabled?: boolean
+  className?: string
+}
+
+export function TicketAlertsButton({ href, onClick, disabled, className }: TicketAlertsButtonProps) {
+  const live = useOptionalTicketLive()
+  // No provider (host didn't opt in) or signed-out viewer → no cell.
+  if (!live || !live.authed) return null
+
+  const handleClick =
+    onClick ??
+    (href
+      ? () => {
+          window.location.assign(href)
+        }
+      : undefined)
+
+  return (
+    <HeaderButton
+      icon={<LifeBuoyIcon className="w-6 h-6" />}
+      showUnreadDot={live.unreadTotal > 0}
+      aria-label={live.unreadTotal > 0 ? `Support tickets (${live.unreadTotal} unread)` : 'Support tickets'}
+      onClick={handleClick}
+      disabled={disabled || !handleClick}
+      className={cn(className)}
+    />
+  )
+}
+
+export default TicketAlertsButton

--- a/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
@@ -10,8 +10,9 @@
  *     `TicketLiveProvider` is mounted and the viewer is signed in) —
  *     appearing IS the indication, and it disappears once everything
  *     is read;
- *   - warning-colored glyph + accent count pill (2 updates → "2"), not
- *     the plain grey icon treatment;
+ *   - standard header-cell glyph coloring (matches the notifications /
+ *     time-tracker cells) + accent count pill (2 updates → "2", the
+ *     sidebar count-pill treatment);
  *   - clicking routes to the ticket with the NEWEST unread reply via the
  *     SSOT deep link (`buildTicketOpenHref` → `<href>?ticket=<id>`): the
  *     `?ticket=` param is the ONE open-drawer source of truth in
@@ -66,8 +67,13 @@ export function TicketAlertsButton({ href, onNavigate, disabled, className }: Ti
   return (
     <HeaderButton
       icon={
+        // Glyph inherits HeaderButton's standard cell coloring (secondary at
+        // rest, primary on active) — SAME treatment as the notifications
+        // bell and time-tracker cells. The indication is carried by the
+        // count pill (sidebar count-pill precedent) and by the cell only
+        // existing while updates are unread — never by tinting the glyph.
         <span className="relative inline-flex">
-          <LifeBuoyIcon className="w-6 h-6 text-ods-warning" />
+          <LifeBuoyIcon className="w-6 h-6" />
           <UnreadCountBadge count={live.unreadTotal} />
         </span>
       }

--- a/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
@@ -5,16 +5,25 @@
  * unread indication. Mounted by BOTH header shells (hub `Header` via
  * `HeaderConfig.tickets`, console `AppHeader` via `showTicketAlerts`).
  *
- * Design note: the console's NATS-backed notifications bell covers
- * OpenFrame-internal events; Help Center replies come from the HubSpot
- * mirror domain and must ALSO surface on the hub, which mounts no
- * notifications system — so the affordance both hosts can share is this
- * dedicated cell, not the bell. (Optional follow-up, out of scope:
- * bridge ticket events into the console bell as well.)
+ * ATTENTION-ONLY element, deliberately unlike the always-on header cells:
+ *   - renders NOTHING unless there are unread support replies (and a
+ *     `TicketLiveProvider` is mounted and the viewer is signed in) —
+ *     appearing IS the indication, and it disappears once everything
+ *     is read;
+ *   - warning-colored glyph + accent count pill (2 updates → "2"), not
+ *     the plain grey icon treatment;
+ *   - clicking routes to the ticket with the NEWEST unread reply:
+ *     `<href>?ticket=<id>#ticket-<id>` — the `?ticket=` param auto-opens
+ *     that drawer (marking it read) and the hash auto-scrolls the row via
+ *     the list's existing deep-link handling. With multiple updates the
+ *     pill stays up with the remaining count and the next click routes
+ *     to the next-newest unread ticket.
  *
- * Renders nothing when no `TicketLiveProvider` is mounted (host didn't
- * opt into ticket realtime) — the cell can be composed unconditionally.
- * Unread state comes exclusively from the provider's single summary map.
+ * Design note: the console's NATS-backed `NotificationsProvider` bell
+ * covers OpenFrame-internal events; Help Center replies come from the
+ * HubSpot mirror domain and must ALSO surface on the hub, which mounts
+ * no notifications system — so the affordance both hosts can share is
+ * this dedicated cell, not the bell.
  */
 
 import React from 'react'
@@ -22,37 +31,46 @@ import { cn } from '../../utils/cn'
 import { LifeBuoyIcon } from '../icons-v2-generated/interface/life-buoy-icon'
 import { useOptionalTicketLive } from '../tickets/ticket-live-provider'
 import { HeaderButton } from './header-button'
+import { UnreadCountBadge } from './unread-dot'
 
 export interface TicketAlertsButtonProps {
-  /** Navigation target for the host's tickets surface (hub `/tickets`,
-   *  console `/help-center/tickets`). Used when `onClick` is absent. */
-  href?: string
-  /** Host-provided navigation (e.g. router push). Wins over `href`. */
-  onClick?: () => void
+  /** BASE path of the host's tickets surface (hub `/tickets`, console
+   *  `/help-center/tickets`). The button appends `?ticket=<id>#ticket-<id>`
+   *  for the newest-unread ticket before navigating. */
+  href: string
+  /** Host navigation (router push) — receives the FULL computed href.
+   *  Defaults to `window.location.assign`. */
+  onNavigate?: (href: string) => void
   disabled?: boolean
   className?: string
 }
 
-export function TicketAlertsButton({ href, onClick, disabled, className }: TicketAlertsButtonProps) {
+export function TicketAlertsButton({ href, onNavigate, disabled, className }: TicketAlertsButtonProps) {
   const live = useOptionalTicketLive()
-  // No provider (host didn't opt in) or signed-out viewer → no cell.
-  if (!live || !live.authed) return null
+  // Attention-only: no provider, signed out, or nothing unread → no cell.
+  if (!live || !live.authed || live.unreadTotal === 0) return null
 
-  const handleClick =
-    onClick ??
-    (href
-      ? () => {
-          window.location.assign(href)
-        }
-      : undefined)
+  const targetId = live.nextUnreadTicketId
+  const target = targetId
+    ? `${href}?ticket=${encodeURIComponent(targetId)}#ticket-${encodeURIComponent(targetId)}`
+    : href
+
+  const handleClick = () => {
+    if (onNavigate) onNavigate(target)
+    else window.location.assign(target)
+  }
 
   return (
     <HeaderButton
-      icon={<LifeBuoyIcon className="w-6 h-6" />}
-      showUnreadDot={live.unreadTotal > 0}
-      aria-label={live.unreadTotal > 0 ? `Support tickets (${live.unreadTotal} unread)` : 'Support tickets'}
+      icon={
+        <span className="relative inline-flex">
+          <LifeBuoyIcon className="w-6 h-6 text-ods-warning" />
+          <UnreadCountBadge count={live.unreadTotal} />
+        </span>
+      }
+      aria-label={`Support tickets — ${live.unreadTotal} unread ${live.unreadTotal === 1 ? 'update' : 'updates'}`}
       onClick={handleClick}
-      disabled={disabled || !handleClick}
+      disabled={disabled}
       className={cn(className)}
     />
   )

--- a/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
+++ b/openframe-frontend-core/src/components/navigation/ticket-alerts-button.tsx
@@ -12,12 +12,13 @@
  *     is read;
  *   - warning-colored glyph + accent count pill (2 updates → "2"), not
  *     the plain grey icon treatment;
- *   - clicking routes to the ticket with the NEWEST unread reply:
- *     `<href>?ticket=<id>#ticket-<id>` — the `?ticket=` param auto-opens
- *     that drawer (marking it read) and the hash auto-scrolls the row via
- *     the list's existing deep-link handling. With multiple updates the
- *     pill stays up with the remaining count and the next click routes
- *     to the next-newest unread ticket.
+ *   - clicking routes to the ticket with the NEWEST unread reply via the
+ *     SSOT deep link (`buildTicketOpenHref` → `<href>?ticket=<id>`): the
+ *     `?ticket=` param is the ONE open-drawer source of truth in
+ *     `HelpCenterList`, and opening the drawer already smooth-scrolls
+ *     the row. With multiple updates the pill stays up with the
+ *     remaining count and the next click routes to the next-newest
+ *     unread ticket.
  *
  * Design note: the console's NATS-backed `NotificationsProvider` bell
  * covers OpenFrame-internal events; Help Center replies come from the
@@ -30,13 +31,17 @@ import React from 'react'
 import { cn } from '../../utils/cn'
 import { LifeBuoyIcon } from '../icons-v2-generated/interface/life-buoy-icon'
 import { useOptionalTicketLive } from '../tickets/ticket-live-provider'
+import { buildTicketOpenHref } from '../tickets/types'
 import { HeaderButton } from './header-button'
 import { UnreadCountBadge } from './unread-dot'
 
 export interface TicketAlertsButtonProps {
-  /** BASE path of the host's tickets surface (hub `/tickets`, console
-   *  `/help-center/tickets`). The button appends `?ticket=<id>#ticket-<id>`
-   *  for the newest-unread ticket before navigating. */
+  /** BASE path of the host's tickets surface — may carry ANY nesting
+   *  prefix (hub `/tickets`, console `/help-center/tickets`, an
+   *  embedder's `/support/portal/tickets`). The deep link is built by
+   *  the SSOT `buildTicketOpenHref` (`<base>?ticket=<id>` — the same
+   *  param `HelpCenterList` derives its drawer state from; opening the
+   *  drawer also smooth-scrolls the row). */
   href: string
   /** Host navigation (router push) — receives the FULL computed href.
    *  Defaults to `window.location.assign`. */
@@ -51,9 +56,7 @@ export function TicketAlertsButton({ href, onNavigate, disabled, className }: Ti
   if (!live || !live.authed || live.unreadTotal === 0) return null
 
   const targetId = live.nextUnreadTicketId
-  const target = targetId
-    ? `${href}?ticket=${encodeURIComponent(targetId)}#ticket-${encodeURIComponent(targetId)}`
-    : href
+  const target = targetId ? buildTicketOpenHref(href, targetId) : href
 
   const handleClick = () => {
     if (onNavigate) onNavigate(target)

--- a/openframe-frontend-core/src/components/navigation/unread-dot.tsx
+++ b/openframe-frontend-core/src/components/navigation/unread-dot.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import React from 'react'
+import { cn } from '../../utils/cn'
+
+/**
+ * The ONE unread-indicator dot (`bg-ods-warning`, top-right of an icon
+ * inside a `relative` wrapper). Previously duplicated in
+ * `NotificationsHeaderButton` and `NavigationSidebarItemButton` — both
+ * now render THIS, as does `TicketAlertsButton`.
+ *
+ * Size variants preserve the two pre-existing renders exactly (neither
+ * may silently change):
+ *   - `responsive` — header cells: `w-1.5 h-1.5 md:w-2 md:h-2`
+ *   - `fixed`      — sidebar collapsed icon: `w-2 h-2`
+ */
+export interface UnreadDotProps {
+  size?: 'responsive' | 'fixed'
+  className?: string
+}
+
+export function UnreadDot({ size = 'responsive', className }: UnreadDotProps) {
+  return (
+    <span
+      className={cn(
+        'absolute top-0 right-0 bg-ods-warning rounded-full',
+        size === 'responsive' ? 'w-1.5 h-1.5 md:w-2 md:h-2' : 'w-2 h-2',
+        className,
+      )}
+    />
+  )
+}
+
+export default UnreadDot

--- a/openframe-frontend-core/src/components/navigation/unread-dot.tsx
+++ b/openframe-frontend-core/src/components/navigation/unread-dot.tsx
@@ -31,4 +31,31 @@ export function UnreadDot({ size = 'responsive', className }: UnreadDotProps) {
   )
 }
 
+/**
+ * Count variant of the unread indicator — a small accent pill anchored
+ * top-right of an icon inside a `relative` wrapper, clamped at "9+".
+ * Same family as `UnreadDot` (dot = "something new", count = "N new");
+ * the sidebar's expanded-row pill stays its own larger treatment.
+ */
+export interface UnreadCountBadgeProps {
+  count: number
+  className?: string
+}
+
+export function UnreadCountBadge({ count, className }: UnreadCountBadgeProps) {
+  if (count <= 0) return null
+  return (
+    <span
+      className={cn(
+        'absolute -top-1.5 -right-1.5 flex items-center justify-center',
+        'min-w-4 h-4 px-1 rounded-full bg-ods-accent',
+        'text-badge text-ods-text-on-accent leading-none',
+        className,
+      )}
+    >
+      {count > 9 ? '9+' : count}
+    </span>
+  )
+}
+
 export default UnreadDot

--- a/openframe-frontend-core/src/components/tickets/.types.md
+++ b/openframe-frontend-core/src/components/tickets/.types.md
@@ -28,7 +28,7 @@ Shared type contracts, constants, and utilities for the OpenFrame ticket system 
 | Name | Value | Purpose |
 |---|---|---|
 | `TICKET_TEXT_MAX_CHARS` | `5000` | Client-side cap on ticket/comment text length |
-| `TICKET_LIVE_POLL_MS` | `8000` | Shared refetch interval (ms) for list + conversation polls on open drawers |
+| `TICKET_MARK_READ_DEBOUNCE_MS` | `2000` | Trailing debounce for drawer mark-read while new messages stream in |
 | `TOAST_COPY` | `as const` object | Centralized, QA-auditable toast strings for all ticket actions |
 
 ## Usage Example
@@ -38,7 +38,6 @@ import {
   AnyTicket,
   isOptimistic,
   TicketsCacheSlot,
-  TICKET_LIVE_POLL_MS,
   TICKET_TEXT_MAX_CHARS,
   TOAST_COPY,
 } from '@openframe/oss-lib'

--- a/openframe-frontend-core/src/components/tickets/.types.md
+++ b/openframe-frontend-core/src/components/tickets/.types.md
@@ -64,9 +64,6 @@ if (body.length > TICKET_TEXT_MAX_CHARS) {
   showError(`Max ${TICKET_TEXT_MAX_CHARS} characters`)
 }
 
-// Consistent poll cadence across list + conversation hooks
-useQuery({ queryKey: ['tickets'], refetchInterval: TICKET_LIVE_POLL_MS })
-
 // Centralized toast copy
 toast(TOAST_COPY.close_success)
 ```

--- a/openframe-frontend-core/src/components/tickets/help-center-card.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-card.tsx
@@ -26,6 +26,7 @@ import {
   TicketDetailDrawer,
   type TicketDetailDrawerProps,
 } from './ticket-detail-drawer'
+import { useOptionalTicketLive } from './ticket-live-provider'
 import type { AnyTicket } from './types'
 import { isOptimistic } from './types'
 
@@ -118,8 +119,23 @@ export function HelpCenterCard({
     return () => cancelAnimationFrame(raf)
   }, [isExpanded])
 
+  // Unread replies for this row — read from the provider's single summary
+  // map (missing key / no provider = 0). The provider masks the open
+  // ticket to 0 and zeroes on markRead, so no local state here.
+  const live = useOptionalTicketLive()
+  const unreadCount =
+    (!optimistic && ticket.external_id && live?.unreadByTicket[ticket.external_id]) || 0
+
   const rightBadges = (
     <>
+      {unreadCount > 0 && (
+        <StatusBadge
+          text={`${unreadCount} NEW`}
+          colorScheme="warning"
+          variant="card"
+          className="border border-ods-border"
+        />
+      )}
       <StatusBadge
         text={rawStatus}
         colorScheme={getStatusColorScheme(rawStatus)}

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -37,7 +37,7 @@ import { UnifiedPagination } from '../unified-pagination'
 import { useChatIdentity } from '../chat/hooks/use-chat-identity'
 import { useScrollToHash } from '../../hooks/use-scroll-to-hash'
 import { STICKY_HEADER_OFFSET_PX } from '../../utils/same-page-hash-nav'
-import { devSectionAnchorId } from '../../utils/dev-sections/dev-section-param-keys'
+import { DEV_SECTION_PARAM_KEYS, devSectionAnchorId } from '../../utils/dev-sections/dev-section-param-keys'
 import { toast as defaultToast } from '../../hooks/use-toast'
 import { useTicketsList } from './hooks/use-tickets-list'
 import { useTicketActions } from './hooks/use-ticket-actions'
@@ -71,7 +71,7 @@ export function HelpCenterList({ toast = defaultToast, backButton, title, shell 
   const router = useRouter()
   const pathname = usePathname()
 
-  const search = searchParams.get('search') || ''
+  const search = searchParams.get(DEV_SECTION_PARAM_KEYS.search) || ''
   const status = searchParams.get('status') || 'all'
   // Deep-link: `?ticket=<external_id>` auto-opens that ticket's drawer on load.
   // Same GET-param plumbing as `?search=` — read here, drilled to the authed

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -44,7 +44,7 @@ import { useTicketActions } from './hooks/use-ticket-actions'
 import { HelpCenterCard } from './help-center-card'
 import { HelpCenterCreateForm, HelpCenterCreateFormSkeleton } from './help-center-create-form'
 import type { AnyTicket, OptimisticTicket, TicketsCacheSlot } from './types'
-import { isOptimistic } from './types'
+import { isOptimistic, TICKET_OPEN_PARAM } from './types'
 
 export interface HelpCenterListProps {
   /** Toast override (test-friendly). Defaults to the lib's shared
@@ -76,7 +76,7 @@ export function HelpCenterList({ toast = defaultToast, backButton, title, shell 
   // Deep-link: `?ticket=<external_id>` auto-opens that ticket's drawer on load.
   // Same GET-param plumbing as `?search=` — read here, drilled to the authed
   // child which expands the matching row once it's in the fetched list.
-  const ticketParam = searchParams.get('ticket') || ''
+  const ticketParam = searchParams.get(TICKET_OPEN_PARAM) || ''
   // 1-based page from the URL. `<UnifiedPagination>` writes `?page=N`
   // on navigation; we read it here and re-fetch on change. Invalid
   // values fall back to page 1.
@@ -193,8 +193,8 @@ function HelpCenterListAuthed({
   const setOpenTicket = useCallback(
     (externalId: string | null) => {
       const params = new URLSearchParams(searchParams.toString())
-      if (externalId) params.set('ticket', externalId)
-      else params.delete('ticket')
+      if (externalId) params.set(TICKET_OPEN_PARAM, externalId)
+      else params.delete(TICKET_OPEN_PARAM)
       const qs = params.toString()
       router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false })
     },

--- a/openframe-frontend-core/src/components/tickets/help-center-list.tsx
+++ b/openframe-frontend-core/src/components/tickets/help-center-list.tsx
@@ -44,7 +44,7 @@ import { useTicketActions } from './hooks/use-ticket-actions'
 import { HelpCenterCard } from './help-center-card'
 import { HelpCenterCreateForm, HelpCenterCreateFormSkeleton } from './help-center-create-form'
 import type { AnyTicket, OptimisticTicket, TicketsCacheSlot } from './types'
-import { isOptimistic, TICKET_LIVE_POLL_MS } from './types'
+import { isOptimistic } from './types'
 
 export interface HelpCenterListProps {
   /** Toast override (test-friendly). Defaults to the lib's shared
@@ -212,11 +212,11 @@ function HelpCenterListAuthed({
     search,
     status,
     page,
-    // Live status: while a drawer is open, poll so an out-of-band HubSpot
-    // status change (e.g. agent closes the ticket) flips the badge +
-    // open/reopen affordance within one interval. Idle (no drawer) → no poll.
-    // `ticketParam` (the open ticket's external_id) is the open signal.
-    refetchInterval: ticketParam ? TICKET_LIVE_POLL_MS : false,
+    // No interval polling (deleted 2026-08): `TicketLiveProvider`
+    // invalidates `['tickets']` on stream events; focus/mount refetch
+    // covers hosts without a stream. Disclosed trade-off: a bare
+    // status/pipeline change with no accompanying reply has no live
+    // path until the next event/focus/reconnect.
   })
 
   // Open state DERIVED from the URL param. `?ticket=` carries the user-facing

--- a/openframe-frontend-core/src/components/tickets/hooks/.use-ticket-engagements.md
+++ b/openframe-frontend-core/src/components/tickets/hooks/.use-ticket-engagements.md
@@ -23,7 +23,7 @@ Fetches and manages the conversation timeline (Note engagements and attachments)
 
 ```typescript
 // Fetch when the drawer opens; live updates arrive via TicketLiveProvider
-const { engagements, isLoading, error } = useTicketEngagements(ticket.externalId)
+const { engagements, isLoading, error } = useTicketEngagements(ticket.external_id)
 ```
 
 ## Notes

--- a/openframe-frontend-core/src/components/tickets/hooks/.use-ticket-engagements.md
+++ b/openframe-frontend-core/src/components/tickets/hooks/.use-ticket-engagements.md
@@ -11,28 +11,19 @@ Fetches and manages the conversation timeline (Note engagements and attachments)
 
 ### Hook
 
-**`useTicketEngagements(externalTicketId, enabled?, refetchInterval?)`**
+**`useTicketEngagements(externalTicketId, enabled?)`**
 
 - Skips fetching for optimistic (`temp-*`) ticket IDs and unauthenticated (`anon`) identities
 - Posts to `/api/chat/agent/list-engagements` via `embedAuthedFetch`
 - Disables all caching (`staleTime: 0`, `gcTime: 0`) to ensure HubSpot truth on every drawer open
-- Supports configurable live-polling via `refetchInterval`; polling automatically stops when the drawer unmounts
+- No interval polling — live refresh is push-driven (`TicketLiveProvider` invalidates `['ticket-engagements', id]` on stream events); focus/mount refetch is the no-stream fallback
 - Fixes a skeleton double-flash by treating a fetchable ticket as "loading" from the very first render, even before `useChatIdentity` resolves
 
 ## Usage Example
 
 ```typescript
-// Basic usage — fetch once when drawer opens
+// Fetch when the drawer opens; live updates arrive via TicketLiveProvider
 const { engagements, isLoading, error } = useTicketEngagements(ticket.externalId)
-
-// Live-polling variant — refresh every 15 seconds while drawer is open
-const TICKET_LIVE_POLL_MS = 15_000
-
-const { engagements, isFetching, refetch } = useTicketEngagements(
-  ticket.externalId,
-  true,
-  TICKET_LIVE_POLL_MS,
-)
 ```
 
 ## Notes

--- a/openframe-frontend-core/src/components/tickets/hooks/.use-tickets-list.md
+++ b/openframe-frontend-core/src/components/tickets/hooks/.use-tickets-list.md
@@ -9,7 +9,6 @@ Input interface controlling the query:
 - `search` — free-text FTS filter; empty string returns all tickets
 - `status` — `'open'` | `'closed'` | `'all'` (empty/`'all'` omits the filter)
 - `page` / `pageSize` — 1-based pagination; server caps `pageSize` at 100
-- `refetchInterval` — optional polling interval (ms) for live status updates; paused on hidden tabs
 
 ### `UseTicketsListReturn`
 Output shape:
@@ -41,7 +40,6 @@ const {
   status: 'open',
   page: currentPage,
   pageSize: 20,
-  refetchInterval: isDrawerOpen ? 10_000 : false,
 })
 ```
 

--- a/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-ticket-actions.ts
@@ -33,6 +33,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRequiredChatRuntime } from '../../../contexts/chat-runtime-context'
 import { embedAuthedFetch } from '../../../utils/embed-authed-fetch'
+import { useOptionalTicketLive } from '../ticket-live-provider'
 import type { ChatAttachment } from '../../chat/utils/chat-attachment-markdown'
 import {
   type AnyTicket,
@@ -154,6 +155,10 @@ export function useTicketActions(options: UseTicketActionsOptions): UseTicketAct
   // the bare hub path when unconfigured.
   const ticketActionEndpoint =
     useRequiredChatRuntime().endpoints.ticketActionUrl ?? TICKET_ACTION_ENDPOINT
+  // Optional live-stream context: a first-ever ticket must retry the
+  // provider's `no-stream` (204) subscription so replies stream in.
+  const ticketLive = useOptionalTicketLive()
+  const notifyTicketCreated = ticketLive?.notifyTicketCreated
   const { prependOptimistic, removeOptimistic, removeTicketFromCache, toast, onSupportSystemDown } = options
 
   // Form-level single-flight uses BOTH a ref (for synchronous guarding
@@ -390,6 +395,9 @@ export function useTicketActions(options: UseTicketActionsOptions): UseTicketAct
             await queryClient.invalidateQueries({ queryKey: ['tickets'] })
             removeOptimistic(placeholderId)
           }
+          // A zero-ticket viewer's stream returned 204 before this
+          // create — nudge the provider to (re)subscribe.
+          notifyTicketCreated?.()
           return true
         })
       } catch (err) {
@@ -409,6 +417,7 @@ export function useTicketActions(options: UseTicketActionsOptions): UseTicketAct
       queryClient,
       toast,
       watchMirrorSync,
+      notifyTicketCreated,
       surfaceError,
     ],
   )

--- a/openframe-frontend-core/src/components/tickets/hooks/use-ticket-engagements.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-ticket-engagements.ts
@@ -77,14 +77,6 @@ export interface UseTicketEngagementsReturn {
 export function useTicketEngagements(
   externalTicketId: string | null | undefined,
   enabled = true,
-  /** Poll cadence (ms) for live conversation refresh while the drawer is
-   *  open. The drawer only mounts this hook when expanded, so a constant
-   *  here is already gated to "drawer open" — closing the drawer unmounts
-   *  the panel and the polling stops. `false`/undefined disables it (the
-   *  default, preserving prior fetch-once-per-open behavior for any other
-   *  caller). Mirrors `useTicketsList.refetchInterval`; see
-   *  `TICKET_LIVE_POLL_MS`. */
-  refetchInterval: number | false = false,
 ): UseTicketEngagementsReturn {
   const identity = useChatIdentity()
   const identityKey = identity.user?.email ?? 'anon'
@@ -115,11 +107,10 @@ export function useTicketEngagements(
     gcTime: 0,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
-    // Live conversation: poll while the caller opts in (drawer open). New
-    // agent replies + attachments appear within one interval without a
-    // manual refresh. `refetchIntervalInBackground` stays false (default)
-    // so polling pauses on a hidden tab.
-    refetchInterval,
+    // NO interval polling (deleted 2026-08): new agent replies arrive via
+    // `TicketLiveProvider`'s stream-driven invalidation of
+    // `['ticket-engagements', id]`; focus/mount refetch is the no-stream
+    // fallback.
     queryFn: async (): Promise<TicketEngagement[]> => {
       const response = await embedAuthedFetch(listEngagementsEndpoint, {
         method: 'POST',

--- a/openframe-frontend-core/src/components/tickets/hooks/use-tickets-list.ts
+++ b/openframe-frontend-core/src/components/tickets/hooks/use-tickets-list.ts
@@ -59,13 +59,6 @@ export interface UseTicketsListFilters {
   page?: number
   /** Items per page (server caps at 100). Defaults to 20. */
   pageSize?: number
-  /** Poll interval (ms) for live updates — e.g. so a ticket CLOSED out-of-band
-   *  on HubSpot flips the status badge + open/reopen affordance without a manual
-   *  refresh. `false`/0/undefined disables polling. The hub passes a value only
-   *  while a drawer is open (mirror webhooks keep the server fresh; this surfaces
-   *  it client-side). TanStack pauses interval polling while the tab is hidden,
-   *  so there are no wasted background requests. */
-  refetchInterval?: number | false
 }
 
 export interface UseTicketsListReturn {
@@ -116,8 +109,6 @@ export function useTicketsList(filters: UseTicketsListFilters): UseTicketsListRe
   // previous identity's data.
   const identityKey = customerEmail || 'anon'
 
-  const refetchInterval = filters.refetchInterval ?? false
-
   const query = useQuery({
     queryKey: ['tickets', 'self', identityKey, search, statusFilter, page, pageSize],
     enabled,
@@ -130,10 +121,8 @@ export function useTicketsList(filters: UseTicketsListFilters): UseTicketsListRe
     gcTime: 0,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,
-    // Live status: poll while the caller opts in (drawer open). Defaults to
-    // false. `refetchIntervalInBackground` stays false (the default) so polling
-    // pauses on a hidden tab — no wasted requests when the user tabs away.
-    refetchInterval,
+    // NO interval polling (deleted 2026-08): live freshness is push-driven
+    // — `TicketLiveProvider` invalidates `['tickets']` on stream events.
     queryFn: async (): Promise<FindTicketResponse> => {
       const body: Record<string, string | number> = {
         query: search,

--- a/openframe-frontend-core/src/components/tickets/index.ts
+++ b/openframe-frontend-core/src/components/tickets/index.ts
@@ -57,4 +57,6 @@ export {
   type TicketUnreadSummary,
   TOAST_COPY as TICKET_TOAST_COPY,
   isOptimistic,
+  TICKET_OPEN_PARAM,
+  buildTicketOpenHref,
 } from './types'

--- a/openframe-frontend-core/src/components/tickets/index.ts
+++ b/openframe-frontend-core/src/components/tickets/index.ts
@@ -54,6 +54,7 @@ export {
   type TicketStreamEvent,
   type TicketStreamEventType,
   type TicketMessageStreamData,
+  type TicketStatusStreamData,
   type TicketUnreadSummary,
   TOAST_COPY as TICKET_TOAST_COPY,
   isOptimistic,

--- a/openframe-frontend-core/src/components/tickets/index.ts
+++ b/openframe-frontend-core/src/components/tickets/index.ts
@@ -39,12 +39,22 @@ export {
   type TicketEngagementFile,
 } from './hooks/use-ticket-engagements'
 export {
+  TicketLiveProvider,
+  useTicketLive,
+  useOptionalTicketLive,
+  type TicketLiveContextValue,
+} from './ticket-live-provider'
+export {
   type TicketData,
   type TicketClickupSummary,
   type OptimisticTicket,
   type AnyTicket,
   type TicketActionErrorCode,
   type MappedTicketActionError,
+  type TicketStreamEvent,
+  type TicketStreamEventType,
+  type TicketMessageStreamData,
+  type TicketUnreadSummary,
   TOAST_COPY as TICKET_TOAST_COPY,
   isOptimistic,
 } from './types'

--- a/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-detail-drawer.tsx
@@ -21,6 +21,7 @@
  * callbacks; we don't reach into the QueryClient.
  */
 
+import { useEffect, useRef } from 'react'
 import { useStickToBottom } from 'use-stick-to-bottom'
 import { Button } from './../ui/button'
 import { useChatIdentity } from './../chat/hooks/use-chat-identity'
@@ -40,13 +41,14 @@ import type {
   TicketEngagementFile,
 } from './hooks/use-ticket-engagements'
 import { TicketLinkedDeliveryCard } from './ticket-linked-delivery-card'
+import { useOptionalTicketLive } from './ticket-live-provider'
 import { TicketReplyComposer } from './ticket-reply-composer'
 import type {
   AnyTicket,
   TicketAssignedOwner,
   MappedTicketActionError,
 } from './types'
-import { isOptimistic, TICKET_LIVE_POLL_MS } from './types'
+import { isOptimistic, TICKET_MARK_READ_DEBOUNCE_MS } from './types'
 
 /** Identity bundle threaded through the action callbacks: local mirror
  *  UUID + HubSpot external_id. Actions send `external_id` to HubSpot
@@ -204,18 +206,48 @@ function TicketTimelinePanel({ ticket }: { ticket: AnyTicket }) {
   // Optimistic placeholders don't have a real external_id yet — skip
   // the engagement fetch until the real ticket lands.
   const externalId = isOptimistic(ticket) ? null : ticket.external_id
-  // Live conversation refresh: this panel only mounts while the drawer is
-  // open, so the constant interval is already gated to "open" (closing the
-  // drawer unmounts the panel → polling stops). New agent replies +
-  // attachments surface within one cadence without a manual refresh — the
-  // same 8s the list-level status/assignee poll uses (single source:
-  // TICKET_LIVE_POLL_MS). A background poll never flashes the skeleton
-  // (the `isLoading` guard below keys off "no data yet", not `isFetching`).
-  const { engagements, isLoading } = useTicketEngagements(
-    externalId,
-    !!externalId,
-    TICKET_LIVE_POLL_MS,
-  )
+  // Live conversation refresh is PUSH-driven: `TicketLiveProvider`
+  // invalidates `['ticket-engagements', id]` on stream events, so new
+  // agent replies surface without any interval (polling was deleted
+  // 2026-08; `refetchOnWindowFocus` remains the no-stream fallback).
+  const { engagements, isLoading } = useTicketEngagements(externalId, !!externalId)
+
+  // Read-state lifecycle — this panel mounts exactly while the drawer is
+  // open, so it owns: register the open ticket (provider suppresses
+  // unread bumps + masks the row), markRead on open, debounced markRead
+  // as new messages stream in, flush on close. The provider's callbacks
+  // are stable (useCallback) so these effects don't re-fire on unrelated
+  // context-value changes.
+  const live = useOptionalTicketLive()
+  const setOpenTicketId = live?.setOpenTicketId
+  const markRead = live?.markRead
+  const markReadDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!externalId || !setOpenTicketId || !markRead) return
+    setOpenTicketId(externalId)
+    void markRead(externalId)
+    return () => {
+      // Flush a pending debounced markRead on close so a reply that
+      // arrived moments before closing is still receipted.
+      if (markReadDebounceRef.current) {
+        clearTimeout(markReadDebounceRef.current)
+        markReadDebounceRef.current = null
+        void markRead(externalId)
+      }
+      setOpenTicketId(null)
+    }
+  }, [externalId, setOpenTicketId, markRead])
+
+  const engagementsCount = engagements.length
+  useEffect(() => {
+    if (!externalId || !markRead || engagementsCount === 0) return
+    if (markReadDebounceRef.current) clearTimeout(markReadDebounceRef.current)
+    markReadDebounceRef.current = setTimeout(() => {
+      markReadDebounceRef.current = null
+      void markRead(externalId)
+    }, TICKET_MARK_READ_DEBOUNCE_MS)
+  }, [engagementsCount, externalId, markRead])
 
   // Slack-style auto-tail (same lib mechanism `ChatMessageList` uses): jump to
   // the newest message on open (`initial:'instant'`), smooth-scroll on a new

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -299,6 +299,19 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       return
     }
 
+    if (eventName === 'ticket-status') {
+      // Meaningful ticket-row change (close/reopen/pipeline move). No
+      // optimistic bump — closures count as unread SERVER-side
+      // (closed_at vs receipt in computeUnreadCounts), so the debounced
+      // flush's summary refetch is the one accounting path. The same
+      // flush invalidates ['tickets'] (status badge flips live) and the
+      // open drawer's engagements.
+      const frame = data as TicketStreamEvent | null
+      const ticketId = (frame?.data as { ticket_external_id?: string } | undefined)?.ticket_external_id
+      scheduleInvalidation(ticketId)
+      return
+    }
+
     if (eventName === 'ticket-message') {
       const frame = data as TicketStreamEvent | null
       const payload = frame?.data

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -1,0 +1,474 @@
+'use client'
+
+/**
+ * TicketLiveProvider — the ONE client home for support-ticket realtime.
+ *
+ * Owns:
+ *   - the SSE subscription lifecycle (`createSseSubscription` over
+ *     `ticketStreamUrl`), with `connected` derived from the SERVER's
+ *     `status` frames (`subscribed` → true; `retrying`/`reconnect_failed`
+ *     → false) — never from "the HTTP stream is open";
+ *   - the unread summary (single source: `ticket-unread-summary`) —
+ *     header badge total AND per-row dots both read this map;
+ *   - resync on every (re)connect (summary refetch + engagements
+ *     invalidation) — the single rule that closes every event-gap class
+ *     (forced maxDuration reconnects, network blips, tab sleep);
+ *   - visibility gating: hidden → 45s grace → disconnect; visible →
+ *     reconnect + resync;
+ *   - `markRead` with local write-through zeroing (no interval polling
+ *     exists — a stale post-close map would re-light the dot forever).
+ *
+ * There is NO polling anywhere: the summary query has no
+ * `refetchInterval`; it refetches on mount, (re)connect, window focus,
+ * and (debounced) stream events. Hosts whose stream endpoint 404s
+ * (terminal) or is absent keep exactly focus/mount freshness.
+ *
+ * Invalidation semantics on events — deliberately `invalidateQueries`,
+ * NOT `setQueryData` patches: the ticket hooks run `gcTime: 0`, so
+ * there is usually no cache entry to patch, and `TicketsCacheSlot`
+ * shape rules apply when there is.
+ */
+
+import React from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useChatRuntime } from '../../contexts/chat-runtime-context'
+import { embedAuthedFetch } from '../../utils/embed-authed-fetch'
+import {
+  createSseSubscription,
+  type SseSubscription,
+  type SseTransportStatus,
+} from '../../utils/sse-subscription'
+import { useChatIdentity } from '../chat/hooks/use-chat-identity'
+import type {
+  TicketMessageStreamData,
+  TicketStreamEvent,
+  TicketUnreadSummary,
+} from './types'
+
+const TICKET_STREAM_ENDPOINT = '/api/chat/agent/ticket-stream'
+const TICKET_READ_ENDPOINT = '/api/chat/agent/ticket-read'
+const TICKET_UNREAD_SUMMARY_ENDPOINT = '/api/chat/agent/ticket-unread-summary'
+
+/** Trailing debounce for event-burst invalidations (an agent pasting 5
+ *  messages must not fire 5 list refetches). */
+const INVALIDATE_DEBOUNCE_MS = 1_500
+/** Grace before disconnecting a hidden tab (Cmd-Tab thrash protection). */
+const HIDDEN_DISCONNECT_GRACE_MS = 45_000
+/** No `status: subscribed` within this window after transport-open →
+ *  treat as disconnected and force a client-side reconnect. */
+const SUBSCRIBE_CONFIRM_TIMEOUT_MS = 15_000
+/** After a server-reported `reconnect_failed`, the next client attempt
+ *  starts at the CAPPED delay — each reconnect costs a full server
+ *  invocation + the server's own Realtime retries; an outage must not
+ *  become a stampede. */
+const FAILED_RECONNECT_DELAY_MS = 30_000
+/** A server `retrying` status means the server is recovering the channel
+ *  itself (exponential backoff, ~5 attempts). Give it this long to reach
+ *  `subscribed` before the client hard-reconnects. */
+const SERVER_RETRY_GRACE_MS = 90_000
+
+export interface TicketLiveContextValue {
+  /** Viewer has a resolved, non-anon chat identity. Surfaces (e.g. the
+   *  header cell) hide themselves when false — computed here so they
+   *  don't each spin up their own identity resolution. */
+  authed: boolean
+  /** Realtime-subscribed (server-confirmed), not merely HTTP-open. */
+  connected: boolean
+  /** Unread total across tickets — drives the header dot. */
+  unreadTotal: number
+  /** Per-ticket unread counts (missing key = 0) — drives row dots.
+   *  The currently-open ticket is masked to 0. */
+  unreadByTicket: Record<string, number>
+  /** Mark a ticket read: POSTs the receipt, then locally zeroes the
+   *  ticket in the summary map (write-through; reconciled by the next
+   *  real refetch). */
+  markRead: (ticketExternalId: string) => Promise<void>
+  /** Drawer open/close registration — suppresses unread bumps for the
+   *  open ticket and masks it in the derived map. */
+  setOpenTicketId: (ticketExternalId: string | null) => void
+  /** Hint that the viewer just created a ticket — retries a `no-stream`
+   *  (204) subscription. */
+  notifyTicketCreated: () => void
+}
+
+const TicketLiveContext = React.createContext<TicketLiveContextValue | null>(null)
+
+export function useOptionalTicketLive(): TicketLiveContextValue | null {
+  return React.useContext(TicketLiveContext)
+}
+
+export function useTicketLive(): TicketLiveContextValue {
+  const ctx = React.useContext(TicketLiveContext)
+  if (!ctx) {
+    throw new Error('useTicketLive must be used within <TicketLiveProvider>')
+  }
+  return ctx
+}
+
+function isTicketMessageData(value: unknown): value is TicketMessageStreamData {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as TicketMessageStreamData).ticket_external_id === 'string'
+  )
+}
+
+export function TicketLiveProvider({ children }: { children: React.ReactNode }) {
+  const runtime = useChatRuntime()
+  const identity = useChatIdentity()
+  const queryClient = useQueryClient()
+
+  const streamUrl = runtime?.endpoints.ticketStreamUrl ?? TICKET_STREAM_ENDPOINT
+  const readUrl = runtime?.endpoints.ticketReadUrl ?? TICKET_READ_ENDPOINT
+  const summaryUrl =
+    runtime?.endpoints.ticketUnreadSummaryUrl ?? TICKET_UNREAD_SUMMARY_ENDPOINT
+
+  const identityKey = identity.user?.email ?? 'anon'
+  const authed = identity.authTier !== 'anon' && !!identity.user?.email
+
+  const [connected, setConnected] = React.useState(false)
+  // State + ref for the open drawer: state drives the derived map,
+  // the ref lets stream callbacks read it without re-subscribing.
+  const [openTicketIdState, setOpenTicketIdState] = React.useState<string | null>(null)
+  const openTicketIdRef = React.useRef<string | null>(null)
+
+  const summaryQueryKey = React.useMemo(
+    () => ['ticket-unread-summary', identityKey] as const,
+    [identityKey],
+  )
+
+  // ONE unread source. No refetchInterval — freshness is event-driven
+  // (mount / focus / (re)connect / debounced stream events).
+  const summaryQuery = useQuery({
+    queryKey: summaryQueryKey,
+    enabled: authed,
+    staleTime: 0,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
+    queryFn: async (): Promise<TicketUnreadSummary> => {
+      const response = await embedAuthedFetch(summaryUrl, {
+        method: 'POST',
+        body: JSON.stringify({}),
+      })
+      if (!response.ok) {
+        throw new Error(`ticket-unread-summary failed: ${response.status}`)
+      }
+      const body = (await response.json()) as Partial<TicketUnreadSummary>
+      return {
+        totalUnread: typeof body.totalUnread === 'number' ? body.totalUnread : 0,
+        tickets: body.tickets ?? {},
+      }
+    },
+  })
+
+  const refetchSummary = React.useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: summaryQueryKey })
+  }, [queryClient, summaryQueryKey])
+
+  // ---- Debounced (trailing) invalidation of ticket queries on events ----
+  const pendingTicketIdsRef = React.useRef<Set<string>>(new Set())
+  const invalidateTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const flushInvalidations = React.useCallback(() => {
+    invalidateTimerRef.current = null
+    const ids = Array.from(pendingTicketIdsRef.current)
+    pendingTicketIdsRef.current.clear()
+    void queryClient.invalidateQueries({ queryKey: ['tickets'] })
+    for (const id of ids) {
+      void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', id] })
+    }
+    refetchSummary()
+  }, [queryClient, refetchSummary])
+  const scheduleInvalidation = React.useCallback(
+    (ticketId?: string) => {
+      if (ticketId) pendingTicketIdsRef.current.add(ticketId)
+      if (invalidateTimerRef.current) return
+      invalidateTimerRef.current = setTimeout(flushInvalidations, INVALIDATE_DEBOUNCE_MS)
+    },
+    [flushInvalidations],
+  )
+
+  // ---- Optimistic unread bump (reconciled by summary refetches) ----
+  const bumpUnread = React.useCallback(
+    (ticketId: string) => {
+      queryClient.setQueryData<TicketUnreadSummary>(summaryQueryKey, (prev) => {
+        const base = prev ?? { totalUnread: 0, tickets: {} }
+        return {
+          totalUnread: base.totalUnread + 1,
+          tickets: { ...base.tickets, [ticketId]: (base.tickets[ticketId] ?? 0) + 1 },
+        }
+      })
+    },
+    [queryClient, summaryQueryKey],
+  )
+
+  const zeroUnread = React.useCallback(
+    (ticketId: string) => {
+      queryClient.setQueryData<TicketUnreadSummary>(summaryQueryKey, (prev) => {
+        if (!prev) return prev
+        const current = prev.tickets[ticketId] ?? 0
+        if (current === 0) return prev
+        const tickets = { ...prev.tickets }
+        delete tickets[ticketId]
+        return { totalUnread: Math.max(0, prev.totalUnread - current), tickets }
+      })
+    },
+    [queryClient, summaryQueryKey],
+  )
+
+  // ---- Stream lifecycle ----
+  const subscriptionRef = React.useRef<SseSubscription | null>(null)
+  const noStreamRef = React.useRef(false)
+  const subscribeConfirmTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const serverRecoveryTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const failedReconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const hiddenGraceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearTimer = (ref: React.MutableRefObject<ReturnType<typeof setTimeout> | null>) => {
+    if (ref.current) {
+      clearTimeout(ref.current)
+      ref.current = null
+    }
+  }
+
+  // Stable handler refs so the subscription effect doesn't churn.
+  const handlersRef = React.useRef<{
+    onEvent: (eventName: string, data: unknown) => void
+    onStatus: (status: SseTransportStatus) => void
+  }>({ onEvent: () => {}, onStatus: () => {} })
+
+  const hardReconnect = React.useCallback((delayMs: number) => {
+    clearTimer(failedReconnectTimerRef)
+    if (delayMs <= 0) {
+      subscriptionRef.current?.reconnectNow()
+      return
+    }
+    failedReconnectTimerRef.current = setTimeout(() => {
+      failedReconnectTimerRef.current = null
+      subscriptionRef.current?.reconnectNow()
+    }, delayMs)
+  }, [])
+
+  handlersRef.current.onEvent = (eventName, data) => {
+    if (eventName === 'status') {
+      const status = (data as { status?: string } | null)?.status
+      if (status === 'subscribed') {
+        clearTimer(subscribeConfirmTimerRef)
+        clearTimer(serverRecoveryTimerRef)
+        setConnected(true)
+        // Resync on EVERY (re)connect — closes all event-gap classes.
+        refetchSummary()
+        const openId = openTicketIdRef.current
+        if (openId) {
+          void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', openId] })
+        }
+      } else if (status === 'retrying') {
+        // Server is recovering its Realtime channel itself — wait for it
+        // (bounded), don't stampede with a client reconnect.
+        setConnected(false)
+        if (!serverRecoveryTimerRef.current) {
+          serverRecoveryTimerRef.current = setTimeout(() => {
+            serverRecoveryTimerRef.current = null
+            hardReconnect(0)
+          }, SERVER_RETRY_GRACE_MS)
+        }
+      } else if (status === 'reconnect_failed') {
+        setConnected(false)
+        clearTimer(serverRecoveryTimerRef)
+        hardReconnect(FAILED_RECONNECT_DELAY_MS)
+      }
+      return
+    }
+
+    if (eventName === 'ticket-resync') {
+      refetchSummary()
+      scheduleInvalidation()
+      return
+    }
+
+    if (eventName === 'ticket-message') {
+      const frame = data as TicketStreamEvent | null
+      const payload = frame?.data
+      if (!isTicketMessageData(payload)) {
+        // Malformed/degraded — treat like a resync hint.
+        refetchSummary()
+        scheduleInvalidation()
+        return
+      }
+      // Always invalidate (own replies from another tab render live);
+      // bump unread ONLY on the server-stamped predicate, and never for
+      // the ticket whose drawer is open.
+      scheduleInvalidation(payload.ticket_external_id)
+      if (payload.countsAsUnread && payload.ticket_external_id !== openTicketIdRef.current) {
+        bumpUnread(payload.ticket_external_id)
+      }
+    }
+  }
+
+  handlersRef.current.onStatus = (status) => {
+    if (status === 'open') {
+      // Transport open ≠ connected. Require `status: subscribed` within
+      // the confirm window or force a reconnect.
+      noStreamRef.current = false
+      clearTimer(subscribeConfirmTimerRef)
+      subscribeConfirmTimerRef.current = setTimeout(() => {
+        subscribeConfirmTimerRef.current = null
+        setConnected(false)
+        hardReconnect(0)
+      }, SUBSCRIBE_CONFIRM_TIMEOUT_MS)
+      return
+    }
+    if (status === 'no-stream') {
+      // Zero owned tickets (204). Retried on create_ticket / visibility.
+      noStreamRef.current = true
+    }
+    // Every non-'open' transport status means we are not subscribed.
+    clearTimer(subscribeConfirmTimerRef)
+    setConnected(false)
+  }
+
+  // Mount/unmount of the subscription — gated on auth + a usable URL.
+  const streamEnabled = authed && !!streamUrl
+  React.useEffect(() => {
+    if (!streamEnabled) return
+    if (typeof window === 'undefined') return
+
+    const subscription = createSseSubscription({
+      url: streamUrl,
+      onEvent: (name, data) => handlersRef.current.onEvent(name, data),
+      onStatusChange: (status) => handlersRef.current.onStatus(status),
+    })
+    subscriptionRef.current = subscription
+
+    const retryIfIdle = () => {
+      // After a 204 (no-stream) or while disconnected-hidden, a
+      // visibility/focus/online signal is the retry trigger.
+      if (noStreamRef.current) {
+        noStreamRef.current = false
+        subscription.reconnectNow()
+      }
+    }
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        if (!hiddenGraceTimerRef.current) {
+          hiddenGraceTimerRef.current = setTimeout(() => {
+            hiddenGraceTimerRef.current = null
+            // Scale relief: a hidden tab holds no server invocation.
+            setConnected(false)
+            subscription.close()
+            subscriptionRef.current = null
+          }, HIDDEN_DISCONNECT_GRACE_MS)
+        }
+        return
+      }
+      // Visible again — cancel the grace, or recreate if already torn down.
+      clearTimer(hiddenGraceTimerRef)
+      if (!subscriptionRef.current) {
+        subscriptionRef.current = createSseSubscription({
+          url: streamUrl,
+          onEvent: (name, data) => handlersRef.current.onEvent(name, data),
+          onStatusChange: (status) => handlersRef.current.onStatus(status),
+        })
+      } else {
+        retryIfIdle()
+      }
+      // Resync regardless — the tab may have slept through events.
+      refetchSummary()
+    }
+
+    const onOnline = () => {
+      subscriptionRef.current?.reconnectNow()
+      refetchSummary()
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('online', onOnline)
+    window.addEventListener('focus', retryIfIdle)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+      window.removeEventListener('online', onOnline)
+      window.removeEventListener('focus', retryIfIdle)
+      clearTimer(hiddenGraceTimerRef)
+      clearTimer(subscribeConfirmTimerRef)
+      clearTimer(serverRecoveryTimerRef)
+      clearTimer(failedReconnectTimerRef)
+      if (invalidateTimerRef.current) {
+        clearTimeout(invalidateTimerRef.current)
+        invalidateTimerRef.current = null
+      }
+      subscriptionRef.current?.close()
+      subscriptionRef.current = null
+      setConnected(false)
+    }
+    // handlersRef is stable; streamUrl/auth changes remount the stream.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [streamEnabled, streamUrl, refetchSummary])
+
+  // ---- Public API ----
+  const markRead = React.useCallback(
+    async (ticketExternalId: string) => {
+      try {
+        const response = await embedAuthedFetch(readUrl, {
+          method: 'POST',
+          body: JSON.stringify({ ticket_id: ticketExternalId }),
+        })
+        if (response.ok) {
+          // Write-through zero — without polling, a stale post-close map
+          // would re-light the dot until the next focus/event/reconnect.
+          zeroUnread(ticketExternalId)
+        }
+      } catch {
+        // Non-fatal — the receipt lands on the next markRead; unread
+        // state reconciles via the summary.
+      }
+    },
+    [readUrl, zeroUnread],
+  )
+
+  const setOpenTicketId = React.useCallback((ticketExternalId: string | null) => {
+    openTicketIdRef.current = ticketExternalId
+    setOpenTicketIdState(ticketExternalId)
+  }, [])
+
+  const notifyTicketCreated = React.useCallback(() => {
+    refetchSummary()
+    if (noStreamRef.current) {
+      noStreamRef.current = false
+      subscriptionRef.current?.reconnectNow()
+    }
+  }, [refetchSummary])
+
+  // Derived unread map — open ticket masked to 0 so a summary refetch
+  // inside the markRead debounce window can't transiently re-badge it.
+  const value = React.useMemo<TicketLiveContextValue>(() => {
+    const summary = summaryQuery.data ?? { totalUnread: 0, tickets: {} }
+    let unreadByTicket = summary.tickets
+    let unreadTotal = summary.totalUnread
+    if (openTicketIdState && unreadByTicket[openTicketIdState]) {
+      const masked = unreadByTicket[openTicketIdState]
+      unreadByTicket = { ...unreadByTicket }
+      delete unreadByTicket[openTicketIdState]
+      unreadTotal = Math.max(0, unreadTotal - masked)
+    }
+    return {
+      authed,
+      connected,
+      unreadTotal,
+      unreadByTicket,
+      markRead,
+      setOpenTicketId,
+      notifyTicketCreated,
+    }
+  }, [
+    summaryQuery.data,
+    authed,
+    connected,
+    openTicketIdState,
+    markRead,
+    setOpenTicketId,
+    notifyTicketCreated,
+  ])
+
+  return <TicketLiveContext.Provider value={value}>{children}</TicketLiveContext.Provider>
+}

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -80,8 +80,9 @@ export interface TicketLiveContextValue {
    *  The currently-open ticket is masked to 0. */
   unreadByTicket: Record<string, number>
   /** The ticket with the NEWEST unread reply (open ticket excluded) —
-   *  the header cell routes to it (`?ticket=<id>#ticket-<id>` opens the
-   *  drawer + scrolls the row). Null when nothing is unread. */
+   *  the header cell routes to it via the SSOT deep link
+   *  (`buildTicketOpenHref` → `?ticket=<id>`, which opens the drawer
+   *  and scrolls the row). Null when nothing is unread. */
   nextUnreadTicketId: string | null
   /** Mark a ticket read: POSTs the receipt, then locally zeroes the
    *  ticket in the summary map (write-through; reconciled by the next

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -8,20 +8,19 @@
  *     `ticketStreamUrl`), with `connected` derived from the SERVER's
  *     `status` frames (`subscribed` → true; `retrying`/`reconnect_failed`
  *     → false) — never from "the HTTP stream is open";
- *   - the unread summary (single source: `ticket-unread-summary`) —
- *     header badge total AND per-row dots both read this map;
- *   - resync on every (re)connect (summary refetch + engagements
- *     invalidation) — the single rule that closes every event-gap class
- *     (forced maxDuration reconnects, network blips, tab sleep);
+ *   - the unread summary — delivered EXCLUSIVELY by the stream
+ *     (`ticket-summary` frames on connect + debounced after events) and
+ *     by `ticket-read` responses. The client holds NO summary fetch
+ *     path: resync-on-(re)connect is served by the SERVER (every
+ *     connect pushes a fresh summary);
  *   - visibility gating: hidden → 45s grace → disconnect; visible →
- *     reconnect + resync;
- *   - `markRead` with local write-through zeroing (no interval polling
- *     exists — a stale post-close map would re-light the dot forever).
+ *     reconnect (which re-delivers the summary);
+ *   - `markRead` with local write-through zeroing for 0-latency,
+ *     reconciled by the response's server-computed summary.
  *
- * There is NO polling anywhere: the summary query has no
- * `refetchInterval`; it refetches on mount, (re)connect, window focus,
- * and (debounced) stream events. Hosts whose stream endpoint 404s
- * (terminal) or is absent keep exactly focus/mount freshness.
+ * There is NO polling anywhere and NO summary endpoint. Hosts whose
+ * stream endpoint 404s (terminal) or is absent get no unread indication
+ * — the indication IS a realtime feature.
  *
  * Invalidation semantics on events — deliberately `invalidateQueries`,
  * NOT `setQueryData` patches: the ticket hooks run `gcTime: 0`, so
@@ -30,7 +29,7 @@
  */
 
 import React from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import { useChatRuntime } from '../../contexts/chat-runtime-context'
 import { embedAuthedFetch } from '../../utils/embed-authed-fetch'
 import {
@@ -47,7 +46,8 @@ import type {
 
 const TICKET_STREAM_ENDPOINT = '/api/chat/agent/ticket-stream'
 const TICKET_READ_ENDPOINT = '/api/chat/agent/ticket-read'
-const TICKET_UNREAD_SUMMARY_ENDPOINT = '/api/chat/agent/ticket-unread-summary'
+
+const EMPTY_SUMMARY: TicketUnreadSummary = { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
 
 /** Trailing debounce for event-burst invalidations (an agent pasting 5
  *  messages must not fire 5 list refetches). */
@@ -81,18 +81,16 @@ export interface TicketLiveContextValue {
   unreadByTicket: Record<string, number>
   /** The ticket with the NEWEST unread reply (open ticket excluded) —
    *  the header cell routes to it via the SSOT deep link
-   *  (`buildTicketOpenHref` → `?ticket=<id>`, which opens the drawer
-   *  and scrolls the row). Null when nothing is unread. */
+   *  (`buildTicketOpenHref`). Null when nothing is unread. */
   nextUnreadTicketId: string | null
-  /** Mark a ticket read: POSTs the receipt, then locally zeroes the
-   *  ticket in the summary map (write-through; reconciled by the next
-   *  real refetch). */
+  /** Mark a ticket read: POSTs the receipt, zeroes the ticket locally
+   *  (0-latency), then applies the response's server-computed summary. */
   markRead: (ticketExternalId: string) => Promise<void>
   /** Drawer open/close registration — suppresses unread bumps for the
    *  open ticket and masks it in the derived map. */
   setOpenTicketId: (ticketExternalId: string | null) => void
-  /** Hint that the viewer just created a ticket — retries a `no-stream`
-   *  (204) subscription. */
+  /** Hint that the viewer just created a ticket — reconnects the stream
+   *  (fresh ownership set + fresh server-pushed summary). */
   notifyTicketCreated: () => void
 }
 
@@ -118,6 +116,15 @@ function isTicketMessageData(value: unknown): value is TicketMessageStreamData {
   )
 }
 
+function isSummaryData(value: unknown): value is TicketUnreadSummary {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as TicketUnreadSummary).totalUnread === 'number' &&
+    typeof (value as TicketUnreadSummary).tickets === 'object'
+  )
+}
+
 export function TicketLiveProvider({ children }: { children: React.ReactNode }) {
   const runtime = useChatRuntime()
   const identity = useChatIdentity()
@@ -125,51 +132,19 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
 
   const streamUrl = runtime?.endpoints.ticketStreamUrl ?? TICKET_STREAM_ENDPOINT
   const readUrl = runtime?.endpoints.ticketReadUrl ?? TICKET_READ_ENDPOINT
-  const summaryUrl =
-    runtime?.endpoints.ticketUnreadSummaryUrl ?? TICKET_UNREAD_SUMMARY_ENDPOINT
 
-  const identityKey = identity.user?.email ?? 'anon'
   const authed = identity.authTier !== 'anon' && !!identity.user?.email
 
   const [connected, setConnected] = React.useState(false)
+  // The SINGLE unread source — written ONLY from server-computed
+  // summaries (stream frames + markRead responses) plus the two
+  // 0-latency optimistic writes (event bump, markRead zero), both
+  // reconciled by the next server summary.
+  const [summary, setSummary] = React.useState<TicketUnreadSummary>(EMPTY_SUMMARY)
   // State + ref for the open drawer: state drives the derived map,
   // the ref lets stream callbacks read it without re-subscribing.
   const [openTicketIdState, setOpenTicketIdState] = React.useState<string | null>(null)
   const openTicketIdRef = React.useRef<string | null>(null)
-
-  const summaryQueryKey = React.useMemo(
-    () => ['ticket-unread-summary', identityKey] as const,
-    [identityKey],
-  )
-
-  // ONE unread source. No refetchInterval — freshness is event-driven
-  // (mount / focus / (re)connect / debounced stream events).
-  const summaryQuery = useQuery({
-    queryKey: summaryQueryKey,
-    enabled: authed,
-    staleTime: 0,
-    refetchOnMount: 'always',
-    refetchOnWindowFocus: true,
-    queryFn: async (): Promise<TicketUnreadSummary> => {
-      const response = await embedAuthedFetch(summaryUrl, {
-        method: 'POST',
-        body: JSON.stringify({}),
-      })
-      if (!response.ok) {
-        throw new Error(`ticket-unread-summary failed: ${response.status}`)
-      }
-      const body = (await response.json()) as Partial<TicketUnreadSummary>
-      return {
-        totalUnread: typeof body.totalUnread === 'number' ? body.totalUnread : 0,
-        tickets: body.tickets ?? {},
-        latestUnreadAt: body.latestUnreadAt ?? {},
-      }
-    },
-  })
-
-  const refetchSummary = React.useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: summaryQueryKey })
-  }, [queryClient, summaryQueryKey])
 
   // ---- Debounced (trailing) invalidation of ticket queries on events ----
   const pendingTicketIdsRef = React.useRef<Set<string>>(new Set())
@@ -182,8 +157,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     for (const id of ids) {
       void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', id] })
     }
-    refetchSummary()
-  }, [queryClient, refetchSummary])
+  }, [queryClient])
   const scheduleInvalidation = React.useCallback(
     (ticketId?: string) => {
       if (ticketId) pendingTicketIdsRef.current.add(ticketId)
@@ -193,41 +167,33 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     [flushInvalidations],
   )
 
-  // ---- Optimistic unread bump (reconciled by summary refetches) ----
-  const bumpUnread = React.useCallback(
-    (ticketId: string, createdAt?: string | null) => {
-      queryClient.setQueryData<TicketUnreadSummary>(summaryQueryKey, (prev) => {
-        const base = prev ?? { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
-        const stamp = createdAt ?? new Date().toISOString()
-        const existing = base.latestUnreadAt[ticketId]
-        return {
-          totalUnread: base.totalUnread + 1,
-          tickets: { ...base.tickets, [ticketId]: (base.tickets[ticketId] ?? 0) + 1 },
-          latestUnreadAt: {
-            ...base.latestUnreadAt,
-            [ticketId]: existing && existing > stamp ? existing : stamp,
-          },
-        }
-      })
-    },
-    [queryClient, summaryQueryKey],
-  )
+  // ---- Optimistic unread writes (reconciled by server summaries) ----
+  const bumpUnread = React.useCallback((ticketId: string, createdAt?: string | null) => {
+    setSummary((prev) => {
+      const stamp = createdAt ?? new Date().toISOString()
+      const existing = prev.latestUnreadAt[ticketId]
+      return {
+        totalUnread: prev.totalUnread + 1,
+        tickets: { ...prev.tickets, [ticketId]: (prev.tickets[ticketId] ?? 0) + 1 },
+        latestUnreadAt: {
+          ...prev.latestUnreadAt,
+          [ticketId]: existing && existing > stamp ? existing : stamp,
+        },
+      }
+    })
+  }, [])
 
-  const zeroUnread = React.useCallback(
-    (ticketId: string) => {
-      queryClient.setQueryData<TicketUnreadSummary>(summaryQueryKey, (prev) => {
-        if (!prev) return prev
-        const current = prev.tickets[ticketId] ?? 0
-        if (current === 0) return prev
-        const tickets = { ...prev.tickets }
-        delete tickets[ticketId]
-        const latestUnreadAt = { ...prev.latestUnreadAt }
-        delete latestUnreadAt[ticketId]
-        return { totalUnread: Math.max(0, prev.totalUnread - current), tickets, latestUnreadAt }
-      })
-    },
-    [queryClient, summaryQueryKey],
-  )
+  const zeroUnread = React.useCallback((ticketId: string) => {
+    setSummary((prev) => {
+      const current = prev.tickets[ticketId] ?? 0
+      if (current === 0) return prev
+      const tickets = { ...prev.tickets }
+      delete tickets[ticketId]
+      const latestUnreadAt = { ...prev.latestUnreadAt }
+      delete latestUnreadAt[ticketId]
+      return { totalUnread: Math.max(0, prev.totalUnread - current), tickets, latestUnreadAt }
+    })
+  }, [])
 
   // ---- Stream lifecycle ----
   const subscriptionRef = React.useRef<SseSubscription | null>(null)
@@ -269,8 +235,8 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
         clearTimer(subscribeConfirmTimerRef)
         clearTimer(serverRecoveryTimerRef)
         setConnected(true)
-        // Resync on EVERY (re)connect — closes all event-gap classes.
-        refetchSummary()
+        // Event-gap healing: the SERVER pushes a fresh summary on every
+        // (re)connect; the open drawer refetches through the ACL'd path.
         const openId = openTicketIdRef.current
         if (openId) {
           void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', openId] })
@@ -293,21 +259,33 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       return
     }
 
+    if (eventName === 'ticket-summary') {
+      const frame = data as TicketStreamEvent | null
+      if (isSummaryData(frame?.data)) {
+        setSummary({
+          totalUnread: frame.data.totalUnread,
+          tickets: frame.data.tickets ?? {},
+          latestUnreadAt: frame.data.latestUnreadAt ?? {},
+        })
+      }
+      return
+    }
+
     if (eventName === 'ticket-resync') {
-      refetchSummary()
+      // Ownership gained / degraded payload — a fresh ticket-summary
+      // frame follows from the server; refresh the query surfaces.
       scheduleInvalidation()
       return
     }
 
     if (eventName === 'ticket-status') {
-      // Meaningful ticket-row change (close/reopen/pipeline move). No
-      // optimistic bump — closures count as unread SERVER-side
-      // (closed_at vs receipt in computeUnreadCounts), so the debounced
-      // flush's summary refetch is the one accounting path. The same
-      // flush invalidates ['tickets'] (status badge flips live) and the
-      // open drawer's engagements.
+      // Meaningful ticket-row change (close/reopen/pipeline move). The
+      // server pushes an updated summary right after (closures count as
+      // unread server-side); here we just refresh the query surfaces so
+      // the status badge flips live.
       const frame = data as TicketStreamEvent | null
-      const ticketId = (frame?.data as { ticket_external_id?: string } | undefined)?.ticket_external_id
+      const ticketId = (frame?.data as { ticket_external_id?: string } | undefined)
+        ?.ticket_external_id
       scheduleInvalidation(ticketId)
       return
     }
@@ -316,14 +294,13 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       const frame = data as TicketStreamEvent | null
       const payload = frame?.data
       if (!isTicketMessageData(payload)) {
-        // Malformed/degraded — treat like a resync hint.
-        refetchSummary()
         scheduleInvalidation()
         return
       }
       // Always invalidate (own replies from another tab render live);
       // bump unread ONLY on the server-stamped predicate, and never for
-      // the ticket whose drawer is open.
+      // the ticket whose drawer is open. The server's debounced summary
+      // push reconciles moments later.
       scheduleInvalidation(payload.ticket_external_id)
       if (payload.countsAsUnread && payload.ticket_external_id !== openTicketIdRef.current) {
         bumpUnread(payload.ticket_external_id, payload.hubspot_created_at)
@@ -366,12 +343,6 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     })
     subscriptionRef.current = subscription
 
-    // `subscriptionRef.current` is the SINGLE source of truth in every
-    // handler below — never the `subscription` constant above. The visible
-    // branch recreates the subscription into the ref, so a captured
-    // constant would go stale after the first hide/show cycle: the next
-    // hide would close the already-dead original and leak the live
-    // replacement (which never terminates by design).
     const retryIfIdle = () => {
       // After a 204 (no-stream) or while disconnected-hidden, a
       // visibility/focus/online signal is the retry trigger.
@@ -394,7 +365,8 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
         }
         return
       }
-      // Visible again — cancel the grace, or recreate if already torn down.
+      // Visible again — cancel the grace, or recreate if already torn
+      // down (the fresh connect delivers a fresh server summary).
       clearTimer(hiddenGraceTimerRef)
       if (!subscriptionRef.current) {
         subscriptionRef.current = createSseSubscription({
@@ -405,13 +377,11 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       } else {
         retryIfIdle()
       }
-      // Resync regardless — the tab may have slept through events.
-      refetchSummary()
     }
 
     const onOnline = () => {
+      // Fresh connect → fresh server-pushed summary.
       subscriptionRef.current?.reconnectNow()
-      refetchSummary()
     }
 
     document.addEventListener('visibilitychange', onVisibilityChange)
@@ -433,10 +403,11 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       subscriptionRef.current?.close()
       subscriptionRef.current = null
       setConnected(false)
+      setSummary(EMPTY_SUMMARY)
     }
     // handlersRef is stable; streamUrl/auth changes remount the stream.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [streamEnabled, streamUrl, refetchSummary])
+  }, [streamEnabled, streamUrl])
 
   // ---- Public API ----
   const markRead = React.useCallback(
@@ -446,14 +417,24 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
           method: 'POST',
           body: JSON.stringify({ ticket_id: ticketExternalId }),
         })
-        if (response.ok) {
-          // Write-through zero — without polling, a stale post-close map
-          // would re-light the dot until the next focus/event/reconnect.
-          zeroUnread(ticketExternalId)
+        if (!response.ok) return
+        // 0-latency local zero, then reconcile with the response's
+        // server-computed summary (THE truth — includes closure
+        // accounting and other tickets).
+        zeroUnread(ticketExternalId)
+        const body = (await response.json().catch(() => null)) as
+          | { summary?: TicketUnreadSummary }
+          | null
+        if (isSummaryData(body?.summary)) {
+          setSummary({
+            totalUnread: body.summary.totalUnread,
+            tickets: body.summary.tickets ?? {},
+            latestUnreadAt: body.summary.latestUnreadAt ?? {},
+          })
         }
       } catch {
         // Non-fatal — the receipt lands on the next markRead; unread
-        // state reconciles via the summary.
+        // state reconciles via the next server summary push.
       }
     },
     [readUrl, zeroUnread],
@@ -465,17 +446,17 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
   }, [])
 
   const notifyTicketCreated = React.useCallback(() => {
-    refetchSummary()
-    if (noStreamRef.current) {
-      noStreamRef.current = false
-      subscriptionRef.current?.reconnectNow()
-    }
-  }, [refetchSummary])
+    // Fresh connect → fresh ownership set + fresh server summary
+    // (covers both the no-stream 204 wait state and an already-live
+    // stream whose set predates the new ticket).
+    noStreamRef.current = false
+    subscriptionRef.current?.reconnectNow()
+  }, [])
 
-  // Derived unread map — open ticket masked to 0 so a summary refetch
-  // inside the markRead debounce window can't transiently re-badge it.
+  // Derived unread map — open ticket masked to 0 so a server summary
+  // landing inside the markRead debounce window can't transiently
+  // re-badge it.
   const value = React.useMemo<TicketLiveContextValue>(() => {
-    const summary = summaryQuery.data ?? { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
     let unreadByTicket = summary.tickets
     let unreadTotal = summary.totalUnread
     if (openTicketIdState && unreadByTicket[openTicketIdState]) {
@@ -507,7 +488,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       notifyTicketCreated,
     }
   }, [
-    summaryQuery.data,
+    summary,
     authed,
     connected,
     openTicketIdState,

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -74,11 +74,15 @@ export interface TicketLiveContextValue {
   authed: boolean
   /** Realtime-subscribed (server-confirmed), not merely HTTP-open. */
   connected: boolean
-  /** Unread total across tickets — drives the header dot. */
+  /** Unread total across tickets — drives the header count badge. */
   unreadTotal: number
   /** Per-ticket unread counts (missing key = 0) — drives row dots.
    *  The currently-open ticket is masked to 0. */
   unreadByTicket: Record<string, number>
+  /** The ticket with the NEWEST unread reply (open ticket excluded) —
+   *  the header cell routes to it (`?ticket=<id>#ticket-<id>` opens the
+   *  drawer + scrolls the row). Null when nothing is unread. */
+  nextUnreadTicketId: string | null
   /** Mark a ticket read: POSTs the receipt, then locally zeroes the
    *  ticket in the summary map (write-through; reconciled by the next
    *  real refetch). */
@@ -157,6 +161,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       return {
         totalUnread: typeof body.totalUnread === 'number' ? body.totalUnread : 0,
         tickets: body.tickets ?? {},
+        latestUnreadAt: body.latestUnreadAt ?? {},
       }
     },
   })
@@ -189,12 +194,18 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
 
   // ---- Optimistic unread bump (reconciled by summary refetches) ----
   const bumpUnread = React.useCallback(
-    (ticketId: string) => {
+    (ticketId: string, createdAt?: string | null) => {
       queryClient.setQueryData<TicketUnreadSummary>(summaryQueryKey, (prev) => {
-        const base = prev ?? { totalUnread: 0, tickets: {} }
+        const base = prev ?? { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
+        const stamp = createdAt ?? new Date().toISOString()
+        const existing = base.latestUnreadAt[ticketId]
         return {
           totalUnread: base.totalUnread + 1,
           tickets: { ...base.tickets, [ticketId]: (base.tickets[ticketId] ?? 0) + 1 },
+          latestUnreadAt: {
+            ...base.latestUnreadAt,
+            [ticketId]: existing && existing > stamp ? existing : stamp,
+          },
         }
       })
     },
@@ -209,7 +220,9 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
         if (current === 0) return prev
         const tickets = { ...prev.tickets }
         delete tickets[ticketId]
-        return { totalUnread: Math.max(0, prev.totalUnread - current), tickets }
+        const latestUnreadAt = { ...prev.latestUnreadAt }
+        delete latestUnreadAt[ticketId]
+        return { totalUnread: Math.max(0, prev.totalUnread - current), tickets, latestUnreadAt }
       })
     },
     [queryClient, summaryQueryKey],
@@ -299,7 +312,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       // the ticket whose drawer is open.
       scheduleInvalidation(payload.ticket_external_id)
       if (payload.countsAsUnread && payload.ticket_external_id !== openTicketIdRef.current) {
-        bumpUnread(payload.ticket_external_id)
+        bumpUnread(payload.ticket_external_id, payload.hubspot_created_at)
       }
     }
   }
@@ -448,7 +461,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
   // Derived unread map — open ticket masked to 0 so a summary refetch
   // inside the markRead debounce window can't transiently re-badge it.
   const value = React.useMemo<TicketLiveContextValue>(() => {
-    const summary = summaryQuery.data ?? { totalUnread: 0, tickets: {} }
+    const summary = summaryQuery.data ?? { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
     let unreadByTicket = summary.tickets
     let unreadTotal = summary.totalUnread
     if (openTicketIdState && unreadByTicket[openTicketIdState]) {
@@ -457,11 +470,24 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       delete unreadByTicket[openTicketIdState]
       unreadTotal = Math.max(0, unreadTotal - masked)
     }
+    // Ticket with the NEWEST unread reply (ISO strings compare
+    // lexicographically) — header cell routes there. Falls back to any
+    // unread key if a timestamp is missing.
+    let nextUnreadTicketId: string | null = null
+    let nextStamp = ''
+    for (const id of Object.keys(unreadByTicket)) {
+      const stamp = summary.latestUnreadAt[id] ?? ''
+      if (nextUnreadTicketId === null || stamp > nextStamp) {
+        nextUnreadTicketId = id
+        nextStamp = stamp
+      }
+    }
     return {
       authed,
       connected,
       unreadTotal,
       unreadByTicket,
+      nextUnreadTicketId,
       markRead,
       setOpenTicketId,
       notifyTicketCreated,

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -53,6 +53,16 @@ const TICKET_READ_ENDPOINT = '/api/tickets/read'
 
 const EMPTY_SUMMARY: TicketUnreadSummary = { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
 
+/** ISO stamps can carry mixed timezone offsets (server `+00:00` vs an
+ *  optimistic local `Z`) — lexicographic string comparison mis-orders
+ *  those, so every stamp comparison goes through parsed epoch ms.
+ *  Missing/unparseable stamps sort oldest. */
+const stampMs = (stamp: string | null | undefined): number => {
+  if (!stamp) return 0
+  const ms = Date.parse(stamp)
+  return Number.isNaN(ms) ? 0 : ms
+}
+
 /** Trailing debounce for event-burst invalidations (an agent pasting 5
  *  messages must not fire 5 list refetches). */
 const INVALIDATE_DEBOUNCE_MS = 1_500
@@ -167,7 +177,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
         tickets: { ...prev.tickets, [ticketId]: (prev.tickets[ticketId] ?? 0) + 1 },
         latestUnreadAt: {
           ...prev.latestUnreadAt,
-          [ticketId]: existing && existing > stamp ? existing : stamp,
+          [ticketId]: existing && stampMs(existing) > stampMs(stamp) ? existing : stamp,
         },
       }
     })
@@ -365,16 +375,17 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
       delete unreadByTicket[openTicketIdState]
       unreadTotal = Math.max(0, unreadTotal - masked)
     }
-    // Ticket with the NEWEST unread reply (ISO strings compare
-    // lexicographically) — header cell routes there. Falls back to any
-    // unread key if a timestamp is missing.
+    // Ticket with the NEWEST unread reply (compared as parsed epoch ms
+    // via `stampMs` — mixed timezone offsets break string ordering) —
+    // header cell routes there. Falls back to any unread key if a
+    // timestamp is missing.
     let nextUnreadTicketId: string | null = null
-    let nextStamp = ''
+    let nextStampMs = 0
     for (const id of Object.keys(unreadByTicket)) {
-      const stamp = summary.latestUnreadAt[id] ?? ''
-      if (nextUnreadTicketId === null || stamp > nextStamp) {
+      const ms = stampMs(summary.latestUnreadAt[id])
+      if (nextUnreadTicketId === null || ms > nextStampMs) {
         nextUnreadTicketId = id
-        nextStamp = stamp
+        nextStampMs = ms
       }
     }
     return {

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -339,12 +339,18 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     })
     subscriptionRef.current = subscription
 
+    // `subscriptionRef.current` is the SINGLE source of truth in every
+    // handler below — never the `subscription` constant above. The visible
+    // branch recreates the subscription into the ref, so a captured
+    // constant would go stale after the first hide/show cycle: the next
+    // hide would close the already-dead original and leak the live
+    // replacement (which never terminates by design).
     const retryIfIdle = () => {
       // After a 204 (no-stream) or while disconnected-hidden, a
       // visibility/focus/online signal is the retry trigger.
       if (noStreamRef.current) {
         noStreamRef.current = false
-        subscription.reconnectNow()
+        subscriptionRef.current?.reconnectNow()
       }
     }
 
@@ -355,7 +361,7 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
             hiddenGraceTimerRef.current = null
             // Scale relief: a hidden tab holds no server invocation.
             setConnected(false)
-            subscription.close()
+            subscriptionRef.current?.close()
             subscriptionRef.current = null
           }, HIDDEN_DISCONNECT_GRACE_MS)
         }

--- a/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
+++ b/openframe-frontend-core/src/components/tickets/ticket-live-provider.tsx
@@ -3,20 +3,21 @@
 /**
  * TicketLiveProvider — the ONE client home for support-ticket realtime.
  *
+ * DOMAIN logic only — connection lifecycle (subscribed-confirm, server
+ * retry grace, failed-reconnect pacing, hidden-tab suspend/resume) is
+ * owned entirely by the common SSE client (`createSseSubscription`);
+ * this provider consumes its consolidated `onConnectedChange` signal.
+ *
  * Owns:
- *   - the SSE subscription lifecycle (`createSseSubscription` over
- *     `ticketStreamUrl`), with `connected` derived from the SERVER's
- *     `status` frames (`subscribed` → true; `retrying`/`reconnect_failed`
- *     → false) — never from "the HTTP stream is open";
  *   - the unread summary — delivered EXCLUSIVELY by the stream
  *     (`ticket-summary` frames on connect + debounced after events) and
  *     by `ticket-read` responses. The client holds NO summary fetch
  *     path: resync-on-(re)connect is served by the SERVER (every
  *     connect pushes a fresh summary);
- *   - visibility gating: hidden → 45s grace → disconnect; visible →
- *     reconnect (which re-delivers the summary);
+ *   - query invalidation on events (list + open drawer refresh live);
  *   - `markRead` with local write-through zeroing for 0-latency,
- *     reconciled by the response's server-computed summary.
+ *     reconciled by the response's server-computed summary;
+ *   - the ticket-contract `no-stream` (204) retry policy.
  *
  * There is NO polling anywhere and NO summary endpoint. Hosts whose
  * stream endpoint 404s (terminal) or is absent get no unread indication
@@ -44,28 +45,17 @@ import type {
   TicketUnreadSummary,
 } from './types'
 
-const TICKET_STREAM_ENDPOINT = '/api/chat/agent/ticket-stream'
-const TICKET_READ_ENDPOINT = '/api/chat/agent/ticket-read'
+// Ticket realtime is its OWN api surface — deliberately NOT under
+// `/api/chat/agent/*` (that prefix is the chat agent's tool surface;
+// ticket streaming/read-receipts are unrelated to chat).
+const TICKET_STREAM_ENDPOINT = '/api/tickets/stream'
+const TICKET_READ_ENDPOINT = '/api/tickets/read'
 
 const EMPTY_SUMMARY: TicketUnreadSummary = { totalUnread: 0, tickets: {}, latestUnreadAt: {} }
 
 /** Trailing debounce for event-burst invalidations (an agent pasting 5
  *  messages must not fire 5 list refetches). */
 const INVALIDATE_DEBOUNCE_MS = 1_500
-/** Grace before disconnecting a hidden tab (Cmd-Tab thrash protection). */
-const HIDDEN_DISCONNECT_GRACE_MS = 45_000
-/** No `status: subscribed` within this window after transport-open →
- *  treat as disconnected and force a client-side reconnect. */
-const SUBSCRIBE_CONFIRM_TIMEOUT_MS = 15_000
-/** After a server-reported `reconnect_failed`, the next client attempt
- *  starts at the CAPPED delay — each reconnect costs a full server
- *  invocation + the server's own Realtime retries; an outage must not
- *  become a stampede. */
-const FAILED_RECONNECT_DELAY_MS = 30_000
-/** A server `retrying` status means the server is recovering the channel
- *  itself (exponential backoff, ~5 attempts). Give it this long to reach
- *  `subscribed` before the client hard-reconnects. */
-const SERVER_RETRY_GRACE_MS = 90_000
 
 export interface TicketLiveContextValue {
   /** Viewer has a resolved, non-anon chat identity. Surfaces (e.g. the
@@ -195,70 +185,31 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     })
   }, [])
 
-  // ---- Stream lifecycle ----
+  // ---- Stream lifecycle (owned by the SSE CLIENT — the provider only
+  // consumes its consolidated signals) ----
   const subscriptionRef = React.useRef<SseSubscription | null>(null)
   const noStreamRef = React.useRef(false)
-  const subscribeConfirmTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  const serverRecoveryTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  const failedReconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-  const hiddenGraceTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  const clearTimer = (ref: React.MutableRefObject<ReturnType<typeof setTimeout> | null>) => {
-    if (ref.current) {
-      clearTimeout(ref.current)
-      ref.current = null
-    }
-  }
 
   // Stable handler refs so the subscription effect doesn't churn.
   const handlersRef = React.useRef<{
     onEvent: (eventName: string, data: unknown) => void
     onStatus: (status: SseTransportStatus) => void
-  }>({ onEvent: () => {}, onStatus: () => {} })
+    onConnected: (connected: boolean) => void
+  }>({ onEvent: () => {}, onStatus: () => {}, onConnected: () => {} })
 
-  const hardReconnect = React.useCallback((delayMs: number) => {
-    clearTimer(failedReconnectTimerRef)
-    if (delayMs <= 0) {
-      subscriptionRef.current?.reconnectNow()
-      return
+  handlersRef.current.onConnected = (isConnected) => {
+    setConnected(isConnected)
+    if (isConnected) {
+      // Event-gap healing on every (re)connect: the SERVER pushes a
+      // fresh summary; the open drawer refetches through the ACL'd path.
+      const openId = openTicketIdRef.current
+      if (openId) {
+        void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', openId] })
+      }
     }
-    failedReconnectTimerRef.current = setTimeout(() => {
-      failedReconnectTimerRef.current = null
-      subscriptionRef.current?.reconnectNow()
-    }, delayMs)
-  }, [])
+  }
 
   handlersRef.current.onEvent = (eventName, data) => {
-    if (eventName === 'status') {
-      const status = (data as { status?: string } | null)?.status
-      if (status === 'subscribed') {
-        clearTimer(subscribeConfirmTimerRef)
-        clearTimer(serverRecoveryTimerRef)
-        setConnected(true)
-        // Event-gap healing: the SERVER pushes a fresh summary on every
-        // (re)connect; the open drawer refetches through the ACL'd path.
-        const openId = openTicketIdRef.current
-        if (openId) {
-          void queryClient.invalidateQueries({ queryKey: ['ticket-engagements', openId] })
-        }
-      } else if (status === 'retrying') {
-        // Server is recovering its Realtime channel itself — wait for it
-        // (bounded), don't stampede with a client reconnect.
-        setConnected(false)
-        if (!serverRecoveryTimerRef.current) {
-          serverRecoveryTimerRef.current = setTimeout(() => {
-            serverRecoveryTimerRef.current = null
-            hardReconnect(0)
-          }, SERVER_RETRY_GRACE_MS)
-        }
-      } else if (status === 'reconnect_failed') {
-        setConnected(false)
-        clearTimer(serverRecoveryTimerRef)
-        hardReconnect(FAILED_RECONNECT_DELAY_MS)
-      }
-      return
-    }
-
     if (eventName === 'ticket-summary') {
       const frame = data as TicketStreamEvent | null
       if (isSummaryData(frame?.data)) {
@@ -309,25 +260,13 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
   }
 
   handlersRef.current.onStatus = (status) => {
-    if (status === 'open') {
-      // Transport open ≠ connected. Require `status: subscribed` within
-      // the confirm window or force a reconnect.
-      noStreamRef.current = false
-      clearTimer(subscribeConfirmTimerRef)
-      subscribeConfirmTimerRef.current = setTimeout(() => {
-        subscribeConfirmTimerRef.current = null
-        setConnected(false)
-        hardReconnect(0)
-      }, SUBSCRIBE_CONFIRM_TIMEOUT_MS)
-      return
-    }
-    if (status === 'no-stream') {
-      // Zero owned tickets (204). Retried on create_ticket / visibility.
-      noStreamRef.current = true
-    }
-    // Every non-'open' transport status means we are not subscribed.
-    clearTimer(subscribeConfirmTimerRef)
-    setConnected(false)
+    // The client owns connection lifecycle (confirm timeout, server
+    // retry grace, failed-reconnect pacing, hidden-suspend). The only
+    // transport status with DOMAIN meaning is the ticket contract's
+    // `no-stream` (204 = zero owned tickets): remember it so a domain
+    // signal (own create_ticket, window focus) can retry.
+    if (status === 'open') noStreamRef.current = false
+    if (status === 'no-stream') noStreamRef.current = true
   }
 
   // Mount/unmount of the subscription — gated on auth + a usable URL.
@@ -336,66 +275,27 @@ export function TicketLiveProvider({ children }: { children: React.ReactNode }) 
     if (!streamEnabled) return
     if (typeof window === 'undefined') return
 
-    const subscription = createSseSubscription({
+    subscriptionRef.current = createSseSubscription({
       url: streamUrl,
       onEvent: (name, data) => handlersRef.current.onEvent(name, data),
       onStatusChange: (status) => handlersRef.current.onStatus(status),
+      onConnectedChange: (isConnected) => handlersRef.current.onConnected(isConnected),
+      // Long-lived per-user stream: suspend while hidden (scale relief),
+      // resume + reconnect on visible/online — all inside the client.
+      pauseWhenHidden: true,
     })
-    subscriptionRef.current = subscription
 
     const retryIfIdle = () => {
-      // After a 204 (no-stream) or while disconnected-hidden, a
-      // visibility/focus/online signal is the retry trigger.
+      // After a 204 (no-stream), a focus signal is the retry trigger.
       if (noStreamRef.current) {
         noStreamRef.current = false
         subscriptionRef.current?.reconnectNow()
       }
     }
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'hidden') {
-        if (!hiddenGraceTimerRef.current) {
-          hiddenGraceTimerRef.current = setTimeout(() => {
-            hiddenGraceTimerRef.current = null
-            // Scale relief: a hidden tab holds no server invocation.
-            setConnected(false)
-            subscriptionRef.current?.close()
-            subscriptionRef.current = null
-          }, HIDDEN_DISCONNECT_GRACE_MS)
-        }
-        return
-      }
-      // Visible again — cancel the grace, or recreate if already torn
-      // down (the fresh connect delivers a fresh server summary).
-      clearTimer(hiddenGraceTimerRef)
-      if (!subscriptionRef.current) {
-        subscriptionRef.current = createSseSubscription({
-          url: streamUrl,
-          onEvent: (name, data) => handlersRef.current.onEvent(name, data),
-          onStatusChange: (status) => handlersRef.current.onStatus(status),
-        })
-      } else {
-        retryIfIdle()
-      }
-    }
-
-    const onOnline = () => {
-      // Fresh connect → fresh server-pushed summary.
-      subscriptionRef.current?.reconnectNow()
-    }
-
-    document.addEventListener('visibilitychange', onVisibilityChange)
-    window.addEventListener('online', onOnline)
     window.addEventListener('focus', retryIfIdle)
 
     return () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange)
-      window.removeEventListener('online', onOnline)
       window.removeEventListener('focus', retryIfIdle)
-      clearTimer(hiddenGraceTimerRef)
-      clearTimer(subscribeConfirmTimerRef)
-      clearTimer(serverRecoveryTimerRef)
-      clearTimer(failedReconnectTimerRef)
       if (invalidateTimerRef.current) {
         clearTimeout(invalidateTimerRef.current)
         invalidateTimerRef.current = null

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -212,18 +212,69 @@ export interface MappedTicketActionError {
 export const TICKET_TEXT_MAX_CHARS = 5000
 
 /**
- * Live-refresh cadence (ms) for an OPEN ticket drawer. Drives BOTH
- * surfaces that must stay current while the customer is looking at a
- * ticket:
- *   - the ticket LIST poll (`useTicketsList.refetchInterval`) → surfaces
- *     out-of-band status / pipeline / priority / assignee changes;
- *   - the CONVERSATION poll (`useTicketEngagements.refetchInterval`) →
- *     surfaces new agent replies + attachments.
- * Single source of truth so the two surfaces never drift. Both leave
- * `refetchIntervalInBackground` at its default (false), so polling pauses
- * on a hidden tab — no wasted requests when the user tabs away.
+ * Wire contract of the ticket live stream (`GET /api/chat/agent/
+ * ticket-stream`, SSE). Producer (the hub route's `mapEvent`) imports
+ * THIS type — same producer/consumer SSOT pattern as
+ * `ConversationEngagementWire = TicketEngagement`. A schema drift here
+ * would be a silent serialization bug; keep one named contract.
+ *
+ * Frames carry METADATA ONLY — never message bodies. Content is always
+ * refetched through the ACL'd `list-engagements` path (one read path).
+ *
+ * Event names (`eventType`):
+ *   - `ticket-message` — a message row landed in the mirror for one of
+ *     the viewer's tickets. `data` carries the metadata.
+ *   - `ticket-resync`  — degraded frame: something happened that the
+ *     server couldn't fully describe (truncated Realtime payload, or
+ *     the connection's ownership set just gained tickets). Clients
+ *     respond by refetching the unread summary + invalidating queries.
+ *
+ * The server also emits `status` frames (`subscribed` / `retrying` /
+ * `reconnect_failed`) from the shared SSE utility — clients derive
+ * `connected` from those, NOT from the HTTP stream being open.
  */
-export const TICKET_LIVE_POLL_MS = 8000
+export type TicketStreamEventType = 'ticket-message' | 'ticket-resync'
+
+/** Metadata payload of a `ticket-message` frame. */
+export type TicketMessageStreamData = {
+  ticket_external_id: string
+  /** Mirror row's HubSpot message id. */
+  message_id: string
+  /** Server-stamped via the same direction predicate the wire mapper
+   *  uses. Clients never re-derive author classification. */
+  authorRole: 'customer' | 'support'
+  /** Server-stamped via the visibility+direction unread predicate
+   *  (`countsAsUnread` in the hub's conversations DAL). ONLY frames
+   *  with `true` may bump client-side unread state. */
+  countsAsUnread: boolean
+  hubspot_created_at: string | null
+}
+
+export interface TicketStreamEvent {
+  eventType: TicketStreamEventType
+  /** Human-readable label (SSE envelope compat) — clients ignore it. */
+  message: string
+  /** Present on `ticket-message`; absent on `ticket-resync`. */
+  data?: TicketMessageStreamData
+}
+
+/**
+ * Wire shape of `POST /api/chat/agent/ticket-unread-summary` — the
+ * SINGLE unread source. Header badge total AND per-row dots both read
+ * this via the `TicketLiveProvider` map; missing keys mean 0.
+ */
+export interface TicketUnreadSummary {
+  totalUnread: number
+  tickets: Record<string, number>
+}
+
+/**
+ * Trailing debounce for `markRead` while the drawer is open and new
+ * messages stream in — flushed on drawer close so a fast open/close
+ * still persists the receipt. Named beside its sibling cadences so
+ * every timing knob lives in one file.
+ */
+export const TICKET_MARK_READ_DEBOUNCE_MS = 2000
 
 /**
  * Centralized toast copy. Keep all wording here so QA / localization

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -229,16 +229,24 @@ export const TICKET_TEXT_MAX_CHARS = 5000
  *     old-vs-new diffing drops no-op writes (sync stamps). Clients
  *     invalidate + refetch the summary (closures count as unread
  *     server-side via `closed_at` vs the read receipt).
+ *   - `ticket-summary` — the server-computed `TicketUnreadSummary`.
+ *     THE stream is the summary webservice: pushed on connect (server-
+ *     side resync-on-reconnect) and re-pushed (debounced) after every
+ *     delivered event. Clients hold NO summary fetch path.
  *   - `ticket-resync`  — degraded frame: something happened that the
  *     server couldn't fully describe (truncated Realtime payload, or
- *     the connection's ownership set just gained tickets). Clients
- *     respond by refetching the unread summary + invalidating queries.
+ *     the connection's ownership set just gained tickets). A fresh
+ *     `ticket-summary` follows it; clients invalidate queries.
  *
  * The server also emits `status` frames (`subscribed` / `retrying` /
  * `reconnect_failed`) from the shared SSE utility — clients derive
  * `connected` from those, NOT from the HTTP stream being open.
  */
-export type TicketStreamEventType = 'ticket-message' | 'ticket-status' | 'ticket-resync'
+export type TicketStreamEventType =
+  | 'ticket-message'
+  | 'ticket-status'
+  | 'ticket-summary'
+  | 'ticket-resync'
 
 /** Metadata payload of a `ticket-message` frame. */
 export type TicketMessageStreamData = {
@@ -269,16 +277,19 @@ export interface TicketStreamEvent {
   /** Human-readable label (SSE envelope compat) — clients ignore it. */
   message: string
   /** `ticket-message` → TicketMessageStreamData; `ticket-status` →
-   *  TicketStatusStreamData; absent on `ticket-resync`. */
-  data?: TicketMessageStreamData | TicketStatusStreamData
+   *  TicketStatusStreamData; `ticket-summary` → TicketUnreadSummary;
+   *  absent on `ticket-resync`. */
+  data?: TicketMessageStreamData | TicketStatusStreamData | TicketUnreadSummary
 }
 
 /**
- * Wire shape of `POST /api/chat/agent/ticket-unread-summary` — the
- * SINGLE unread source. Header badge total AND per-row dots both read
- * this via the `TicketLiveProvider` map; missing keys mean 0.
+ * The SINGLE unread source, delivered EXCLUSIVELY over the stream
+ * (`ticket-summary` frames on connect + after events) and in
+ * `ticket-read` responses. There is no summary fetch endpoint. Header
+ * badge total AND per-row dots both read this via the
+ * `TicketLiveProvider` map; missing keys mean 0.
  */
-export interface TicketUnreadSummary {
+export type TicketUnreadSummary = {
   totalUnread: number
   tickets: Record<string, number>
   /** ISO timestamp of the NEWEST unread message per ticket (same keys as

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -266,6 +266,10 @@ export interface TicketStreamEvent {
 export interface TicketUnreadSummary {
   totalUnread: number
   tickets: Record<string, number>
+  /** ISO timestamp of the NEWEST unread message per ticket (same keys as
+   *  `tickets`). Drives "route to the most recent update" on the header
+   *  cell: the ticket with the max value here is `nextUnreadTicketId`. */
+  latestUnreadAt: Record<string, string>
 }
 
 /**

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -281,6 +281,33 @@ export interface TicketUnreadSummary {
 export const TICKET_MARK_READ_DEBOUNCE_MS = 2000
 
 /**
+ * THE single source of truth for "which ticket is open" — the URL query
+ * param `HelpCenterList` derives its drawer state from (same model the
+ * chat uses for its URL-driven state). Every producer of a ticket deep
+ * link goes through `buildTicketOpenHref`; every consumer reads THIS
+ * param name. No hash fragment: opening the drawer already smooth-
+ * scrolls the row into view (`HelpCenterCard`'s expand effect), and a
+ * second scroll mechanism (`#ticket-<id>`) fights it — hand-appending
+ * the hash also produced double-hash URLs when composed with hosts'
+ * own hash handling.
+ */
+export const TICKET_OPEN_PARAM = 'ticket'
+
+/**
+ * Build the deep link that opens a ticket's drawer:
+ * `<base>?ticket=<external_id>`.
+ *
+ * `base` is the host's tickets surface path and may carry ANY nesting
+ * prefix (hub `/tickets`, console `/help-center/tickets`, an embedder's
+ * `/support/portal/tickets`) — the builder only appends the open-param.
+ * Bases that already carry a query string are composed with `&`.
+ */
+export function buildTicketOpenHref(base: string, ticketExternalId: string): string {
+  const sep = base.includes('?') ? '&' : '?'
+  return `${base}${sep}${TICKET_OPEN_PARAM}=${encodeURIComponent(ticketExternalId)}`
+}
+
+/**
  * Centralized toast copy. Keep all wording here so QA / localization
  * can find every user-visible string in one file.
  */

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -281,31 +281,16 @@ export interface TicketUnreadSummary {
 export const TICKET_MARK_READ_DEBOUNCE_MS = 2000
 
 /**
- * THE single source of truth for "which ticket is open" — the URL query
- * param `HelpCenterList` derives its drawer state from (same model the
- * chat uses for its URL-driven state). Every producer of a ticket deep
- * link goes through `buildTicketOpenHref`; every consumer reads THIS
- * param name. No hash fragment: opening the drawer already smooth-
- * scrolls the row into view (`HelpCenterCard`'s expand effect), and a
- * second scroll mechanism (`#ticket-<id>`) fights it — hand-appending
- * the hash also produced double-hash URLs when composed with hosts'
- * own hash handling.
+ * Ticket deep-link SSOT — DEFINED in the server-safe param-keys module
+ * (`utils/dev-sections/dev-section-param-keys.ts`, beside its sibling
+ * `devSectionAnchorId`) because producers span both worlds: the hub's
+ * SERVER-side chat-ref builder and the client header cell. Re-exported
+ * here so ticket-surface consumers keep one import home.
  */
-export const TICKET_OPEN_PARAM = 'ticket'
-
-/**
- * Build the deep link that opens a ticket's drawer:
- * `<base>?ticket=<external_id>`.
- *
- * `base` is the host's tickets surface path and may carry ANY nesting
- * prefix (hub `/tickets`, console `/help-center/tickets`, an embedder's
- * `/support/portal/tickets`) — the builder only appends the open-param.
- * Bases that already carry a query string are composed with `&`.
- */
-export function buildTicketOpenHref(base: string, ticketExternalId: string): string {
-  const sep = base.includes('?') ? '&' : '?'
-  return `${base}${sep}${TICKET_OPEN_PARAM}=${encodeURIComponent(ticketExternalId)}`
-}
+export {
+  TICKET_OPEN_PARAM,
+  buildTicketOpenHref,
+} from '../../utils/dev-sections/dev-section-param-keys'
 
 /**
  * Centralized toast copy. Keep all wording here so QA / localization

--- a/openframe-frontend-core/src/components/tickets/types.ts
+++ b/openframe-frontend-core/src/components/tickets/types.ts
@@ -224,6 +224,11 @@ export const TICKET_TEXT_MAX_CHARS = 5000
  * Event names (`eventType`):
  *   - `ticket-message` — a message row landed in the mirror for one of
  *     the viewer's tickets. `data` carries the metadata.
+ *   - `ticket-status`  — a MEANINGFUL ticket-row change (status /
+ *     pipeline stage / closure) landed in the mirror. Server-side
+ *     old-vs-new diffing drops no-op writes (sync stamps). Clients
+ *     invalidate + refetch the summary (closures count as unread
+ *     server-side via `closed_at` vs the read receipt).
  *   - `ticket-resync`  — degraded frame: something happened that the
  *     server couldn't fully describe (truncated Realtime payload, or
  *     the connection's ownership set just gained tickets). Clients
@@ -233,7 +238,7 @@ export const TICKET_TEXT_MAX_CHARS = 5000
  * `reconnect_failed`) from the shared SSE utility — clients derive
  * `connected` from those, NOT from the HTTP stream being open.
  */
-export type TicketStreamEventType = 'ticket-message' | 'ticket-resync'
+export type TicketStreamEventType = 'ticket-message' | 'ticket-status' | 'ticket-resync'
 
 /** Metadata payload of a `ticket-message` frame. */
 export type TicketMessageStreamData = {
@@ -250,12 +255,22 @@ export type TicketMessageStreamData = {
   hubspot_created_at: string | null
 }
 
+/** Metadata payload of a `ticket-status` frame. */
+export type TicketStatusStreamData = {
+  ticket_external_id: string
+  /** Canonical OPEN | CLOSED after the change. */
+  status: string | null
+  pipeline_stage_label: string | null
+  closed_at: string | null
+}
+
 export interface TicketStreamEvent {
   eventType: TicketStreamEventType
   /** Human-readable label (SSE envelope compat) — clients ignore it. */
   message: string
-  /** Present on `ticket-message`; absent on `ticket-resync`. */
-  data?: TicketMessageStreamData
+  /** `ticket-message` → TicketMessageStreamData; `ticket-status` →
+   *  TicketStatusStreamData; absent on `ticket-resync`. */
+  data?: TicketMessageStreamData | TicketStatusStreamData
 }
 
 /**

--- a/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
+++ b/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
@@ -55,14 +55,15 @@ export interface ChatRuntime {
     findTicketUrl?: string
     ticketActionUrl?: string
     listEngagementsUrl?: string
-    /** Ticket live-stream + unread endpoints (Help Center realtime).
-     *  OPTIONAL — same fallback convention as the three above: unset →
-     *  bare hub paths (`/api/chat/agent/{ticket-stream,ticket-read,
-     *  ticket-unread-summary}`). Reverse-proxy embedders set their
-     *  proxied paths. Consumed by `TicketLiveProvider`. */
+    /** Ticket live-stream + read-receipt endpoints (Help Center
+     *  realtime). OPTIONAL — same fallback convention as the three
+     *  above: unset → bare hub paths (`/api/chat/agent/{ticket-stream,
+     *  ticket-read}`). Reverse-proxy embedders set their proxied paths.
+     *  Consumed by `TicketLiveProvider`. The unread summary has NO
+     *  endpoint — it arrives as `ticket-summary` frames on the stream
+     *  and in `ticket-read` responses. */
     ticketStreamUrl?: string
     ticketReadUrl?: string
-    ticketUnreadSummaryUrl?: string
     /** GET slash-command catalog. Hub: '/api/docs/commands'. */
     commandsUrl: string
     /** GET server-side conversation history (`?conversationId=<id>`) — the

--- a/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
+++ b/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
@@ -55,6 +55,14 @@ export interface ChatRuntime {
     findTicketUrl?: string
     ticketActionUrl?: string
     listEngagementsUrl?: string
+    /** Ticket live-stream + unread endpoints (Help Center realtime).
+     *  OPTIONAL — same fallback convention as the three above: unset →
+     *  bare hub paths (`/api/chat/agent/{ticket-stream,ticket-read,
+     *  ticket-unread-summary}`). Reverse-proxy embedders set their
+     *  proxied paths. Consumed by `TicketLiveProvider`. */
+    ticketStreamUrl?: string
+    ticketReadUrl?: string
+    ticketUnreadSummaryUrl?: string
     /** GET slash-command catalog. Hub: '/api/docs/commands'. */
     commandsUrl: string
     /** GET server-side conversation history (`?conversationId=<id>`) — the

--- a/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
+++ b/openframe-frontend-core/src/contexts/chat-runtime-context.tsx
@@ -56,12 +56,13 @@ export interface ChatRuntime {
     ticketActionUrl?: string
     listEngagementsUrl?: string
     /** Ticket live-stream + read-receipt endpoints (Help Center
-     *  realtime). OPTIONAL — same fallback convention as the three
-     *  above: unset → bare hub paths (`/api/chat/agent/{ticket-stream,
-     *  ticket-read}`). Reverse-proxy embedders set their proxied paths.
-     *  Consumed by `TicketLiveProvider`. The unread summary has NO
-     *  endpoint — it arrives as `ticket-summary` frames on the stream
-     *  and in `ticket-read` responses. */
+     *  realtime). OPTIONAL — unset → bare hub paths under the DEDICATED
+     *  ticket surface (`/api/tickets/{stream,read}` — deliberately NOT
+     *  the chat agent's `/api/chat/agent/*` prefix). Reverse-proxy
+     *  embedders set their proxied paths. Consumed by
+     *  `TicketLiveProvider`. The unread summary has NO endpoint — it
+     *  arrives as `ticket-summary` frames on the stream and in
+     *  `ticket-read` responses. */
     ticketStreamUrl?: string
     ticketReadUrl?: string
     /** GET slash-command catalog. Hub: '/api/docs/commands'. */

--- a/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
+++ b/openframe-frontend-core/src/hooks/use-scroll-to-hash.ts
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 import { scrollElementIntoView } from '../utils/scroll-into-view'
-import { normalizeHashFragment } from '../utils/same-page-hash-nav'
+import { getHashTargetElement, normalizeHashFragment } from '../utils/same-page-hash-nav'
 
 /** ~1s at 60fps — long enough to outlast Radix accordion expand + SWR
  *  mount, short enough that a missed anchor doesn't hang the page. */
@@ -50,7 +50,9 @@ export function useScrollToHash(
       cancelPoll()
       let frames = 0
       const tick = () => {
-        const el = document.getElementById(hash)
+        // Raw-then-decoded lookup — encoded fragments from href
+        // composers must match the unencoded ids rows render.
+        const el = getHashTargetElement(hash)
         if (el) {
           rafId = null
           scrollElementIntoView(el, { headerOffset })

--- a/openframe-frontend-core/src/types/navigation.ts
+++ b/openframe-frontend-core/src/types/navigation.ts
@@ -56,6 +56,16 @@ export interface HeaderConfig {
      *  for the default "Mingo AI". */
     label?: string
   }
+  /** Support-ticket alerts cell (`TicketAlertsButton`), rendered before
+   *  the Mingo launcher in the flush cell row. Renders nothing unless a
+   *  `<TicketLiveProvider>` is mounted, so hosts can declare it purely
+   *  from platform config. */
+  tickets?: {
+    /** Tickets surface to navigate to (e.g. '/tickets'). */
+    href: string
+    /** Optional host navigation override (router push). Wins over href. */
+    onClick?: () => void
+  }
   className?: string
   style?: React.CSSProperties
   autoHide?: boolean

--- a/openframe-frontend-core/src/types/navigation.ts
+++ b/openframe-frontend-core/src/types/navigation.ts
@@ -57,14 +57,16 @@ export interface HeaderConfig {
     label?: string
   }
   /** Support-ticket alerts cell (`TicketAlertsButton`), rendered before
-   *  the Mingo launcher in the flush cell row. Renders nothing unless a
-   *  `<TicketLiveProvider>` is mounted, so hosts can declare it purely
-   *  from platform config. */
+   *  the Mingo launcher in the flush cell row. Attention-only: renders
+   *  nothing unless a `<TicketLiveProvider>` is mounted AND there are
+   *  unread support replies — declaring it is side-effect-free. */
   tickets?: {
-    /** Tickets surface to navigate to (e.g. '/tickets'). */
+    /** BASE path of the tickets surface (e.g. '/tickets'). The cell
+     *  appends `?ticket=<id>#ticket-<id>` for the newest-unread ticket. */
     href: string
-    /** Optional host navigation override (router push). Wins over href. */
-    onClick?: () => void
+    /** Optional host navigation (router push) — receives the FULL
+     *  computed href. Defaults to `window.location.assign`. */
+    onClick?: (href: string) => void
   }
   className?: string
   style?: React.CSSProperties

--- a/openframe-frontend-core/src/types/navigation.ts
+++ b/openframe-frontend-core/src/types/navigation.ts
@@ -61,8 +61,9 @@ export interface HeaderConfig {
    *  nothing unless a `<TicketLiveProvider>` is mounted AND there are
    *  unread support replies — declaring it is side-effect-free. */
   tickets?: {
-    /** BASE path of the tickets surface (e.g. '/tickets'). The cell
-     *  appends `?ticket=<id>#ticket-<id>` for the newest-unread ticket. */
+    /** BASE path of the tickets surface (any nesting prefix allowed —
+     *  '/tickets', '/support/portal/tickets'). The cell builds the SSOT
+     *  deep link `<href>?ticket=<id>` for the newest-unread ticket. */
     href: string
     /** Optional host navigation (router push) — receives the FULL
      *  computed href. Defaults to `window.location.assign`. */

--- a/openframe-frontend-core/src/utils/dev-sections/dev-section-param-keys.ts
+++ b/openframe-frontend-core/src/utils/dev-sections/dev-section-param-keys.ts
@@ -33,3 +33,42 @@ export type DevSectionAnchorKind = 'roadmap' | 'delivery' | 'ticket'
 export function devSectionAnchorId(section: DevSectionAnchorKind, id: string): string {
   return `${section}-${id}`
 }
+
+/**
+ * THE single source of truth for "which ticket is open" — the URL query
+ * param `HelpCenterList` derives its drawer state from. Every producer
+ * of a ticket deep link goes through `buildTicketOpenHref`; every
+ * consumer reads THIS param name. Lives HERE (pure, server-safe, beside
+ * its sibling param keys) because producers span both worlds: the hub's
+ * SERVER-side chat-ref builder and the client header cell.
+ */
+export const TICKET_OPEN_PARAM = 'ticket'
+
+/**
+ * Build THE canonical ticket deep link — the ONE producer for every
+ * surface that links to a ticket (chat inline cards via the hub's
+ * `buildChatRefFromTicketRow`, the header `TicketAlertsButton`, any
+ * future caller). Byte-identical output everywhere:
+ *
+ *   `<base>?ticket=<id>&search=<id>#ticket-<id>`
+ *
+ * All three parts are load-bearing:
+ *   - `?ticket=`  — drawer auto-open (`HelpCenterList` derives its open
+ *                   state from this param);
+ *   - `&search=`  — filters the list to ONLY that ticket so the
+ *                   drawer-open lookup hits regardless of which PAGE the
+ *                   ticket would normally land on (without it, tickets
+ *                   on page 2+ silently fail to auto-open);
+ *   - `#ticket-…` — scroll anchor via the dev-section deep-link
+ *                   dispatch (`useScrollToHash` + `devSectionAnchorId`).
+ *
+ * `base` is the host's tickets surface path and may carry ANY nesting
+ * prefix (hub `/tickets`, console `/help-center/tickets`, an embedder's
+ * `/support/portal/tickets`). Bases already carrying a query string are
+ * composed with `&`.
+ */
+export function buildTicketOpenHref(base: string, ticketExternalId: string): string {
+  const enc = encodeURIComponent(ticketExternalId)
+  const sep = base.includes('?') ? '&' : '?'
+  return `${base}${sep}${TICKET_OPEN_PARAM}=${enc}&${DEV_SECTION_PARAM_KEYS.search}=${enc}#${devSectionAnchorId('ticket', enc)}`
+}

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -59,6 +59,8 @@ export {
   DEV_SECTION_PARAM_KEYS,
   devSectionAnchorId,
   type DevSectionAnchorKind,
+  TICKET_OPEN_PARAM,
+  buildTicketOpenHref,
 } from './dev-sections/dev-section-param-keys'
 // Dynamic icon registry — single source of truth lives at
 // components/chat/utils/icon-registry. Re-exported here so existing

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -178,6 +178,18 @@ export {
   setEmbedAuthAdapter,
   type EmbedAuthAdapter,
 } from './embed-authed-fetch'
+// THE common SSE client (fetch-based, standard `event:`/`data:` frames,
+// silence-based liveness, never-terminating capped backoff). Consumed by
+// the lib's `TicketLiveProvider` AND the hub's workflow/invocation stream
+// hooks — the hub's old EventSource-based `sse-client.ts` was deleted in
+// favor of this. Streams that END (terminal events) must `close()` from
+// their event handler, or the never-terminating reconnect re-opens them.
+export {
+  createSseSubscription,
+  type SseSubscription,
+  type SseSubscriptionOptions,
+  type SseTransportStatus,
+} from './sse-subscription'
 export {
   type EmbedProxyAuth,
   getEmbedProxyAuth,

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -23,6 +23,27 @@ export function normalizeHashFragment(hash: string): string {
   return second < 0 ? hash : hash.slice(0, second)
 }
 
+/**
+ * Resolve the DOM element a hash fragment id points at. Tries the raw
+ * id first (ordinary anchors), then the percent-decoded form — href
+ * composers like `buildTicketOpenHref` encode the id into the fragment
+ * while rows render the raw id, so `#ticket-a%2Fb` must still find
+ * `id="ticket-a/b"`. A malformed escape sequence falls back to the
+ * raw lookup result.
+ */
+export function getHashTargetElement(id: string): HTMLElement | null {
+  if (!id) return null
+  const direct = document.getElementById(id)
+  if (direct) return direct
+  try {
+    const decoded = decodeURIComponent(id)
+    if (decoded !== id) return document.getElementById(decoded)
+  } catch {
+    // malformed escape — the raw lookup above already covered it
+  }
+  return null
+}
+
 export interface NavigateSamePageHashOptions {
   /** Pixels to subtract for sticky chrome. */
   headerOffset?: number
@@ -98,7 +119,7 @@ export function navigateSamePageHash(
       newURL: window.location.href,
     }))
   }
-  const el = id ? document.getElementById(id) : null
+  const el = id ? getHashTargetElement(id) : null
   if (id && !el && process.env.NODE_ENV === 'development') {
     // eslint-disable-next-line no-console
     console.warn(

--- a/openframe-frontend-core/src/utils/sse-subscription.ts
+++ b/openframe-frontend-core/src/utils/sse-subscription.ts
@@ -194,7 +194,10 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
     }
     if (status === 'retrying') {
       // Server is recovering its own channel — wait (bounded) before a
-      // client hard reconnect stampedes it.
+      // client hard reconnect stampedes it. Disarm the subscribe-confirm
+      // timer: a pre-`subscribed` retry would otherwise fire the 15s hard
+      // reconnect and the grace window would never apply.
+      confirmTimerId = clearLifecycleTimer(confirmTimerId)
       setConnected(false)
       if (!serverGraceTimerId) {
         serverGraceTimerId = setTimeout(() => {
@@ -205,6 +208,9 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
       return
     }
     if (status === 'reconnect_failed') {
+      // Same disarm as `retrying` — a still-armed confirm timer would
+      // preempt the deliberate 30s failed-reconnect delay.
+      confirmTimerId = clearLifecycleTimer(confirmTimerId)
       setConnected(false)
       serverGraceTimerId = clearLifecycleTimer(serverGraceTimerId)
       internalReconnect(FAILED_RECONNECT_DELAY_MS)

--- a/openframe-frontend-core/src/utils/sse-subscription.ts
+++ b/openframe-frontend-core/src/utils/sse-subscription.ts
@@ -33,15 +33,15 @@
 
 import { embedAuthedFetch } from './embed-authed-fetch'
 
-/** Transport-level status. Server-sent `status` FRAMES (`subscribed` /
- *  `retrying` / `reconnect_failed`) arrive via `onEvent('status', …)` —
- *  callers derive their "connected" notion from those, not from these. */
+/** Transport-level status. `suspended` = paused by `pauseWhenHidden`
+ *  after the hidden grace elapsed (resumes automatically on visible). */
 export type SseTransportStatus =
   | 'connecting'
   | 'open'
   | 'reconnecting'
   | 'no-stream'
   | 'terminal'
+  | 'suspended'
   | 'closed'
 
 export interface SseSubscriptionOptions {
@@ -49,9 +49,33 @@ export interface SseSubscriptionOptions {
   /** Defaults to `embedAuthedFetch` (adapter headers + credentials). */
   fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>
   /** Called per parsed frame: `eventName` from `event:` (default
-   *  'message'), `data` JSON-parsed when possible (raw string otherwise). */
+   *  'message'), `data` JSON-parsed when possible (raw string otherwise).
+   *  Server `status` frames are ALSO forwarded here (after the client's
+   *  own lifecycle handling) for consumers that render health detail. */
   onEvent: (eventName: string, data: unknown) => void
   onStatusChange?: (status: SseTransportStatus) => void
+  /**
+   * Consolidated liveness signal — true only when the SERVER confirmed
+   * its Realtime subscription (`status: subscribed` frame), never merely
+   * "HTTP open". THE CLIENT owns the whole lifecycle policy:
+   *   - transport open without `subscribed` within 15s → hard reconnect;
+   *   - server `retrying` → connected=false, give the server 90s to
+   *     recover before a client hard reconnect;
+   *   - server `reconnect_failed` → connected=false, hard reconnect at
+   *     the capped 30s delay (no stampedes);
+   *   - any transport drop → connected=false (reconnect via backoff).
+   * Fired only on transitions.
+   */
+  onConnectedChange?: (connected: boolean) => void
+  /**
+   * Pause the subscription while the tab is hidden (45s grace so
+   * Cmd-Tab thrash doesn't churn connections), resume + reconnect on
+   * visible, and reconnect on `online`. OPT-IN — short-lived streams
+   * (workflow/invocation monitors) must keep running in background
+   * tabs. Long-lived per-user streams should enable it (scale relief:
+   * a hidden tab holds no server invocation).
+   */
+  pauseWhenHidden?: boolean
   /** Silence threshold before the connection is presumed dead. MUST be
    *  ≥2.5× the server keepalive cadence or jitter causes false-disconnect
    *  churn (each one costs a full server invocation). */
@@ -71,6 +95,19 @@ export interface SseSubscription {
 const DEFAULT_SILENCE_TIMEOUT_MS = 45_000
 const DEFAULT_MAX_BACKOFF_MS = 30_000
 const DEFAULT_INITIAL_BACKOFF_MS = 1_000
+/** No server `subscribed` frame within this window after transport-open
+ *  → the subscription is presumed dead behind a live HTTP stream. */
+const SUBSCRIBE_CONFIRM_TIMEOUT_MS = 15_000
+/** Server `retrying` = it is recovering its own Realtime channel
+ *  (exponential backoff, ~5 attempts). Grace before the client gives up
+ *  waiting and hard-reconnects. */
+const SERVER_RETRY_GRACE_MS = 90_000
+/** After a server `reconnect_failed`, the next client attempt starts at
+ *  this capped delay — each reconnect costs a full server invocation +
+ *  the server's own Realtime retries; an outage must not stampede. */
+const FAILED_RECONNECT_DELAY_MS = 30_000
+/** Grace before a hidden tab's subscription is suspended. */
+const HIDDEN_GRACE_MS = 45_000
 
 export function createSseSubscription(options: SseSubscriptionOptions): SseSubscription {
   const {
@@ -78,12 +115,15 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
     fetchImpl = embedAuthedFetch,
     onEvent,
     onStatusChange,
+    onConnectedChange,
+    pauseWhenHidden = false,
     silenceTimeoutMs = DEFAULT_SILENCE_TIMEOUT_MS,
     maxBackoffMs = DEFAULT_MAX_BACKOFF_MS,
     initialBackoffMs = DEFAULT_INITIAL_BACKOFF_MS,
   } = options
 
   let closed = false
+  let suspended = false
   let attempt = 0
   /** Connection generation — bumped by each connect() and by
    *  reconnectNow(). A stale loop (aborted, still unwinding) compares
@@ -94,10 +134,81 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
   let abortController: AbortController | null = null
   let retryTimerId: ReturnType<typeof setTimeout> | null = null
   let silenceTimerId: ReturnType<typeof setTimeout> | null = null
+  // Lifecycle timers — the client owns the WHOLE connected-state policy.
+  let confirmTimerId: ReturnType<typeof setTimeout> | null = null
+  let serverGraceTimerId: ReturnType<typeof setTimeout> | null = null
+  let failedDelayTimerId: ReturnType<typeof setTimeout> | null = null
+  let hiddenGraceTimerId: ReturnType<typeof setTimeout> | null = null
+
+  let connected = false
+  const setConnected = (next: boolean) => {
+    if (connected === next) return
+    connected = next
+    try {
+      onConnectedChange?.(next)
+    } catch (err) {
+      console.error('[sse-subscription] onConnectedChange threw:', err)
+    }
+  }
+
+  const clearLifecycleTimer = (id: ReturnType<typeof setTimeout> | null) => {
+    if (id) clearTimeout(id)
+    return null
+  }
 
   const setStatus = (status: SseTransportStatus) => {
     if (closed && status !== 'closed') return
+    // ANY transport transition means the server subscription is not
+    // (or not yet) confirmed — `subscribed` frames re-assert true.
+    setConnected(false)
+    serverGraceTimerId = clearLifecycleTimer(serverGraceTimerId)
+    if (status !== 'open') {
+      confirmTimerId = clearLifecycleTimer(confirmTimerId)
+    }
     onStatusChange?.(status)
+  }
+
+  /** Hard reconnect, optionally delayed — used by the lifecycle policy
+   *  (confirm timeout / server give-up / failed-reconnect pacing). */
+  const internalReconnect = (delayMs: number) => {
+    failedDelayTimerId = clearLifecycleTimer(failedDelayTimerId)
+    if (delayMs <= 0) {
+      doReconnect()
+      return
+    }
+    failedDelayTimerId = setTimeout(() => {
+      failedDelayTimerId = null
+      doReconnect()
+    }, delayMs)
+  }
+
+  /** Interpret server `status` frames — the server-side Realtime
+   *  subscription health channel emitted by the hub's SSE engine. */
+  const handleServerStatus = (data: unknown) => {
+    const status = (data as { status?: string } | null)?.status
+    if (status === 'subscribed') {
+      confirmTimerId = clearLifecycleTimer(confirmTimerId)
+      serverGraceTimerId = clearLifecycleTimer(serverGraceTimerId)
+      setConnected(true)
+      return
+    }
+    if (status === 'retrying') {
+      // Server is recovering its own channel — wait (bounded) before a
+      // client hard reconnect stampedes it.
+      setConnected(false)
+      if (!serverGraceTimerId) {
+        serverGraceTimerId = setTimeout(() => {
+          serverGraceTimerId = null
+          doReconnect()
+        }, SERVER_RETRY_GRACE_MS)
+      }
+      return
+    }
+    if (status === 'reconnect_failed') {
+      setConnected(false)
+      serverGraceTimerId = clearLifecycleTimer(serverGraceTimerId)
+      internalReconnect(FAILED_RECONNECT_DELAY_MS)
+    }
   }
 
   const clearTimers = () => {
@@ -109,6 +220,10 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
       clearTimeout(silenceTimerId)
       silenceTimerId = null
     }
+    confirmTimerId = clearLifecycleTimer(confirmTimerId)
+    serverGraceTimerId = clearLifecycleTimer(serverGraceTimerId)
+    failedDelayTimerId = clearLifecycleTimer(failedDelayTimerId)
+    hiddenGraceTimerId = clearLifecycleTimer(hiddenGraceTimerId)
   }
 
   const armSilenceTimer = () => {
@@ -121,7 +236,7 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
   }
 
   const scheduleReconnect = () => {
-    if (closed || retryTimerId) return
+    if (closed || suspended || retryTimerId) return
     setStatus('reconnecting')
     const backoff = Math.min(maxBackoffMs, initialBackoffMs * 2 ** attempt)
     const jitter = backoff * 0.25 * Math.random()
@@ -151,6 +266,11 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
     } catch {
       // Non-JSON data frame — deliver the raw string.
     }
+    // Lifecycle FIRST (server `status` frames drive `connected`), then
+    // forward every frame — status included — to the domain handler.
+    if (eventName === 'status') {
+      handleServerStatus(data)
+    }
     try {
       onEvent(eventName, data)
     } catch (err) {
@@ -159,7 +279,7 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
   }
 
   const connect = async (): Promise<void> => {
-    if (closed) return
+    if (closed || suspended) return
     const gen = ++generation
     setStatus('connecting')
     abortController = new AbortController()
@@ -210,6 +330,14 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
     attempt = 0
     setStatus('open')
     armSilenceTimer()
+    // Transport open ≠ connected: require the server's `subscribed`
+    // status frame within the confirm window, else the subscription is
+    // presumed dead behind a live HTTP stream → hard reconnect.
+    confirmTimerId = clearLifecycleTimer(confirmTimerId)
+    confirmTimerId = setTimeout(() => {
+      confirmTimerId = null
+      if (!connected) doReconnect()
+    }, SUBSCRIBE_CONFIRM_TIMEOUT_MS)
 
     const reader = response.body.getReader()
     const decoder = new TextDecoder()
@@ -264,6 +392,57 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
     if (!closed && gen === generation) scheduleReconnect()
   }
 
+  /** Hard reconnect core — invalidate the current loop BEFORE aborting
+   *  so its unwinding never schedules a competing (backoff) reconnect. */
+  function doReconnect() {
+    if (closed || suspended) return
+    generation += 1
+    clearTimers()
+    attempt = 0
+    abortController?.abort()
+    void connect()
+  }
+
+  // ---- pauseWhenHidden: suspend/resume with the tab, reconnect on
+  // network return. Registered here (not in callers) — this is client
+  // lifecycle policy, not domain logic.
+  const suspend = () => {
+    if (closed || suspended) return
+    suspended = true
+    generation += 1
+    clearTimers()
+    abortController?.abort()
+    setStatus('suspended')
+  }
+  const onVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      if (!hiddenGraceTimerId) {
+        hiddenGraceTimerId = setTimeout(() => {
+          hiddenGraceTimerId = null
+          // Scale relief: a hidden tab holds no server invocation.
+          suspend()
+        }, HIDDEN_GRACE_MS)
+      }
+      return
+    }
+    // Visible again — cancel the grace, or resume if already suspended
+    // (the fresh connect re-delivers server-pushed state).
+    hiddenGraceTimerId = clearLifecycleTimer(hiddenGraceTimerId)
+    if (suspended) {
+      suspended = false
+      void connect()
+    }
+  }
+  const onOnline = () => {
+    if (!suspended) doReconnect()
+  }
+  const listenersActive =
+    pauseWhenHidden && typeof document !== 'undefined' && typeof window !== 'undefined'
+  if (listenersActive) {
+    document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('online', onOnline)
+  }
+
   void connect()
 
   return {
@@ -273,17 +452,17 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
       generation += 1
       clearTimers()
       abortController?.abort()
+      if (listenersActive) {
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+        window.removeEventListener('online', onOnline)
+      }
+      setConnected(false)
       onStatusChange?.('closed')
     },
     reconnectNow: () => {
       if (closed) return
-      // Invalidate the current loop BEFORE aborting so its unwinding
-      // never schedules a competing (backoff) reconnect.
-      generation += 1
-      clearTimers()
-      attempt = 0
-      abortController?.abort()
-      void connect()
+      suspended = false
+      doReconnect()
     },
   }
 }

--- a/openframe-frontend-core/src/utils/sse-subscription.ts
+++ b/openframe-frontend-core/src/utils/sse-subscription.ts
@@ -223,6 +223,18 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
         // the frame parser below will drop.
         armSilenceTimer()
         buffer += decoder.decode(value, { stream: true })
+        // SSE line terminators may be CRLF, LF, or bare CR per spec.
+        // Normalize to LF before boundary scanning — a CRLF stream would
+        // otherwise never match '\n\n' and frames would pile up unparsed.
+        // A trailing CR is held back one iteration: it may be the first
+        // half of a CRLF split across reads (normalization is idempotent
+        // on the already-normalized remainder).
+        let pendingCr = ''
+        if (buffer.endsWith('\r')) {
+          pendingCr = '\r'
+          buffer = buffer.slice(0, -1)
+        }
+        buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
         // Frames are separated by a blank line (\n\n).
         for (;;) {
           const boundary = buffer.indexOf('\n\n')
@@ -231,6 +243,7 @@ export function createSseSubscription(options: SseSubscriptionOptions): SseSubsc
           buffer = buffer.slice(boundary + 2)
           parseFrame(rawFrame)
         }
+        buffer += pendingCr
       }
     } catch {
       // Aborted (silence timer / reconnectNow) or stream error — fall

--- a/openframe-frontend-core/src/utils/sse-subscription.ts
+++ b/openframe-frontend-core/src/utils/sse-subscription.ts
@@ -1,0 +1,276 @@
+/**
+ * Fetch-based SSE subscription primitive.
+ *
+ * Why not `EventSource`: cross-origin embedders authenticate via the
+ * `embedAuthedFetch` adapter's HEADERS (OpenFrame bearer), which
+ * `EventSource` cannot carry. This reads `response.body` from a normal
+ * authed fetch and parses standard `event:`/`data:` frames.
+ *
+ * Lifecycle (never-terminating by design):
+ *   - Infinite reconnects with capped exponential backoff (~30s max +
+ *     jitter), reset on a successful open. Do NOT copy the terminating
+ *     `maxRetries → exhausted` model of the hub's server-side
+ *     `RealtimeRetryManager` — a long outage must self-heal when the
+ *     backend returns, because there is NO polling fallback behind this.
+ *   - Liveness by silence: the server keepalives every ~15s; any bytes
+ *     (INCLUDING `: keepalive` comment lines — they reset the timer
+ *     before frame parsing drops them) count as life. Silence beyond
+ *     `silenceTimeoutMs` (default 45s = 3× keepalive) aborts + reconnects.
+ *   - Terminal responses (NO retry): any 4xx except 408/429 — the
+ *     `x-block-layer` header, when readable, is logged for attribution
+ *     only, never used as a retry gate (proxies may strip it); and
+ *     204 → a distinct `no-stream` status (the caller decides when to
+ *     try again). Backoff-retry is for transport errors, 408/429, and 5xx.
+ *
+ * THE common SSE client for lib + hosts — exported from the `utils`
+ * barrel. Consumers: `TicketLiveProvider` (lib) and the hub's
+ * workflow/invocation stream hooks (which replaced the hub's old
+ * EventSource-based `sse-client.ts`). Finite streams (workflows,
+ * invocations) end with a terminal event and a server-side close —
+ * their handlers MUST call `close()` on the terminal event, or the
+ * never-terminating reconnect loop re-opens the finished stream.
+ */
+
+import { embedAuthedFetch } from './embed-authed-fetch'
+
+/** Transport-level status. Server-sent `status` FRAMES (`subscribed` /
+ *  `retrying` / `reconnect_failed`) arrive via `onEvent('status', …)` —
+ *  callers derive their "connected" notion from those, not from these. */
+export type SseTransportStatus =
+  | 'connecting'
+  | 'open'
+  | 'reconnecting'
+  | 'no-stream'
+  | 'terminal'
+  | 'closed'
+
+export interface SseSubscriptionOptions {
+  url: string
+  /** Defaults to `embedAuthedFetch` (adapter headers + credentials). */
+  fetchImpl?: (url: string, init?: RequestInit) => Promise<Response>
+  /** Called per parsed frame: `eventName` from `event:` (default
+   *  'message'), `data` JSON-parsed when possible (raw string otherwise). */
+  onEvent: (eventName: string, data: unknown) => void
+  onStatusChange?: (status: SseTransportStatus) => void
+  /** Silence threshold before the connection is presumed dead. MUST be
+   *  ≥2.5× the server keepalive cadence or jitter causes false-disconnect
+   *  churn (each one costs a full server invocation). */
+  silenceTimeoutMs?: number
+  maxBackoffMs?: number
+  initialBackoffMs?: number
+}
+
+export interface SseSubscription {
+  /** Permanently stop — no further reconnects, no callbacks. */
+  close: () => void
+  /** Drop the current connection (if any) and reconnect immediately,
+   *  resetting backoff. No-op after `close()`. */
+  reconnectNow: () => void
+}
+
+const DEFAULT_SILENCE_TIMEOUT_MS = 45_000
+const DEFAULT_MAX_BACKOFF_MS = 30_000
+const DEFAULT_INITIAL_BACKOFF_MS = 1_000
+
+export function createSseSubscription(options: SseSubscriptionOptions): SseSubscription {
+  const {
+    url,
+    fetchImpl = embedAuthedFetch,
+    onEvent,
+    onStatusChange,
+    silenceTimeoutMs = DEFAULT_SILENCE_TIMEOUT_MS,
+    maxBackoffMs = DEFAULT_MAX_BACKOFF_MS,
+    initialBackoffMs = DEFAULT_INITIAL_BACKOFF_MS,
+  } = options
+
+  let closed = false
+  let attempt = 0
+  /** Connection generation — bumped by each connect() and by
+   *  reconnectNow(). A stale loop (aborted, still unwinding) compares
+   *  its captured generation before scheduling a reconnect, so an
+   *  explicit reconnect can never race a zombie loop into two
+   *  concurrent connections. */
+  let generation = 0
+  let abortController: AbortController | null = null
+  let retryTimerId: ReturnType<typeof setTimeout> | null = null
+  let silenceTimerId: ReturnType<typeof setTimeout> | null = null
+
+  const setStatus = (status: SseTransportStatus) => {
+    if (closed && status !== 'closed') return
+    onStatusChange?.(status)
+  }
+
+  const clearTimers = () => {
+    if (retryTimerId) {
+      clearTimeout(retryTimerId)
+      retryTimerId = null
+    }
+    if (silenceTimerId) {
+      clearTimeout(silenceTimerId)
+      silenceTimerId = null
+    }
+  }
+
+  const armSilenceTimer = () => {
+    if (silenceTimerId) clearTimeout(silenceTimerId)
+    silenceTimerId = setTimeout(() => {
+      // Dead-air: the read loop is stuck on a connection that will never
+      // produce again. Abort → the loop's catch schedules a reconnect.
+      abortController?.abort()
+    }, silenceTimeoutMs)
+  }
+
+  const scheduleReconnect = () => {
+    if (closed || retryTimerId) return
+    setStatus('reconnecting')
+    const backoff = Math.min(maxBackoffMs, initialBackoffMs * 2 ** attempt)
+    const jitter = backoff * 0.25 * Math.random()
+    attempt += 1
+    retryTimerId = setTimeout(() => {
+      retryTimerId = null
+      void connect()
+    }, backoff + jitter)
+  }
+
+  const parseFrame = (rawFrame: string) => {
+    let eventName = 'message'
+    const dataLines: string[] = []
+    for (const line of rawFrame.split('\n')) {
+      if (line.startsWith(':')) continue // comment (keepalive) — liveness only
+      if (line.startsWith('event:')) {
+        eventName = line.slice(6).trim() || 'message'
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice(5).trimStart())
+      }
+    }
+    if (dataLines.length === 0) return
+    const rawData = dataLines.join('\n')
+    let data: unknown = rawData
+    try {
+      data = JSON.parse(rawData)
+    } catch {
+      // Non-JSON data frame — deliver the raw string.
+    }
+    try {
+      onEvent(eventName, data)
+    } catch (err) {
+      console.error('[sse-subscription] onEvent handler threw:', err)
+    }
+  }
+
+  const connect = async (): Promise<void> => {
+    if (closed) return
+    const gen = ++generation
+    setStatus('connecting')
+    abortController = new AbortController()
+
+    let response: Response
+    try {
+      response = await fetchImpl(url, {
+        method: 'GET',
+        // Explicit Accept — embedAuthedFetch otherwise injects
+        // `Content-Type: application/json` defaults meant for POSTs.
+        headers: { Accept: 'text/event-stream' },
+        signal: abortController.signal,
+      })
+    } catch {
+      // Network error / abort — transport-level, retryable.
+      if (!closed && gen === generation) scheduleReconnect()
+      return
+    }
+    if (closed || gen !== generation) return
+
+    if (response.status === 204) {
+      // Contract: nothing to stream for this identity. Caller decides
+      // when to try again — no retry loop here.
+      setStatus('no-stream')
+      return
+    }
+    if (!response.ok) {
+      const retryable = response.status === 408 || response.status === 429 || response.status >= 500
+      if (retryable) {
+        scheduleReconnect()
+        return
+      }
+      // Terminal 4xx. x-block-layer (proxy surface block) is logged for
+      // attribution when readable — never gates the decision.
+      const blockLayer = response.headers.get('x-block-layer')
+      console.warn(
+        `[sse-subscription] terminal ${response.status} for ${url}${blockLayer ? ` (x-block-layer: ${blockLayer})` : ''} — not retrying`,
+      )
+      setStatus('terminal')
+      return
+    }
+    if (!response.body) {
+      scheduleReconnect()
+      return
+    }
+
+    // Successful open — reset backoff, start liveness accounting.
+    attempt = 0
+    setStatus('open')
+    armSilenceTimer()
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    try {
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (closed || gen !== generation) return
+        if (done) break
+        // ANY bytes are liveness — including comment keepalives, which
+        // the frame parser below will drop.
+        armSilenceTimer()
+        buffer += decoder.decode(value, { stream: true })
+        // Frames are separated by a blank line (\n\n).
+        for (;;) {
+          const boundary = buffer.indexOf('\n\n')
+          if (boundary === -1) break
+          const rawFrame = buffer.slice(0, boundary)
+          buffer = buffer.slice(boundary + 2)
+          parseFrame(rawFrame)
+        }
+      }
+    } catch {
+      // Aborted (silence timer / reconnectNow) or stream error — fall
+      // through to reconnect.
+    } finally {
+      if (silenceTimerId) {
+        clearTimeout(silenceTimerId)
+        silenceTimerId = null
+      }
+      try {
+        reader.releaseLock()
+      } catch {
+        // Already released.
+      }
+    }
+
+    // Server closed the stream (e.g. Vercel maxDuration) — reconnect.
+    if (!closed && gen === generation) scheduleReconnect()
+  }
+
+  void connect()
+
+  return {
+    close: () => {
+      if (closed) return
+      closed = true
+      generation += 1
+      clearTimers()
+      abortController?.abort()
+      onStatusChange?.('closed')
+    },
+    reconnectNow: () => {
+      if (closed) return
+      // Invalidate the current loop BEFORE aborting so its unwinding
+      // never schedules a competing (backoff) reconnect.
+      generation += 1
+      clearTimers()
+      attempt = 0
+      abortController?.abort()
+      void connect()
+    },
+  }
+}

--- a/react-embedding-example/scripts/ensure-setup.mjs
+++ b/react-embedding-example/scripts/ensure-setup.mjs
@@ -1,18 +1,33 @@
 #!/usr/bin/env node
 /**
- * One-shot bootstrap that fronts `npm run dev`. Each step is gated on a
- * concrete artifact, so warm runs are sub-100ms (a few `existsSync` calls)
- * and only the first launch — or one after blowing away node_modules /
- * .yalc / the lib's dist — pays the install cost.
+ * One-shot bootstrap that fronts `npm run dev`.
  *
- * Why this exists: the embed used to consume the lib via `file:../openframe-frontend-core`,
- * which let it share the lib's own `node_modules` automatically. Switching
- * to yalc made every consumer responsible for installing the lib's
- * transitive deps locally — without this script, `npm run dev` failed with
- * `Could not resolve "lucide-react" / "@react-aria/utils" / …` on a fresh
- * clone or after a `node_modules` wipe.
+ * FRESHNESS-GATED, not existence-gated (hardened 2026-08-01 after repeat
+ * "does not provide an export named X" breakages): an existence check
+ * happily serves a WEEKS-STALE `.yalc` snapshot after the lib gains new
+ * exports — vite prebundles the stale copy and the app explodes at
+ * runtime. Every gate below compares mtimes so `npm run dev` self-heals:
+ *
+ *   1. lib dist    — rebuilt when missing OR older than the newest file
+ *                    in the lib's src/ (uncommitted edits included).
+ *   2. .yalc snap  — re-published + re-added when missing OR older than
+ *                    the lib dist it mirrors; the vite dep cache
+ *                    (node_modules/.vite) is purged in the same breath
+ *                    (belt-and-suspenders — `dev` also passes --force).
+ *   3. embed deps  — unchanged sentinel (lucide-react) for the lib's
+ *                    transitive deps.
+ *
+ * Warm-run cost: one recursive mtime scan of the lib's src/ (~200ms) +
+ * a few statSync calls. Only a genuinely stale artifact pays more.
+ *
+ * Why this exists at all: the embed used to consume the lib via
+ * `file:../openframe-frontend-core`, which shared the lib's node_modules
+ * automatically. Switching to yalc made every consumer responsible for
+ * installing the lib's transitive deps locally — without this script,
+ * `npm run dev` failed with `Could not resolve "lucide-react" / …` on a
+ * fresh clone or after a `node_modules` wipe.
  */
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { execSync } from 'node:child_process'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -26,22 +41,43 @@ function step(msg, cmd, cwd) {
   execSync(cmd, { cwd, stdio: 'inherit' })
 }
 
-// 1. Lib must have a built dist — Vite resolves `@flamingo-stack/openframe-frontend-core/components/...`
-//    against it. `yalc:watch` keeps it fresh in steady state, but cold starts need a one-shot build.
-if (!existsSync(join(libDir, 'dist', 'index.js'))) {
+/** Newest file mtime under a directory (recursive). Fast enough to run
+ *  on every dev start; correctness beats shaving 200ms off cold starts. */
+function newestMtimeMs(dir) {
+  let newest = 0
+  for (const entry of readdirSync(dir, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile()) continue
+    const m = statSync(join(entry.parentPath ?? entry.path, entry.name)).mtimeMs
+    if (m > newest) newest = m
+  }
+  return newest
+}
+
+const mtimeOrZero = (p) => (existsSync(p) ? statSync(p).mtimeMs : 0)
+
+// 1. Lib dist — Vite resolves `@flamingo-stack/openframe-frontend-core/components/...`
+//    against it. Rebuild when missing OR stale vs the lib's src tree, so a
+//    branch switch / fresh lib edit can never serve yesterday's bundle.
+const distIndex = join(libDir, 'dist', 'index.js')
+if (mtimeOrZero(distIndex) < newestMtimeMs(join(libDir, 'src'))) {
   if (!existsSync(join(libDir, 'node_modules'))) {
     step('lib deps missing — installing', 'npm install', libDir)
   }
-  step('lib dist missing — building', 'npm run build', libDir)
+  step('lib dist missing/stale — building', 'npm run build', libDir)
 }
 
-// 2. Yalc snapshot present locally. `yalc publish` in the lib registers the package in the
-//    user's global yalc registry; `yalc add` in the embed materializes `.yalc/` + edits package.json.
-//    On warm runs both no-op (yalc detects no version change), so this is just safety net for
-//    fresh clones that picked up the new `file:.yalc/...` dep from git but have no `.yalc/` yet.
-if (!existsSync(join(root, '.yalc', '@flamingo-stack', 'openframe-frontend-core', 'package.json'))) {
-  step('publishing lib to yalc store', 'yalc publish', libDir)
-  step('adding lib snapshot to embed', 'yalc add @flamingo-stack/openframe-frontend-core', root)
+// 2. Yalc snapshot — refresh when missing OR older than the dist it mirrors.
+//    `yalc publish` registers the lib in the user's global yalc store;
+//    `yalc add` re-materializes `.yalc/` + the node_modules copy. On a
+//    refresh, ALSO purge vite's prebundle cache: a prebundle of the
+//    previous snapshot is exactly the "does not provide an export
+//    named …" failure mode.
+const snapDist = join(root, '.yalc', '@flamingo-stack', 'openframe-frontend-core', 'dist', 'index.js')
+if (mtimeOrZero(snapDist) < mtimeOrZero(distIndex)) {
+  step('yalc snapshot missing/stale — publishing lib', 'yalc publish', libDir)
+  step('refreshing embed snapshot', 'yalc add @flamingo-stack/openframe-frontend-core', root)
+  rmSync(join(root, 'node_modules', '.vite'), { recursive: true, force: true })
+  console.log('[setup] purged vite dep cache (stale prebundle would miss new lib exports)')
 }
 
 // 3. Embed's own node_modules has the lib's transitive deps. We sentinel on a single dep

--- a/react-embedding-example/src/components/app-shell.tsx
+++ b/react-embedding-example/src/components/app-shell.tsx
@@ -54,10 +54,12 @@ export function AppShell() {
         href: '/tickets',
         onClick: (href) => navigate(href),
       },
-      // No Mingo header launcher here — the example keeps its floating
-      // <AskAi /> trigger below. No mobile burger either: the demo's nav
-      // collapses into the shell's center zone; real hosts opt into
-      // `mobile.enabled` with their own icons.
+      // Mingo launcher in the header — THE chat entry (dispatches
+      // `ask-ai:open`; the always-mounted panel in <AskAi /> listens).
+      // Same retired-floating-dock model as the hub. No mobile burger:
+      // the demo's nav collapses into the shell's center zone; real
+      // hosts opt into `mobile.enabled` with their own icons.
+      mingo: { enabled: true },
     }),
     [pathname, navigate],
   )
@@ -82,7 +84,8 @@ export function AppShell() {
       <main className="w-full">
         <Outlet />
       </main>
-      {/* Floating Ask-AI trigger, available on every route. */}
+      {/* Always-mounted chat panel (headless — opened by the header's
+          Mingo launcher via the ask-ai:open event; no floating trigger). */}
       <AskAi />
       {/* Floating walkthrough-video widget (bottom-left), fetched via /content. */}
       <WalkthroughVideo />

--- a/react-embedding-example/src/components/app-shell.tsx
+++ b/react-embedding-example/src/components/app-shell.tsx
@@ -1,5 +1,10 @@
-import { NavLink, Outlet } from 'react-router-dom'
+import { useMemo } from 'react'
+import { Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { AnnouncementBar } from '@flamingo-stack/openframe-frontend-core/components'
+import {
+  Header,
+  type HeaderConfig,
+} from '@flamingo-stack/openframe-frontend-core/components/navigation'
 import { AskAi } from './ask-ai'
 import { WalkthroughVideo } from './walkthrough-video'
 import { DOCS_BASE_ROUTE } from '../config/content'
@@ -19,11 +24,44 @@ const NAV = [
 ] as const
 
 export function AppShell() {
-  // No router bridge / nav wiring here. react-router is registered into the lib's
-  // embed-shims once (see providers/embed-router-bridge), so every lib surface this
-  // app mounts — chat source chips / markdown anchors / entity-card dispatch,
-  // onboarding cards, the releases list — soft-navigates through that registered
-  // router directly. No runtime.navigation callback, no document-click interceptor.
+  const { pathname } = useLocation()
+  const navigate = useNavigate()
+
+  // The SHARED lib header — the same `Header` shell every hub platform
+  // mounts, proving it embeds cleanly too. Nav links soft-navigate because
+  // react-router is registered into the lib's embed-shims Link (see
+  // providers/embed-router-bridge); no per-item onClick wiring needed.
+  const headerConfig = useMemo<HeaderConfig>(
+    () => ({
+      logo: {
+        element: <span className="font-semibold text-ods-text-primary">OpenFrame embed</span>,
+        href: '/',
+      },
+      navigation: {
+        items: NAV.map((n) => ({
+          id: n.to,
+          label: n.label,
+          href: n.to,
+          isActive:
+            'end' in n && n.end ? pathname === n.to : pathname.startsWith(n.to),
+        })),
+        position: 'center',
+      },
+      // Support-ticket alerts cell — attention-only (appears with unread
+      // replies, count pill, deep-links to the newest-unread ticket).
+      // Fed by the app-wide <TicketLiveProvider> in app-providers.tsx.
+      tickets: {
+        href: '/tickets',
+        onClick: (href) => navigate(href),
+      },
+      // No Mingo header launcher here — the example keeps its floating
+      // <AskAi /> trigger below. No mobile burger either: the demo's nav
+      // collapses into the shell's center zone; real hosts opt into
+      // `mobile.enabled` with their own icons.
+    }),
+    [pathname, navigate],
+  )
+
   return (
     <div className="min-h-full bg-ods-bg text-ods-text-primary">
       {/* Client-only mode (no SSR), mounted PROP-LESS: reads its endpoint from
@@ -36,27 +74,7 @@ export function AppShell() {
           cookie on THIS embed's domain. SSR hosts use the other mode: resolve
           server-side and pass `initialAnnouncement`. */}
       <AnnouncementBar />
-      <header className="sticky top-0 z-40 border-b border-ods-border bg-ods-card/95 backdrop-blur">
-        <nav className="mx-auto flex max-w-6xl flex-wrap items-center gap-1 px-4 py-3">
-          <span className="mr-3 font-semibold">OpenFrame embed</span>
-          {NAV.map((n) => (
-            <NavLink
-              key={n.to}
-              to={n.to}
-              end={'end' in n ? n.end : undefined}
-              className={({ isActive }) =>
-                `rounded-md px-3 py-1.5 text-sm ${
-                  isActive
-                    ? 'bg-ods-bg text-ods-text-primary'
-                    : 'text-ods-text-secondary hover:text-ods-text-primary'
-                }`
-              }
-            >
-              {n.label}
-            </NavLink>
-          ))}
-        </nav>
-      </header>
+      <Header config={headerConfig} />
       {/* No container constraint here — each route's lib component manages its
        *  own width (e.g. <DocsHubPage> uses `max-w-[1920px]`, <HelpCenterList>
        *  uses <DevSectionPage>). Wrapping in `max-w-6xl` clipped the docs

--- a/react-embedding-example/src/components/ask-ai.tsx
+++ b/react-embedding-example/src/components/ask-ai.tsx
@@ -8,6 +8,11 @@ import { DOCS_BASE_ROUTE } from '../config/content'
  * Identity (Michael) is resolved server-side via the proxy's act-as headers, so the
  * greeting just works.
  *
+ * ENTRY POINT: the shared header's Mingo launcher (`HeaderConfig.mingo` in
+ * app-shell.tsx) — the same `ask-ai:open` event bus the hub uses. The lib's
+ * floating internal trigger is disabled (`showInternalTrigger={false}`),
+ * matching the hub's retired-dock model.
+ *
  * OpenFrame AGENT MODE (Fae / Mingo): the demo chooser below sets `activeAgentSlug`.
  * Agent mode reuses the same `<EmbeddableChat>` — it just OVERRIDES the empty-state
  * config URL, fetching the agent's display config (greeting + suggested prompts +
@@ -50,10 +55,15 @@ export function AskAi() {
         ))}
       </div>
 
+      {/* Headless panel — the floating internal trigger is DISABLED (same as
+          the hub): the shared header's MingoAiButton (HeaderConfig.mingo in
+          app-shell.tsx) is the ONLY chat entry; it dispatches `ask-ai:open`
+          and this always-mounted panel listens. */}
       <EmbeddableChat
         modes={{ guide: {} }}
         defaultActiveMode="guide"
         baseRoute={DOCS_BASE_ROUTE}
+        showInternalTrigger={false}
         activeAgentSlug={activeAgentSlug}
         onAgentChange={setActiveAgentSlug}
       />

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -3,8 +3,8 @@
 // no endpoint literal exists twice.
 import { CONTENT } from './content'
 
-// approvalToolUrl + (once the optional lib seam lands) the three tickets paths
-// all derive from this one agent base, so `/chat/agent` lives in a single spot.
+// approvalToolUrl + the six tickets paths all derive from this one agent
+// base, so `/chat/agent` lives in a single spot.
 const AGENT_BASE = `${CONTENT}/chat/agent`
 
 export const EP = {
@@ -32,6 +32,16 @@ export const EP = {
   resolveLink: `${CONTENT}/docs/resolve-link`,
   agentBase: AGENT_BASE,
   approval: `${AGENT_BASE}/confirm-tool`,
+  // tickets (Help Center) — reads/writes + the live stream + unread state.
+  // `ticketStream` is a long-lived GET SSE response consumed by the lib's
+  // `TicketLiveProvider` (fetch-based reader, works cross-origin with the
+  // embed auth adapter's headers).
+  findTicket: `${AGENT_BASE}/find-ticket`,
+  ticketAction: `${AGENT_BASE}/ticket-action`,
+  listEngagements: `${AGENT_BASE}/list-engagements`,
+  ticketStream: `${AGENT_BASE}/ticket-stream`,
+  ticketRead: `${AGENT_BASE}/ticket-read`,
+  ticketUnreadSummary: `${AGENT_BASE}/ticket-unread-summary`,
   attachmentUpload: `${CONTENT}/storage/generate-upload-url`,
   attachmentViewPrefix: `${CONTENT}/storage/view/chat-attachments/`,
   identity: `${CONTENT}/auth/identity`,

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -32,16 +32,16 @@ export const EP = {
   resolveLink: `${CONTENT}/docs/resolve-link`,
   agentBase: AGENT_BASE,
   approval: `${AGENT_BASE}/confirm-tool`,
-  // tickets (Help Center) — reads/writes + the live stream + unread state.
+  // tickets (Help Center) — reads/writes + the live stream + read receipts.
   // `ticketStream` is a long-lived GET SSE response consumed by the lib's
   // `TicketLiveProvider` (fetch-based reader, works cross-origin with the
-  // embed auth adapter's headers).
+  // embed auth adapter's headers). The unread summary has NO endpoint —
+  // it arrives as `ticket-summary` frames on the stream.
   findTicket: `${AGENT_BASE}/find-ticket`,
   ticketAction: `${AGENT_BASE}/ticket-action`,
   listEngagements: `${AGENT_BASE}/list-engagements`,
   ticketStream: `${AGENT_BASE}/ticket-stream`,
   ticketRead: `${AGENT_BASE}/ticket-read`,
-  ticketUnreadSummary: `${AGENT_BASE}/ticket-unread-summary`,
   attachmentUpload: `${CONTENT}/storage/generate-upload-url`,
   attachmentViewPrefix: `${CONTENT}/storage/view/chat-attachments/`,
   identity: `${CONTENT}/auth/identity`,

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -40,8 +40,10 @@ export const EP = {
   findTicket: `${AGENT_BASE}/find-ticket`,
   ticketAction: `${AGENT_BASE}/ticket-action`,
   listEngagements: `${AGENT_BASE}/list-engagements`,
-  ticketStream: `${AGENT_BASE}/ticket-stream`,
-  ticketRead: `${AGENT_BASE}/ticket-read`,
+  // Realtime lives on its OWN surface (/api/tickets/*) — not the chat
+  // agent prefix.
+  ticketStream: `${CONTENT}/tickets/stream`,
+  ticketRead: `${CONTENT}/tickets/read`,
   attachmentUpload: `${CONTENT}/storage/generate-upload-url`,
   attachmentViewPrefix: `${CONTENT}/storage/view/chat-attachments/`,
   identity: `${CONTENT}/auth/identity`,

--- a/react-embedding-example/src/config/endpoints.ts
+++ b/react-embedding-example/src/config/endpoints.ts
@@ -3,8 +3,10 @@
 // no endpoint literal exists twice.
 import { CONTENT } from './content'
 
-// approvalToolUrl + the six tickets paths all derive from this one agent
-// base, so `/chat/agent` lives in a single spot.
+// approvalToolUrl + the three conversational ticket tool paths derive from
+// this one agent base, so `/chat/agent` lives in a single spot. Ticket
+// REALTIME (stream + read receipts) is NOT agent-based — it lives on the
+// dedicated `/api/tickets/*` surface below.
 const AGENT_BASE = `${CONTENT}/chat/agent`
 
 export const EP = {
@@ -32,16 +34,18 @@ export const EP = {
   resolveLink: `${CONTENT}/docs/resolve-link`,
   agentBase: AGENT_BASE,
   approval: `${AGENT_BASE}/confirm-tool`,
-  // tickets (Help Center) — reads/writes + the live stream + read receipts.
-  // `ticketStream` is a long-lived GET SSE response consumed by the lib's
-  // `TicketLiveProvider` (fetch-based reader, works cross-origin with the
-  // embed auth adapter's headers). The unread summary has NO endpoint —
-  // it arrives as `ticket-summary` frames on the stream.
+  // tickets (Help Center) — conversational reads/writes. These three are
+  // chat-agent TOOL routes on the hub (`/api/chat/agent/*`), hence
+  // AGENT_BASE.
   findTicket: `${AGENT_BASE}/find-ticket`,
   ticketAction: `${AGENT_BASE}/ticket-action`,
   listEngagements: `${AGENT_BASE}/list-engagements`,
-  // Realtime lives on its OWN surface (/api/tickets/*) — not the chat
-  // agent prefix.
+  // Ticket REALTIME lives on its OWN surface (`/api/tickets/*`) — not the
+  // chat agent prefix. `ticketStream` is a long-lived GET SSE response
+  // consumed by the lib's `TicketLiveProvider` (fetch-based reader, works
+  // cross-origin with the embed auth adapter's headers). The unread
+  // summary has NO endpoint — it arrives as `ticket-summary` frames on
+  // the stream; `ticketRead` responses also carry a fresh summary.
   ticketStream: `${CONTENT}/tickets/stream`,
   ticketRead: `${CONTENT}/tickets/read`,
   attachmentUpload: `${CONTENT}/storage/generate-upload-url`,

--- a/react-embedding-example/src/pages/tickets.tsx
+++ b/react-embedding-example/src/pages/tickets.tsx
@@ -1,8 +1,4 @@
-import { TicketAlertsButton } from '@flamingo-stack/openframe-frontend-core/components/navigation'
-import {
-  HelpCenterList,
-  TicketLiveProvider,
-} from '@flamingo-stack/openframe-frontend-core/components/tickets'
+import { HelpCenterList } from '@flamingo-stack/openframe-frontend-core/components/tickets'
 
 /**
  * HelpCenterList composes the lib's DevSectionPage chrome + create form + ticket
@@ -10,24 +6,13 @@ import {
  * All six ticket endpoints (reads/writes + live stream + unread state) come from
  * `runtime.endpoints` (see content-runtime.ts / EP).
  *
- * `TicketLiveProvider` demonstrates the realtime layer end-to-end:
- *   - SSE subscription to `EP.ticketStream` (fetch-based reader — carries the
- *     embed auth adapter's bearer, which `EventSource` cannot);
- *   - a header-style `TicketAlertsButton` cell whose `bg-ods-warning` dot
- *     lights up when a support reply lands (server-stamped unread predicate);
- *   - live drawer/list updates via stream-driven query invalidation — no
- *     client-side polling anywhere.
+ * Realtime is APP-WIDE, not page-local: `TicketLiveProvider` is mounted in
+ * app-providers.tsx, and the unread indication renders in the SHARED lib
+ * header (`HeaderConfig.tickets` → TicketAlertsButton in app-shell.tsx) —
+ * count pill when replies are unread, deep-link to the newest-unread ticket,
+ * live drawer/list updates via stream-driven invalidation. This page is just
+ * the destination surface.
  */
 export function TicketsPage() {
-  return (
-    <TicketLiveProvider>
-      {/* Minimal header strip demonstrating the unified alerts cell — real
-          hosts mount it inside their header shell (hub `HeaderConfig.tickets`,
-          console `AppHeader.showTicketAlerts`). */}
-      <div className="flex h-14 items-center justify-end border-b border-ods-border">
-        <TicketAlertsButton href="/tickets" className="border-l border-ods-border" />
-      </div>
-      <HelpCenterList />
-    </TicketLiveProvider>
-  )
+  return <HelpCenterList />
 }

--- a/react-embedding-example/src/pages/tickets.tsx
+++ b/react-embedding-example/src/pages/tickets.tsx
@@ -1,11 +1,33 @@
-import { HelpCenterList } from '@flamingo-stack/openframe-frontend-core/components/tickets'
+import { TicketAlertsButton } from '@flamingo-stack/openframe-frontend-core/components/navigation'
+import {
+  HelpCenterList,
+  TicketLiveProvider,
+} from '@flamingo-stack/openframe-frontend-core/components/tickets'
 
 /**
  * HelpCenterList composes the lib's DevSectionPage chrome + create form + ticket
  * list internally, and identifies the (proxy-injected) customer via ChatRuntime.
- * Its hooks currently call bare `/api/chat/agent/*`, covered by the dev-only proxy
- * fallback in vite.config.ts until the optional lib `agentBaseUrl` seam lands.
+ * All six ticket endpoints (reads/writes + live stream + unread state) come from
+ * `runtime.endpoints` (see content-runtime.ts / EP).
+ *
+ * `TicketLiveProvider` demonstrates the realtime layer end-to-end:
+ *   - SSE subscription to `EP.ticketStream` (fetch-based reader — carries the
+ *     embed auth adapter's bearer, which `EventSource` cannot);
+ *   - a header-style `TicketAlertsButton` cell whose `bg-ods-warning` dot
+ *     lights up when a support reply lands (server-stamped unread predicate);
+ *   - live drawer/list updates via stream-driven query invalidation — no
+ *     client-side polling anywhere.
  */
 export function TicketsPage() {
-  return <HelpCenterList />
+  return (
+    <TicketLiveProvider>
+      {/* Minimal header strip demonstrating the unified alerts cell — real
+          hosts mount it inside their header shell (hub `HeaderConfig.tickets`,
+          console `AppHeader.showTicketAlerts`). */}
+      <div className="flex h-14 items-center justify-end border-b border-ods-border">
+        <TicketAlertsButton href="/tickets" className="border-l border-ods-border" />
+      </div>
+      <HelpCenterList />
+    </TicketLiveProvider>
+  )
 }

--- a/react-embedding-example/src/providers/app-providers.tsx
+++ b/react-embedding-example/src/providers/app-providers.tsx
@@ -11,6 +11,7 @@ import {
 } from '@flamingo-stack/openframe-frontend-core/contexts'
 import { ChatIdentityProvider } from '@flamingo-stack/openframe-frontend-core/components/chat'
 import { RichMarkdownRuntimeProvider } from '@flamingo-stack/openframe-frontend-core/components/embeds'
+import { TicketLiveProvider } from '@flamingo-stack/openframe-frontend-core/components/tickets'
 import { buildChatRuntime, buildEndpointsRuntime } from './content-runtime'
 import { EP } from '../config/endpoints'
 
@@ -39,7 +40,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
               twitterProxyUrl={EP.twitterProxy}
               ogScraperUrl={EP.ogScraper}
             >
-              {children}
+              {/* Ticket realtime + unread state, app-wide: ONE SSE
+                  subscription (EP.ticketStream) feeds the shared header's
+                  TicketAlertsButton AND the /tickets page. Mounted inside
+                  ChatIdentityProvider (streams only for authed identities)
+                  and the runtime contexts (reads endpoints). */}
+              <TicketLiveProvider>{children}</TicketLiveProvider>
             </RichMarkdownRuntimeProvider>
           </EndpointsRuntimeContext.Provider>
         </ChatIdentityProvider>

--- a/react-embedding-example/src/providers/content-runtime.ts
+++ b/react-embedding-example/src/providers/content-runtime.ts
@@ -54,6 +54,16 @@ export function buildChatRuntime(): Omit<ChatRuntime, 'source'> {
       attachmentViewUrlPrefix: EP.attachmentViewPrefix,
       identityUrl: EP.identity,
       imageProxyUrlPrefix: EP.imageProxy,
+      // Help Center tickets — reads/writes + live stream + unread state,
+      // all proxied under `/content` like every other endpoint (the bare
+      // `/api/chat/agent/*` fallback in vite.config.ts is no longer relied
+      // on for tickets).
+      findTicketUrl: EP.findTicket,
+      ticketActionUrl: EP.ticketAction,
+      listEngagementsUrl: EP.listEngagements,
+      ticketStreamUrl: EP.ticketStream,
+      ticketReadUrl: EP.ticketRead,
+      ticketUnreadSummaryUrl: EP.ticketUnreadSummary,
     },
     navigation: {
       // 'host' = this app owns routing. react-router is registered into the lib's

--- a/react-embedding-example/src/providers/content-runtime.ts
+++ b/react-embedding-example/src/providers/content-runtime.ts
@@ -63,7 +63,6 @@ export function buildChatRuntime(): Omit<ChatRuntime, 'source'> {
       listEngagementsUrl: EP.listEngagements,
       ticketStreamUrl: EP.ticketStream,
       ticketReadUrl: EP.ticketRead,
-      ticketUnreadSummaryUrl: EP.ticketUnreadSummary,
     },
     navigation: {
       // 'host' = this app owns routing. react-router is registered into the lib's

--- a/react-embedding-example/vite.config.ts
+++ b/react-embedding-example/vite.config.ts
@@ -20,11 +20,12 @@ export default defineConfig(({ mode }) => {
   const proxy = {
     // Canonical namespace: /content/api/* → ${HUB_ORIGIN}/api/* .
     [CONTENT_PREFIX]: { ...inject, rewrite },
-    // Dev-only fallback for the two surfaces whose lib hooks still hardcode bare /api
-    // (the onboarding catalog's in-view doc-search + the tickets hooks). Forwarded as-is.
-    // Drop these once the optional lib seam (catalog searchEndpoint + tickets agentBaseUrl) lands.
+    // Dev-only fallback for the ONE surface whose lib hook still hardcodes a bare /api
+    // path (the onboarding catalog's in-view doc-search). Forwarded as-is; drop once
+    // the catalog's optional searchEndpoint seam lands. (The tickets fallback that
+    // used to sit beside it is GONE — all six ticket endpoints now flow through
+    // `runtime.endpoints` → /content, see content-runtime.ts.)
     '/api/docs/search': inject,
-    '/api/chat/agent': inject,
   }
   return {
     plugins: [react()],


### PR DESCRIPTION
## What

The shared-lib half of the support-ticket realtime feature (pairs with the multi-platform-hub PR):

- **`TicketLiveProvider`** (`components/tickets/ticket-live-provider.tsx`) — the ONE client home for ticket realtime: SSE subscription over `ChatRuntime.endpoints.ticketStreamUrl`, `connected` derived from server `status` frames (never HTTP-open), resync-on-every-(re)connect, visibility gating (45s hidden grace), single unread summary map (badge total + row dots), `markRead` with local write-through zeroing, debounced query invalidation.
- **`createSseSubscription`** (`utils/sse-subscription.ts`, exported from `./utils`) — THE common SSE client: fetch-based (carries the embed auth adapter's bearer, which `EventSource` cannot), standard frame parsing, comment-keepalives reset the 45s silence timer, never-terminating capped backoff, terminal 4xx + distinct `no-stream` (204) statuses. The hub's old EventSource-based `sse-client.ts` is deleted in the hub PR; its hooks migrated onto this.
- **Client-side ticket polling DELETED** — `TICKET_LIVE_POLL_MS` and every `refetchInterval` consumer removed (unify-means-delete). Live freshness is push-driven; `refetchOnMount`/`refetchOnWindowFocus` remain the no-stream fallback.
- **Unified header indication** — shared `UnreadDot` + `showUnreadDot` on `HeaderButton` (NotificationsHeaderButton + sidebar refactored onto it, no third copy), new `TicketAlertsButton`, `AppHeader.showTicketAlerts` + `HeaderConfig.tickets` slots.
- **Wire contracts** — `TicketStreamEvent` / `TicketUnreadSummary` in `components/tickets/types.ts` (hub imports them; same producer/consumer SSOT pattern as `ConversationEngagementWire`); three new optional `ChatRuntime` endpoints (`ticketStreamUrl`, `ticketReadUrl`, `ticketUnreadSummaryUrl`).
- **`react-embedding-example`** — all six ticket endpoints in `EP`, threaded through the runtime, tickets page demos the provider + alerts cell.

## Notes

- Frames carry metadata only (never bodies); content always refetches through the ACL'd `list-engagements` path.
- Unread bumps happen only on the server-stamped `countsAsUnread` predicate — clients never re-derive author/visibility classification.
- Disclosed trade-off of polling deletion: bare status/property changes (agent closes without replying) have no live path until the next event/focus/reconnect.
- Type-check: clean (`npx tsc --noEmit`).
- After merge: cut a release and bump the hub + console pins (hub PR builds against the published lib until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time support-ticket updates, unread summaries, and ticket alerts in the header.
  * Added unread indicators to ticket cards, navigation buttons, and sidebar items.
  * Added direct links to the newest unread ticket.
  * Ticket drawers now mark conversations as read and refresh engagement activity automatically.
* **Improvements**
  * Replaced interval-based refreshing with live updates and refresh-on-focus or reconnect behavior.
  * Added resilient reconnection handling for real-time ticket events.
* **Documentation**
  * Updated endpoint and integration guidance for ticket streaming, read status, and unread summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->