### PR TITLE
Delete RollingFileAppender for logs as redundant

### DIFF
--- a/openframe-config-core/src/main/resources/logging/README.md
+++ b/openframe-config-core/src/main/resources/logging/README.md
@@ -1,0 +1,40 @@
+# Shared Logback Configurations
+
+Logback configurations served by the config server (`openframe-saas-config` /
+`openframe-config-server`) and loaded by every OpenFrame service at startup via the
+`logging.config` property, e.g.:
+
+```yaml
+logging:
+  config: ${SPRING_CONFIG_URL:http://openframe-saas-config:8888}/logging/shared-logback-spring-logfmt-shortened.xml
+```
+
+## Variants
+
+| Entry point | Format | Stack traces |
+|---|---|---|
+| `shared-logback-spring.xml` | classic pattern | full |
+| `shared-logback-spring-logfmt.xml` | logfmt (`ts= level= service= msg=`) | full |
+| `shared-logback-spring-logfmt-shortened.xml` | logfmt | shortened, single-line (`%exShort`) |
+
+Each `shared-logback-spring*.xml` is a thin wrapper that resolves Spring properties and
+includes the matching `shared-logback-includes*.xml` with the actual appenders.
+
+## Logging is stdout-only — deployments must handle collection and retention
+
+All variants log **exclusively to the console (stdout)**. File appenders were removed
+deliberately: log files inside containers were an unread duplicate of stdout and are not
+part of any pipeline.
+
+This library does **not** ship a log collector. Every deployment is responsible for
+guaranteeing stdout forwarding and retention itself, otherwise logs only live in the
+container runtime's rotated files (`/var/log/pods/...`) and are lost on pod deletion.
+
+The reference OpenFrame setup does this with a Grafana Alloy DaemonSet that tails
+`/var/log/pods/<pod-uid>/<container>/*.log` for pods annotated
+`loki.grafana.com/scrape: "true"` and pushes to Loki, where retention is configured.
+Any equivalent stack (Promtail, Fluent Bit, Vector, a cloud provider's log agent, ...)
+works the same way — the contract is only: *collect stdout, own the retention*.
+
+The logfmt variants keep every event on a single line (exception stacks are flattened
+with `|` separators) precisely so line-based collectors ingest one event per line.

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
@@ -10,7 +10,8 @@
 
 
 
-    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
+    <!-- Console (stdout) only, no file appenders: the deployment's log collector (e.g. Alloy -> Loki)
+         must scrape container stdout and own retention. See README.md in this directory. -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
     </root>

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt-shortened.xml
@@ -8,81 +8,10 @@
         </encoder>
     </appender>
 
-    <!-- Rolling File Appender (Text Format - logfmt) -->
-    <appender name="RollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>ts=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} level=%-5level service=${SPRING_APP_NAME} logger=%logger{36} thread=%thread msg="%replace(%msg){'\r?\n',' '}" stack="%replace(%exShort{30,full,2048,rootFirst,inlineHash,FastClassByCGLIB,EnhancerBySpringCGLIB,^sun\.reflect\..*\.invoke,^com\.sun\.,^sun\.net\.,^net\.sf\.cglib\.proxy\.MethodProxy\.invoke,^org\.springframework\.cglib\.,^org\.springframework\.transaction\.,^org\.springframework\.validation\.,^org\.springframework\.app\.,^org\.springframework\.aop\.,^java\.lang\.reflect\.Method\.invoke,^org\.springframework\.ws\..*\.invoke,^org\.springframework\.ws\.transport\.,^org\.springframework\.ws\.soap\.saaj\.SaajSoapMessage\.,^org\.springframework\.ws\.client\.core\.WebServiceTemplate\.,^org\.springframework\.web\.filter\.,^org\.apache\.tomcat\.,^org\.apache\.catalina\.,^org\.apache\.coyote\.,^java\.util\.concurrent\.ThreadPoolExecutor\.runWorker,^java\.lang\.Thread\.run}){'\r?\n',' | '}"%n</pattern>
-        </encoder>
-    </appender>
 
-    <!-- JSON rolling appender with shortened stack trace -->
-    <appender name="JsonRollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.json</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.json</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp />
-                <logLevel />
-                <threadName />
-                <loggerName />
-                <message />
-                <stackTrace>
-                    <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                        <maxDepthPerThrowable>30</maxDepthPerThrowable>
-                        <maxLength>2048</maxLength>
-                        <rootCauseFirst>true</rootCauseFirst>
-                        <inlineHash>true</inlineHash>
 
-                        <!-- https://github.com/logfellow/logstash-logback-encoder/blob/main/stack-hash.md#recommended-exclusion-patterns -->
-                        <!-- generated class names -->
-                        <exclude>\$\$FastClassByCGLIB\$\$</exclude>
-                        <exclude>\$\$EnhancerBySpringCGLIB\$\$</exclude>
-                        <exclude>^sun\.reflect\..*\.invoke</exclude>
-                        <!-- JDK internals -->
-                        <exclude>^com\.sun\.</exclude>
-                        <exclude>^sun\.net\.</exclude>
-                        <!-- dynamic invocation -->
-                        <exclude>^net\.sf\.cglib\.proxy\.MethodProxy\.invoke</exclude>
-                        <exclude>^org\.springframework\.cglib\.</exclude>
-                        <exclude>^org\.springframework\.transaction\.</exclude>
-                        <exclude>^org\.springframework\.validation\.</exclude>
-                        <exclude>^org\.springframework\.app\.</exclude>
-                        <exclude>^org\.springframework\.aop\.</exclude>
-                        <exclude>^java\.lang\.reflect\.Method\.invoke</exclude>
-                        <!-- Spring plumbing -->
-                        <exclude>^org\.springframework\.ws\..*\.invoke</exclude>
-                        <exclude>^org\.springframework\.ws\.transport\.</exclude>
-                        <exclude>^org\.springframework\.ws\.soap\.saaj\.SaajSoapMessage\.</exclude>
-                        <exclude>^org\.springframework\.ws\.client\.core\.WebServiceTemplate\.</exclude>
-                        <exclude>^org\.springframework\.web\.filter\.</exclude>
-                        <!-- Tomcat internals -->
-                        <exclude>^org\.apache\.tomcat\.</exclude>
-                        <exclude>^org\.apache\.catalina\.</exclude>
-                        <exclude>^org\.apache\.coyote\.</exclude>
-                        <exclude>^java\.util\.concurrent\.ThreadPoolExecutor\.runWorker</exclude>
-                        <exclude>^java\.lang\.Thread\.run$</exclude>
-                    </throwableConverter>
-                </stackTrace>
-            </providers>
-        </encoder>
-    </appender>
-
-    <!-- Add all appenders to root -->
+    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
-        <appender-ref ref="RollingFileAppender" />
-        <appender-ref ref="JsonRollingFileAppender" />
     </root>
 </included>

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt.xml
@@ -7,46 +7,9 @@
         </encoder>
     </appender>
 
-    <!-- Rolling File Appender (Text Format - logfmt) -->
-    <appender name="RollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>ts=%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} level=%-5level service=${SPRING_APP_NAME} logger=%logger{36} thread=%thread msg="%replace(%msg){'\r?\n',' '}" stack="%replace(%ex){'\r?\n',' | '}"%n</pattern>
-        </encoder>
-    </appender>
-
-    <!-- Keep JSON rolling appender as-is for optional local use -->
-    <appender name="JsonRollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.json</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.json</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp />
-                <logLevel />
-                <threadName />
-                <loggerName />
-                <message />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-
-    <!-- Add all appenders to root -->
+    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
-        <appender-ref ref="RollingFileAppender" />
-        <appender-ref ref="JsonRollingFileAppender" />
     </root>
 </included>
 

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes-logfmt.xml
@@ -7,7 +7,8 @@
         </encoder>
     </appender>
 
-    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
+    <!-- Console (stdout) only, no file appenders: the deployment's log collector (e.g. Alloy -> Loki)
+         must scrape container stdout and own retention. See README.md in this directory. -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
     </root>

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes.xml
@@ -7,46 +7,8 @@
         </encoder>
     </appender>
 
-    <!-- Rolling File Appender (Text Format) -->
-    <appender name="RollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <!-- Rolling File Appender (JSON Format) -->
-    <appender name="JsonRollingFileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_PATH}/${SPRING_APP_NAME}.json</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_PATH}/${SPRING_APP_NAME}.%d{yyyy-MM-dd}.%i.json</fileNamePattern>
-            <maxFileSize>10MB</maxFileSize>
-            <totalSizeCap>50MB</totalSizeCap>
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp />
-                <logLevel />
-                <threadName />
-                <loggerName />
-                <message />
-                <mdc />
-                <stackTrace />
-            </providers>
-        </encoder>
-    </appender>
-
-    <!-- Add all appenders to root -->
+    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
-        <appender-ref ref="RollingFileAppender" />
-        <appender-ref ref="JsonRollingFileAppender" />
     </root>
 </included>

--- a/openframe-config-core/src/main/resources/logging/shared-logback-includes.xml
+++ b/openframe-config-core/src/main/resources/logging/shared-logback-includes.xml
@@ -7,7 +7,8 @@
         </encoder>
     </appender>
 
-    <!-- Console only: stdout is scraped by Alloy/Loki; file logging is intentionally disabled -->
+    <!-- Console (stdout) only, no file appenders: the deployment's log collector (e.g. Alloy -> Loki)
+         must scrape container stdout and own retention. See README.md in this directory. -->
     <root level="info">
         <appender-ref ref="ConsoleAppender" />
     </root>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated logging configuration to output logs exclusively to the console.
  * Removed rolling text and JSON file logging, including file rotation settings.
  * Retained informational-level root logging and console output for external log collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->