### PR TITLE
feat(cards): assignee avatar stacks on delivery/roadmap cards

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
@@ -14,6 +14,7 @@ import React, { useState } from 'react'
 import Image from '../../../embed-shims/next-image'
 import { ThumbsUp, ThumbsDown } from 'lucide-react'
 import { RoadmapVoteButton } from './roadmap-vote-button'
+import { AvatarStack, type AvatarStackPerson } from '../../ui/avatar-stack'
 import { FigmaIcon } from '../../icons/figma-icon'
 import { ImageIcon } from '../../icons/image-icon'
 import { Button } from '../../ui/button/button'
@@ -110,6 +111,17 @@ export interface RoadmapCardProps {
   userVote?: VoteType | null
   onVote?: (voteType: 'up' | 'down') => void
   isVoting?: boolean
+}
+
+/** Wire assignees → AvatarStack people (name+avatar only on the wire). */
+function assigneePeople(
+  assignees: Array<{ id: number; name: string | null; avatarUrl: string | null }> | undefined,
+): AvatarStackPerson[] {
+  return (assignees ?? []).map((a) => ({
+    key: a.id,
+    name: a.name ?? 'Unknown',
+    avatarUrl: a.avatarUrl,
+  }))
 }
 
 export function RoadmapCard({
@@ -220,6 +232,9 @@ export function RoadmapCard({
                 <span>{item.screenshots.length}</span>
               </span>
             ) : null}
+            {item.assignees && item.assignees.length > 0 ? (
+              <AvatarStack size="xs" people={assigneePeople(item.assignees)} className="shrink-0" />
+            ) : null}
           </span>
           <span className={COMPACT_CARD_META_ROW_BOX}>
             <span className={COMPACT_CARD_SUMMARY}>
@@ -321,7 +336,10 @@ export function RoadmapCard({
           </div>
         )}
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          {item.assignees && item.assignees.length > 0 ? (
+            <AvatarStack size="xs" people={assigneePeople(item.assignees)} className="shrink-0" />
+          ) : null}
           {item.screenshots && item.screenshots.length > 0 && (
             <Button
               variant="outline"

--- a/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/roadmap-card.tsx
@@ -54,6 +54,9 @@ export function RoadmapCardSkeleton({ size = 'default' }: { size?: CardSize }) {
           <span className={`${COMPACT_CARD_META_ROW_BOX} flex-nowrap gap-2`}>
             <span className="h-3 w-2/5 rounded bg-ods-bg/60 flex-1" />
             <span className="h-3 w-10 rounded bg-ods-bg/40 shrink-0" />
+            {/* assignee-stack placeholder — mirrors the xs AvatarStack
+                slot so row width doesn't shift when assignees load */}
+            <span className="h-6 w-14 rounded-full bg-ods-bg/40 shrink-0" />
           </span>
           <span className={COMPACT_CARD_META_ROW_BOX}>
             <span className="h-3 w-5/6 rounded bg-ods-bg/40" />
@@ -80,7 +83,12 @@ export function RoadmapCardSkeleton({ size = 'default' }: { size?: CardSize }) {
       <div className="flex-1" />
       <div className="flex items-center justify-between">
         <div className="h-12 w-32 bg-ods-bg rounded" />
-        <div className="h-8 w-20 bg-ods-bg rounded" />
+        <div className="flex items-center gap-2">
+          {/* assignee-stack placeholder — matches the xs AvatarStack in
+              the loaded card's action row */}
+          <div className="h-6 w-14 rounded-full bg-ods-bg/60" />
+          <div className="h-8 w-20 bg-ods-bg rounded" />
+        </div>
       </div>
     </div>
   )

--- a/openframe-frontend-core/src/components/chat/types/entities/roadmap-item.ts
+++ b/openframe-frontend-core/src/components/chat/types/entities/roadmap-item.ts
@@ -16,6 +16,9 @@
  */
 
 export interface RoadmapItem {
+  /** Assignee display identities (name + avatar, never email) — see
+   *  `TaskAssigneeDisplay` in types/delivery.ts. Optional. */
+  assignees?: Array<{ id: number; name: string | null; avatarUrl: string | null }>
   id: string;
   title: string;
   description: string;

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
@@ -111,8 +111,13 @@ export function DeliveryRow({
         </div>
       </div>
 
-      {/* Right: status + task-type badges + assignee stack */}
-      <div className="flex-shrink-0 self-start flex flex-col items-end gap-2">
+      {/* Right (desktop): badges + assignee stack in a right-aligned
+          column. Mobile: ONE horizontal footer row — badges lead,
+          avatars anchor the right edge (kanban-card convention: the
+          assignee owns the trailing slot of the meta row; a column of
+          right-aligned orphans under the description reads as clutter
+          on small screens). */}
+      <div className="flex-shrink-0 self-stretch md:self-start w-full md:w-auto flex flex-row md:flex-col items-center md:items-end gap-2">
         <StatusBadge
           text={item.status.toUpperCase()}
           colorScheme={statusBadgeScheme}
@@ -127,6 +132,7 @@ export function DeliveryRow({
         {item.assignees && item.assignees.length > 0 ? (
           <AvatarStack
             size="xs"
+            className="ml-auto md:ml-0"
             people={item.assignees.map((a) => ({
               key: a.id,
               name: a.name ?? 'Unknown',

--- a/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
+++ b/openframe-frontend-core/src/components/shared/delivery/delivery-row.tsx
@@ -27,6 +27,7 @@
 import * as React from 'react'
 import Link from '../../../embed-shims/next-link'
 import { StatusBadge } from '../../ui/status-badge'
+import { AvatarStack } from '../../ui/avatar-stack'
 import { getStatusColorScheme } from '../../../utils'
 import {
   type DeliveryItem,
@@ -110,8 +111,8 @@ export function DeliveryRow({
         </div>
       </div>
 
-      {/* Right: status + task-type badges */}
-      <div className="flex-shrink-0 self-start flex flex-col gap-2">
+      {/* Right: status + task-type badges + assignee stack */}
+      <div className="flex-shrink-0 self-start flex flex-col items-end gap-2">
         <StatusBadge
           text={item.status.toUpperCase()}
           colorScheme={statusBadgeScheme}
@@ -123,6 +124,16 @@ export function DeliveryRow({
           variant="card"
           className={`border border-ods-border ${typeBadgeTextColor}`}
         />
+        {item.assignees && item.assignees.length > 0 ? (
+          <AvatarStack
+            size="xs"
+            people={item.assignees.map((a) => ({
+              key: a.id,
+              name: a.name ?? 'Unknown',
+              avatarUrl: a.avatarUrl,
+            }))}
+          />
+        ) : null}
       </div>
     </div>
   )

--- a/openframe-frontend-core/src/components/ui/avatar-stack.tsx
+++ b/openframe-frontend-core/src/components/ui/avatar-stack.tsx
@@ -41,9 +41,6 @@ const OVERFLOW_CIRCLE_SIZE: Record<NonNullable<AvatarStackProps['size']>, string
   lg: 'h-12 w-12',
 }
 
-/** xs has no SquareAvatar bucket — rendered via exact sizePx. */
-const XS_PX = 24
-
 export function AvatarStack({
   people,
   max = 3,
@@ -64,8 +61,7 @@ export function AvatarStack({
         <SquareAvatar
           key={person.key ?? `${person.name}-${i}`}
           variant="round"
-          size={size === 'xs' ? 'sm' : size}
-          sizePx={size === 'xs' ? XS_PX : undefined}
+          size={size}
           src={person.avatarUrl ?? undefined}
           alt={person.name}
           fallback={person.name}

--- a/openframe-frontend-core/src/components/ui/avatar-stack.tsx
+++ b/openframe-frontend-core/src/components/ui/avatar-stack.tsx
@@ -14,22 +14,30 @@ import { cn } from '../../utils/cn'
 export interface AvatarStackPerson {
   name: string
   avatarUrl?: string | null
+  /** Stable render key — pass when names can collide or be blank
+   *  (e.g. ClickUp member id). Falls back to name+index. */
+  key?: string | number
 }
 
 export interface AvatarStackProps {
   people: AvatarStackPerson[]
   /** Avatars shown before collapsing into the "+N" circle. */
   max?: number
-  /** SquareAvatar size bucket (also sizes the "+N" circle). */
-  size?: 'sm' | 'md' | 'lg'
+  /** Size bucket (also sizes the "+N" circle). `xs` (24px) is for
+   *  dense card meta rows (chat compact cards, delivery rows). */
+  size?: 'xs' | 'sm' | 'md' | 'lg'
   className?: string
 }
 
 const OVERFLOW_CIRCLE_SIZE: Record<NonNullable<AvatarStackProps['size']>, string> = {
+  xs: 'h-6 w-6',
   sm: 'h-8 w-8',
   md: 'h-10 w-10',
   lg: 'h-12 w-12',
 }
+
+/** xs has no SquareAvatar bucket — rendered via exact sizePx. */
+const XS_PX = 24
 
 export function AvatarStack({ people, max = 3, size = 'md', className }: AvatarStackProps) {
   if (people.length === 0) return null
@@ -37,19 +45,21 @@ export function AvatarStack({ people, max = 3, size = 'md', className }: AvatarS
     <div className={cn('flex items-center', className)}>
       {people.slice(0, max).map((person, i) => (
         <SquareAvatar
-          key={person.name}
+          key={person.key ?? `${person.name}-${i}`}
           variant="round"
-          size={size}
+          size={size === 'xs' ? 'sm' : size}
+          sizePx={size === 'xs' ? XS_PX : undefined}
           src={person.avatarUrl ?? undefined}
           alt={person.name}
           fallback={person.name}
-          className={i > 0 ? '-ml-3' : undefined}
+          className={cn(i > 0 && (size === 'xs' ? '-ml-2' : '-ml-3'))}
         />
       ))}
       {people.length > max && (
         <span
           className={cn(
-            '-ml-3 flex shrink-0 items-center justify-center rounded-full border border-ods-border bg-ods-bg text-h6 text-ods-text-secondary',
+            'flex shrink-0 items-center justify-center rounded-full border border-ods-border bg-ods-bg text-ods-text-secondary',
+            size === 'xs' ? '-ml-2 text-badge' : '-ml-3 text-h6',
             OVERFLOW_CIRCLE_SIZE[size],
           )}
         >

--- a/openframe-frontend-core/src/components/ui/avatar-stack.tsx
+++ b/openframe-frontend-core/src/components/ui/avatar-stack.tsx
@@ -26,6 +26,11 @@ export interface AvatarStackProps {
   /** Size bucket (also sizes the "+N" circle). `xs` (24px) is for
    *  dense card meta rows (chat compact cards, delivery rows). */
   size?: 'xs' | 'sm' | 'md' | 'lg'
+  /** Ring color class separating overlapped avatars from each other —
+   *  MUST match the surface the stack sits on (default: card surface).
+   *  Without the surface-colored ring, overlapping photos read as one
+   *  smeared blob — the ring is what makes a stack look deliberate. */
+  ringClassName?: string
   className?: string
 }
 
@@ -39,11 +44,23 @@ const OVERFLOW_CIRCLE_SIZE: Record<NonNullable<AvatarStackProps['size']>, string
 /** xs has no SquareAvatar bucket — rendered via exact sizePx. */
 const XS_PX = 24
 
-export function AvatarStack({ people, max = 3, size = 'md', className }: AvatarStackProps) {
+export function AvatarStack({
+  people,
+  max = 3,
+  size = 'md',
+  ringClassName = 'ring-ods-card',
+  className,
+}: AvatarStackProps) {
   if (people.length === 0) return null
+  const visible = people.slice(0, max)
+  const overflow = people.slice(max)
   return (
-    <div className={cn('flex items-center', className)}>
-      {people.slice(0, max).map((person, i) => (
+    <div
+      className={cn('flex items-center', className)}
+      role="group"
+      aria-label={`Assignees: ${people.map((p) => p.name).join(', ')}`}
+    >
+      {visible.map((person, i) => (
         <SquareAvatar
           key={person.key ?? `${person.name}-${i}`}
           variant="round"
@@ -52,18 +69,24 @@ export function AvatarStack({ people, max = 3, size = 'md', className }: AvatarS
           src={person.avatarUrl ?? undefined}
           alt={person.name}
           fallback={person.name}
-          className={cn(i > 0 && (size === 'xs' ? '-ml-2' : '-ml-3'))}
+          title={person.name}
+          className={cn('relative ring-2', ringClassName, i > 0 && (size === 'xs' ? '-ml-2' : '-ml-3'))}
+          // Leftmost (primary assignee) on TOP — later avatars tuck
+          // BEHIND, so the first face is always fully visible.
+          style={{ zIndex: visible.length - i }}
         />
       ))}
-      {people.length > max && (
+      {overflow.length > 0 && (
         <span
+          title={overflow.map((p) => p.name).join(', ')}
           className={cn(
-            'flex shrink-0 items-center justify-center rounded-full border border-ods-border bg-ods-bg text-ods-text-secondary',
+            'relative z-0 flex shrink-0 items-center justify-center rounded-full ring-2 bg-ods-bg text-ods-text-secondary',
+            ringClassName,
             size === 'xs' ? '-ml-2 text-badge' : '-ml-3 text-h6',
             OVERFLOW_CIRCLE_SIZE[size],
           )}
         >
-          +{people.length - max}
+          +{overflow.length}
         </span>
       )}
     </div>

--- a/openframe-frontend-core/src/components/ui/square-avatar.tsx
+++ b/openframe-frontend-core/src/components/ui/square-avatar.tsx
@@ -9,7 +9,7 @@ import { getFirstLastInitials } from "../../utils/format";
 interface SquareAvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string;
   alt?: string;
-  size?: 'sm' | 'md' | 'lg' | 'xl';
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   /** Exact pixel size (width & height). Overrides the `size` bucket dimensions —
    *  for callers with a numeric-px API (e.g. UserDisplay/MSPDisplay). */
   sizePx?: number;
@@ -25,6 +25,10 @@ const SquareAvatar = React.memo(React.forwardRef<HTMLDivElement, SquareAvatarPro
   ({ className, src, alt, size = 'md', sizePx, fallback, variant = 'square', initialsClassName, style, ...props }, ref) => {
     const resolvedSrc = useAuthedImageSrc(src)
     const sizeClasses = {
+      // xs (24px): dense card meta rows — avatar stacks on delivery/
+      // roadmap cards. Part of the shared scale so no caller ever
+      // bypasses the buckets with raw sizePx for a standard size.
+      xs: 'h-6 w-6',
       sm: 'h-8 w-8',
       md: 'h-10 w-10',
       lg: 'h-12 w-12',
@@ -32,6 +36,7 @@ const SquareAvatar = React.memo(React.forwardRef<HTMLDivElement, SquareAvatarPro
     };
 
     const sizePxBySize = {
+      xs: 24,
       sm: 32,
       md: 40,
       lg: 48,

--- a/openframe-frontend-core/src/types/delivery.ts
+++ b/openframe-frontend-core/src/types/delivery.ts
@@ -8,6 +8,20 @@
  * related delivery items) share one canonical shape.
  */
 
+/**
+ * Display identity for a task assignee — WIRE-SAFE shape: name + avatar
+ * only, resolved server-side (ClickUp assignee × profiles). Emails are
+ * deliberately NOT on the wire; the roadmap/delivery boards are public
+ * surfaces (same policy as the RAG mappers). Feeds `AvatarStack`
+ * directly.
+ */
+export interface TaskAssigneeDisplay {
+  /** ClickUp member id — stable render key. */
+  id: number;
+  name: string | null;
+  avatarUrl: string | null;
+}
+
 export interface DeliveryItem {
   id: string;
   title: string;
@@ -23,6 +37,10 @@ export interface DeliveryItem {
    * `lib/utils/clickup-task-type-utils.ts` (hub-side).
    */
   customItemId: number | null;
+  /** Assignee display identities (name + avatar, never email) — powers
+   *  the AvatarStack on cards. Optional: producers that don't enrich
+   *  (e.g. activity-cache recent_tasks) simply omit it. */
+  assignees?: TaskAssigneeDisplay[];
   /**
    * Every ClickUp list the task is associated with (home list + ClickUp's
    * "Tasks in Multiple Lists" locations). UI joins these for display.


### PR DESCRIPTION
Adds the shared `AvatarStack` (with a new 24px `xs` size + stable keying) to `DeliveryRow` and both `RoadmapCard` densities, powered by a new wire-safe `TaskAssigneeDisplay` type — name + avatar only, emails never leave the server (matches the existing RAG-mapper identity policy). Hub PR wires the data: profiles cross-reference in the ClickUp DAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roadmap cards now display assigned people with avatars in compact and standard layouts.
  * Delivery rows now show assignee avatar stacks when available.
  * Added extra-small avatar stacks for compact displays, including improved overflow handling.
  * Assignee names and avatar images are supported in roadmap and delivery data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->