### PR TITLE
fix(api-service-core): un-exclude graphql-dgs-mocking — consumers fail on boot without it

### DIFF
--- a/openframe-api-service-core/pom.xml
+++ b/openframe-api-service-core/pom.xml
@@ -50,13 +50,6 @@
             <groupId>com.netflix.graphql.dgs</groupId>
             <artifactId>graphql-dgs-spring-boot-starter</artifactId>
             <version>${netflix.dgs.version}</version>
-            <exclusions>
-                <!-- test-data generator pulled in by the DGS starter; unused at runtime -->
-                <exclusion>
-                    <groupId>com.netflix.graphql.dgs</groupId>
-                    <artifactId>graphql-dgs-mocking</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
ClickUp: https://app.clickup.com/t/9013925967/86ajtc6gp

Dependency-only fix for the boot regression introduced by #1614: reverts the `graphql-dgs-mocking` exclusion from the DGS starter in `api-service-core`. One file, 7 deleted lines.

## Why

`DgsAutoConfiguration` references `com.netflix.graphql.mocking.MockProvider` in method signatures, and Kotlin reflection loads those during **condition evaluation at startup** — with the jar excluded, consumers die on boot:

```
TypeNotPresentException: Type com.netflix.graphql.mocking.MockProvider not present
```

flamingo-stack/openframe-saas-tenant#2375 (merged) removed the tenant-side exclusions, but that only fixes ai-agent, which declares the DGS starter directly. **saas-api inherits the exclusion from this library's pom** — a consumer cannot undo an exclusion declared upstream, so saas-api remains boot-broken on 6.22.x until this releases and the tenant repo bumps.

## Scope note

The sibling servlet-api regression (`BaseGlobalExceptionHandler`'s MVC handler types extend `jakarta.servlet.ServletException`; reactive apps scanning `com.openframe.core` crash without the servlet jar) is handled in the affected consumers — flamingo-stack/openframe-saas-shared#1634 (logs-gateway, crashing in dev now) and flamingo-stack/openframe-saas-tenant#2376 (tenant gateway, same latent exposure). `openframe-exception` keeps `jakarta.servlet-api` at `provided` scope. Audit: those two gateways are the only affected services across both app repos — every other service scanning `com.openframe.core` is servlet-based, so embedded Tomcat supplies the class.

## Verification

- `mvn install` + `mvn test` for `openframe-api-service-core`: 285 tests, 0 failures.
- With the exclusion reverted, `graphql-dgs-mocking:9.0.3` returns to the saas-api tree transitively (few hundred KB — no meaningful size impact on the #1614 reduction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)