### PR TITLE
fix(client-core): log transformed agentToolId in tool-connection update messages

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/service/ToolConnectionService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/ToolConnectionService.java
@@ -74,13 +74,14 @@ public class ToolConnectionService {
             boolean lastAttempt
     ) {
         if (toolConnection.getStatus() == ConnectionStatus.DISCONNECTED) {
+            String transformedAgentToolId = toolAgentIdTransformerService.transform(toolType, openframeAgentId, agentId, lastAttempt);
             toolConnection.setStatus(ConnectionStatus.CONNECTED);
-            toolConnection.setAgentToolId(toolAgentIdTransformerService.transform(toolType, openframeAgentId, agentId, lastAttempt));
+            toolConnection.setAgentToolId(transformedAgentToolId);
             toolConnection.setConnectedAt(Instant.now());
             toolConnection.setDisconnectedAt(null);
             toolConnectionRepository.save(toolConnection);
 
-            log.info("Updated existing tool connection with machineId {} tool {} agentToolId {}", openframeAgentId, toolType, agentId);
+            log.info("Updated existing tool connection with machineId {} tool {} agentToolId {} rawAgentId {}", openframeAgentId, toolType, transformedAgentToolId, agentId);
         } else {
             // Connection is already CONNECTED
             String currentAgentToolId = toolConnection.getAgentToolId();
@@ -89,8 +90,8 @@ public class ToolConnectionService {
                 toolConnection.setAgentToolId(transformedAgentToolId);
                 toolConnection.setLastSyncAt(Instant.now());
                 toolConnectionRepository.save(toolConnection);
-                log.info("Updated agentToolId for existing connected tool connection: machineId={} tool={} oldAgentToolId={} newAgentToolId={}", 
-                        openframeAgentId, toolType, currentAgentToolId, agentId);
+                log.info("Updated agentToolId for existing connected tool connection: machineId={} tool={} oldAgentToolId={} newAgentToolId={} rawAgentId={}",
+                        openframeAgentId, toolType, currentAgentToolId, transformedAgentToolId, agentId);
             } else {
                 // Same ID and already connected - no action needed
                 log.info("Tool connection already exists with same agentToolId: machineId={} tool={} agentToolId={}", 


### PR DESCRIPTION
## Problem

In `ToolConnectionService.processExistingToolConnection`, both update branches stored the **transformed** agentToolId but logged the **raw** pre-transform `agentId`. For `FLEET_MDM` the raw value is the osquery UUID while the stored value is the numeric Fleet host id, so prod logs showed e.g. `oldAgentToolId=86 newAgentToolId=56437ACA-31D5-...` even though `176` was actually stored — actively misleading during incident debugging.

## Fix

- **CONNECTED branch** (`~line 92`): log `transformedAgentToolId` as `newAgentToolId` instead of the raw `agentId`; keep the raw value as a separate `rawAgentId` field.
- **DISCONNECTED branch** (`~line 83`): extract the `transform(...)` result into a `transformedAgentToolId` variable so the logged `agentToolId` matches what is saved; also append the raw `agentId` as `rawAgentId`.

Logs now show the value that was actually persisted, with the raw agent id retained for traceability.

## Verification

`mvn compile -pl openframe-client-core -am` — BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection logs to include both the processed tool identifier and the original agent identifier during reconnection and synchronization.
  * Connection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->