### PR TITLE
fix(meeting-scheduler): keep host avatars visible on mobile directory rows

### DIFF
--- a/openframe-frontend-core/src/components/meeting-scheduler/directory.tsx
+++ b/openframe-frontend-core/src/components/meeting-scheduler/directory.tsx
@@ -107,7 +107,10 @@ function DirectoryRow({
           <StatusBadge text={`For ${audienceLabel}`} singleLine className="shrink-0 hidden sm:inline-flex" />
         )}
 
-        <AvatarStack people={link.hosts} max={3} size="md" className="hidden sm:flex shrink-0" />
+        {/* Hosts stay visible on mobile too — the facepile is the row's "who
+            you're booking with" signal; only the chip and next-available meta
+            collapse on narrow widths. */}
+        <AvatarStack people={link.hosts} max={3} size="md" className="flex shrink-0" />
 
         <div className="hidden md:flex w-44 shrink-0 flex-col items-end justify-center">
           <p className="text-h6 text-ods-text-secondary">Next available</p>
@@ -134,7 +137,7 @@ export function MeetingSchedulerDirectoryRowSkeleton() {
         <Skeleton className="h-4 w-1/3" />
       </div>
       <Skeleton className="hidden sm:block h-6 w-28 shrink-0" />
-      <Skeleton className="hidden sm:block h-10 w-10 shrink-0 rounded-full" />
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
       <div className="hidden md:flex w-44 shrink-0 flex-col items-end gap-1">
         <Skeleton className="h-4 w-24" />
         <Skeleton className="h-5 w-32" />


### PR DESCRIPTION
Mobile directory rows on `/schedule-a-call` dropped the host facepile (`AvatarStack` was `hidden sm:flex`), leaving no "who you're booking with" signal on phones. Keep the avatars visible at every width — only the audience chip and the next-available meta still collapse on narrow screens. Skeleton row updated for 1:1 parity (avatar circle no longer hidden on mobile).

Requested from the flamingo mobile screenshot review, 2026-08-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host avatars in meeting directory rows are now visible on mobile devices.
  * Loading placeholders for host avatars now appear consistently across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->