### PR TITLE
test(device): expose Fleet host id and hostname on FleetHost

### DIFF
--- a/openframe-test-service-core/src/main/java/com/openframe/test/data/dto/device/fleet/.FleetHost.md
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/data/dto/device/fleet/.FleetHost.md
@@ -1,10 +1,12 @@
-<!-- source-hash: c4e8013bea85965c3a95acc3316e90da -->
-Data Transfer Object (DTO) representing a host/device within a Fleet inventory, mapping hardware details, users, software, and derived vulnerability data from JSON responses.
+<!-- source-hash: 41906c9e6a6777020239acfa5d30cb26 -->
+Data Transfer Object (DTO) representing a host/device within a Fleet inventory, mapping identity, hardware details, users, software, and derived vulnerability data from JSON responses.
 
 ## Key Components
 
 | Member | Type | Description |
 |---|---|---|
+| `id` | `long` | Fleet's own host id; matches the `agentToolId` of the device's `FLEET_MDM` tool connection |
+| `hostname` | `String` | Host name as reported by osquery |
 | `computerName` | `String` | Mapped from `computer_name` |
 | `hardwareVendor` / `hardwareModel` / `hardwareSerial` | `String` | Hardware identification fields |
 | `cpuType` / `cpuSubtype` / `cpuBrand` | `String` | CPU descriptor fields |

--- a/openframe-test-service-core/src/main/java/com/openframe/test/data/dto/device/fleet/FleetHost.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/data/dto/device/fleet/FleetHost.java
@@ -18,6 +18,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FleetHost {
 
+    // Identity
+    private long id;
+
+    private String hostname;
+
     // Hardware
     @JsonProperty("computer_name")
     private String computerName;


### PR DESCRIPTION
## Summary

`FleetHost` mapped only hardware, users and software, so a Fleet `GET /hosts/{id}` response could not be tied back to the OpenFrame device it describes. This adds the two fields needed for that.

```java
// Identity
private long id;

private String hostname;
```

The join key is the device's `FLEET_MDM` tool connection: its `agentToolId` equals Fleet's `host.id`. `hostname` corroborates it — it matched exactly on both a Windows host (`vm114267`) and a Mac (`Ilonas-MacBook-Pro.local`).

## Notes for callers

- Both keys are single-word in the Fleet payload, so no `@JsonProperty` is needed.
- `id` is a `long` while `ToolConnection.agentToolId` is a `String`, so the join needs a conversion.
- `id` is primitive: a missing value deserializes to `0`, not `null`. An identity assertion should reject `0` explicitly rather than relying on a null check.
- Do **not** compare `Machine.machineId` to Fleet's `uuid` — both are UUIDs but they are unrelated identifiers (OpenFrame's own machine id vs. the osquery/hardware UUID). The backend field that would hold the latter, `osUuid`, is currently null.
- Prefer `host.hostname` over `host.display_name` — Fleet uppercases the latter on Windows (`VM114267`) and it can carry a curly apostrophe on macOS (`Ilona's MacBook Pro`).

## Test plan

- `mvn -o -pl openframe-test-service-core compile` passes (this module keeps its tests under `src/main/java`, so this covers them).
- No behavioural impact on existing tests. `FleetHost` is referenced in exactly two places — `DeviceApi.getFleetInfo` and `DevicesTest.testFleetInfo` — and neither reads `id`/`hostname`, builds a `FleetHost` via the builder, nor compares two instances. The class is `@JsonIgnoreProperties(ignoreUnknown = true)`, so both keys were previously parsed and dropped.

## Out of scope

`platform` was not added, so an OS-level cross-source check still has nothing to read on the Fleet side, and `DeviceApi.getFleetOsVersion` still reaches around the DTO with a raw `jsonPath("host.os_version")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fleet host data now includes the host’s unique identifier and hostname.

* **Documentation**
  * Updated Fleet host documentation to describe identity, hardware, user, software, and vulnerability mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->