### PR TITLE
feat(data-nats): assetsBaseUrl placeholder in download link resolver

### DIFF
--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
@@ -2,14 +2,29 @@ package com.openframe.data.nats.resolver;
 
 import com.openframe.data.document.clientconfiguration.DownloadConfiguration;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import static org.springframework.util.StringUtils.hasText;
 
 @Component
 @Slf4j
 public class DownloadConfigurationLinkResolver {
 
     private static final String VERSION_PLACEHOLDER = "{version}";
+    private static final String ASSETS_BASE_URL_PLACEHOLDER = "{assetsBaseUrl}";
 
+    private final String assetsBaseUrl;
+
+    /**
+     * Base URL of the shared gateway assets endpoint (e.g. {@code https://openframe.ai}),
+     * substituted for {@code {assetsBaseUrl}} in link templates. Empty by default, so templates
+     * that do not use the placeholder — and deployments that do not set the property — resolve
+     * exactly as before.
+     */
+    public DownloadConfigurationLinkResolver(@Value("${openframe.assets.base-url:}") String assetsBaseUrl) {
+        this.assetsBaseUrl = stripTrailingSlash(assetsBaseUrl);
+    }
 
     public String resolve(DownloadConfiguration config, String version) {
         String linkTemplate = config.getLinkTemplate();
@@ -19,8 +34,15 @@ public class DownloadConfigurationLinkResolver {
     }
 
     private String resolveLink(String linkTemplate, String version) {
-        return linkTemplate.replace(VERSION_PLACEHOLDER, version);
+        String link = linkTemplate.replace(VERSION_PLACEHOLDER, version);
+        if (hasText(assetsBaseUrl)) {
+            link = link.replace(ASSETS_BASE_URL_PLACEHOLDER, assetsBaseUrl);
+        }
+        return link;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value != null && value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
 }
-

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
@@ -16,14 +16,8 @@ public class DownloadConfigurationLinkResolver {
 
     private final String assetsBaseUrl;
 
-    /**
-     * Base URL of the shared gateway assets endpoint (e.g. {@code https://openframe.ai}),
-     * substituted for {@code {assetsBaseUrl}} in link templates. Empty by default, so templates
-     * that do not use the placeholder — and deployments that do not set the property — resolve
-     * exactly as before.
-     */
     public DownloadConfigurationLinkResolver(@Value("${openframe.assets.base-url:}") String assetsBaseUrl) {
-        this.assetsBaseUrl = stripTrailingSlash(assetsBaseUrl);
+        this.assetsBaseUrl = stripTrailingSlashes(assetsBaseUrl);
     }
 
     public String resolve(DownloadConfiguration config, String version) {
@@ -41,8 +35,8 @@ public class DownloadConfigurationLinkResolver {
         return link;
     }
 
-    private static String stripTrailingSlash(String value) {
-        return value != null && value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    private static String stripTrailingSlashes(String value) {
+        return value == null ? null : value.replaceAll("/+$", "");
     }
 
 }

--- a/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
+++ b/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
@@ -41,6 +41,15 @@ class DownloadConfigurationLinkResolverTest {
     }
 
     @Test
+    void shouldStripAllConsecutiveTrailingSlashesFromConfiguredBaseUrl() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build///");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
     void shouldLeavePlaceholderUntouchedWhenBaseUrlNotConfigured() {
         DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("");
 

--- a/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
+++ b/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
@@ -1,0 +1,66 @@
+package com.openframe.data.nats.resolver;
+
+import com.openframe.data.document.clientconfiguration.DownloadConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DownloadConfigurationLinkResolverTest {
+
+    private static final String GITHUB_TEMPLATE =
+            "https://github.com/flamingo-stack/openframe-oss-tenant/releases/download/{version}/openframe-client_macos.tar.gz";
+    private static final String GATEWAY_TEMPLATE =
+            "{assetsBaseUrl}/v0/api/assets/download?agent=chat&platform=macos";
+
+    @Test
+    void shouldSubstituteVersionPlaceholder() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("");
+
+        String resolved = resolver.resolve(config(GITHUB_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo(
+                "https://github.com/flamingo-stack/openframe-oss-tenant/releases/download/1.0.19/openframe-client_macos.tar.gz");
+    }
+
+    @Test
+    void shouldSubstituteAssetsBaseUrlPlaceholder() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldStripTrailingSlashFromConfiguredBaseUrl() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build/");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldLeavePlaceholderUntouchedWhenBaseUrlNotConfigured() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo(GATEWAY_TEMPLATE);
+    }
+
+    @Test
+    void shouldLeaveTemplatesWithoutPlaceholdersUnchanged() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build");
+
+        String plain = "https://example.com/static/openframe-client_macos.tar.gz";
+
+        assertThat(resolver.resolve(config(plain), "1.0.19")).isEqualTo(plain);
+    }
+
+    private DownloadConfiguration config(String linkTemplate) {
+        DownloadConfiguration config = new DownloadConfiguration();
+        config.setLinkTemplate(linkTemplate);
+        return config;
+    }
+}


### PR DESCRIPTION
> **ClickUp:** https://app.clickup.com/t/9013925967/86ajrybqc

## Why

Agent binaries (openframe-client, OpenFrame Chat) are moving from public GitHub release URLs to the shared gateway's public assets endpoint (`GET /v0/api/assets/download?agent={client|chat}&platform={macos|windows}`, flamingo-stack/openframe-saas-shared#1642). The seed `linkTemplate`s are static JSON, but the gateway host differs per environment — so the publish-time link resolution needs one new substitution.

## What

`DownloadConfigurationLinkResolver` now replaces `{assetsBaseUrl}` with the value of the `openframe.assets.base-url` property (trailing slash stripped), alongside the existing `{version}` substitution. A SaaS-tenant template can then read:

```
{assetsBaseUrl}/v0/api/assets/download?agent=chat&platform=macos
```

and resolve per environment via config (e.g. `https://${SHARED_HOST_URL}`).

## Backward compatibility

Fully backward compatible:

- The property defaults to **empty**, and substitution only runs when it is set — deployments that don't configure it behave byte-identically.
- Templates without the placeholder (all existing GitHub URLs, OSS included) resolve exactly as before; `{version}` handling is untouched — covered by explicit tests.
- The constructor gained a `@Value` parameter; the bean is only ever Spring-instantiated (verified: no direct `new DownloadConfigurationLinkResolver()` anywhere across the four downstream repos).

## Testing

`mvn test -pl openframe-data-nats` — 104 tests green, including 5 new `DownloadConfigurationLinkResolverTest` cases: `{version}` substitution unchanged, `{assetsBaseUrl}` substitution, trailing-slash stripping, placeholder untouched when unconfigured, plain templates untouched.

## Consumers (separate PRs, not in this one)

`openframe-saas-tenant` will set `openframe.assets.base-url` and repoint the chat + client seed templates after this releases (requires the `openframe.oss.libs.version` bump there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable asset base URLs when generating download links.
  * Asset URLs are normalized to prevent duplicate trailing slashes.
  * Existing link behavior is preserved when no asset base URL is configured.

* **Bug Fixes**
  * Improved replacement of asset URL placeholders in download configuration links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->