### PR TITLE
Add user status to graphql, delete purge user as outdated functionality

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/controller/UserController.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/controller/UserController.java
@@ -51,12 +51,6 @@ public class UserController {
         userService.softDeleteUser(id, principal.getId());
     }
 
-    @DeleteMapping("/{id}/purge")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void purgeUser(@PathVariable String id) {
-        userService.purgeUser(id);
-    }
-
     @PostMapping("/{id}/transfer-ownership")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAuthority('OWNER')")

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/user/UserService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/user/UserService.java
@@ -26,7 +26,6 @@ import static com.openframe.data.document.user.UserRole.ADMIN;
 import static com.openframe.data.document.user.UserRole.OWNER;
 import static com.openframe.data.document.user.UserStatus.ACTIVE;
 import static com.openframe.data.document.user.UserStatus.DELETED;
-import static com.openframe.data.document.user.UserStatus.REMOVED;
 import static com.openframe.data.document.user.UserStatus.SELF_DELETED;
 
 @Service
@@ -47,7 +46,7 @@ public class UserService {
 
     public UserPageResponse listUsers(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<User> p = userRepository.findByStatusNot(REMOVED, pageable);
+        Page<User> p = userRepository.findAll(pageable);
         UserPageResponse response = UserPageResponse.builder()
                 .items(p.getContent().stream().map(userMapper::toResponse).toList())
                 .page(p.getNumber())
@@ -74,10 +73,7 @@ public class UserService {
         }
         List<User> users = userRepository.findAllById(ids);
         UserPageResponse pageResponse = UserPageResponse.builder()
-                .items(users.stream()
-                        .filter(user -> user.getStatus() != REMOVED)
-                        .map(userMapper::toResponse)
-                        .toList())
+                .items(users.stream().map(userMapper::toResponse).toList())
                 .build();
         userProcessor.postProcessUserGet(pageResponse);
         return pageResponse.getItems();
@@ -123,29 +119,6 @@ public class UserService {
     }
 
     /**
-     * Permanently remove an already soft-deleted user: anonymize personal data and move to the
-     * terminal REMOVED status, after which the user is excluded from all user lists. The document
-     * itself is kept so historical references by id stay resolvable. Idempotent.
-     */
-    public void purgeUser(String id) {
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new UserNotFoundException(id));
-
-        if (user.getStatus() == REMOVED) {
-            return;
-        }
-        if (user.getStatus() == ACTIVE) {
-            throw new OperationNotAllowedException("User must be deleted before permanent removal");
-        }
-
-        user.setStatus(REMOVED);
-        anonymize(user);
-        User savedUser = userRepository.save(user);
-
-        userProcessor.postProcessUserDeleted(savedUser);
-    }
-
-    /**
      * Transfer the OWNER role from the requester to another active user in the tenant.
      * Only the current owner can transfer ownership. The new owner is granted first and the
      * requester demoted after, so a failure in between leaves two owners (recoverable by a
@@ -178,7 +151,7 @@ public class UserService {
     }
 
     /**
-     * Erase personal data on self-deletion or permanent removal. The email tombstone must stay unique per user
+     * Erase personal data on self-deletion. The email tombstone must stay unique per user
      * because of the unique {tenantId, email} index on the users collection, and freeing the
      * real email lets the person register a fresh account later instead of reactivating this
      * one. The document is an AuthUser at runtime (polymorphic {@code _class} mapping), so

--- a/openframe-api-service-core/src/main/resources/schema/knowledge-base.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/knowledge-base.graphqls
@@ -177,6 +177,8 @@ type User implements Node {
     firstName: String
     lastName: String
     email: String
+    "ACTIVE, DELETED or SELF_DELETED"
+    status: String
     image: UserImage
 }
 

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/user/UserStatus.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/user/UserStatus.java
@@ -11,11 +11,5 @@ public enum UserStatus {
      * credentials) is anonymized and the account is never reactivated; signing up
      * again with the same email creates a brand-new user.
      */
-    SELF_DELETED,
-    /**
-     * Terminal state after an admin permanently removes an already-deleted user.
-     * Personal data is anonymized and the user is excluded from all user lists;
-     * the document is kept only so historical references by id stay resolvable.
-     */
-    REMOVED
+    SELF_DELETED
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/CustomUserRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/CustomUserRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.openframe.data.repository.user;
 
 import com.openframe.data.document.user.User;
-import com.openframe.data.document.user.UserStatus;
 import com.openframe.data.document.user.filter.UserQueryFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +28,6 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
 
     @Override
     public List<User> findUsersBySearch(UserQueryFilter filter, int limit) {
-        // REMOVED users are permanently erased and never surface in any user list
-        if (filter != null && filter.getStatus() == UserStatus.REMOVED) {
-            return List.of();
-        }
         Query query = buildQuery(filter);
         query.limit(limit);
         query.with(Sort.by(Sort.Direction.DESC, FIELD_CREATED_AT));
@@ -43,13 +38,10 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
     private Query buildQuery(UserQueryFilter filter) {
         Query query = new Query();
         if (filter == null) {
-            query.addCriteria(Criteria.where(FIELD_STATUS).ne(UserStatus.REMOVED));
             return query;
         }
         if (filter.getStatus() != null) {
             query.addCriteria(Criteria.where(FIELD_STATUS).is(filter.getStatus()));
-        } else {
-            query.addCriteria(Criteria.where(FIELD_STATUS).ne(UserStatus.REMOVED));
         }
         if (hasText(filter.getEmailRegex())) {
             query.addCriteria(Criteria.where(FIELD_EMAIL)

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/UserRepository.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/UserRepository.java
@@ -3,8 +3,6 @@ package com.openframe.data.repository.user;
 import com.openframe.data.document.user.User;
 import com.openframe.data.document.user.UserRole;
 import com.openframe.data.document.user.UserStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
@@ -24,10 +22,6 @@ public interface UserRepository extends MongoRepository<User, String>, BaseUserR
     Boolean existsByEmailAndStatus(String email, UserStatus status);
 
     List<User> findByRolesInAndStatus(Collection<UserRole> roles, UserStatus status);
-
-    Page<User> findByStatusNot(UserStatus status, Pageable pageable);
-
-    List<User> findByStatusNot(UserStatus status);
 
     /**
      * Whether a user with the given id is a member of the given tenant. Tenant-first form so the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * User records now include a status field in GraphQL responses, with values for active, deleted, and self-deleted accounts.
  * User listings and bulk retrieval include deleted records when no status filter is specified.
  * Removed the permanent user purge operation; soft deletion and ownership transfer remain available.
  * Retired the legacy “removed” user status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->