### PR TITLE
fix(deps): un-exclude graphql-dgs-mocking — DGS requires it at boot

### DIFF
--- a/openframe-api-service-core/pom.xml
+++ b/openframe-api-service-core/pom.xml
@@ -50,13 +50,6 @@
             <groupId>com.netflix.graphql.dgs</groupId>
             <artifactId>graphql-dgs-spring-boot-starter</artifactId>
             <version>${netflix.dgs.version}</version>
-            <exclusions>
-                <!-- test-data generator pulled in by the DGS starter; unused at runtime -->
-                <exclusion>
-                    <groupId>com.netflix.graphql.dgs</groupId>
-                    <artifactId>graphql-dgs-mocking</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## What

Reverts the `graphql-dgs-mocking` exclusion on `api-service-core`'s DGS starter. The "test-data generator; unused at runtime" assumption is wrong: `DgsAutoConfiguration` references `com.netflix.graphql.mocking.MockProvider` in its method signatures, and Kotlin reflection loads those during **condition evaluation at startup** — every consumer of `api-service-core` that doesn't declare a DGS starter of its own dies on boot:

```
IllegalStateException: Error processing condition on com.netflix.graphql.dgs.autoconfig.DgsAutoConfiguration.dataFetcherExceptionHandler
Caused by: java.lang.TypeNotPresentException: Type com.netflix.graphql.mocking.MockProvider not present
```

Proven live: on saas-tenant both `saas-api` and `ai-agent` went straight to CrashLoopBackOff with exactly this trace after the sister exclusion landed there; removing it restored boot (flamingo-stack/openframe-saas-tenant#2375, merged). The saas-api там несёт временную явную зависимость `graphql-dgs-mocking` как workaround — её можно снять, когда этот фикс доедет через релиз в `openframe.oss.libs.version`.

CI compiles fine either way — the breakage is runtime-reflection-only, which is why it slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKdcCJmnHipDNZe1qYqp9H

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restored the standard mocking support included with the Netflix DGS starter dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->