### PR TITLE
Resolve chat-card, doc-anchor and search links through one seam

### DIFF
--- a/openframe-frontend-core/src/components/chat/__tests__/remark-mention-chips.test.ts
+++ b/openframe-frontend-core/src/components/chat/__tests__/remark-mention-chips.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import type { Root, Text, Link, Paragraph } from 'mdast'
+import { remarkMentionChips } from '../remark-mention-chips'
+
+/** One-paragraph tree holding a single text leaf — what the plugin walks. */
+function treeOf(text: string): Root {
+  return { type: 'root', children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }] }
+}
+
+function run(text: string): Array<Text | Link> {
+  const tree = treeOf(text)
+  ;(remarkMentionChips() as (t: Root) => void)(tree)
+  return (tree.children[0] as Paragraph).children as Array<Text | Link>
+}
+
+/** `mention://marker:id` urls the plugin emitted, in order. */
+function mentions(text: string): string[] {
+  return run(text).flatMap((n) => (n.type === 'link' ? [n.url] : []))
+}
+
+describe('remarkMentionChips markers', () => {
+  it('parses the lowercase markers', () => {
+    expect(mentions('see @device:64f0a1 and @kb:5')).toEqual([
+      'mention://device:64f0a1',
+      'mention://kb:5',
+    ])
+  })
+
+  it('parses a camelCase marker', () => {
+    // Regression: `ContextItemType.SCHEDULED_SCRIPT` ships as `scheduledScript`,
+    // and a lowercase-only grammar matched NOTHING in the token — the mention
+    // silently stayed raw text in the bubble instead of becoming a chip.
+    expect(mentions('run @scheduledScript:6a6c9342f8e10b2477900c08 now')).toEqual([
+      'mention://scheduledScript:6a6c9342f8e10b2477900c08',
+    ])
+  })
+
+  it('keeps the surrounding text intact around a camelCase mention', () => {
+    const parts = run('run @scheduledScript:6a6c9342f8e10b2477900c08 now')
+    expect(parts.map((n) => (n.type === 'text' ? n.value : `[${(n as Link).url}]`))).toEqual([
+      'run ',
+      '[mention://scheduledScript:6a6c9342f8e10b2477900c08]',
+      ' now',
+    ])
+  })
+
+  it('fires inside punctuation but never mid-word', () => {
+    expect(mentions('(@scheduledScript:6a6c9342f8e10b2477900c08)')).toEqual([
+      'mention://scheduledScript:6a6c9342f8e10b2477900c08',
+    ])
+    // An email-shaped host:port is not a mention — the `@` is preceded by a word char.
+    expect(mentions('mail user@Host:1234 stays text')).toEqual([])
+  })
+
+  it('leaves a trailing sentence period out of the id', () => {
+    expect(mentions('ran @scheduledScript:6a6c9342f8e10b2477900c08.')).toEqual([
+      'mention://scheduledScript:6a6c9342f8e10b2477900c08',
+    ])
+  })
+})

--- a/openframe-frontend-core/src/components/chat/__tests__/remark-mention-chips.test.ts
+++ b/openframe-frontend-core/src/components/chat/__tests__/remark-mention-chips.test.ts
@@ -7,9 +7,16 @@ function treeOf(text: string): Root {
   return { type: 'root', children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }] }
 }
 
+/**
+ * unified's `Plugin` type declares a `this: Processor` parameter, so calling the
+ * attacher bare (outside a pipeline) is a TS2684 — cast the attacher itself, not
+ * just its return value, to drop that `this`.
+ */
+const attach = remarkMentionChips as unknown as () => (t: Root) => void
+
 function run(text: string): Array<Text | Link> {
   const tree = treeOf(text)
-  ;(remarkMentionChips() as (t: Root) => void)(tree)
+  attach()(tree)
   return (tree.children[0] as Paragraph).children as Array<Text | Link>
 }
 

--- a/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-enhanced.tsx
@@ -27,8 +27,9 @@ import type { MessageSegment, MessageContent, ChatMessageEnhancedProps } from ".
  *  (e.g. it matches `x@device:1` mid-word, which the plugin skips), so a context
  *  item would be stripped from the chip strip yet never rendered inline — lost
  *  from display entirely. The id is capture group 2 (group 1 is the boundary).
- *  Marker lowercase; id is the mention-token charset. */
-const MENTION_MARKER_REGEX = /(^|[^\w@])@[a-z]+:([A-Za-z0-9_.+/=-]*[A-Za-z0-9_+/=])/g
+ *  Marker `[a-zA-Z]+` (markers are mostly lowercase but not all — e.g.
+ *  `scheduledScript`); id is the mention-token charset. */
+const MENTION_MARKER_REGEX = /(^|[^\w@])@[a-zA-Z]+:([A-Za-z0-9_.+/=-]*[A-Za-z0-9_+/=])/g
 
 /**
  * Same regex shape as `remarkCardLinks` — kept in lockstep so the

--- a/openframe-frontend-core/src/components/chat/chat-message-list.tsx
+++ b/openframe-frontend-core/src/components/chat/chat-message-list.tsx
@@ -6,6 +6,7 @@ import { cn } from "../../utils/cn"
 import { ChatMessageEnhanced } from "./chat-message-enhanced"
 import { ChatMessageListSkeleton } from "./chat-message-skeleton"
 import { DotsLoaderIcon, Arrow02DownIcon } from "../icons-v2-generated"
+import { OverlayOpenRegistryProvider } from "../ui/overlay-open-registry"
 import { CyclingPhrase } from "./cycling-phrase"
 import type { ChatMessageListProps } from "./types"
 import { SCROLL_ANCHOR } from "./types/message.types"
@@ -141,10 +142,44 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     // effect below owns first-paint positioning so re-opening a chat
     // with prior history lands at the bottom without a smooth-scroll
     // animation playing over the cold-paint.
-    const { scrollRef, contentRef, scrollToBottom, stopScroll } = useStickToBottom({
-      resize: 'smooth',
-      initial: false,
-    })
+    const { scrollRef, contentRef, scrollToBottom, stopScroll, isAtBottom } =
+      useStickToBottom({
+        resize: 'smooth',
+        initial: false,
+      })
+
+    // ---- Overlay guard: don't move the ground under an open menu -------
+    // A ⋯ menu inside a bubble stays anchored to its trigger. While a reply
+    // streams in, the follow-the-bottom scroll carries that trigger upward and
+    // drags the menu with it, until the menu sits at the panel edge detached
+    // from its card. So: while any overlay in this thread is open, stop
+    // chasing the bottom (the same thing ChatGPT/Claude do once you interact
+    // with the transcript), then catch up on close if we were at the bottom
+    // when it opened. New content still renders — we simply stop scrolling to
+    // it, and the existing "scroll to bottom" affordance stays available.
+    const overlayOpenRef = useRef(false)
+    const wasAtBottomOnOpenRef = useRef(false)
+    const isAtBottomRef = useRef(isAtBottom)
+    isAtBottomRef.current = isAtBottom
+    const handleOverlayOpenChange = useCallback(
+      (hasOpenOverlay: boolean) => {
+        overlayOpenRef.current = hasOpenOverlay
+        if (hasOpenOverlay) {
+          wasAtBottomOnOpenRef.current = isAtBottomRef.current
+          // Cancel any in-flight spring so the thread settles immediately
+          // instead of drifting for another few hundred ms under the menu.
+          stopScroll()
+          return
+        }
+        // Closed again: resume only if the reader was pinned to the bottom
+        // before opening it. Someone who had scrolled up to read history keeps
+        // their position.
+        if (wasAtBottomOnOpenRef.current) {
+          void scrollToBottom({ animation: 'smooth' })
+        }
+      },
+      [scrollToBottom, stopScroll],
+    )
 
     // ---- Prepend / load-more state (NOT owned by the library) --------
     const sentinelRef = useRef<HTMLDivElement>(null)
@@ -263,7 +298,12 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
         const prevLastIdx = prevLastId ? messages.findIndex((m) => m.id === prevLastId) : -1
         const newSlice = prevLastIdx >= 0 ? messages.slice(prevLastIdx + 1) : messages.slice(prevCount)
         const hasNewUser = newSlice.some((m) => m.role === 'user')
-        if (hasNewUser) {
+        // An open overlay suppresses even this one: `ignoreEscapes` would yank
+        // the thread out from under it — and with it the follow intent, which
+        // would re-assert the jump on every later resize. A user who just sent
+        // a message with a menu open is rare; a menu jumping away mid-click is
+        // not worth it.
+        if (hasNewUser && !overlayOpenRef.current) {
           // Arms the follow intent for the WHOLE turn: the answer's
           // async growth (attachment images, streamed tokens, entity
           // cards resolving out of their skeletons long after the
@@ -657,6 +697,8 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
 
     useLayoutEffect(() => {
       if (!autoScroll) return
+      // Top-anchored display turns also move the ground — same guard.
+      if (overlayOpenRef.current) return
       const last = messages[messages.length - 1]
       if (!last || last.role !== 'assistant' || last.scrollAnchor !== SCROLL_ANCHOR.TOP) return
       // Metadata frame arrives BEFORE body. Wait for content so we don't
@@ -847,6 +889,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
       !(pendingApprovals && pendingApprovals.length > 0)
 
     return (
+      <OverlayOpenRegistryProvider onOpenChange={handleOverlayOpenChange}>
       <div className="flex-1 min-h-0 flex flex-col">
         {/* Positioning box for the jump-to-bottom button: it wraps ONLY the
             scroller, so `absolute bottom-…` really is the scroller's lower
@@ -1029,6 +1072,7 @@ const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
           </div>
         )}
       </div>
+      </OverlayOpenRegistryProvider>
     )
   },
 )

--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -52,7 +52,7 @@ import { MingoHistoryRail } from './mingo-history-rail'
 import { GuideWelcome, type GuideWelcomeProps } from './guide-welcome'
 import { accentFromIdentityIcon, getAgentAccent } from './quick-action-chip'
 import { GuideModeBanner } from './guide-mode-banner'
-import { PortalContainerContext } from '../ui/portal-container'
+import { CollisionBoundaryContext, PortalContainerContext } from '../ui/portal-container'
 import { ChatPanelHeader, type ChatPanelHeaderProps } from './chat-panel-header'
 import { SquareAvatar } from '../ui/square-avatar'
 import { ChatHeaderIconButton } from './chat-header-icon-button'
@@ -1795,6 +1795,13 @@ function EmbeddableChatInner({
 
   // Host node for in-panel Radix portals (see the body wrapper below).
   const [portalHost, setPortalHost] = useState<HTMLDivElement | null>(null)
+  // The panel element itself, published as the COLLISION boundary for overlays
+  // opened inside it. Radix otherwise collides against the viewport, so a ⋯ menu
+  // near the top of the thread flips upward past the panel and renders over the
+  // app header (reported: an entity card's menu landing in the top-right corner,
+  // detached from its card). `portalHost` can't serve here — it is
+  // `display: contents` and has no box to measure.
+  const [panelBoundary, setPanelBoundary] = useState<HTMLDivElement | null>(null)
 
   // ── Split (wide) Mingo layout ─────────────────────────────────────────────
   // The panel measures its own width and, in Mingo mode, promotes the inline
@@ -1815,6 +1822,14 @@ function EmbeddableChatInner({
     ro.observe(el)
     setPanelWidth(el.clientWidth)
     return () => ro.disconnect()
+  }, [])
+
+  // One ref for two consumers: the width measurement above (a plain ref, read
+  // once on mount) and the collision-boundary context (state, so provider
+  // consumers re-render once the node exists).
+  const setPanelNode = useCallback((node: HTMLDivElement | null) => {
+    panelMeasureRef.current = node
+    setPanelBoundary(node)
   }, [])
 
   // Rail collapse toggle (Figma ⟶| control), persisted so it survives the
@@ -2003,6 +2018,7 @@ function EmbeddableChatInner({
   // document root. See `PortalContainerContext`.
   const body = (
         <PortalContainerContext.Provider value={portalHost}>
+         <CollisionBoundaryContext.Provider value={panelBoundary}>
             {/* Panel surface depends on state (Figma):
                   • Narrow "Current Chats" LIST + FULL-PANEL archive page → grey
                     `ods-card` (#212121) — matching the grey rail those lists live
@@ -2017,7 +2033,7 @@ function EmbeddableChatInner({
                 grey), so the chat block on the right must keep the conversation's
                 dark surface instead of following the archive. */}
             <div
-              ref={panelMeasureRef}
+              ref={setPanelNode}
               className={`flex h-full flex-col overflow-hidden transition-colors duration-200 ${
                 (archiveOpen && !splitActive) || stackedListView
                   ? 'bg-ods-card'
@@ -2587,6 +2603,7 @@ function EmbeddableChatInner({
             {/* Portal target for in-panel Radix overlays — `display: contents`
                 so it adds no box; content is positioned `fixed` by Radix. */}
             <div ref={setPortalHost} style={{ display: 'contents' }} />
+         </CollisionBoundaryContext.Provider>
           </PortalContainerContext.Provider>
   )
 

--- a/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
@@ -36,6 +36,7 @@ import type { ChatRef } from '../chat-ref.types'
 import { useChatCardItem } from '../hooks/use-chat-card-item'
 import { handleChatNavClick } from '../utils/nav-click-handler'
 import { resolveSourceRowCTA, resolveSourceIcon, sourceRowCtxFromRuntime } from '../utils/source-row-cta'
+import { resolveFetchedCardHref, readFetchedCardTitle } from '../utils/resolve-fetched-card-href'
 import { resolveHrefForRuntime } from '../utils/chat-nav-resolution'
 import {
   computeIsNewTab,
@@ -1000,8 +1001,15 @@ type ChatCardRegistryEntry =
        *  resolved ref — so the wrapper sees a non-null `href`, the
        *  pre-computed `isNewTab` reflects the actual destination, and
        *  the click goes through `handleChatNavClick` (no silent
-       *  bypass of embed-mode / close-on-nav). */
+       *  bypass of embed-mode / close-on-nav). Takes precedence over the
+       *  `composeContentUrl` fallback below. */
       fallbackHref?: (item: any) => string | null
+      /** Opt OUT of the post-fetch `composeContentUrl` fallback (see
+       *  `resolveFetchedCardHref`). Set for types with NO public destination
+       *  — the seam would otherwise synthesize `<contentOrigin>/<type>/<id>`
+       *  from its default branch and hand the user a 404. Types with a real
+       *  route (hosted, or covered by a host `override`) leave it unset. */
+      noComposedHref?: boolean
     }
 
 interface FinancialCardConfig {
@@ -1106,6 +1114,8 @@ interface RoadmapEntryConfig {
   label: string
   cardType: RoadmapCardType
   contentRefType: string
+  /** See `ChatCardRegistryEntry.noComposedHref`. */
+  noComposedHref?: boolean
 }
 const ROADMAP_CARD_CONFIGS: Record<string, RoadmapEntryConfig> = {
   roadmap_item: { label: 'Roadmap item', cardType: 'roadmap_item', contentRefType: 'roadmap_item' },
@@ -1118,6 +1128,9 @@ const ROADMAP_CARD_CONFIGS: Record<string, RoadmapEntryConfig> = {
     label: 'Internal task',
     cardType: 'internal_task',
     contentRefType: 'internal_task',
+    // Internal ClickUp work has no public destination on any platform — the
+    // seam's default branch would synthesize `<hub>/internal_task/<id>`.
+    noComposedHref: true,
   },
 }
 function roadmapRegistryEntries(): Record<string, ChatCardRegistryEntry> {
@@ -1128,6 +1141,7 @@ function roadmapRegistryEntries(): Record<string, ChatCardRegistryEntry> {
       label: cfg.label,
       contentRefType: cfg.contentRefType,
       bareInline: true,
+      ...(cfg.noComposedHref ? { noComposedHref: true } : {}),
       skeleton: () => <RoadmapCardSkeleton size="sm" />,
       render: (item, chatRef, opts) => (
         <RoadmapChatCard
@@ -1420,6 +1434,17 @@ function ChatCardNavWrap({
   const onClickCapture = (e: React.MouseEvent<HTMLElement>) => {
     if (!href) return
     const targetEl = e.target as HTMLElement
+    // Only claim clicks that physically happened INSIDE this card.
+    //
+    // The card's "⋯" menu renders through a React PORTAL: its DOM lives in the
+    // panel's portal host, but React still bubbles its events through this
+    // subtree — so this capture handler sees them first and, being a capture
+    // phase, runs BEFORE the menu row's own `stopPropagation`. That swallowed
+    // the menu's trailing "↗ Open in new tab" button: `executeNavigation`
+    // called `preventDefault()` and routed the card's href in the SAME tab,
+    // so the anchor's `target="_blank"` never applied.
+    const host = e.currentTarget as HTMLElement | null
+    if (!host?.contains(targetEl)) return
     // Buttons rendered INSIDE the card's outer `<a>` (e.g. RoadmapCard
     // vote buttons, ImageGallery thumbnails) bubble up with
     // `closest('a')` truthy — without this guard, clicking them would
@@ -1522,18 +1547,54 @@ export function ChatCardLoader({
   )
   if (!entry) return null
 
-  // Apply per-type fallback URL AFTER fetch (e.g. campaign → /admin/...).
+  // Apply the post-fetch URL fallback (the ref carried no `externalUrl`).
   // We mutate `resolvedChatRef.url` BEFORE computing isNewTab so the
   // wrapper's interceptor sees the destination the user will actually
   // visit. `safeHref` blocks `javascript:` / `data:` payloads even
   // though the registry callers compose hub-internal strings today.
-  const finalChatRef: ChatRef =
+  //
+  // Two sources, in order:
+  //   1. the registry's per-type `fallbackHref` — an explicit non-content
+  //      destination (marketing campaign → `/admin/...`);
+  //   2. the host's `composeContentUrl` seam via `resolveFetchedCardHref` —
+  //      the SAME resolver page cards and SSE chat cards go through. This is
+  //      what makes Mingo/NATS cards clickable: that transport ships bare
+  //      `[card://type:id]` markers with no refs metadata, so the ref reaches
+  //      us with `url: null` and `resolveSourceRowCTA` has nothing to route.
+  const composedHref =
+    fetchEntry && !resolvedChatRef.url && item && !fetchEntry.fallbackHref && !fetchEntry.noComposedHref
+      ? resolveFetchedCardHref({
+          contentRefType: fetchEntry.contentRefType,
+          id: resolvedChatRef.id,
+          item,
+          composeContentUrl: runtime.composeContentUrl,
+        })
+      : null
+  const hrefResolvedChatRef: ChatRef =
     fetchEntry && !resolvedChatRef.url && item && fetchEntry.fallbackHref
       ? {
           ...resolvedChatRef,
           url: safeHref(fetchEntry.fallbackHref(item)),
         }
-      : resolvedChatRef
+      : composedHref
+        ? {
+            ...resolvedChatRef,
+            url: safeHref(composedHref.href),
+            targetPlatform: composedHref.targetPlatform ?? resolvedChatRef.targetPlatform ?? null,
+          }
+        : resolvedChatRef
+
+  // Title enrichment, same synthetic-ref gap as the href above: a Mingo
+  // `[card://type:id]` marker produces `title: <id>` because the transport
+  // ships no ref metadata. Downstream consumers that read `ref.title` — most
+  // visibly the "Ask Mingo" prompt, which would otherwise send
+  // "Tell me more about 86ad3qvv5" — get the row's real title once it loads.
+  // A ref that already carries a distinct title (the SSE path) is untouched.
+  const fetchedTitle = fetchEntry && item ? readFetchedCardTitle(item) : null
+  const finalChatRef: ChatRef =
+    fetchedTitle && (!hrefResolvedChatRef.title || hrefResolvedChatRef.title === hrefResolvedChatRef.id)
+      ? { ...hrefResolvedChatRef, title: fetchedTitle }
+      : hrefResolvedChatRef
 
   // Pre-compute new-tab decision ONCE here (the same rule chips use).
   // Render branches that pass `target` / `rel` to their card pull this

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -56,6 +56,7 @@ import { createChatDialogStore, DEFAULT_DIALOG_SIDE } from '../stream/chat-dialo
 import { useChatStreamReducer } from '../stream/use-chat-stream-reducer'
 import { processHistoricalMessagesWithErrors } from '../utils/process-historical-messages'
 import { extractIncompleteTailState } from '../utils/extract-incomplete-message-state'
+import { buildDiscussPrompt } from '../utils/discuss-ref-prompt'
 import type {
   ChunkData,
   FetchChunksFunction,
@@ -1076,10 +1077,26 @@ export function useNatsChatAdapter(
     [],
   )
 
-  // No-op refs — Mingo agent has no RAG entity-card affordances.
-  const discussRef = useCallback((_ref: ChatRef) => {
-    /* no-op in Mingo mode */
-  }, [])
+  // "Ask Mingo" on an inline entity card. The agent transport has NO
+  // entity-id-filtered retrieval (its `ContextItemType` enum covers DEVICE /
+  // SCRIPT / TICKET / ORGANIZATION / USER / KB_ARTICLE / POLICY / QUERY /
+  // SCHEDULED_SCRIPT — no content types), so unlike the SSE path there is no
+  // `commandOverride.entityIdFilter` to send: the prompt carries the type + id
+  // as text and the agent resolves the row itself. Same sentence as guide mode
+  // (shared builder) so the affordance reads identically in both.
+  //
+  // This used to be a no-op, which made the card's "Ask Mingo" menu item dead
+  // in Mingo mode. Swap `includeReference` for a structured filter once the
+  // agent backend accepts one.
+  const discussRef = useCallback(
+    (reference: ChatRef) => {
+      const prompt = buildDiscussPrompt(reference, { includeReference: true })
+      void sendMessage(prompt)
+    },
+    [sendMessage],
+  )
+  // Display stays a no-op: it dispatches a `/…  display "<x>"` slash command,
+  // and the agent transport has no slash-command registry.
   const displayRef = useCallback((_ref: ChatRef) => {
     /* no-op in Mingo mode */
   }, [])

--- a/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-nats-chat-adapter.ts
@@ -1091,7 +1091,14 @@ export function useNatsChatAdapter(
   const discussRef = useCallback(
     (reference: ChatRef) => {
       const prompt = buildDiscussPrompt(reference, { includeReference: true })
-      void sendMessage(prompt)
+      // Menu-item click, so there is no composer promise for the rejection to
+      // surface through — a bare `void` would leave it unhandled. Logged in the
+      // same shape as `stopMessage`'s. NOTE: recovering the optimistic rows and
+      // the stuck `thinking` phase after a failed publish is a `sendMessage`
+      // concern (it affects composer sends identically) and is not done here.
+      void sendMessage(prompt).catch((err) => {
+        console.error('[useNatsChatAdapter] discussRef send failed:', err)
+      })
     },
     [sendMessage],
   )

--- a/openframe-frontend-core/src/components/chat/hooks/use-sse-chat-adapter.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-sse-chat-adapter.ts
@@ -67,6 +67,7 @@ import {
 } from '../utils/chat-conversation-storage'
 import { useChatHistoryHydration } from './use-chat-history-hydration'
 import { sanitizeTitleForChat } from '../utils/slash-dispatch-utils'
+import { buildDiscussPrompt } from '../utils/discuss-ref-prompt'
 import { defaultTableIdForDocumentType } from '../utils/source-icons'
 import type { WireCommandOverride } from '../utils/slash-dispatch-utils'
 import type { ChatAttachment } from '../utils/chat-attachment-markdown'
@@ -657,9 +658,10 @@ export function useSseChatAdapter(
       }
       // RETRIEVAL IS STRICTLY PRIMARY-KEY-DRIVEN. The visible prose
       // ("Tell me more about <title>") is UX-only; retrieval narrows
-      // via `entityIdFilter` before the LLM is invoked.
-      const sanitizedTitle = sanitizeTitleForChat(reference.title)
-      const prompt = `Tell me more about ${sanitizedTitle || 'this item'}`
+      // via `entityIdFilter` before the LLM is invoked. The sentence itself
+      // comes from the shared builder so the Mingo transport (which has no
+      // id filter and leans on the prose) phrases it identically.
+      const prompt = buildDiscussPrompt(reference)
       sendMessage(prompt, {
         commandOverride: { entityIdFilter: { tableId, id: refId } },
       })

--- a/openframe-frontend-core/src/components/chat/remark-mention-chips.ts
+++ b/openframe-frontend-core/src/components/chat/remark-mention-chips.ts
@@ -15,9 +15,12 @@
  * intact, and the marker disappears before any rehype-raw HTML pass.
  *
  * Grammar:
- *   - marker: `[a-z]+` — the backend `ContextItemType.marker()` short form
+ *   - marker: `[a-zA-Z]+` — the backend `ContextItemType.marker()` short form
  *     (`device`, `script`, `ticket`, `organization`, `user`, `kb`, `policy`,
- *     `query`, …). Always lowercase.
+ *     `query`, `scheduledScript`, …). Mostly lowercase, but NOT guaranteed to be:
+ *     the marker is matched verbatim by the backend's `MentionParser`, and
+ *     `SCHEDULED_SCRIPT` ships as camelCase `scheduledScript` — a lowercase-only
+ *     grammar silently dropped that whole token (no chip, raw text in the bubble).
  *   - id: charset `[A-Za-z0-9_.+/=-]` (UUIDs with hyphens, fleet numeric ids,
  *     base64 global ids, etc.; matches the composer's `MENTION_TOKEN`) — but the
  *     id may NOT END in `.` or `-`, so a trailing SENTENCE period/dash isn't
@@ -35,7 +38,7 @@ import type { Plugin } from 'unified'
 import type { Root, Text, Link } from 'mdast'
 import { visit, SKIP } from 'unist-util-visit'
 
-const MENTION_REGEX = /(^|[^\w@])@([a-z]+):([A-Za-z0-9_.+/=-]*[A-Za-z0-9_+/=])/g
+const MENTION_REGEX = /(^|[^\w@])@([a-zA-Z]+):([A-Za-z0-9_.+/=-]*[A-Za-z0-9_+/=])/g
 
 export const remarkMentionChips: Plugin<[], Root> = () => {
   return (tree: Root) => {

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/discuss-ref-prompt.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/discuss-ref-prompt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiscussPrompt } from '../discuss-ref-prompt'
+import { readFetchedCardTitle } from '../resolve-fetched-card-href'
+
+const ROADMAP_REF = {
+  type: 'roadmap_item',
+  id: '86ad3qvv5',
+  title: 'Deep Google Workspace tenant management',
+}
+
+describe('buildDiscussPrompt', () => {
+  it('guide/SSE shape — prose only, retrieval rides entityIdFilter', () => {
+    expect(buildDiscussPrompt(ROADMAP_REF)).toBe(
+      'Tell me more about Deep Google Workspace tenant management',
+    )
+  })
+
+  it('Mingo shape — appends the reference the agent has no filter for', () => {
+    expect(buildDiscussPrompt(ROADMAP_REF, { includeReference: true })).toBe(
+      'Tell me more about Deep Google Workspace tenant management (roadmap_item 86ad3qvv5)',
+    )
+  })
+
+  it('a synthetic ref (title === id) never leaks the id as the subject', () => {
+    const synthetic = { type: 'roadmap_item', id: '86ad3qvv5', title: '86ad3qvv5' }
+    expect(buildDiscussPrompt(synthetic, { includeReference: true })).toBe(
+      'Tell me more about this item (roadmap_item 86ad3qvv5)',
+    )
+  })
+
+  it('missing / blank title falls back to "this item"', () => {
+    expect(buildDiscussPrompt({ type: 'blog_post', id: 'b1' })).toBe('Tell me more about this item')
+    expect(buildDiscussPrompt({ type: 'blog_post', id: 'b1', title: '   ' })).toBe(
+      'Tell me more about this item',
+    )
+  })
+
+  it('no id → no reference suffix', () => {
+    expect(buildDiscussPrompt({ type: 'blog_post', id: '', title: 'Hello' }, { includeReference: true })).toBe(
+      'Tell me more about Hello',
+    )
+  })
+})
+
+describe('readFetchedCardTitle — what upgrades a synthetic ref before the prompt', () => {
+  it('prefers title, then name', () => {
+    expect(readFetchedCardTitle({ title: 'Roadmap row' })).toBe('Roadmap row')
+    expect(readFetchedCardTitle({ name: 'Named row' })).toBe('Named row')
+    expect(readFetchedCardTitle({ title: '  ', name: 'Named row' })).toBe('Named row')
+  })
+
+  it('null for rows with neither (and for non-objects)', () => {
+    expect(readFetchedCardTitle({ headline: 'nope' })).toBeNull()
+    expect(readFetchedCardTitle(null)).toBeNull()
+    expect(readFetchedCardTitle('string')).toBeNull()
+    expect(readFetchedCardTitle({ title: 42 })).toBeNull()
+  })
+
+  it('end to end: fetched row title reaches the prompt', () => {
+    const synthetic = { type: 'roadmap_item', id: '86ad3qvv5', title: '86ad3qvv5' }
+    const row = { id: 'db-9', title: 'Deep Google Workspace tenant management' }
+    const enriched = { ...synthetic, title: readFetchedCardTitle(row) ?? synthetic.title }
+    expect(buildDiscussPrompt(enriched, { includeReference: true })).toBe(
+      'Tell me more about Deep Google Workspace tenant management (roadmap_item 86ad3qvv5)',
+    )
+  })
+})

--- a/openframe-frontend-core/src/components/chat/utils/__tests__/resolve-fetched-card-href.test.ts
+++ b/openframe-frontend-core/src/components/chat/utils/__tests__/resolve-fetched-card-href.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { makeComposeContentUrl } from '../../../../utils/content-href'
+import { resolveFetchedCardHref } from '../resolve-fetched-card-href'
+
+const HUB = 'https://www.flamingo.run'
+
+/** The OpenFrame Help Center seam, verbatim in shape from
+ *  `openframe-oss-frontend/src/app/(app)/help-center/help-center-content-href.ts`. */
+const compose = makeComposeContentUrl({
+  hostedTypes: new Set(['onboarding_guide', 'product_release']),
+  contentOrigin: HUB,
+  suffixes: {
+    onboarding_guide: 'help-center/onboarding-guides',
+    product_release: 'help-center/releases',
+    blog_post: 'blog',
+    case_study: 'case-studies',
+  },
+  overrides: {
+    roadmap_item: (id) => ({
+      href: `/help-center/roadmap?search=${encodeURIComponent(id)}`,
+      targetPlatform: null,
+    }),
+  },
+})
+
+describe('resolveFetchedCardHref — Mingo cards with no ref metadata', () => {
+  it('override type deep-links on the MARKER id, not the fetched row id', () => {
+    // The `[card://roadmap_item:86ad3qvv5]` id is the ClickUp task id the
+    // roadmap list filters by; the fetched row carries its own db id.
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'roadmap_item',
+        id: '86ad3qvv5',
+        item: { id: 'db-uuid-9', title: 'Deep Google Workspace tenant management' },
+        composeContentUrl: compose,
+      }),
+    ).toEqual({ href: '/help-center/roadmap?search=86ad3qvv5', targetPlatform: null })
+  })
+
+  it('hosted type uses the fetched row slug for its in-app detail route', () => {
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'product_release',
+        id: 'row-uuid-1',
+        item: { id: 'row-uuid-1', slug: 'v1-2-0' },
+        composeContentUrl: compose,
+      }),
+    ).toEqual({ href: '/help-center/releases/v1-2-0', targetPlatform: null })
+  })
+
+  it('hosted type with no slug falls back to the marker id', () => {
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'onboarding_guide',
+        id: 'guide-7',
+        item: { id: 'guide-7' },
+        composeContentUrl: compose,
+      }),
+    ).toEqual({ href: '/help-center/onboarding-guides/guide-7', targetPlatform: null })
+  })
+
+  it('non-hosted type resolves to the content hub', () => {
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'case_study',
+        id: 'cs-1',
+        item: { id: 'cs-1', slug: 'acme-migration' },
+        composeContentUrl: compose,
+      }),
+    ).toEqual({ href: `${HUB}/case-studies/acme-migration`, targetPlatform: null })
+  })
+
+  it('legacy rail-vocab alias resolves to the SAME url as the canonical type', () => {
+    // The card registry keys blog entries by `blog_post_existing` (what
+    // `buildListUrl` wants). Both spellings must produce one url — the reported
+    // split was `/blog/what-is-mdr` vs `/blog_post_existing/bitwarden-…`.
+    const canonical = resolveFetchedCardHref({
+      contentRefType: 'blog_post',
+      id: 'p1',
+      item: { id: 'p1', slug: 'bitwarden-review-for-msps' },
+      composeContentUrl: compose,
+    })
+    const alias = resolveFetchedCardHref({
+      contentRefType: 'blog_post_existing',
+      id: 'p1',
+      item: { id: 'p1', slug: 'bitwarden-review-for-msps' },
+      composeContentUrl: compose,
+    })
+    expect(alias).toEqual(canonical)
+    expect(alias).toEqual({
+      href: `${HUB}/blog/bitwarden-review-for-msps`,
+      targetPlatform: null,
+    })
+  })
+
+  it('no seam wired → null (card stays unlinked, pre-existing behavior)', () => {
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'roadmap_item',
+        id: '86ad3qvv5',
+        item: { id: '86ad3qvv5' },
+      }),
+    ).toBeNull()
+  })
+
+  it('guards a missing type / id / malformed item', () => {
+    expect(
+      resolveFetchedCardHref({ contentRefType: '', id: 'x', item: {}, composeContentUrl: compose }),
+    ).toBeNull()
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'case_study',
+        id: '',
+        item: {},
+        composeContentUrl: compose,
+      }),
+    ).toBeNull()
+    // A non-object item (or a non-string slug) must not throw — it just loses
+    // the slug hint and falls back to the marker id.
+    expect(
+      resolveFetchedCardHref({
+        contentRefType: 'case_study',
+        id: 'cs-2',
+        item: { slug: 42 },
+        composeContentUrl: compose,
+      }),
+    ).toEqual({ href: `${HUB}/case-studies/cs-2`, targetPlatform: null })
+  })
+})
+
+describe('makeComposeContentUrl — the new `slug` hint', () => {
+  it('externalUrl still wins over the hint (SSE path unchanged)', () => {
+    expect(
+      compose({
+        type: 'product_release',
+        identifier: 'row-uuid-1',
+        slug: 'from-the-row',
+        externalUrl: `${HUB}/releases/from-the-url`,
+      }),
+    ).toEqual({ href: '/help-center/releases/from-the-url', targetPlatform: null })
+  })
+
+  it('applies to non-hosted types too — hub detail routes are slug-based', () => {
+    expect(compose({ type: 'blog_post', identifier: 'id-1', slug: 'hello-world' })).toEqual({
+      href: `${HUB}/blog/hello-world`,
+      targetPlatform: null,
+    })
+  })
+
+  it('no hint → identifier, unchanged for page-view and SSE callers', () => {
+    expect(compose({ type: 'blog_post', identifier: 'hello-world' })).toEqual({
+      href: `${HUB}/blog/hello-world`,
+      targetPlatform: null,
+    })
+  })
+})

--- a/openframe-frontend-core/src/components/chat/utils/discuss-ref-prompt.ts
+++ b/openframe-frontend-core/src/components/chat/utils/discuss-ref-prompt.ts
@@ -1,0 +1,63 @@
+/**
+ * The ONE place the "Ask Mingo" (discuss) prompt for an inline entity card is
+ * composed — shared by every transport so the affordance reads identically
+ * wherever it is clicked.
+ *
+ * ## Why the two transports still differ underneath
+ *
+ * The prose is UX only. What narrows retrieval differs:
+ *
+ *   - **SSE / guide** — `sendMessage(prompt, { commandOverride: { entityIdFilter:
+ *     { tableId, id } } })`. Retrieval is strictly primary-key-driven; the
+ *     sentence is decoration.
+ *   - **Mingo / NATS** — the agent backend has no entity-id-filtered retrieval
+ *     (`ContextItemType` covers DEVICE / SCRIPT / TICKET / ORGANIZATION / USER /
+ *     KB_ARTICLE / POLICY / QUERY / SCHEDULED_SCRIPT — no content types), so the
+ *     prompt is ALL the agent gets. Hence `includeReference`, which appends the
+ *     type + id so the agent can still identify the exact row by text.
+ *
+ * When the backend grows an id-filter for the agent transport, the Mingo callers
+ * switch to it and drop `includeReference` — the prose stays put.
+ */
+
+import { sanitizeTitleForChat } from './slash-dispatch-utils'
+
+export interface DiscussPromptRef {
+  /** documentType, e.g. `'roadmap_item'`. */
+  type: string
+  /** Primary key — the id from the `[card://type:id]` marker. */
+  id: string
+  /** Display title. May be the bare id on a synthetic ref (Mingo). */
+  title?: string | null
+}
+
+export interface BuildDiscussPromptOptions {
+  /**
+   * Append `(<type> <id>)` so a transport WITHOUT structured entity filtering
+   * still points the agent at the exact row. Default `false` — the SSE path
+   * sends `entityIdFilter` and must keep the sentence clean.
+   */
+  includeReference?: boolean
+}
+
+/**
+ * `Tell me more about <title>` — plus `(<type> <id>)` when
+ * `includeReference` is set and the title alone is ambiguous.
+ *
+ * Falls back to `this item` when the ref has no usable title, matching the
+ * long-standing SSE behavior. A title that is just the id (the synthetic ref a
+ * Mingo `[card://…]` marker produces before its row loads) is treated as
+ * missing, so the prompt never degrades to `Tell me more about 86ad3qvv5`.
+ */
+export function buildDiscussPrompt(
+  reference: DiscussPromptRef,
+  options: BuildDiscussPromptOptions = {},
+): string {
+  const id = (reference.id ?? '').trim()
+  const rawTitle = (reference.title ?? '').trim()
+  const usableTitle = rawTitle && rawTitle !== id ? sanitizeTitleForChat(rawTitle) : ''
+  const prompt = `Tell me more about ${usableTitle || 'this item'}`
+  if (!options.includeReference || !id) return prompt
+  // Only worth the noise when the reference adds something the title doesn't.
+  return `${prompt} (${reference.type} ${id})`
+}

--- a/openframe-frontend-core/src/components/chat/utils/index.ts
+++ b/openframe-frontend-core/src/components/chat/utils/index.ts
@@ -196,4 +196,20 @@ export {
   resolveSourceIcon,
 } from './source-row-cta'
 
+// Post-fetch enrichment for the synthetic ChatRef a `[card://type:id]` marker
+// produces when the transport ships no refs metadata (Mingo/NATS).
+export {
+  resolveFetchedCardHref,
+  readFetchedCardTitle,
+  type FetchedCardHrefInput,
+} from './resolve-fetched-card-href'
+
+// The ONE "Ask Mingo" prompt builder — shared by the SSE adapter, the NATS
+// adapter, and hosts that inject their own Mingo state (openframe-frontend).
+export {
+  buildDiscussPrompt,
+  type DiscussPromptRef,
+  type BuildDiscussPromptOptions,
+} from './discuss-ref-prompt'
+
 export * from './scripted-stream'

--- a/openframe-frontend-core/src/components/chat/utils/resolve-fetched-card-href.ts
+++ b/openframe-frontend-core/src/components/chat/utils/resolve-fetched-card-href.ts
@@ -1,0 +1,104 @@
+/**
+ * Post-fetch href fallback for an inline chat card whose `ChatRef` carried no
+ * `externalUrl`.
+ *
+ * ## Why a fetch-mode card can arrive without a URL
+ *
+ * The two chat transports deliver entity references differently:
+ *
+ *   - **SSE / guide transport** — the server ships a `refs` metadata frame, so
+ *     each `[card://type:id]` marker expands into a FULL `ChatRef`
+ *     (`title` / `url` / `targetPlatform` / `sourceRepo`). `resolveSourceRowCTA`
+ *     then routes that `externalUrl` through the host's `composeContentUrl`
+ *     seam and the card is clickable.
+ *   - **Mingo / NATS transport** (`messageData: [{ type: 'GUIDE' | 'TEXT', text }]`)
+ *     — the body carries bare `[card://type:id]` markers and NOTHING else.
+ *     `chat-message-enhanced.tsx` synthesizes a minimal `{ type, id, title: id,
+ *     url: null }` ref so fetch-mode cards can still self-fetch their row, but
+ *     `resolveSourceRowCTA` has no `externalUrl`, no `path` and no
+ *     `targetPlatform` to work with → `href: null` → the card renders with its
+ *     real title and description but goes nowhere when clicked.
+ *
+ * This resolver closes that gap WITHOUT a second URL vocabulary: it calls the
+ * exact same `composeContentUrl` seam the page cards (`resolveContentHref`) and
+ * the SSE cards (`resolveSourceRowCTA`) use, so one host config —
+ * `hostedTypes` / `suffixes` / `overrides` — governs all three.
+ *
+ * `identifier` stays the marker's primary key (that is what `overrides` such as
+ * roadmap's `?search=<task id>` deep-link on); the row's `slug` rides the
+ * separate `slug` hint for hosted types whose detail route is slug-based.
+ *
+ * Pure — no React, no DOM. The caller owns `safeHref` validation.
+ */
+
+import type { ComposeContentUrl } from '../../../utils/content-href'
+import { canonicalContentRefType } from '../../../utils/list-url'
+
+export interface FetchedCardHrefInput {
+  /** Canonical `documentType` for the seam (registry `contentRefType`). */
+  contentRefType: string
+  /** The marker's primary key — `ChatRef.id`, NOT the fetched row's id. */
+  id: string
+  /** The row the card fetched. Shape is per-type and opaque here; only
+   *  `slug` and `platforms` are read, both defensively. */
+  item: unknown
+  /** Host seam. Absent (unwired runtime) → no fallback, same as today. */
+  composeContentUrl?: ComposeContentUrl
+}
+
+/** Read `item.slug` when it is a non-empty string. */
+function readSlug(item: unknown): string | null {
+  if (!item || typeof item !== 'object') return null
+  const slug = (item as { slug?: unknown }).slug
+  return typeof slug === 'string' && slug.trim() ? slug.trim() : null
+}
+
+/**
+ * Human title of a fetched row — `title`, else `name`, else null.
+ *
+ * A Mingo synthetic ref carries `title: <the marker id>` because that is all
+ * the transport shipped. Everything downstream that prints or sends the title
+ * (the "Ask Mingo" prompt, host renderers falling back to `ref.title`) would
+ * otherwise say `86ad3qvv5`. Once the row loads, this is the real title.
+ */
+export function readFetchedCardTitle(item: unknown): string | null {
+  if (!item || typeof item !== 'object') return null
+  for (const key of ['title', 'name'] as const) {
+    const value = (item as Record<string, unknown>)[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+/** Read `item.platforms` when it is an array — the hub composer keys its
+ *  cross-platform topology off it; the embedder default ignores it. */
+function readPlatforms(item: unknown): Array<{ name?: string }> | undefined {
+  if (!item || typeof item !== 'object') return undefined
+  const platforms = (item as { platforms?: unknown }).platforms
+  return Array.isArray(platforms) ? (platforms as Array<{ name?: string }>) : undefined
+}
+
+/**
+ * Resolve `{href, targetPlatform}` for a freshly fetched card row, or `null`
+ * when the host wired no seam (the caller then keeps the card unlinked, which
+ * is the pre-existing behavior).
+ */
+export function resolveFetchedCardHref({
+  contentRefType,
+  id,
+  item,
+  composeContentUrl,
+}: FetchedCardHrefInput): { href: string; targetPlatform: string | null } | null {
+  if (!composeContentUrl || !contentRefType || !id) return null
+  return composeContentUrl({
+    // The card registry keys some entries by the legacy rail vocabulary
+    // (`blog_post_existing`) because that is what `buildListUrl` expects.
+    // The seam speaks the CANONICAL vocabulary — a host's `hostedTypes` /
+    // `overrides` are written against `blog_post`, so an un-aliased type
+    // misses them all and lands on `<origin>/blog_post_existing/<slug>`.
+    type: canonicalContentRefType(contentRefType),
+    identifier: id,
+    slug: readSlug(item),
+    platforms: readPlatforms(item),
+  })
+}

--- a/openframe-frontend-core/src/components/chat/utils/source-row-cta.ts
+++ b/openframe-frontend-core/src/components/chat/utils/source-row-cta.ts
@@ -29,6 +29,7 @@ import { getBaseUrl } from '../../../utils/cn'
 import { safeHref } from './compact-card-classes'
 import type { ChatRef } from '../chat-ref.types'
 import type { ComposeContentUrl } from '../../../utils/content-href'
+import { canonicalContentRefType } from '../../../utils/list-url'
 
 /** Path sanitization — keep alphanumerics, slash, dash, dot, underscore;
  *  strip everything else. Defends against a hostile mapper returning a
@@ -233,7 +234,10 @@ export function resolveSourceRowCTA(
     // from the externalUrl) and everything else to the externalUrl verbatim —
     // the SAME resolver the page-view cards use, so chat + page links match.
     const composed = ctx.composeContentUrl({
-      type: row.documentType,
+      // Canonical vocabulary only — a rail-vocab alias would miss the host's
+      // `hostedTypes` / `overrides` and fall through to the seam's default
+      // `<origin>/<type>/<id>` branch. Same canonicalizer `buildListUrl` uses.
+      type: canonicalContentRefType(row.documentType),
       identifier: idValue,
       externalUrl: row.externalUrl,
       targetPlatform: row.targetPlatform ?? null,

--- a/openframe-frontend-core/src/components/shared/doc-search/__tests__/resolve-search-result-action.test.ts
+++ b/openframe-frontend-core/src/components/shared/doc-search/__tests__/resolve-search-result-action.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { makeComposeContentUrl } from '../../../../utils/content-href'
+import type { SearchResult } from '../../../ui/search-input'
+import { resolveSearchResultAction } from '../resolve-search-result-action'
+
+const HUB = 'https://www.flamingo.run'
+
+/** A RAG row for a guide the hub owns, shaped like `mapDocSearchResults` emits. */
+const guideRow: SearchResult = {
+  id: 'onboarding-guides/deploy-first-device',
+  title: 'Deploy your first device',
+  path: 'onboarding-guides/deploy-first-device',
+  metadata: {
+    documentType: 'onboarding_guide',
+    externalUrl: `${HUB}/onboarding-guides/deploy-first-device`,
+    sourceRepo: 'onboarding-guides',
+    id: 'guide-123',
+    targetPlatform: 'openframe',
+  },
+}
+
+/** The OpenFrame Help Center seam: the two hosted types live under
+ *  `/help-center/...`, list-filter types deep-link with `?search=<id>`. */
+const helpCenterCompose = makeComposeContentUrl({
+  hostedTypes: new Set(['onboarding_guide', 'product_release']),
+  contentOrigin: HUB,
+  suffixes: {
+    onboarding_guide: 'help-center/onboarding-guides',
+    product_release: 'help-center/releases',
+    blog_post: 'blog',
+  },
+  overrides: {
+    delivery_item: (id) => ({ href: `/help-center/bug-fixes?search=${id}`, targetPlatform: null }),
+  },
+})
+
+describe('resolveSearchResultAction — composeContentUrl seam', () => {
+  it('no seam wired → the RAG externalUrl verbatim (legacy behavior)', () => {
+    expect(resolveSearchResultAction(guideRow, 'openframe')).toEqual({
+      kind: 'navigate-same-tab',
+      href: `${HUB}/onboarding-guides/deploy-first-device`,
+    })
+  })
+
+  it('hosted type → the host in-app route, slug recovered from externalUrl', () => {
+    expect(
+      resolveSearchResultAction(guideRow, 'openframe', 'host', helpCenterCompose),
+    ).toEqual({
+      kind: 'navigate-same-tab',
+      href: '/help-center/onboarding-guides/deploy-first-device',
+    })
+  })
+
+  it('relative composed href stays same-tab even in embed mode', () => {
+    // `decideNewTab` forces new-tab under embed; an in-app path must not be
+    // handed to window.open — the short-circuit runs before that decision.
+    expect(
+      resolveSearchResultAction(guideRow, 'openframe', 'embed', helpCenterCompose),
+    ).toEqual({
+      kind: 'navigate-same-tab',
+      href: '/help-center/onboarding-guides/deploy-first-device',
+    })
+  })
+
+  it('override type → the host deep-link, primary key as identifier', () => {
+    const row: SearchResult = {
+      id: 'delivery-1',
+      title: 'Fix the thing',
+      metadata: {
+        documentType: 'delivery_item',
+        externalUrl: `${HUB}/bug-fixes-and-enhancements?search=abc123`,
+        sourceRepo: 'clickup-delivery',
+        id: 'abc123',
+      },
+    }
+    expect(resolveSearchResultAction(row, 'openframe', 'host', helpCenterCompose)).toEqual({
+      kind: 'navigate-same-tab',
+      href: '/help-center/bug-fixes?search=abc123',
+    })
+  })
+
+  it('non-hosted type → the seam returns externalUrl verbatim, opens out', () => {
+    const row: SearchResult = {
+      id: 'blog-1',
+      title: 'Hello',
+      metadata: {
+        documentType: 'blog_post',
+        externalUrl: `${HUB}/blog/hello`,
+        sourceRepo: 'blog-posts',
+        id: 'blog-1',
+        targetPlatform: 'flamingo',
+      },
+    }
+    expect(resolveSearchResultAction(row, 'openframe', 'host', helpCenterCompose)).toEqual({
+      kind: 'navigate-new-tab',
+      href: `${HUB}/blog/hello`,
+    })
+  })
+
+  it('row without documentType → seam skipped, externalUrl verbatim', () => {
+    const row: SearchResult = {
+      id: 'x',
+      title: 'Untyped',
+      metadata: { externalUrl: `${HUB}/somewhere`, targetPlatform: 'openframe' },
+    }
+    expect(resolveSearchResultAction(row, 'openframe', 'host', helpCenterCompose)).toEqual({
+      kind: 'navigate-same-tab',
+      href: `${HUB}/somewhere`,
+    })
+  })
+
+  it('no externalUrl → unchanged ask-ai / route / noop fallbacks', () => {
+    expect(
+      resolveSearchResultAction(
+        {
+          id: 'cap-1',
+          title: 'Cap Table',
+          metadata: { documentType: 'cap_table', sourceRepo: 'financial-cap-table', id: 'row-9' },
+        },
+        'company-hub',
+        'host',
+        helpCenterCompose,
+      ),
+    ).toEqual({
+      kind: 'ask-ai',
+      detail: {
+        source: 'company-hub',
+        ref: { type: 'cap_table', id: 'row-9', title: 'Cap Table', url: null },
+      },
+    })
+
+    expect(
+      resolveSearchResultAction(
+        { id: 'doc', title: 'Doc', path: 'repo/architecture/api.md' },
+        'openframe',
+        'host',
+        helpCenterCompose,
+      ),
+    ).toEqual({ kind: 'route', path: 'repo/architecture/api.md' })
+
+    expect(
+      resolveSearchResultAction({ id: 'empty', title: 'Empty' }, 'openframe', 'host', helpCenterCompose),
+    ).toEqual({ kind: 'noop' })
+  })
+})

--- a/openframe-frontend-core/src/components/shared/doc-search/resolve-search-result-action.ts
+++ b/openframe-frontend-core/src/components/shared/doc-search/resolve-search-result-action.ts
@@ -3,8 +3,9 @@
  * Returns one of five typed actions so the caller is a single switch.
  *
  * Resolution order:
- *  1. `externalUrl` present → use `decideNewTab` to choose same-tab vs
- *     new-tab against the row's `targetPlatform`.
+ *  1. `externalUrl` present → resolve the href through the host's
+ *     `composeContentUrl` seam (when wired), then use `decideNewTab` to
+ *     choose same-tab vs new-tab against the resolved `targetPlatform`.
  *  2. Row has `id` + `sourceRepo` + `documentType` → synth an Ask-AI
  *     action (entity drill-in via primary key, no URL).
  *  3. Row has only `path` → legacy navigation fallback.
@@ -16,7 +17,15 @@
 
 import type { SearchResult } from '../../ui/search-input'
 import type { ChatRef } from '../../chat/chat-ref.types'
+import type { ComposeContentUrl } from '../../../utils/content-href'
 import { decideNewTab } from '../../chat/utils/decide-new-tab'
+
+/** True for `https://…` and protocol-relative `//…`. A composed href that is
+ *  NOT absolute is an in-app route the host claimed via `hostedTypes` /
+ *  `overrides`. */
+function isAbsoluteHref(href: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test(href)
+}
 
 export type SearchResultAction =
   | { kind: 'navigate-same-tab'; href: string }
@@ -29,29 +38,56 @@ export function resolveSearchResultAction(
   result: SearchResult,
   source: string,
   runtimeMode?: 'host' | 'embed',
+  /** The host's unified content-href seam (`runtime.composeContentUrl`).
+   *  When wired, an entity row's RAG `externalUrl` is re-resolved through it,
+   *  so a type the host serves in-app (`hostedTypes`) or deep-links itself
+   *  (`overrides`) lands on the SAME href the catalog cards and chat cards
+   *  use. Omitted → the legacy verbatim-`externalUrl` behavior. */
+  composeContentUrl?: ComposeContentUrl,
 ): SearchResultAction {
   const meta = result.metadata ?? {}
   const externalUrl = meta.externalUrl as string | undefined
+  const rowId = meta.id as string | undefined
+  const sourceRepo = meta.sourceRepo as string | undefined
+  const documentType = meta.documentType as string | undefined
   if (externalUrl) {
+    const targetPlatform = meta.targetPlatform as string | null | undefined
+    // Unified content-href seam — the same call `resolveSourceRowCTA` makes
+    // for chat rows. Hosted types relativize the slug out of `externalUrl`;
+    // everything else comes back verbatim, so an unwired host (or a row with
+    // no `documentType`) keeps today's behavior byte-for-byte.
+    const composed =
+      composeContentUrl && documentType
+        ? composeContentUrl({
+            type: documentType,
+            identifier: rowId ?? '',
+            externalUrl,
+            targetPlatform: targetPlatform ?? null,
+          })
+        : null
+    const href = composed?.href || externalUrl
+    // A RELATIVE composed href means the host claimed this row as in-app.
+    // Short-circuit BEFORE `decideNewTab`: in embed mode that helper forces
+    // new-tab unconditionally, which would fire `window.open()` on a path
+    // that only resolves inside this app.
+    if (composed && !isAbsoluteHref(href)) {
+      return { kind: 'navigate-same-tab', href }
+    }
     // Same pure helper `useNavLink` and `useUnifiedNav` call — single
     // decision rule across cards, chips, and autocomplete rows. Thread
     // the caller's `source` as `currentSource` so the platform-vs-
     // platform comparison matches the hub's pre-migration behavior.
-    const targetPlatform = meta.targetPlatform as string | null | undefined
     const isNewTab = decideNewTab({
-      href: externalUrl,
-      targetPlatform,
+      href,
+      targetPlatform: composed ? composed.targetPlatform : targetPlatform,
       surface: 'useUnifiedNav',
       runtimeMode,
       currentSource: source,
     })
     return isNewTab
-      ? { kind: 'navigate-new-tab', href: externalUrl }
-      : { kind: 'navigate-same-tab', href: externalUrl }
+      ? { kind: 'navigate-new-tab', href }
+      : { kind: 'navigate-same-tab', href }
   }
-  const rowId = meta.id as string | undefined
-  const sourceRepo = meta.sourceRepo as string | undefined
-  const documentType = meta.documentType as string | undefined
   if (rowId && sourceRepo && documentType) {
     return {
       kind: 'ask-ai',

--- a/openframe-frontend-core/src/components/shared/doc-search/use-doc-search.ts
+++ b/openframe-frontend-core/src/components/shared/doc-search/use-doc-search.ts
@@ -26,6 +26,16 @@
  * Everything else (debounce, `useChatRuntime` for embed-mode short-
  * circuit, embed-shim router, the action-resolver + result-mapper) is
  * now lib-resident.
+ *
+ * ## Result hrefs go through the content-href seam
+ *
+ * A row's href is NOT the RAG `externalUrl` verbatim any more: when the
+ * host wires `runtime.composeContentUrl` (or passes `composeContentUrl`
+ * here), the row is re-resolved through it — the SAME seam the catalog
+ * cards and the chat entity cards use. So a host that serves onboarding
+ * guides at `/help-center/onboarding-guides/<slug>` gets that path from
+ * the dropdown too, instead of bouncing the user to the canonical hub
+ * URL. Unwired hosts keep the verbatim-`externalUrl` behavior.
  */
 
 import { useState, useEffect, useCallback } from 'react'
@@ -39,6 +49,7 @@ import {
   stripSameOriginToPath,
   NEW_TAB_FEATURES,
 } from '../../chat/utils/chat-nav-resolution'
+import type { ComposeContentUrl } from '../../../utils/content-href'
 import type { DocSearchResult } from './types'
 import { mapDocSearchResults } from './map-doc-search-results'
 import { resolveSearchResultAction } from './resolve-search-result-action'
@@ -72,6 +83,12 @@ export interface UseDocSearchConfig {
    *  (the hub's reverse-proxy route). Embedders with a different
    *  path can override. */
   searchEndpoint?: string
+  /** Optional content-href seam override. Same fall-back chain as
+   *  `searchEndpoint`: prop → `runtime.composeContentUrl` → none. Wired,
+   *  it makes a result row honor the host's `hostedTypes` / `overrides`
+   *  instead of navigating to the RAG's canonical hub URL — so a row
+   *  lands where the catalog card for the same entity lands. */
+  composeContentUrl?: ComposeContentUrl
 }
 
 export function useDocSearch(config: UseDocSearchConfig) {
@@ -82,6 +99,7 @@ export function useDocSearch(config: UseDocSearchConfig) {
     tableIds,
     onInPageSwap,
     searchEndpoint,
+    composeContentUrl,
   } = config
   const tableIdsKey = tableIds && tableIds.length > 0 ? tableIds.join(',') : ''
 
@@ -94,6 +112,11 @@ export function useDocSearch(config: UseDocSearchConfig) {
   const runtime = useChatRuntime()
   const resolvedSearchEndpoint =
     searchEndpoint ?? runtime?.endpoints.docsSearchUrl ?? '/api/docs/search'
+  // Content-href seam, same prop → runtime → none chain. Threading it into
+  // `resolveSearchResultAction` is what makes the dropdown obey the host's
+  // route map; without it the row navigates to the RAG's canonical hub URL
+  // even when the host serves that content in-app under a different path.
+  const resolvedComposeContentUrl = composeContentUrl ?? runtime?.composeContentUrl
 
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
@@ -172,6 +195,7 @@ export function useDocSearch(config: UseDocSearchConfig) {
         result,
         source,
         runtime?.navigation.mode,
+        resolvedComposeContentUrl,
       )
       // Modifier / non-primary mouse click → force new tab regardless of
       // same-tab/new-tab decision. The dropdown row is a `<div>`, not an
@@ -188,19 +212,6 @@ export function useDocSearch(config: UseDocSearchConfig) {
           (typeof modifiers.button === 'number' && modifiers.button !== 0))
       switch (action.kind) {
         case 'navigate-same-tab': {
-          // Embed-mode short-circuit — autocomplete row clicked while
-          // the chat panel is hosted inside an embedding app.
-          if (runtime?.navigation.mode === 'embed') {
-            setKeepOpen(true)
-            const targetPlatform =
-              (result.metadata?.targetPlatform as string | null | undefined) ?? null
-            resolveExternalNavigation({
-              href: action.href,
-              targetPlatform,
-              runtime,
-            }).open()
-            return
-          }
           if (wantsNewTab) {
             setKeepOpen(true)
             window.open(action.href, '_blank', NEW_TAB_FEATURES)
@@ -226,6 +237,21 @@ export function useDocSearch(config: UseDocSearchConfig) {
           // product-hub) — open in a new tab. Keep dropdown open so the
           // user can pick another result without re-searching.
           setKeepOpen(true)
+          // Embed-mode short-circuit — the row was clicked while the panel is
+          // hosted inside an embedding app, so absolutize against the
+          // embedder-supplied content origin and honor its `openExternal`
+          // override. (`decideNewTab` forces new-tab whenever the runtime is
+          // in embed mode, so this is the ONLY branch embed reaches.)
+          if (runtime?.navigation.mode === 'embed') {
+            const targetPlatform =
+              (result.metadata?.targetPlatform as string | null | undefined) ?? null
+            resolveExternalNavigation({
+              href: action.href,
+              targetPlatform,
+              runtime,
+            }).open()
+            return
+          }
           window.open(action.href, '_blank', NEW_TAB_FEATURES)
           return
         case 'ask-ai':
@@ -249,7 +275,15 @@ export function useDocSearch(config: UseDocSearchConfig) {
           return
       }
     },
-    [onNavigate, source, baseRoute, router, onInPageSwap, runtime],
+    [
+      onNavigate,
+      source,
+      baseRoute,
+      router,
+      onInPageSwap,
+      runtime,
+      resolvedComposeContentUrl,
+    ],
   )
 
   // Reset keepOpen when query changes.

--- a/openframe-frontend-core/src/components/shared/doc-search/use-doc-search.ts
+++ b/openframe-frontend-core/src/components/shared/doc-search/use-doc-search.ts
@@ -240,8 +240,10 @@ export function useDocSearch(config: UseDocSearchConfig) {
           // Embed-mode short-circuit — the row was clicked while the panel is
           // hosted inside an embedding app, so absolutize against the
           // embedder-supplied content origin and honor its `openExternal`
-          // override. (`decideNewTab` forces new-tab whenever the runtime is
-          // in embed mode, so this is the ONLY branch embed reaches.)
+          // override. Not the only path an embed host takes: a composed
+          // RELATIVE href resolves to `navigate-same-tab` above and never
+          // reaches `decideNewTab`, which is what lets an embedder keep its
+          // own in-app routes in-app.
           if (runtime?.navigation.mode === 'embed') {
             const targetPlatform =
               (result.metadata?.targetPlatform as string | null | undefined) ?? null

--- a/openframe-frontend-core/src/components/ui/__tests__/overlay-open-registry.test.tsx
+++ b/openframe-frontend-core/src/components/ui/__tests__/overlay-open-registry.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { useState } from 'react'
+import {
+  OverlayOpenRegistryProvider,
+  useReportOverlayOpen,
+} from '../overlay-open-registry'
+
+/** Stand-in for `ActionsMenuDropdown` — reports its open state, renders nothing. */
+function Overlay({ open }: { open: boolean }) {
+  useReportOverlayOpen(open)
+  return null
+}
+
+describe('OverlayOpenRegistry', () => {
+  it('fires only on 0 → 1 and 1 → 0, not per overlay', () => {
+    const onOpenChange = vi.fn()
+    function Harness({ a, b }: { a: boolean; b: boolean }) {
+      return (
+        <OverlayOpenRegistryProvider onOpenChange={onOpenChange}>
+          <Overlay open={a} />
+          <Overlay open={b} />
+        </OverlayOpenRegistryProvider>
+      )
+    }
+    const { rerender } = render(<Harness a={false} b={false} />)
+    expect(onOpenChange).not.toHaveBeenCalled()
+
+    rerender(<Harness a b={false} />)
+    expect(onOpenChange.mock.calls).toEqual([[true]])
+
+    // Second overlay opens while the first is still open — no new signal.
+    rerender(<Harness a b />)
+    expect(onOpenChange.mock.calls).toEqual([[true]])
+
+    // First closes, one still open — still no signal.
+    rerender(<Harness a={false} b />)
+    expect(onOpenChange.mock.calls).toEqual([[true]])
+
+    rerender(<Harness a={false} b={false} />)
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('releases when an open overlay unmounts', () => {
+    const onOpenChange = vi.fn()
+    function Harness({ mounted }: { mounted: boolean }) {
+      return (
+        <OverlayOpenRegistryProvider onOpenChange={onOpenChange}>
+          {mounted ? <Overlay open /> : null}
+        </OverlayOpenRegistryProvider>
+      )
+    }
+    const { rerender } = render(<Harness mounted />)
+    expect(onOpenChange.mock.calls).toEqual([[true]])
+    rerender(<Harness mounted={false} />)
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]])
+  })
+
+  it('is inert without a provider — no throw, no crash', () => {
+    expect(() => render(<Overlay open />)).not.toThrow()
+  })
+
+  it('a stable context value keeps overlays from re-rendering on count changes', () => {
+    const renderSpy = vi.fn()
+    function CountingOverlay({ open }: { open: boolean }) {
+      renderSpy()
+      useReportOverlayOpen(open)
+      return null
+    }
+    let bump: (() => void) | undefined
+    function Harness() {
+      const [, setTick] = useState(0)
+      bump = () => setTick((t) => t + 1)
+      return (
+        <OverlayOpenRegistryProvider>
+          <CountingOverlay open={false} />
+        </OverlayOpenRegistryProvider>
+      )
+    }
+    render(<Harness />)
+    const before = renderSpy.mock.calls.length
+    act(() => bump?.())
+    // One re-render from the parent's own state, not extra churn from context.
+    expect(renderSpy.mock.calls.length).toBe(before + 1)
+  })
+})

--- a/openframe-frontend-core/src/components/ui/actions-menu.tsx
+++ b/openframe-frontend-core/src/components/ui/actions-menu.tsx
@@ -13,6 +13,16 @@ import {
 	DropdownMenuContent,
 	DropdownMenuTrigger,
 } from "./dropdown-menu";
+import {
+	COLLISION_PADDING_PX,
+	useCollisionBoundary,
+	usePortalContainer,
+} from "./portal-container";
+import { useReportOverlayOpen } from "./overlay-open-registry";
+
+/** Trigger movement (px) that counts as "the user scrolled away" rather than
+ *  touch-momentum jitter or the sub-pixel settle right after opening. */
+const SCROLL_DISMISS_THRESHOLD_PX = 12;
 
 export interface ActionsMenuItemIconAction {
 	icon: React.ReactNode;
@@ -126,6 +136,10 @@ const SecondaryAction: React.FC<{ action: ActionsMenuItemIconAction }> = ({ acti
 };
 
 const MenuItem: React.FC<MenuItemProps> = ({ item, onItemClick }) => {
+	// Submenus below portal + collide against the OWNING surface, matching the
+	// root menu (`DropdownMenuContent`). Read unconditionally — hooks first.
+	const portalContainer = usePortalContainer();
+	const collisionBoundary = useCollisionBoundary();
 	const activate = useCallback(() => {
 		if (item.disabled) return;
 		if (item.type === "checkbox") {
@@ -265,9 +279,14 @@ const MenuItem: React.FC<MenuItemProps> = ({ item, onItemClick }) => {
 					>
 						{rowContent}
 					</DropdownMenuPrimitive.SubTrigger>
-					<DropdownMenuPrimitive.Portal>
+					<DropdownMenuPrimitive.Portal container={portalContainer ?? undefined}>
 						<DropdownMenuPrimitive.SubContent
 							sideOffset={4}
+							// Confine flip/shift (and the available-height this menu sizes
+							// itself by) to the owning surface — see `useCollisionBoundary`.
+							collisionBoundary={collisionBoundary ?? undefined}
+							collisionPadding={collisionBoundary ? COLLISION_PADDING_PX : undefined}
+							hideWhenDetached
 							className="z-[1500] min-w-[256px] max-h-[var(--radix-popper-available-height)] bg-ods-bg border border-ods-border rounded-md shadow-xl overflow-y-auto p-0"
 						>
 							{item.submenu.map((subItem, index) => (
@@ -377,6 +396,50 @@ export const ActionsMenuDropdown: React.FC<ActionsMenuDropdownProps> = ({
 		onChange: onOpenChange,
 	});
 
+	// Tell the surrounding surface an overlay is open, so it can stop moving
+	// the ground under it (the chat thread suspends its follow-the-bottom
+	// auto-scroll — see `OverlayOpenRegistryProvider`). Inert without a
+	// provider, so menus elsewhere are unaffected.
+	useReportOverlayOpen(open);
+
+	// Dismiss once the USER scrolls the trigger away.
+	//
+	// Two different situations, two different answers. Content moving on its own
+	// (a streaming reply) is handled above by suspending the auto-scroll — the
+	// menu must survive that, nobody asked for it to close. A deliberate scroll
+	// is the opposite: the reader left, and an anchored menu would ride along
+	// until it hovers over unrelated chrome. `hideWhenDetached` only kicks in
+	// once the trigger is FULLY clipped, so a half-scrolled trigger still drags
+	// a visible menu across the header.
+	//
+	// Scoped deliberately:
+	//   • only scrolls of containers that actually contain the trigger — a
+	//     scroll in a neighbouring column is none of our business;
+	//   • only past `SCROLL_DISMISS_THRESHOLD_PX` of movement, so touch
+	//     momentum and the ~1px settle after opening don't close the menu the
+	//     user is reaching for.
+	const triggerRef = React.useRef<HTMLButtonElement | null>(null);
+	React.useEffect(() => {
+		if (!open) return;
+		if (typeof document === "undefined") return;
+		const trigger = triggerRef.current;
+		if (!trigger) return;
+		const anchorTop = trigger.getBoundingClientRect().top;
+		const onScroll = (event: Event) => {
+			const target = event.target as Node | null;
+			// `document` fires for the page scroll and contains everything.
+			const scrolledTheTrigger =
+				target === document ||
+				(target instanceof Node && target.contains(trigger));
+			if (!scrolledTheTrigger) return;
+			const moved = Math.abs(trigger.getBoundingClientRect().top - anchorTop);
+			if (moved > SCROLL_DISMISS_THRESHOLD_PX) setOpen(false);
+		};
+		document.addEventListener("scroll", onScroll, { capture: true, passive: true });
+		return () =>
+			document.removeEventListener("scroll", onScroll, { capture: true });
+	}, [open, setOpen]);
+
 	const handleItemClick = useCallback(
 		(item: ActionsMenuItem) => {
 			onItemClick?.(item);
@@ -393,7 +456,7 @@ export const ActionsMenuDropdown: React.FC<ActionsMenuDropdownProps> = ({
 
 	return (
 		<DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
-			<DropdownMenuTrigger asChild>
+			<DropdownMenuTrigger asChild ref={triggerRef}>
 				{customTrigger ?? (
 					<Button
 						variant="outline"

--- a/openframe-frontend-core/src/components/ui/dropdown-menu.tsx
+++ b/openframe-frontend-core/src/components/ui/dropdown-menu.tsx
@@ -49,22 +49,32 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, collisionBoundary, collisionPadding, hideWhenDetached, ...props }, ref) => {
+  // Same container as the root content — `DropdownMenuContent` portals, and a
+  // submenu left un-portaled inherits whatever clipping/stacking context its
+  // parent sits in instead of the one the host published. (The hand-rolled
+  // submenu in `actions-menu` already portals; this keeps the shared primitive
+  // consistent with both.)
+  const container = usePortalContainer()
   // Same boundary as the root content — a submenu must not escape the surface
   // its parent menu is confined to.
   const boundary = useCollisionBoundary()
   const resolvedBoundary = collisionBoundary ?? boundary ?? undefined
   return (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    collisionBoundary={resolvedBoundary}
-    collisionPadding={collisionPadding ?? (resolvedBoundary ? COLLISION_PADDING_PX : undefined)}
-    hideWhenDetached={hideWhenDetached ?? true}
-    className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ods-border bg-ods-card p-1 text-ods-text-primary shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <DropdownMenuPrimitive.Portal container={container ?? undefined}>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      collisionBoundary={resolvedBoundary}
+      collisionPadding={collisionPadding ?? (resolvedBoundary ? COLLISION_PADDING_PX : undefined)}
+      // Only defaulted ON where a boundary was published (i.e. inside a panel
+      // that owns its menus) — see `DropdownMenuContent`.
+      hideWhenDetached={hideWhenDetached ?? (resolvedBoundary ? true : undefined)}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ods-border bg-ods-card p-1 text-ods-text-primary shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
   )
 })
 DropdownMenuSubContent.displayName =
@@ -103,7 +113,12 @@ const DropdownMenuContent = React.forwardRef<
       // pinned to that off-screen anchor, so it slides to the surface edge and
       // reads as a detached popup floating over unrelated chrome.
       // `hideWhenDetached` makes it disappear with its trigger instead.
-      hideWhenDetached={hideWhenDetached ?? true}
+      //
+      // Defaulted ON only where a boundary was published. This is a SHARED
+      // primitive: flipping it on globally would change dismissal behavior for
+      // every dropdown in every consumer, and the detached-popup problem it
+      // solves is specific to a menu living inside a scrolling panel.
+      hideWhenDetached={hideWhenDetached ?? (resolvedBoundary ? true : undefined)}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ods-border bg-ods-card p-1 text-ods-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className

--- a/openframe-frontend-core/src/components/ui/dropdown-menu.tsx
+++ b/openframe-frontend-core/src/components/ui/dropdown-menu.tsx
@@ -5,7 +5,11 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "../../utils/cn"
-import { usePortalContainer } from "./portal-container"
+import {
+  COLLISION_PADDING_PX,
+  useCollisionBoundary,
+  usePortalContainer,
+} from "./portal-container"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -44,31 +48,62 @@ DropdownMenuSubTrigger.displayName =
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
+>(({ className, collisionBoundary, collisionPadding, hideWhenDetached, ...props }, ref) => {
+  // Same boundary as the root content — a submenu must not escape the surface
+  // its parent menu is confined to.
+  const boundary = useCollisionBoundary()
+  const resolvedBoundary = collisionBoundary ?? boundary ?? undefined
+  return (
   <DropdownMenuPrimitive.SubContent
     ref={ref}
+    collisionBoundary={resolvedBoundary}
+    collisionPadding={collisionPadding ?? (resolvedBoundary ? COLLISION_PADDING_PX : undefined)}
+    hideWhenDetached={hideWhenDetached ?? true}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ods-border bg-ods-card p-1 text-ods-text-primary shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
   />
-))
+  )
+})
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => {
+>(({
+  className,
+  sideOffset = 4,
+  collisionBoundary,
+  collisionPadding,
+  hideWhenDetached,
+  ...props
+}, ref) => {
   // Portal into the active container (e.g. a drawer) so the menu inherits its
   // stacking context; falls back to `document.body` when none is provided.
   const container = usePortalContainer()
+  // Keep flip/shift inside the surface that owns the menu. Without this Radix
+  // collides against the VIEWPORT, so a menu opened near the top of the chat
+  // panel grows upward past the panel and lands over the app header. An
+  // explicit prop still wins; no provider → viewport, Radix's own default.
+  const boundary = useCollisionBoundary()
+  const resolvedBoundary = collisionBoundary ?? boundary ?? undefined
   return (
   <DropdownMenuPrimitive.Portal container={container ?? undefined}>
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      collisionBoundary={resolvedBoundary}
+      collisionPadding={collisionPadding ?? (resolvedBoundary ? COLLISION_PADDING_PX : undefined)}
+      // A menu tracks its trigger for as long as it is open. When the trigger
+      // scrolls out of its clipping ancestor — a chat card carried away by the
+      // thread's auto-scroll while the menu is open — Radix keeps the menu
+      // pinned to that off-screen anchor, so it slides to the surface edge and
+      // reads as a detached popup floating over unrelated chrome.
+      // `hideWhenDetached` makes it disappear with its trigger instead.
+      hideWhenDetached={hideWhenDetached ?? true}
       className={cn(
         "z-50 min-w-[8rem] overflow-hidden rounded-md border border-ods-border bg-ods-card p-1 text-ods-text-primary shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className

--- a/openframe-frontend-core/src/components/ui/markdown/base-components.tsx
+++ b/openframe-frontend-core/src/components/ui/markdown/base-components.tsx
@@ -21,6 +21,11 @@ import {
   useHeadingId,
 } from './heading-ids';
 import { slugifyHeadingText } from '../../../utils/markdown-heading-id';
+import {
+  getHashTargetElement,
+  navigateSamePageHash,
+  HUB_HEADER_OFFSET_PX,
+} from '../../../utils/same-page-hash-nav';
 
 /**
  * True when an image `src` is worth rendering. Shared by the base `img` and
@@ -284,12 +289,33 @@ export function buildBaseComponents({
         );
       }
 
+      // In-page anchor. Doc TOCs are authored against GitHub's slugger
+      // (`## 📚 Table of Contents` → `#-table-of-contents`) while our heading
+      // ids trim the emoji's leftover hyphen, so the raw href resolves to
+      // nothing and the browser silently ignores the click. Resolve through
+      // `getHashTargetElement` — the same resolver deep links use — then hand
+      // the real id to the canonical hash-nav helper, which also lands the
+      // heading BELOW the sticky header instead of under it, matching how the
+      // "On this page" rail scrolls.
+      const isInPageAnchor = typeof href === 'string' && href.startsWith('#') && href.length > 1;
+      const handleAnchorClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        // Let modifier / non-primary clicks keep their native behavior.
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+        const target = getHashTargetElement(href.slice(1));
+        // Nothing matched anywhere in the document → leave the browser's
+        // default alone rather than swallowing a click that isn't ours.
+        if (!target?.id) return;
+        e.preventDefault();
+        navigateSamePageHash(`#${target.id}`, { headerOffset: HUB_HEADER_OFFSET_PX });
+      };
+
       return (
         <a
           href={href}
           className={`text-ods-accent no-underline relative transition-colors duration-200 hover:after:w-full after:content-[''] after:absolute after:w-0 after:h-0.5 after:-bottom-0.5 after:left-0 after:bg-ods-accent after:transition-all after:duration-300 ${linkClassName || ''}`}
           target={href?.startsWith('http') ? '_blank' : undefined}
           rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
+          onClick={isInPageAnchor ? handleAnchorClick : undefined}
         >
           {children}
         </a>

--- a/openframe-frontend-core/src/components/ui/overlay-open-registry.tsx
+++ b/openframe-frontend-core/src/components/ui/overlay-open-registry.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * A surface-scoped count of overlays (⋯ menus, popovers) currently open INSIDE
+ * that surface, so the surface can suspend behaviour that would move the ground
+ * under them.
+ *
+ * ## Why
+ *
+ * An open menu stays anchored to its trigger. In a chat thread the ground moves
+ * on its own: a streaming reply grows the transcript and the auto-scroll follows
+ * the bottom, carrying the trigger — and its menu — upward until the menu is
+ * pinned to an off-screen anchor at the panel edge, visually detached from the
+ * card it belongs to.
+ *
+ * The honest fix is not to dismiss the menu on every scroll event (that breaks
+ * touch, where momentum scrolling fires constantly) but to stop pulling the
+ * ground: while an overlay is open the thread stops chasing the bottom, exactly
+ * how ChatGPT/Claude stop chasing once you interact with the transcript. When
+ * the overlay closes, the thread catches up if it was at the bottom before.
+ *
+ * ## Wiring
+ *
+ * Surface: wrap the region in `<OverlayOpenRegistryProvider onOpenChange={…}>`.
+ * Overlay: call `useReportOverlayOpen(open)`. No provider → the hook is inert,
+ * so overlays outside such a surface behave exactly as before.
+ */
+
+import * as React from 'react'
+
+export interface OverlayOpenRegistry {
+  /** Register one open overlay; call the returned fn to release it. */
+  acquire: () => () => void
+}
+
+export const OverlayOpenRegistryContext =
+  React.createContext<OverlayOpenRegistry | null>(null)
+
+/** Read the surrounding registry (or `null` when there is no provider). */
+export function useOverlayOpenRegistry(): OverlayOpenRegistry | null {
+  return React.useContext(OverlayOpenRegistryContext)
+}
+
+/**
+ * Report this overlay's open state to the surrounding surface. Safe to call
+ * unconditionally — with no provider it does nothing.
+ */
+export function useReportOverlayOpen(open: boolean): void {
+  const registry = useOverlayOpenRegistry()
+  React.useEffect(() => {
+    if (!open || !registry) return
+    return registry.acquire()
+  }, [open, registry])
+}
+
+export interface OverlayOpenRegistryProviderProps {
+  /** Fires on 0 → 1 and 1 → 0 transitions only, not on every acquire. */
+  onOpenChange?: (hasOpenOverlay: boolean) => void
+  children: React.ReactNode
+}
+
+/**
+ * Owns the count for one surface. The context value is referentially stable, so
+ * mounting this provider does not re-render overlays when the count changes —
+ * only the surface's own `onOpenChange` callback fires.
+ */
+export function OverlayOpenRegistryProvider({
+  onOpenChange,
+  children,
+}: OverlayOpenRegistryProviderProps) {
+  const countRef = React.useRef(0)
+  const onOpenChangeRef = React.useRef(onOpenChange)
+  onOpenChangeRef.current = onOpenChange
+
+  const registry = React.useMemo<OverlayOpenRegistry>(
+    () => ({
+      acquire: () => {
+        countRef.current += 1
+        if (countRef.current === 1) onOpenChangeRef.current?.(true)
+        let released = false
+        return () => {
+          // Guard against a double release (StrictMode double-invokes effect
+          // cleanups in development) driving the count negative.
+          if (released) return
+          released = true
+          countRef.current -= 1
+          if (countRef.current === 0) onOpenChangeRef.current?.(false)
+        }
+      },
+    }),
+    [],
+  )
+
+  return (
+    <OverlayOpenRegistryContext.Provider value={registry}>
+      {children}
+    </OverlayOpenRegistryContext.Provider>
+  )
+}

--- a/openframe-frontend-core/src/components/ui/portal-container.tsx
+++ b/openframe-frontend-core/src/components/ui/portal-container.tsx
@@ -26,3 +26,34 @@ export const PortalContainerContext = React.createContext<HTMLElement | null>(
 export function usePortalContainer(): HTMLElement | null {
   return React.useContext(PortalContainerContext)
 }
+
+/**
+ * The element Radix overlays should treat as their COLLISION boundary — the
+ * surface they must stay inside of.
+ *
+ * Separate from {@link PortalContainerContext} on purpose: the portal target is
+ * a `display: contents` node (no box, so it can't be measured), while a
+ * collision boundary must be a real, laid-out element.
+ *
+ * Why it matters: Radix positions overlays `position: fixed` and, by default,
+ * flips/shifts them against the VIEWPORT. A menu opened near the top of a
+ * panel therefore happily grows upward past the panel's edge and lands on top
+ * of the app header — visually detached from the surface it belongs to. Handing
+ * Radix the panel element instead keeps flip/shift (and the
+ * `--radix-popper-available-height` a menu sizes itself by) inside that panel.
+ *
+ * Default `null` → viewport, i.e. Radix's own default, unchanged everywhere a
+ * provider isn't present.
+ */
+export const CollisionBoundaryContext = React.createContext<HTMLElement | null>(
+  null,
+)
+
+/** Read the active collision boundary (or `null` for the viewport). */
+export function useCollisionBoundary(): HTMLElement | null {
+  return React.useContext(CollisionBoundaryContext)
+}
+
+/** Padding (px) kept between an overlay and its boundary edge. Matches the
+ *  panel's own gutter so a shifted menu never sits flush against the edge. */
+export const COLLISION_PADDING_PX = 8

--- a/openframe-frontend-core/src/utils/__tests__/anchor-id.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/anchor-id.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { extractSections } from '../markdown-section-extractor'
+import { findAnchorElementByNormalizedId, normalizeAnchorId } from '../anchor-id'
+import { getHashTargetElement } from '../same-page-hash-nav'
+
+describe('normalizeAnchorId', () => {
+  it('drops the hyphen GitHub leaves behind a stripped emoji', () => {
+    expect(normalizeAnchorId('-getting-started')).toBe('getting-started')
+    expect(normalizeAnchorId('-architecture-diagrams')).toBe('architecture-diagrams')
+  })
+
+  it('collapses the hyphen run GitHub emits around a dropped "&"', () => {
+    expect(normalizeAnchorId('-community--support')).toBe('community-support')
+  })
+
+  it('is a no-op for an already-clean id', () => {
+    expect(normalizeAnchorId('table-of-contents')).toBe('table-of-contents')
+  })
+
+  it('normalizes raw heading text too', () => {
+    expect(normalizeAnchorId('🚀 Getting Started')).toBe('getting-started')
+  })
+})
+
+describe('findAnchorElementByNormalizedId', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <h1 id="openframe-cli-documentation">OpenFrame CLI — Documentation</h1>
+      <h2 id="table-of-contents">📚 Table of Contents</h2>
+      <h2 id="getting-started">🚀 Getting Started</h2>
+      <h2 id="community-support">💬 Community &amp; Support</h2>
+      <h3 id="a---b">A - B</h3>
+    `
+  })
+
+  it('resolves a GitHub-style anchor onto our heading id', () => {
+    expect(findAnchorElementByNormalizedId('-getting-started', document)?.id).toBe('getting-started')
+    expect(findAnchorElementByNormalizedId('-table-of-contents', document)?.id).toBe(
+      'table-of-contents',
+    )
+  })
+
+  it('resolves the double-hyphen "&" form', () => {
+    expect(findAnchorElementByNormalizedId('-community--support', document)?.id).toBe(
+      'community-support',
+    )
+  })
+
+  it('matches an id whose own raw form normalizes differently', () => {
+    // `a---b` is not reachable by normalized lookup — only the heading scan finds it.
+    expect(findAnchorElementByNormalizedId('a-b', document)?.id).toBe('a---b')
+  })
+
+  it('returns null for an anchor with no heading behind it', () => {
+    expect(findAnchorElementByNormalizedId('nope', document)).toBeNull()
+    expect(findAnchorElementByNormalizedId('', document)).toBeNull()
+  })
+})
+
+describe('getHashTargetElement — the fuzzy pass is wired into THE resolver', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <h2 id="getting-started">🚀 Getting Started</h2>
+      <div id="ticket-a/b">encoded-id row</div>
+    `
+  })
+
+  it('exact ids still win, unchanged', () => {
+    expect(getHashTargetElement('getting-started')?.id).toBe('getting-started')
+  })
+
+  it('percent-decoding still runs before the fuzzy pass', () => {
+    expect(getHashTargetElement('ticket-a%2Fb')?.id).toBe('ticket-a/b')
+  })
+
+  it('falls back to a normalized match — the TOC bug, through the public entry point', () => {
+    expect(getHashTargetElement('-getting-started')?.id).toBe('getting-started')
+  })
+
+  it('still returns null when nothing matches', () => {
+    expect(getHashTargetElement('nope')).toBeNull()
+    expect(getHashTargetElement('')).toBeNull()
+  })
+})
+
+describe('the openframe-cli doc that reported the bug', () => {
+  // Verbatim shapes from
+  // GET /api/docs/sources/openframe-docs/content?path=openframe-cli
+  const headings = [
+    '# OpenFrame CLI — Documentation',
+    '## 📚 Table of Contents',
+    '## 🚀 Getting Started',
+    '## 🛠️ Development',
+    '## 💬 Community & Support',
+  ].join('\n\n')
+  const tocHrefs = ['#-getting-started', '#-development', '#-community--support']
+
+  it('every TOC href resolves to the id the section extractor emits', () => {
+    const sections = extractSections(headings)
+    document.body.innerHTML = sections
+      .map((s) => `<h2 id="${s.id}">${s.title}</h2>`)
+      .join('')
+
+    const resolved = tocHrefs.map((href) => getHashTargetElement(href.slice(1))?.id ?? null)
+    expect(resolved).toEqual(['getting-started', 'development', 'community-support'])
+    // …and none of them resolved before this helper existed:
+    expect(tocHrefs.map((href) => document.getElementById(href.slice(1)))).toEqual([
+      null,
+      null,
+      null,
+    ])
+  })
+})

--- a/openframe-frontend-core/src/utils/__tests__/anchor-id.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/anchor-id.test.ts
@@ -58,6 +58,31 @@ describe('findAnchorElementByNormalizedId', () => {
   })
 })
 
+describe('duplicate headings — GitHub numbers from -1, our deduper from -2', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <h2 id="setup">Setup</h2>
+      <h2 id="setup-2">Setup</h2>
+      <h2 id="setup-3">Setup</h2>
+      <h2 id="step-2">Step 2</h2>
+    `
+  })
+
+  it('shifts a GitHub duplicate fragment onto our id', () => {
+    expect(getHashTargetElement('setup-1')?.id).toBe('setup-2')
+    expect(getHashTargetElement('setup-2')?.id).toBe('setup-2')
+  })
+
+  it('an id that genuinely ends in a number is matched exactly, never shifted', () => {
+    // `step-2` exists, so the exact lookup wins and `step-3` is never consulted.
+    expect(getHashTargetElement('step-2')?.id).toBe('step-2')
+  })
+
+  it('does not invent a match when the shifted id is absent too', () => {
+    expect(getHashTargetElement('missing-1')).toBeNull()
+  })
+})
+
 describe('getHashTargetElement — the fuzzy pass is wired into THE resolver', () => {
   beforeEach(() => {
     document.body.innerHTML = `

--- a/openframe-frontend-core/src/utils/__tests__/content-href.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/content-href.test.ts
@@ -82,9 +82,16 @@ describe('makeComposeContentUrl (unified single-object seam)', () => {
       href: `${HUB}/blog/x`,
       targetPlatform: null,
     })
+    // An unresolvable owner reports `null`, NOT its own name: the href came
+    // from `contentOrigin`, and `decideNewTab` prefers `targetPlatform` over
+    // its origin check — so claiming a platform here forced a same-host link
+    // into a new tab.
     expect(
       compose({ type: 'blog_post', identifier: 'x', platforms: [{ name: 'not-a-platform' }] }),
-    ).toEqual({ href: `${HUB}/blog/x`, targetPlatform: 'not-a-platform' })
+    ).toEqual({ href: `${HUB}/blog/x`, targetPlatform: null })
+    expect(
+      compose({ type: 'blog_post', identifier: 'x', targetPlatform: 'not-a-platform' }),
+    ).toEqual({ href: `${HUB}/blog/x`, targetPlatform: null })
   })
 
   it('externalUrl still wins — the RAG url is authoritative', () => {

--- a/openframe-frontend-core/src/utils/__tests__/content-href.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/content-href.test.ts
@@ -32,6 +32,73 @@ describe('makeComposeContentUrl (unified single-object seam)', () => {
     })
   })
 
+  it('canonicalizes rail-vocab aliases before matching suffixes', () => {
+    // `blog_post_existing` is the legacy ContentRef spelling `buildListUrl`
+    // accepts. Without canonicalization here it missed `suffixes` entirely and
+    // emitted `<hub>/blog_post_existing/<slug>` — the same post reachable at
+    // two different urls depending on which call site produced the link.
+    expect(compose({ type: 'blog_post_existing', identifier: 'hello' })).toEqual(
+      compose({ type: 'blog_post', identifier: 'hello' }),
+    )
+    expect(compose({ type: 'blog_post_existing', identifier: 'hello' })).toEqual({
+      href: `${HUB}/blog/hello`,
+      targetPlatform: null,
+    })
+  })
+
+  it('non-hosted row resolves to the OWNING platform, not to contentOrigin', () => {
+    // The reported bug: an OpenMSP-owned blog post linked to flamingo.run.
+    expect(
+      compose({ type: 'blog_post', identifier: 'why-mdr', platforms: [{ name: 'openmsp' }] }),
+    ).toEqual({ href: 'https://www.openmsp.ai/blog/why-mdr', targetPlatform: 'openmsp' })
+  })
+
+  it('reads all three junction shapes the DALs produce', () => {
+    const shapes = [
+      [{ name: 'openmsp' }],
+      [{ platform_name: 'openmsp' } as unknown as { name?: string }],
+      [{ platforms: { name: 'openmsp' } } as unknown as { name?: string }],
+    ]
+    for (const platforms of shapes) {
+      expect(compose({ type: 'blog_post', identifier: 'x', platforms }).href).toBe(
+        'https://www.openmsp.ai/blog/x',
+      )
+    }
+  })
+
+  it('explicit targetPlatform wins over the junction', () => {
+    expect(
+      compose({
+        type: 'blog_post',
+        identifier: 'x',
+        targetPlatform: 'tmcg',
+        platforms: [{ name: 'openmsp' }],
+      }),
+    ).toEqual({ href: 'https://www.tmcg.miami/blog/x', targetPlatform: 'tmcg' })
+  })
+
+  it('falls back to contentOrigin for an unknown or absent platform', () => {
+    expect(compose({ type: 'blog_post', identifier: 'x' })).toEqual({
+      href: `${HUB}/blog/x`,
+      targetPlatform: null,
+    })
+    expect(
+      compose({ type: 'blog_post', identifier: 'x', platforms: [{ name: 'not-a-platform' }] }),
+    ).toEqual({ href: `${HUB}/blog/x`, targetPlatform: 'not-a-platform' })
+  })
+
+  it('externalUrl still wins — the RAG url is authoritative', () => {
+    expect(
+      compose({
+        type: 'blog_post',
+        identifier: 'x',
+        externalUrl: 'https://www.openmsp.ai/blog/x',
+        targetPlatform: 'openmsp',
+        platforms: [{ name: 'flamingo' }],
+      }),
+    ).toEqual({ href: 'https://www.openmsp.ai/blog/x', targetPlatform: 'openmsp' })
+  })
+
   it('always returns a tuple (never null) — even for an unknown type', () => {
     expect(compose({ type: 'totally_unknown', identifier: 'x' })).toEqual({
       href: `${HUB}/totally_unknown/x`,

--- a/openframe-frontend-core/src/utils/__tests__/list-url.test.ts
+++ b/openframe-frontend-core/src/utils/__tests__/list-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildListUrl } from '../list-url'
+import { buildListUrl, canonicalContentRefType } from '../list-url'
 
 /**
  * Byte-parity gate for the shared `buildListUrl`.
@@ -31,6 +31,16 @@ const BASELINE: Record<string, string> = {
 describe('buildListUrl — byte parity with the hub mappers', () => {
   it.each(Object.entries(BASELINE))('%s → exact prior listApi output', (type, expected) => {
     expect(buildListUrl(type, ['a', 'b'])).toBe(expected)
+  })
+
+  it('canonicalContentRefType: aliases resolve, prototype keys do not', () => {
+    expect(canonicalContentRefType('blog_post_existing')).toBe('blog_post')
+    expect(canonicalContentRefType('roadmap_item')).toBe('roadmap_item')
+    // A bare `ALIASES[key]` read returned `Object` here, which downstream
+    // interpolated into a URL path.
+    expect(canonicalContentRefType('constructor')).toBe('constructor')
+    expect(canonicalContentRefType('__proto__')).toBe('__proto__')
+    expect(canonicalContentRefType('toString')).toBe('toString')
   })
 
   it('un-aliases blog_post_existing → blog_post (mirrors hub LEGACY_TYPE_ALIASES)', () => {

--- a/openframe-frontend-core/src/utils/anchor-id.ts
+++ b/openframe-frontend-core/src/utils/anchor-id.ts
@@ -1,0 +1,78 @@
+/**
+ * GitHub-compatible anchor resolution for in-page `#hash` links.
+ *
+ * ## The mismatch this exists to bridge
+ *
+ * Doc authors write their table of contents against GitHub's slugger, which
+ * keeps the separator left behind by a stripped emoji:
+ *
+ *   `## 📚 Table of Contents`  →  GitHub anchor `#-table-of-contents`
+ *
+ * Our heading ids come from the shared slug SSOT (`markdown-heading-id`),
+ * whose `slugifyHeadingBase` trims leading and trailing hyphens — so the same
+ * heading renders as `id="table-of-contents"`. The "On this page" rail
+ * navigates by those ids and works; the in-body TOC link points at an id that
+ * does not exist and the browser silently does nothing.
+ *
+ * Rather than change the id shape (it is already baked into shared URLs and
+ * the rail), resolution is made tolerant: compare a *normalized* form of both
+ * sides. This module owns ONLY that tolerance — the slug chain itself is
+ * imported, never re-implemented, so a change to the id shape lands in one
+ * place and both sides move together.
+ *
+ * Callers do not reach for this directly: `getHashTargetElement`
+ * (`utils/same-page-hash-nav`) is the ONE resolver every hash consumer goes
+ * through, and it applies this as its last pass.
+ */
+import { slugifyHeadingText } from './markdown-heading-id'
+
+/**
+ * Reduce an anchor id (ours or GitHub's) to a comparable form.
+ *
+ * Everything but the final hyphen-run collapse is the shared heading-slug
+ * chain: emoji strip → lowercase → drop non-word chars → spaces to hyphens →
+ * trim edge hyphens. The collapse is this module's own addition, covering
+ * GitHub's *interior* divergence — `## 💬 Community & Support` slugs to
+ * `#-community--support` (a double hyphen around the dropped `&`) against our
+ * `community-support`.
+ *
+ *   `'-getting-started'`     → `'getting-started'`
+ *   `'-community--support'`  → `'community-support'`
+ *   `'Getting Started'`      → `'getting-started'`
+ */
+export function normalizeAnchorId(raw: string): string {
+  return slugifyHeadingText(raw).replace(/-+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+/** Heading elements carrying an id — the candidate set for the fuzzy pass. */
+const HEADING_SELECTOR = 'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]'
+
+/**
+ * Resolve a `#hash` id that no exact lookup matched, by comparing normalized
+ * forms. Returns `null` when nothing in the document matches, so the caller
+ * can leave the browser's default behavior alone rather than hijacking a
+ * click that was never ours to handle.
+ *
+ * Two passes, cheapest first:
+ *   1. a single `getElementById` on the normalized id — catches the whole
+ *      emoji-hyphen family without walking the DOM;
+ *   2. a heading scan — catches ids whose own raw form normalizes differently
+ *      (e.g. `a---b`, from a title containing a literal ` - `).
+ */
+export function findAnchorElementByNormalizedId(
+  rawId: string,
+  doc: Document,
+): HTMLElement | null {
+  const normalized = normalizeAnchorId(rawId)
+  if (!normalized) return null
+
+  if (normalized !== rawId) {
+    const direct = doc.getElementById(normalized)
+    if (direct) return direct
+  }
+
+  for (const heading of Array.from(doc.querySelectorAll<HTMLElement>(HEADING_SELECTOR))) {
+    if (normalizeAnchorId(heading.id) === normalized) return heading
+  }
+  return null
+}

--- a/openframe-frontend-core/src/utils/anchor-id.ts
+++ b/openframe-frontend-core/src/utils/anchor-id.ts
@@ -47,16 +47,38 @@ export function normalizeAnchorId(raw: string): string {
 /** Heading elements carrying an id — the candidate set for the fuzzy pass. */
 const HEADING_SELECTOR = 'h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]'
 
+/** A `base-N` id, split into its base and ordinal. */
+const DUPLICATE_SUFFIX_RE = /^(.+)-(\d+)$/
+
+/**
+ * The two sides also disagree on where duplicate-heading numbering STARTS.
+ * For a document with two `## Setup` headings GitHub emits `setup` and
+ * `setup-1`, while `createHeadingIdDeduper` emits `setup` and `setup-2` (its
+ * suffix is the occurrence COUNT, not the offset). So a GitHub `#setup-1`
+ * needs our `setup-2` — every duplicate is off by exactly one.
+ *
+ * Only reached after the exact lookup missed, so a heading that genuinely
+ * slugs to `step-2` is already resolved and never gets shifted.
+ */
+function findDuplicateShifted(normalized: string, doc: Document): HTMLElement | null {
+  const parts = DUPLICATE_SUFFIX_RE.exec(normalized)
+  if (!parts) return null
+  const ordinal = Number(parts[2])
+  if (!Number.isSafeInteger(ordinal)) return null
+  return doc.getElementById(`${parts[1]}-${ordinal + 1}`)
+}
+
 /**
  * Resolve a `#hash` id that no exact lookup matched, by comparing normalized
  * forms. Returns `null` when nothing in the document matches, so the caller
  * can leave the browser's default behavior alone rather than hijacking a
  * click that was never ours to handle.
  *
- * Two passes, cheapest first:
+ * Three passes, cheapest first:
  *   1. a single `getElementById` on the normalized id — catches the whole
  *      emoji-hyphen family without walking the DOM;
- *   2. a heading scan — catches ids whose own raw form normalizes differently
+ *   2. the duplicate-heading shift (see `findDuplicateShifted`);
+ *   3. a heading scan — catches ids whose own raw form normalizes differently
  *      (e.g. `a---b`, from a title containing a literal ` - `).
  */
 export function findAnchorElementByNormalizedId(
@@ -74,5 +96,8 @@ export function findAnchorElementByNormalizedId(
   for (const heading of Array.from(doc.querySelectorAll<HTMLElement>(HEADING_SELECTOR))) {
     if (normalizeAnchorId(heading.id) === normalized) return heading
   }
-  return null
+
+  // Last: the shift would happily match an unrelated `x-3` for a `x-2` that
+  // has no heading at all, so it runs only once the scan has come up empty.
+  return findDuplicateShifted(normalized, doc)
 }

--- a/openframe-frontend-core/src/utils/anchor-id.ts
+++ b/openframe-frontend-core/src/utils/anchor-id.ts
@@ -57,8 +57,9 @@ const DUPLICATE_SUFFIX_RE = /^(.+)-(\d+)$/
  * suffix is the occurrence COUNT, not the offset). So a GitHub `#setup-1`
  * needs our `setup-2` — every duplicate is off by exactly one.
  *
- * Only reached after the exact lookup missed, so a heading that genuinely
- * slugs to `step-2` is already resolved and never gets shifted.
+ * Runs LAST, after the exact lookup and the heading scan have both missed: a
+ * heading that genuinely slugs to `step-2` is resolved long before this, and
+ * the shift is the one pass that can match an id it was not asked for.
  */
 function findDuplicateShifted(normalized: string, doc: Document): HTMLElement | null {
   const parts = DUPLICATE_SUFFIX_RE.exec(normalized)
@@ -74,12 +75,14 @@ function findDuplicateShifted(normalized: string, doc: Document): HTMLElement | 
  * can leave the browser's default behavior alone rather than hijacking a
  * click that was never ours to handle.
  *
- * Three passes, cheapest first:
+ * Three passes, in order of how much they assume:
  *   1. a single `getElementById` on the normalized id — catches the whole
  *      emoji-hyphen family without walking the DOM;
- *   2. the duplicate-heading shift (see `findDuplicateShifted`);
- *   3. a heading scan — catches ids whose own raw form normalizes differently
- *      (e.g. `a---b`, from a title containing a literal ` - `).
+ *   2. a heading scan — catches ids whose own raw form normalizes differently
+ *      (e.g. `a---b`, from a title containing a literal ` - `);
+ *   3. the duplicate-heading shift (see `findDuplicateShifted`) — last,
+ *      because it is the only pass that resolves to an id the fragment did
+ *      not name.
  */
 export function findAnchorElementByNormalizedId(
   rawId: string,

--- a/openframe-frontend-core/src/utils/content-href.ts
+++ b/openframe-frontend-core/src/utils/content-href.ts
@@ -26,6 +26,9 @@
  *   })
  */
 
+import { canonicalContentRefType } from './list-url'
+import { byKey, getPlatformProductionUrl } from '../platform-domains'
+
 /**
  * Type → in-app route suffix. The public-hostable subset of the hub's
  * `PUBLIC_URL_PATHS` (`lib/utils/content-url-builder.ts`); the hub keeps
@@ -56,14 +59,32 @@ export const DEFAULT_CONTENT_SUFFIXES: Record<string, string> = {
  *  `identifier` (the primary-key id) + `externalUrl` (the canonical hub URL,
  *  from which the slug is recovered for in-app routing). */
 export interface ComposeContentUrlInput {
-  /** The content's documentType (e.g. `'product_release'`, `'blog_post'`). */
+  /** The content's CANONICAL documentType (e.g. `'product_release'`,
+   *  `'blog_post'`).
+   *
+   *  Rail-vocab aliases (`'blog_post_existing'`) must be canonicalized by the
+   *  caller via `canonicalContentRefType` BEFORE they reach the seam: a host
+   *  writes its `hostedTypes` / `suffixes` / `overrides` against the canonical
+   *  vocabulary, so an alias silently misses every one of them and falls
+   *  through to the default `<contentOrigin>/<type>/<id>` branch — which is how
+   *  the same blog post reached `/blog/<slug>` from one path and
+   *  `/blog_post_existing/<slug>` from another. */
   type: string
   /** Content identifier. Page views pass the slug; chat rows pass the
    *  primary-key id (the slug is recovered from `externalUrl` when hosted). */
   identifier: string
-  /** Hydrated platform junction (page views). Unused by the embedder default
-   *  — `hostedTypes` membership decides in-vs-out — but threaded for the hub
-   *  composer's cross-platform topology. */
+  /** Preferred path segment for HOSTED types when there is no `externalUrl`
+   *  to recover the slug from — the Mingo/NATS transport ships bare
+   *  `[card://type:id]` markers with no ref metadata, so a fetch-mode card
+   *  knows the row's slug only AFTER it loads the row. `identifier` must stay
+   *  the primary key (that is what `overrides` deep-link on), hence a separate
+   *  field rather than overloading it. Ignored for non-hosted types. */
+  slug?: string | null
+  /** Hydrated platform junction from the list APIs. `hostedTypes` membership
+   *  still decides in-app vs out; this decides WHICH origin an out-link points
+   *  at — an OpenMSP-owned row resolves to openmsp.ai, not to the embedder's
+   *  `contentOrigin`. Read only when `targetPlatform` is absent. Accepts the
+   *  three junction shapes the DALs produce (see `primaryPlatformOf`). */
   platforms?: Array<{ name?: string }>
   /** The canonical hub URL when the caller already has it (chat entity rows
    *  carry it from the RAG mapper). Hosted types relativize it to an in-app
@@ -78,8 +99,11 @@ export interface ContentHrefOptions {
   /** Types THIS host serves in-app → relative href (soft-nav). Everything
    *  else resolves to the row's `externalUrl` / `contentOrigin` (opens out). */
   hostedTypes: ReadonlySet<string>
-  /** Hub origin for non-hosted types with no `externalUrl` (e.g.
-   *  `https://openframe.app`). */
+  /** Fallback origin for non-hosted types with no `externalUrl` AND no
+   *  resolvable owning platform (e.g. `https://openframe.app`). When the row
+   *  DOES name its platform, that platform's canonical origin wins — otherwise
+   *  cross-platform content (an OpenMSP blog post) would be linked to the
+   *  wrong site. */
   contentOrigin: string
   /** Per-type route suffix. Defaults to {@link DEFAULT_CONTENT_SUFFIXES}. */
   suffixes?: Record<string, string>
@@ -94,6 +118,35 @@ export interface ContentHrefOptions {
 export type ComposeContentUrl = (
   input: ComposeContentUrlInput,
 ) => { href: string; targetPlatform: string | null }
+
+/**
+ * Owning platform of a content row, from the hydrated junction the list APIs
+ * return. Mirrors the hub's `extractPrimaryPlatform` (`lib/utils/content-url-
+ * builder.ts`): the same junction arrives in three shapes depending on which
+ * DAL produced it, so all three are read.
+ *
+ *   1. `{ platforms: { name } }`  — raw Supabase row (rag-mappers)
+ *   2. `{ platform_name }`        — legacy pre-flattened admin endpoints
+ *   3. `{ name }`                 — modern flattened shape (blog / case-study utils)
+ *
+ * Returns the FIRST resolvable name; `null` when the junction is absent or
+ * carries no usable platform (caller then falls back to `contentOrigin`).
+ */
+function primaryPlatformOf(
+  platforms: ComposeContentUrlInput['platforms'],
+): string | null {
+  if (!Array.isArray(platforms)) return null
+  for (const entry of platforms) {
+    const row = entry as {
+      name?: unknown
+      platform_name?: unknown
+      platforms?: { name?: unknown }
+    }
+    const name = row?.platforms?.name ?? row?.platform_name ?? row?.name
+    if (typeof name === 'string' && name.trim()) return name.trim()
+  }
+  return null
+}
 
 /** Last non-empty path segment of a URL (relative or absolute) — the content
  *  slug of a canonical detail URL like `https://hub/releases/my-release`.
@@ -127,7 +180,19 @@ function lastPathSegment(url: string): string | null {
  */
 export function makeComposeContentUrl(opts: ContentHrefOptions): ComposeContentUrl {
   const suffixes = opts.suffixes ?? DEFAULT_CONTENT_SUFFIXES
-  return ({ type, identifier, externalUrl, targetPlatform }) => {
+  return ({
+    type: rawType,
+    identifier,
+    slug: slugHint,
+    externalUrl,
+    targetPlatform,
+    platforms,
+  }) => {
+    // Defence in depth: callers are expected to hand over a canonical
+    // documentType (see `ComposeContentUrlInput.type`), but a stray alias must
+    // not silently produce a `<origin>/blog_post_existing/<slug>` URL. Same
+    // canonicalizer `buildListUrl` uses — one alias table, both paths.
+    const type = canonicalContentRefType(rawType)
     const override =
       opts.overrides && Object.prototype.hasOwnProperty.call(opts.overrides, type)
         ? opts.overrides[type]
@@ -143,15 +208,43 @@ export function makeComposeContentUrl(opts: ContentHrefOptions): ComposeContentU
       // segment is the type's OWN suffix (e.g. a malformed/list externalUrl like
       // `https://hub/releases/` → `'releases'`), fall back to `identifier` instead
       // of emitting a nonsensical `/releases/releases`.
+      //
+      // `slug` (the explicit hint) sits between the two: a Mingo fetch-mode card
+      // has NO externalUrl to recover from but DOES know the row's slug once it
+      // loads, and its `identifier` must stay the primary key so `overrides`
+      // still deep-link correctly.
       const recovered = externalUrl ? lastPathSegment(externalUrl) : null
-      const slug = recovered && recovered !== seg ? recovered : identifier
+      const slug =
+        recovered && recovered !== seg ? recovered : (slugHint?.trim() || identifier)
       return { href: `/${seg}/${slug}`, targetPlatform: null }
     }
-    // Not hosted → opens out. Prefer the RAG-authoritative `externalUrl` (chat);
-    // else compose against the hub origin (page views with no externalUrl).
-    return externalUrl
-      ? { href: externalUrl, targetPlatform: targetPlatform ?? null }
-      : { href: `${opts.contentOrigin}/${seg}/${identifier}`, targetPlatform: null }
+    // Not hosted → opens out. Prefer the RAG-authoritative `externalUrl` (chat).
+    if (externalUrl) return { href: externalUrl, targetPlatform: targetPlatform ?? null }
+
+    // No externalUrl → compose it. The destination is the origin of the
+    // platform that OWNS the row, not a fixed hub: an OpenMSP blog post lives
+    // on openmsp.ai, and pinning every non-hosted type to `contentOrigin` sent
+    // it to flamingo.run (a 404 / wrong site). Owner comes from the explicit
+    // `targetPlatform`, else the hydrated platforms junction — mirroring the
+    // hub's `composeContentUrlFromPlatforms` + `extractPrimaryPlatform`.
+    // Origins resolve through the platform-domain SSOT (env override → default
+    // production URL), so a per-deploy `NEXT_PUBLIC_*_URL` is honoured here too.
+    //
+    // `contentOrigin` stays the fallback for rows with no resolvable owner and
+    // for platform names the registry doesn't know — an embedder's explicit
+    // configuration must win over the registry's flamingo default.
+    const owner = targetPlatform ?? primaryPlatformOf(platforms)
+    const origin = owner && byKey(owner) ? getPlatformProductionUrl(owner) : opts.contentOrigin
+    // The hub's public detail routes are SLUG-based, so the `slug` hint wins
+    // over `identifier` here too — a Mingo fetch-mode card knows the row's slug
+    // but its `identifier` is the marker's primary key, which would 404.
+    return {
+      href: `${origin.replace(/\/+$/, '')}/${seg}/${slugHint?.trim() || identifier}`,
+      // Report the owner so `decideNewTab` can compare it against the current
+      // app instead of falling back to an origin guess (which is unreliable in
+      // dev, where every platform shares localhost).
+      targetPlatform: owner ?? null,
+    }
   }
 }
 

--- a/openframe-frontend-core/src/utils/content-href.ts
+++ b/openframe-frontend-core/src/utils/content-href.ts
@@ -233,8 +233,14 @@ export function makeComposeContentUrl(opts: ContentHrefOptions): ComposeContentU
     // `contentOrigin` stays the fallback for rows with no resolvable owner and
     // for platform names the registry doesn't know — an embedder's explicit
     // configuration must win over the registry's flamingo default.
-    const owner = targetPlatform ?? primaryPlatformOf(platforms)
-    const origin = owner && byKey(owner) ? getPlatformProductionUrl(owner) : opts.contentOrigin
+    // Only a REGISTRY-RESOLVED owner counts. An unknown name (a platform the
+    // registry doesn't carry) falls back to `contentOrigin` for the href, and
+    // reporting it as the `targetPlatform` anyway made the two disagree:
+    // `decideNewTab` prefers `targetPlatform` over its origin check, so a link
+    // pointing at the CURRENT host opened in a new tab.
+    const claimedOwner = targetPlatform ?? primaryPlatformOf(platforms)
+    const owner = claimedOwner && byKey(claimedOwner) ? claimedOwner : null
+    const origin = owner ? getPlatformProductionUrl(owner) : opts.contentOrigin
     // The hub's public detail routes are SLUG-based, so the `slug` hint wins
     // over `identifier` here too — a Mingo fetch-mode card knows the row's slug
     // but its `identifier` is the marker's primary key, which would 404.
@@ -242,8 +248,9 @@ export function makeComposeContentUrl(opts: ContentHrefOptions): ComposeContentU
       href: `${origin.replace(/\/+$/, '')}/${seg}/${slugHint?.trim() || identifier}`,
       // Report the owner so `decideNewTab` can compare it against the current
       // app instead of falling back to an origin guess (which is unreliable in
-      // dev, where every platform shares localhost).
-      targetPlatform: owner ?? null,
+      // dev, where every platform shares localhost). `null` whenever the href
+      // came from `contentOrigin`, so the two never disagree.
+      targetPlatform: owner,
     }
   }
 }

--- a/openframe-frontend-core/src/utils/index.ts
+++ b/openframe-frontend-core/src/utils/index.ts
@@ -299,6 +299,14 @@ export {
   type NavigateSamePageHashOptions,
 } from './same-page-hash-nav'
 
+// GitHub-compatible anchor resolution. Doc TOCs are authored against
+// GitHub's slugger (`## 📚 Table of Contents` → `#-table-of-contents`)
+// while our heading ids trim the emoji's leftover hyphen — this bridges
+// that without changing the id shape the "On this page" rail and every
+// shared URL already depend on. Consumers resolving a hash want
+// `getHashTargetElement` (above), which applies this as its last pass.
+export { findAnchorElementByNormalizedId, normalizeAnchorId } from './anchor-id'
+
 // Shared list-API URL builder — the single source for the per-type chat
 // entity-card fetch shapes. The hub's 12 RAG mapper `listApi` closures
 // delegate here (byte-parity test guards the migration); embedders wire

--- a/openframe-frontend-core/src/utils/list-url.ts
+++ b/openframe-frontend-core/src/utils/list-url.ts
@@ -43,7 +43,12 @@ const ALIASES: Record<string, string> = { blog_post_existing: 'blog_post' }
  *  registry entityTypes (e.g. the related-content rail's same-type-first
  *  ordering) share THIS alias map instead of re-declaring it. */
 export function canonicalContentRefType(contentRefType: string): string {
-  return ALIASES[contentRefType] ?? contentRefType
+  // `hasOwnProperty` guard, same as `buildListUrl` below: a bare index read
+  // resolves prototype keys, so `canonicalContentRefType('constructor')`
+  // returned `Object` itself — which then got interpolated into a URL path.
+  return Object.prototype.hasOwnProperty.call(ALIASES, contentRefType)
+    ? ALIASES[contentRefType]
+    : contentRefType
 }
 
 /**

--- a/openframe-frontend-core/src/utils/same-page-hash-nav.ts
+++ b/openframe-frontend-core/src/utils/same-page-hash-nav.ts
@@ -1,4 +1,5 @@
 import { scrollElementIntoView } from './scroll-into-view'
+import { findAnchorElementByNormalizedId } from './anchor-id'
 
 /** Pages with a section-nav STRIP on top of the global hub header
  *  (dev-center roadmap/delivery/tickets, FAQ category-pill nav).
@@ -24,24 +25,42 @@ export function normalizeHashFragment(hash: string): string {
 }
 
 /**
- * Resolve the DOM element a hash fragment id points at. Tries the raw
- * id first (ordinary anchors), then the percent-decoded form — href
- * composers like `buildTicketOpenHref` encode the id into the fragment
- * while rows render the raw id, so `#ticket-a%2Fb` must still find
- * `id="ticket-a/b"`. A malformed escape sequence falls back to the
- * raw lookup result.
+ * Resolve the DOM element a hash fragment id points at — THE hash resolver;
+ * `navigateSamePageHash`, `useScrollToHash` and the markdown link renderer
+ * all go through this one, so a fragment that resolves for a deep link
+ * resolves for an in-body click too.
+ *
+ * Three passes, cheapest first:
+ *   1. the raw id (ordinary anchors — the overwhelming common case);
+ *   2. the percent-decoded form — href composers like `buildTicketOpenHref`
+ *      encode the id into the fragment while rows render the raw id, so
+ *      `#ticket-a%2Fb` must still find `id="ticket-a/b"`. A malformed escape
+ *      sequence just falls through;
+ *   3. a NORMALIZED match against the document's headings — doc bodies are
+ *      authored on GitHub, whose slugger keeps the hyphen left behind by a
+ *      stripped emoji (`## 📚 Table of Contents` → `#-table-of-contents`)
+ *      while our ids trim it. Without this every in-body TOC link in every
+ *      GitHub-authored doc resolves to nothing and clicking one does nothing.
+ *      See `utils/anchor-id`.
  */
 export function getHashTargetElement(id: string): HTMLElement | null {
   if (!id) return null
   const direct = document.getElementById(id)
   if (direct) return direct
+
+  let decoded = id
   try {
-    const decoded = decodeURIComponent(id)
-    if (decoded !== id) return document.getElementById(decoded)
+    decoded = decodeURIComponent(id)
+    if (decoded !== id) {
+      const decodedEl = document.getElementById(decoded)
+      if (decodedEl) return decodedEl
+    }
   } catch {
     // malformed escape — the raw lookup above already covered it
+    decoded = id
   }
-  return null
+
+  return findAnchorElementByNormalizedId(decoded, document)
 }
 
 export interface NavigateSamePageHashOptions {


### PR DESCRIPTION
Five fixes around chat entity cards, doc anchors and search links. They share one theme: **every content link should resolve through one seam**, so the same item can't open at two different urls depending on which surface rendered it.

Rebased onto `main` — the anchor fix was rewritten to fit the unified markdown engine rather than merged mechanically (see the last section).

## What's in here

**1. Search-result hrefs go through `composeContentUrl`** — the RAG search dropdown built links from the row's `externalUrl` alone, so an embedder whose content lives on different routes had no way to override them, even though page-view cards and chat rows already resolved through the seam. Also moves the embed branch out of `navigate-same-tab`, where it was unreachable, into `navigate-new-tab`.

**2. Table-of-Contents links scroll again** — doc bodies are authored on GitHub, so their TOCs carry GitHub-slugger anchors (`## 📚 Table of Contents` → `#-table-of-contents`, emoji hyphen and all) while our heading ids trim that hyphen. Every TOC link resolved to no element, while the "On this page" rail — which builds hrefs from the ids themselves — worked fine.

  Note this is *not* fixed by `stripHeadingEmojis`: that normalizes the **id** side, while these hrefs arrive from GitHub already slugged. The tolerance goes into `getHashTargetElement` as a third pass, so deep links, `navigateSamePageHash` and in-body markdown links all inherit it from one place; `normalizeAnchorId` builds on `slugifyHeadingText` rather than re-implementing the chain, so a future id-shape change moves both sides together. Fixing the id shape instead would have been the smaller diff, but the ids are what the rail and every already-shared deep link depend on.

**3. NATS Mingo cards get the actions guide-mode cards have** — guide mode ships a full `ChatRef` per card; Mingo over NATS ships only a `[card://type:id]` marker, so its cards rendered with the id as their title, no link, and a dead Ask button. All three are now resolved post-fetch from the row the card already fetches, through the *same* seam the page views use. Two SSOT holes surfaced while wiring it, both visible as wrong links:
  - the seam never canonicalized rail-vocab aliases, so one post opened at `/blog/what-is-mdr` from one call site and `/blog_post_existing/…` from another;
  - non-hosted rows always resolved against `contentOrigin`, so OpenMSP content linked to the Flamingo site — the seam now picks the owning platform's origin.

  Plus a prototype hole the new tests caught: `canonicalContentRefType('constructor')` returned `Object` itself, which then interpolated into a url path.

**4. Card action menus stay inside the chat panel** — they collided against the viewport rather than the panel, so in an embedded panel a menu opened half outside the component, and the thread kept auto-scrolling underneath it (the menu is portaled and position-fixed, so it stayed pinned mid-air while its trigger scrolled away). Adds a collision-boundary context the panel publishes itself into, an overlay registry that pauses stick-to-bottom while a menu is open, and a scroll-dismiss scoped to the thread — deliberately not a document-wide listener, which fought touch inertia. Also fixes the ↗ button, which never opened its link: a capture handler swallowed the click, because a React portal still bubbles through the React tree.

**5. Zero type-check errors** — a TS2684 introduced by the mention-chips test on this branch.

## Testing

`npm run type-check` clean. `npm run test:run` — **4723 passing, 49 files, no failures**, including 52 new tests across the five areas.

## Notes for review — how the rebase resolved

This branch predated [#1506](https://github.com/flamingo-stack/openframe-oss-lib/pull/1506) (markdown + stream-reading unification), so three of the four conflicts were resolved by *moving* the change rather than merging it:

| Conflict | Resolution |
|---|---|
| `ui/rich-markdown-renderer.tsx` — deleted on main | anchor-click handler moved to `ui/markdown/base-components.tsx`; the deletion is accepted |
| `hooks/use-scroll-to-hash.ts` | main's version taken **unchanged** — the fix moved down into `getHashTargetElement`, which the hook already calls |
| `chat/chat-message-list.tsx` | the overlay guard now also gates main's new `followBottomRef` follow-intent: an open menu must not arm a follow that re-asserts the jump on every later resize |
| `chat/hooks/use-nats-chat-adapter.ts` | import-only (`extractIncompleteMessageState` → `extractIncompleteTailState`) |

The consumer-side changes (`openframe-oss-frontend`) ship separately — they import `buildDiscussPrompt`, so that PR is blocked until this releases.
