### PR TITLE
Add filtering and sorting by startAt

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleFilterInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleFilterInput.java
@@ -27,4 +27,7 @@ public class ScriptScheduleFilterInput {
 
     private Instant updatedAtFrom;
     private Instant updatedAtTo;
+
+    private Instant startAtFrom;
+    private Instant startAtTo;
 }

--- a/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleFilterInput.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/dto/rmm/schedule/ScriptScheduleFilterInput.java
@@ -22,12 +22,6 @@ public class ScriptScheduleFilterInput {
 
     private List<String> authorIds;
 
-    private Instant createdAtFrom;
-    private Instant createdAtTo;
-
-    private Instant updatedAtFrom;
-    private Instant updatedAtTo;
-
     private Instant startAtFrom;
     private Instant startAtTo;
 }

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
@@ -181,10 +181,6 @@ public class ScriptScheduleService {
                 .statuses(input.getStatuses())
                 .supportedPlatforms(input.getSupportedPlatforms())
                 .createdByIds(input.getAuthorIds())
-                .createdAtFrom(input.getCreatedAtFrom())
-                .createdAtTo(input.getCreatedAtTo())
-                .updatedAtFrom(input.getUpdatedAtFrom())
-                .updatedAtTo(input.getUpdatedAtTo())
                 .startAtFrom(input.getStartAtFrom())
                 .startAtTo(input.getStartAtTo())
                 .build();

--- a/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/service/rmm/ScriptScheduleService.java
@@ -185,6 +185,8 @@ public class ScriptScheduleService {
                 .createdAtTo(input.getCreatedAtTo())
                 .updatedAtFrom(input.getUpdatedAtFrom())
                 .updatedAtTo(input.getUpdatedAtTo())
+                .startAtFrom(input.getStartAtFrom())
+                .startAtTo(input.getStartAtTo())
                 .build();
     }
 

--- a/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
@@ -11,7 +11,9 @@ extend type Query {
 
     """Cursor-paginated list of schedules within the current tenant (Relay Connection Spec).
     Default order is newest-first by _id. Optional filter / search / sort.
-    Sortable fields: _id (default), name, createdAt, updatedAt, repeat, deviceCount.
+    Sortable fields: _id (default), name, createdAt, updatedAt, startAt, repeat, deviceCount.
+    When sorting by a date field (createdAt / updatedAt / startAt), DEVICE_ONLINE schedules
+    are always ordered last (they are event-driven and have no startAt).
     Ties are broken by _id so the order is stable. Search is a
     case-insensitive substring match on name."""
     scriptSchedules(
@@ -269,4 +271,7 @@ input ScriptScheduleFilterInput {
     createdAtTo: Instant
     updatedAtFrom: Instant
     updatedAtTo: Instant
+    "Filter by first-run instant (startAt). DEVICE_ONLINE schedules have no startAt, so a startAt range excludes them."
+    startAtFrom: Instant
+    startAtTo: Instant
 }

--- a/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/script-schedule.graphqls
@@ -11,9 +11,9 @@ extend type Query {
 
     """Cursor-paginated list of schedules within the current tenant (Relay Connection Spec).
     Default order is newest-first by _id. Optional filter / search / sort.
-    Sortable fields: _id (default), name, createdAt, updatedAt, startAt, repeat, deviceCount.
-    When sorting by a date field (createdAt / updatedAt / startAt), DEVICE_ONLINE schedules
-    are always ordered last (they are event-driven and have no startAt).
+    Sortable fields: _id (default), name, startAt, repeat, deviceCount.
+    When sorting by startAt, DEVICE_ONLINE schedules are always ordered last
+    (they are event-driven and have no startAt).
     Ties are broken by _id so the order is stable. Search is a
     case-insensitive substring match on name."""
     scriptSchedules(
@@ -267,10 +267,6 @@ input ScriptScheduleFilterInput {
     statuses: [ScriptStatus!]
     supportedPlatforms: [OsType!]
     authorIds: [ID!]
-    createdAtFrom: Instant
-    createdAtTo: Instant
-    updatedAtFrom: Instant
-    updatedAtTo: Instant
     "Filter by first-run instant (startAt). DEVICE_ONLINE schedules have no startAt, so a startAt range excludes them."
     startAtFrom: Instant
     startAtTo: Instant

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
@@ -281,6 +281,8 @@ class ScriptScheduleServiceTest {
         Instant createdFrom = Instant.parse("2026-01-01T00:00:00Z");
         Instant createdTo = Instant.parse("2026-02-01T00:00:00Z");
         Instant updatedFrom = Instant.parse("2026-03-01T00:00:00Z");
+        Instant startFrom = Instant.parse("2026-04-01T00:00:00Z");
+        Instant startTo = Instant.parse("2026-05-01T00:00:00Z");
         ScriptScheduleFilterInput filter = ScriptScheduleFilterInput.builder()
                 .statuses(List.of(ScriptStatus.ACTIVE))
                 .supportedPlatforms(List.of(OsType.WINDOWS))
@@ -288,6 +290,8 @@ class ScriptScheduleServiceTest {
                 .createdAtFrom(createdFrom)
                 .createdAtTo(createdTo)
                 .updatedAtFrom(updatedFrom)
+                .startAtFrom(startFrom)
+                .startAtTo(startTo)
                 .build();
         when(scheduleRepository.countForTenant(eq(TENANT_ID), any(), any())).thenReturn(0L);
         when(scheduleRepository.findPageForTenant(any(), any(), any(), any(), any(), any(), eq(false), eq(21)))
@@ -306,6 +310,8 @@ class ScriptScheduleServiceTest {
         assertThat(forwarded.getCreatedAtTo()).isEqualTo(createdTo);
         assertThat(forwarded.getUpdatedAtFrom()).isEqualTo(updatedFrom);
         assertThat(forwarded.getUpdatedAtTo()).isNull();
+        assertThat(forwarded.getStartAtFrom()).isEqualTo(startFrom);
+        assertThat(forwarded.getStartAtTo()).isEqualTo(startTo);
     }
 
     @Test

--- a/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/service/rmm/ScriptScheduleServiceTest.java
@@ -278,18 +278,12 @@ class ScriptScheduleServiceTest {
     @DisplayName("list: API filter is translated into a data-layer ScriptScheduleQueryFilter and forwarded")
     void list_filterForwardedToRepository() {
         stubSortDefault();
-        Instant createdFrom = Instant.parse("2026-01-01T00:00:00Z");
-        Instant createdTo = Instant.parse("2026-02-01T00:00:00Z");
-        Instant updatedFrom = Instant.parse("2026-03-01T00:00:00Z");
         Instant startFrom = Instant.parse("2026-04-01T00:00:00Z");
         Instant startTo = Instant.parse("2026-05-01T00:00:00Z");
         ScriptScheduleFilterInput filter = ScriptScheduleFilterInput.builder()
                 .statuses(List.of(ScriptStatus.ACTIVE))
                 .supportedPlatforms(List.of(OsType.WINDOWS))
                 .authorIds(List.of("user-7"))
-                .createdAtFrom(createdFrom)
-                .createdAtTo(createdTo)
-                .updatedAtFrom(updatedFrom)
                 .startAtFrom(startFrom)
                 .startAtTo(startTo)
                 .build();
@@ -306,10 +300,6 @@ class ScriptScheduleServiceTest {
         assertThat(forwarded.getStatuses()).containsExactly(ScriptStatus.ACTIVE);
         assertThat(forwarded.getSupportedPlatforms()).containsExactly(OsType.WINDOWS);
         assertThat(forwarded.getCreatedByIds()).containsExactly("user-7");
-        assertThat(forwarded.getCreatedAtFrom()).isEqualTo(createdFrom);
-        assertThat(forwarded.getCreatedAtTo()).isEqualTo(createdTo);
-        assertThat(forwarded.getUpdatedAtFrom()).isEqualTo(updatedFrom);
-        assertThat(forwarded.getUpdatedAtTo()).isNull();
         assertThat(forwarded.getStartAtFrom()).isEqualTo(startFrom);
         assertThat(forwarded.getStartAtTo()).isEqualTo(startTo);
     }

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/filter/ScriptScheduleQueryFilter.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/filter/ScriptScheduleQueryFilter.java
@@ -39,4 +39,7 @@ public class ScriptScheduleQueryFilter {
 
     private Instant updatedAtFrom;
     private Instant updatedAtTo;
+
+    private Instant startAtFrom;
+    private Instant startAtTo;
 }

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/filter/ScriptScheduleQueryFilter.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/rmm/filter/ScriptScheduleQueryFilter.java
@@ -34,12 +34,6 @@ public class ScriptScheduleQueryFilter {
      */
     private List<String> createdByIds;
 
-    private Instant createdAtFrom;
-    private Instant createdAtTo;
-
-    private Instant updatedAtFrom;
-    private Instant updatedAtTo;
-
     private Instant startAtFrom;
     private Instant startAtTo;
 }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
@@ -1,8 +1,8 @@
 package com.openframe.data.repository.rmm;
 
 import com.openframe.data.document.rmm.ScriptSchedule;
-import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import com.openframe.data.document.rmm.ScriptScheduleMachineAssigned;
+import com.openframe.data.document.rmm.ScriptScheduleTrigger;
 import com.openframe.data.document.rmm.ScriptStatus;
 import com.openframe.data.document.rmm.filter.ScriptScheduleQueryFilter;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -50,8 +49,6 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
     private static final String FIELD_STATUS = "status";
     private static final String FIELD_NAME = "name";
     private static final String FIELD_SUPPORTED_PLATFORMS = "supportedPlatforms";
-    private static final String FIELD_CREATED_AT = "createdAt";
-    private static final String FIELD_UPDATED_AT = "updatedAt";
     private static final String FIELD_START_AT = "startAt";
     private static final String FIELD_CREATED_BY = "createdBy";
     private static final String FIELD_COUNT = "count";
@@ -66,9 +63,7 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
     private static final String CURSOR_SEPARATOR = "|";
 
     private static final Set<String> SORTABLE_FIELDS =
-            Set.of(FIELD_ID, FIELD_NAME, FIELD_CREATED_AT, FIELD_UPDATED_AT, FIELD_START_AT, FIELD_REPEAT, FIELD_DEVICE_COUNT);
-
-    private static final Set<String> DATE_SORT_FIELDS = Set.of(FIELD_CREATED_AT, FIELD_UPDATED_AT, FIELD_START_AT);
+            Set.of(FIELD_ID, FIELD_NAME, FIELD_START_AT, FIELD_REPEAT, FIELD_DEVICE_COUNT);
 
     private final MongoTemplate mongoTemplate;
 
@@ -86,8 +81,8 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         if (FIELD_DEVICE_COUNT.equals(sortField)) {
             return findPageAggregatedByDeviceCount(tenantId, filter, search, effectiveDir, cursor, limit);
         }
-        if (DATE_SORT_FIELDS.contains(sortField)) {
-            return findPageAggregatedByDateTriggerLast(tenantId, filter, search, sortField, effectiveDir, backward, cursor, limit);
+        if (FIELD_START_AT.equals(sortField)) {
+            return findPageAggregatedByStartAtTriggerLast(tenantId, filter, search, effectiveDir, backward, cursor, limit);
         }
 
         Criteria criteria = buildBaseCriteria(tenantId, filter, search);
@@ -165,23 +160,22 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         ops.add(ctx -> new Document("$match", orExpr));
     }
 
-    private List<ScriptSchedule> findPageAggregatedByDateTriggerLast(String tenantId,
-                                                                     ScriptScheduleQueryFilter filter,
-                                                                     String search,
-                                                                     String dateField,
-                                                                     Sort.Direction effectiveDir,
-                                                                     boolean backward,
-                                                                     String cursor,
-                                                                     int limit) {
+    private List<ScriptSchedule> findPageAggregatedByStartAtTriggerLast(String tenantId,
+                                                                        ScriptScheduleQueryFilter filter,
+                                                                        String search,
+                                                                        Sort.Direction effectiveDir,
+                                                                        boolean backward,
+                                                                        String cursor,
+                                                                        int limit) {
         Sort.Direction bucketDir = backward ? Sort.Direction.DESC : Sort.Direction.ASC;
 
         List<AggregationOperation> ops = new ArrayList<>();
         ops.add(Aggregation.match(buildBaseCriteria(tenantId, filter, search)));
         ops.add(triggerBucketAddFieldsStage());
-        appendDateTriggerCursor(ops, cursor, dateField, effectiveDir, bucketDir);
+        appendStartAtTriggerCursor(ops, cursor, effectiveDir, bucketDir);
         ops.add(Aggregation.sort(Sort.by(
                 new Sort.Order(bucketDir, FIELD_TRIGGER_BUCKET),
-                new Sort.Order(effectiveDir, dateField),
+                new Sort.Order(effectiveDir, FIELD_START_AT),
                 new Sort.Order(effectiveDir, FIELD_ID))));
         ops.add(Aggregation.limit(limit));
 
@@ -197,15 +191,14 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         return ctx -> addFields;
     }
 
-    private static void appendDateTriggerCursor(List<AggregationOperation> ops, String cursor,
-                                                String dateField, Sort.Direction effectiveDir,
-                                                Sort.Direction bucketDir) {
+    private static void appendStartAtTriggerCursor(List<AggregationOperation> ops, String cursor,
+                                                   Sort.Direction effectiveDir, Sort.Direction bucketDir) {
         if (isBlank(cursor)) {
             return;
         }
         String[] parts = cursor.split("\\" + CURSOR_SEPARATOR);
         if (parts.length != 3) {
-            log.warn("Invalid date-trigger cursor (expected bucket|millis|id): '{}' — falling back to first page", cursor);
+            log.warn("Invalid startAt cursor (expected bucket|millis|id): '{}' — falling back to first page", cursor);
             return;
         }
         ObjectId cursorId = parseObjectId(parts[2]);
@@ -213,12 +206,12 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
             return;
         }
         int bucket;
-        Date dateValue;
+        Date startAt;   // null = the row's startAt was null; the whole bucket is null (DEVICE_ONLINE has no startAt)
         try {
             bucket = Integer.parseInt(parts[0]);
-            dateValue = parts[1].isEmpty() ? null : new Date(Long.parseLong(parts[1]));
+            startAt = parts[1].isEmpty() ? null : new Date(Long.parseLong(parts[1]));
         } catch (NumberFormatException ex) {
-            log.warn("Unparseable bucket/date in date-trigger cursor '{}' — falling back to first page", cursor);
+            log.warn("Unparseable bucket/startAt in cursor '{}' — falling back to first page", cursor);
             return;
         }
 
@@ -226,13 +219,17 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         String bucketCmp = bucketDir == Sort.Direction.ASC ? "$gt" : "$lt";
 
         List<Document> arms = new ArrayList<>();
+        // Cross-bucket: everything past this bucket in bucket order (e.g. the whole DEVICE_ONLINE tail).
         arms.add(new Document(FIELD_TRIGGER_BUCKET, new Document(bucketCmp, bucket)));
-        if (dateValue == null) {
-            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, null)
+        if (startAt == null) {
+            // Null-startAt bucket (DEVICE_ONLINE): startAt is constant (null) across it, so order by
+            // _id alone. A range against a sentinel Date never matches null, which would silently
+            // drop the rest of the bucket.
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, null)
                     .append(FIELD_ID, new Document(cmp, cursorId)));
         } else {
-            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, new Document(cmp, dateValue)));
-            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, dateValue)
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, new Document(cmp, startAt)));
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, startAt)
                     .append(FIELD_ID, new Document(cmp, cursorId)));
         }
         ops.add(ctx -> new Document("$match", new Document("$or", arms)));
@@ -263,7 +260,7 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         applyStatusFilter(criteria, filter);
         applyPlatformsFilter(criteria, filter);
         applyCreatedByFilter(criteria, filter);
-        applyDateRangeFilters(criteria, filter);
+        applyStartAtRangeFilter(criteria, filter);
         applySearch(criteria, search);
         return criteria;
     }
@@ -292,7 +289,7 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         if (!FIELD_CREATED_BY.equals(excludeField)) {
             applyCreatedByFilter(criteria, filter);
         }
-        applyDateRangeFilters(criteria, filter);
+        applyStartAtRangeFilter(criteria, filter);
         return criteria;
     }
 
@@ -349,14 +346,12 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         }
     }
 
-    private static void applyDateRangeFilters(Criteria criteria, ScriptScheduleQueryFilter filter) {
+    private static void applyStartAtRangeFilter(Criteria criteria, ScriptScheduleQueryFilter filter) {
         if (filter == null) {
             return;
         }
-        applyRange(criteria, FIELD_CREATED_AT, filter.getCreatedAtFrom(), filter.getCreatedAtTo());
-        applyRange(criteria, FIELD_UPDATED_AT, filter.getUpdatedAtFrom(), filter.getUpdatedAtTo());
-        // startAt is null for DEVICE_ONLINE (and timing-less) schedules, so a startAt range
-        // naturally excludes them — a value window can't match a schedule that has no start.
+        // startAt is null for DEVICE_ONLINE schedules, so a startAt range naturally excludes
+        // them — a value window can't match a schedule that has no start.
         applyRange(criteria, FIELD_START_AT, filter.getStartAtFrom(), filter.getStartAtTo());
     }
 
@@ -500,9 +495,10 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         if (FIELD_ID.equals(sortField)) {
             return schedule.getId();
         }
-        if (DATE_SORT_FIELDS.contains(sortField)) {
-            Instant date = dateSortValue(schedule, sortField);
-            String millis = date == null ? "" : String.valueOf(date.toEpochMilli());
+        if (FIELD_START_AT.equals(sortField)) {
+            // bucket|millis|id — millis empty when startAt is null (the whole DEVICE_ONLINE bucket).
+            Instant startAt = schedule.getStartAt();
+            String millis = startAt == null ? "" : String.valueOf(startAt.toEpochMilli());
             return triggerBucket(schedule) + CURSOR_SEPARATOR + millis + CURSOR_SEPARATOR + schedule.getId();
         }
         return encodeSortValue(schedule, sortField) + CURSOR_SEPARATOR + schedule.getId();
@@ -510,14 +506,6 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
 
     private static int triggerBucket(ScriptSchedule schedule) {
         return schedule.getTrigger() == TRIGGER_LAST ? 1 : 0;
-    }
-
-    private static Instant dateSortValue(ScriptSchedule schedule, String dateField) {
-        return switch (dateField) {
-            case FIELD_UPDATED_AT -> schedule.getUpdatedAt();
-            case FIELD_START_AT -> schedule.getStartAt();
-            default -> schedule.getCreatedAt();
-        };
     }
 
     /**
@@ -545,9 +533,8 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
      * the whole list) come back in a stable, repeatable order instead of Mongo's arbitrary
      * one. Redundant when already sorting by {@code _id}.
      *
-     * <p>Note: the cursor predicate is still {@code _id}-only, so deep paging across a tie
-     * boundary on a non-{@code _id} sort can skip/repeat rows. Pre-existing for
-     * name/createdAt/updatedAt; a compound keyset cursor is the proper fix.
+     * <p>Applies to the plain-query sorts (name / repeat); the startAt and deviceCount sorts run
+     * through their own aggregation keyset instead.
      */
     private static Sort sortWithIdTiebreaker(Sort.Direction direction, String sortField) {
         if (FIELD_ID.equals(sortField)) {

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
@@ -52,6 +52,7 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
     private static final String FIELD_SUPPORTED_PLATFORMS = "supportedPlatforms";
     private static final String FIELD_CREATED_AT = "createdAt";
     private static final String FIELD_UPDATED_AT = "updatedAt";
+    private static final String FIELD_START_AT = "startAt";
     private static final String FIELD_CREATED_BY = "createdBy";
     private static final String FIELD_COUNT = "count";
     private static final String FIELD_REPEAT = "repeat";
@@ -65,9 +66,9 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
     private static final String CURSOR_SEPARATOR = "|";
 
     private static final Set<String> SORTABLE_FIELDS =
-            Set.of(FIELD_ID, FIELD_NAME, FIELD_CREATED_AT, FIELD_UPDATED_AT, FIELD_REPEAT, FIELD_DEVICE_COUNT);
+            Set.of(FIELD_ID, FIELD_NAME, FIELD_CREATED_AT, FIELD_UPDATED_AT, FIELD_START_AT, FIELD_REPEAT, FIELD_DEVICE_COUNT);
 
-    private static final Set<String> DATE_SORT_FIELDS = Set.of(FIELD_CREATED_AT, FIELD_UPDATED_AT);
+    private static final Set<String> DATE_SORT_FIELDS = Set.of(FIELD_CREATED_AT, FIELD_UPDATED_AT, FIELD_START_AT);
 
     private final MongoTemplate mongoTemplate;
 
@@ -215,7 +216,7 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         Date dateValue;
         try {
             bucket = Integer.parseInt(parts[0]);
-            dateValue = new Date(Long.parseLong(parts[1]));
+            dateValue = parts[1].isEmpty() ? null : new Date(Long.parseLong(parts[1]));
         } catch (NumberFormatException ex) {
             log.warn("Unparseable bucket/date in date-trigger cursor '{}' — falling back to first page", cursor);
             return;
@@ -223,12 +224,18 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
 
         String cmp = effectiveDir == Sort.Direction.ASC ? "$gt" : "$lt";
         String bucketCmp = bucketDir == Sort.Direction.ASC ? "$gt" : "$lt";
-        Document orExpr = new Document("$or", List.of(
-                new Document(FIELD_TRIGGER_BUCKET, new Document(bucketCmp, bucket)),
-                new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, new Document(cmp, dateValue)),
-                new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, dateValue)
-                        .append(FIELD_ID, new Document(cmp, cursorId))));
-        ops.add(ctx -> new Document("$match", orExpr));
+
+        List<Document> arms = new ArrayList<>();
+        arms.add(new Document(FIELD_TRIGGER_BUCKET, new Document(bucketCmp, bucket)));
+        if (dateValue == null) {
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, null)
+                    .append(FIELD_ID, new Document(cmp, cursorId)));
+        } else {
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, new Document(cmp, dateValue)));
+            arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(dateField, dateValue)
+                    .append(FIELD_ID, new Document(cmp, cursorId)));
+        }
+        ops.add(ctx -> new Document("$match", new Document("$or", arms)));
     }
 
     private ScriptSchedule toSchedule(Document doc) {
@@ -348,6 +355,9 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         }
         applyRange(criteria, FIELD_CREATED_AT, filter.getCreatedAtFrom(), filter.getCreatedAtTo());
         applyRange(criteria, FIELD_UPDATED_AT, filter.getUpdatedAtFrom(), filter.getUpdatedAtTo());
+        // startAt is null for DEVICE_ONLINE (and timing-less) schedules, so a startAt range
+        // naturally excludes them — a value window can't match a schedule that has no start.
+        applyRange(criteria, FIELD_START_AT, filter.getStartAtFrom(), filter.getStartAtTo());
     }
 
     private static void applyRange(Criteria criteria, String field, Instant from, Instant to) {
@@ -491,9 +501,9 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
             return schedule.getId();
         }
         if (DATE_SORT_FIELDS.contains(sortField)) {
-            return triggerBucket(schedule) + CURSOR_SEPARATOR
-                    + dateEpochMillis(schedule, sortField) + CURSOR_SEPARATOR
-                    + schedule.getId();
+            Instant date = dateSortValue(schedule, sortField);
+            String millis = date == null ? "" : String.valueOf(date.toEpochMilli());
+            return triggerBucket(schedule) + CURSOR_SEPARATOR + millis + CURSOR_SEPARATOR + schedule.getId();
         }
         return encodeSortValue(schedule, sortField) + CURSOR_SEPARATOR + schedule.getId();
     }
@@ -502,9 +512,12 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
         return schedule.getTrigger() == TRIGGER_LAST ? 1 : 0;
     }
 
-    private static long dateEpochMillis(ScriptSchedule schedule, String dateField) {
-        Instant value = FIELD_UPDATED_AT.equals(dateField) ? schedule.getUpdatedAt() : schedule.getCreatedAt();
-        return value == null ? 0L : value.toEpochMilli();
+    private static Instant dateSortValue(ScriptSchedule schedule, String dateField) {
+        return switch (dateField) {
+            case FIELD_UPDATED_AT -> schedule.getUpdatedAt();
+            case FIELD_START_AT -> schedule.getStartAt();
+            default -> schedule.getCreatedAt();
+        };
     }
 
     /**

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImpl.java
@@ -217,20 +217,25 @@ public class CustomScriptScheduleRepositoryImpl implements CustomScriptScheduleR
 
         String cmp = effectiveDir == Sort.Direction.ASC ? "$gt" : "$lt";
         String bucketCmp = bucketDir == Sort.Direction.ASC ? "$gt" : "$lt";
+        boolean ascending = effectiveDir == Sort.Direction.ASC;
 
         List<Document> arms = new ArrayList<>();
         // Cross-bucket: everything past this bucket in bucket order (e.g. the whole DEVICE_ONLINE tail).
         arms.add(new Document(FIELD_TRIGGER_BUCKET, new Document(bucketCmp, bucket)));
         if (startAt == null) {
-            // Null-startAt bucket (DEVICE_ONLINE): startAt is constant (null) across it, so order by
-            // _id alone. A range against a sentinel Date never matches null, which would silently
-            // drop the rest of the bucket.
+            // Cursor sits in this bucket's null group: continue it by _id...
             arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, null)
                     .append(FIELD_ID, new Document(cmp, cursorId)));
+            if (ascending) {
+                arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, new Document("$ne", null)));
+            }
         } else {
             arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, new Document(cmp, startAt)));
             arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, startAt)
                     .append(FIELD_ID, new Document(cmp, cursorId)));
+            if (!ascending) {
+                arms.add(new Document(FIELD_TRIGGER_BUCKET, bucket).append(FIELD_START_AT, null));
+            }
         }
         ops.add(ctx -> new Document("$match", new Document("$or", arms)));
     }

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplDateFilterTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplDateFilterTest.java
@@ -28,30 +28,6 @@ class CustomScriptScheduleRepositoryImplDateFilterTest {
     }
 
     @Test
-    void createdAtRange_appliesInclusiveGteLte() {
-        Instant from = Instant.parse("2026-01-01T00:00:00Z");
-        Instant to = Instant.parse("2026-02-01T00:00:00Z");
-
-        Document createdAt = (Document) countQueryFor(ScriptScheduleQueryFilter.builder()
-                .createdAtFrom(from).createdAtTo(to).build()).get("createdAt");
-
-        assertThat(createdAt).isNotNull();
-        assertThat(createdAt.get("$gte")).isEqualTo(from);
-        assertThat(createdAt.get("$lte")).isEqualTo(to);
-    }
-
-    @Test
-    void updatedAtRange_openEnded_onlyLowerBound() {
-        Instant from = Instant.parse("2026-03-01T00:00:00Z");
-
-        Document updatedAt = (Document) countQueryFor(ScriptScheduleQueryFilter.builder()
-                .updatedAtFrom(from).build()).get("updatedAt");
-
-        assertThat(updatedAt).containsKey("$gte");
-        assertThat(updatedAt).doesNotContainKey("$lte");
-    }
-
-    @Test
     void startAtRange_appliesInclusiveGteLte() {
         Instant from = Instant.parse("2026-04-01T00:00:00Z");
         Instant to = Instant.parse("2026-05-01T00:00:00Z");
@@ -65,11 +41,31 @@ class CustomScriptScheduleRepositoryImplDateFilterTest {
     }
 
     @Test
-    void noDateFilter_addsNoDateCriteria() {
+    void startAtRange_openEnded_onlyLowerBound() {
+        Instant from = Instant.parse("2026-04-01T00:00:00Z");
+
+        Document startAt = (Document) countQueryFor(ScriptScheduleQueryFilter.builder()
+                .startAtFrom(from).build()).get("startAt");
+
+        assertThat(startAt).containsKey("$gte");
+        assertThat(startAt).doesNotContainKey("$lte");
+    }
+
+    @Test
+    void startAtRange_openEnded_onlyUpperBound() {
+        Instant to = Instant.parse("2026-05-01T00:00:00Z");
+
+        Document startAt = (Document) countQueryFor(ScriptScheduleQueryFilter.builder()
+                .startAtTo(to).build()).get("startAt");
+
+        assertThat(startAt).containsKey("$lte");
+        assertThat(startAt).doesNotContainKey("$gte");
+    }
+
+    @Test
+    void noStartAtFilter_addsNoStartAtCriteria() {
         Document q = countQueryFor(ScriptScheduleQueryFilter.builder().build());
 
-        assertThat(q).doesNotContainKey("createdAt");
-        assertThat(q).doesNotContainKey("updatedAt");
         assertThat(q).doesNotContainKey("startAt");
     }
 }

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplDateFilterTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplDateFilterTest.java
@@ -52,10 +52,24 @@ class CustomScriptScheduleRepositoryImplDateFilterTest {
     }
 
     @Test
+    void startAtRange_appliesInclusiveGteLte() {
+        Instant from = Instant.parse("2026-04-01T00:00:00Z");
+        Instant to = Instant.parse("2026-05-01T00:00:00Z");
+
+        Document startAt = (Document) countQueryFor(ScriptScheduleQueryFilter.builder()
+                .startAtFrom(from).startAtTo(to).build()).get("startAt");
+
+        assertThat(startAt).isNotNull();
+        assertThat(startAt.get("$gte")).isEqualTo(from);
+        assertThat(startAt.get("$lte")).isEqualTo(to);
+    }
+
+    @Test
     void noDateFilter_addsNoDateCriteria() {
         Document q = countQueryFor(ScriptScheduleQueryFilter.builder().build());
 
         assertThat(q).doesNotContainKey("createdAt");
         assertThat(q).doesNotContainKey("updatedAt");
+        assertThat(q).doesNotContainKey("startAt");
     }
 }

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
@@ -87,6 +87,55 @@ class CustomScriptScheduleRepositoryImplSortTest {
     }
 
     @Test
+    void startAtSort_deviceOnlineLast_bucketThenStartAtThenId() {
+        Document sort = (Document) stage(pipelineForDateSort("startAt", Sort.Direction.ASC, null), "$sort").get("$sort");
+        assertThat(new ArrayList<>(sort.keySet())).containsExactly("_triggerBucket", "startAt", "_id");
+        assertThat(sort.get("_triggerBucket")).isEqualTo(1);   // DEVICE_ONLINE always last
+        assertThat(sort.get("startAt")).isEqualTo(1);
+    }
+
+    @Test
+    void encodeCursor_startAtSort_dateTime_usesStartAtMillis_bucketZero() {
+        Instant startAt = Instant.parse("2026-03-15T00:00:00Z");
+        ScriptSchedule s = new ScriptSchedule();
+        s.setId("507f1f77bcf86cd799439011");
+        s.setStartAt(startAt);
+        s.setTrigger(ScriptScheduleTrigger.DATE_TIME);
+
+        assertThat(repo.encodeCursor(s, "startAt"))
+                .isEqualTo("0|" + startAt.toEpochMilli() + "|507f1f77bcf86cd799439011");
+    }
+
+    @Test
+    void encodeCursor_startAtSort_deviceOnline_nullStartAt_isEmptyMillisBucketOne() {
+        // DEVICE_ONLINE always has null startAt (invariant); the millis segment must be empty,
+        // not a 0 sentinel, so the keyset can match on null instead of Date(0).
+        ScriptSchedule s = new ScriptSchedule();
+        s.setId("507f1f77bcf86cd799439011");
+        s.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);   // startAt left null
+
+        assertThat(repo.encodeCursor(s, "startAt")).isEqualTo("1||507f1f77bcf86cd799439011");
+    }
+
+    @Test
+    void startAtCursor_nullDatedBucket_keysetMatchesNullNotSentinel_soDeviceOnlineTailPaginates() {
+        // Regression: a cursor sitting inside the DEVICE_ONLINE tail (null startAt) must continue
+        // by _id within bucket 1. Matching startAt == Date(0) would hit nothing and drop the rest.
+        List<Document> pipeline = pipelineForDateSort("startAt", Sort.Direction.ASC,
+                "1||507f1f77bcf86cd799439011");
+        Document match = pipeline.stream()
+                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
+                .findFirst().orElseThrow();
+        @SuppressWarnings("unchecked")
+        List<Document> or = (List<Document>) ((Document) match.get("$match")).get("$or");
+        Document tieArm = or.get(1);
+        assertThat(tieArm.get("_triggerBucket")).isEqualTo(1);
+        assertThat(tieArm.containsKey("startAt")).isTrue();
+        assertThat(tieArm.get("startAt")).isNull();                 // matches null, not Date(0)
+        assertThat((Document) tieArm.get("_id")).containsKey("$gt");
+    }
+
+    @Test
     void updatedAtSort_ascending_bucketStillAscending() {
         Document sort = (Document) stage(pipelineForDateSort("updatedAt", Sort.Direction.ASC, null), "$sort").get("$sort");
         assertThat(sort.get("_triggerBucket")).isEqualTo(1);   // bucket never flips — DEVICE_ONLINE always last

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
@@ -2,6 +2,7 @@ package com.openframe.data.repository.rmm;
 
 import com.openframe.data.document.rmm.ScriptSchedule;
 import com.openframe.data.document.rmm.ScriptScheduleTrigger;
+import com.openframe.data.document.rmm.filter.ScriptScheduleQueryFilter;
 import org.bson.Document;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -12,6 +13,7 @@ import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,76 +28,106 @@ class CustomScriptScheduleRepositoryImplSortTest {
     private final MongoTemplate mongoTemplate = mock(MongoTemplate.class);
     private final CustomScriptScheduleRepositoryImpl repo = new CustomScriptScheduleRepositoryImpl(mongoTemplate);
 
-    private List<Document> pipelineForDateSort(String sortField, Sort.Direction dir, String cursor) {
-        return pipelineForDateSort(sortField, dir, cursor, false);
+    private List<Document> startAtPipeline(Sort.Direction dir, String cursor) {
+        return startAtPipeline(dir, cursor, false, null);
     }
 
-    private List<Document> pipelineForDateSort(String sortField, Sort.Direction dir, String cursor, boolean backward) {
+    private List<Document> startAtPipeline(Sort.Direction dir, String cursor, boolean backward) {
+        return startAtPipeline(dir, cursor, backward, null);
+    }
+
+    private List<Document> startAtPipeline(Sort.Direction dir, String cursor, boolean backward,
+                                           ScriptScheduleQueryFilter filter) {
         when(mongoTemplate.aggregate(any(Aggregation.class), eq("script_schedules"), eq(Document.class)))
                 .thenReturn(new AggregationResults<>(List.of(), new Document()));
 
-        repo.findPageForTenant("t1", null, null, sortField, dir, cursor, backward, 20);
+        repo.findPageForTenant("t1", filter, null, "startAt", dir, cursor, backward, 20);
 
         ArgumentCaptor<Aggregation> captor = ArgumentCaptor.forClass(Aggregation.class);
         verify(mongoTemplate).aggregate(captor.capture(), eq("script_schedules"), eq(Document.class));
         return captor.getValue().toPipeline(Aggregation.DEFAULT_CONTEXT);
     }
 
+    private static boolean hasKeysetStage(List<Document> pipeline) {
+        return pipeline.stream().anyMatch(d ->
+                d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"));
+    }
+
     private static Document stage(List<Document> pipeline, String key) {
         return pipeline.stream().filter(d -> d.containsKey(key)).findFirst().orElseThrow();
     }
 
+    private static List<Document> keysetArms(List<Document> pipeline) {
+        Document match = pipeline.stream()
+                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
+                .findFirst().orElseThrow();
+        @SuppressWarnings("unchecked")
+        List<Document> or = (List<Document>) ((Document) match.get("$match")).get("$or");
+        return or;
+    }
+
     @Test
-    void createdAtSort_primaryKeyIsTriggerBucketAsc_deviceOnlineLast() {
-        List<Document> pipeline = pipelineForDateSort("createdAt", Sort.Direction.DESC, null);
+    void startAtSort_descending_bucketAscThenStartAtDescThenIdDesc_deviceOnlineLast() {
+        List<Document> pipeline = startAtPipeline(Sort.Direction.DESC, null);
 
         // $addFields _triggerBucket = (trigger == DEVICE_ONLINE ? 1 : 0)
         Document addFields = (Document) stage(pipeline, "$addFields").get("$addFields");
         assertThat(addFields).containsKey("_triggerBucket");
         assertThat(addFields.toJson()).contains("DEVICE_ONLINE");
 
-        // $sort: bucket ASC first (so DEVICE_ONLINE trails), then createdAt DESC, then _id DESC
+        // $sort: bucket ASC first (so DEVICE_ONLINE trails), then startAt DESC, then _id DESC
         Document sort = (Document) stage(pipeline, "$sort").get("$sort");
-        assertThat(new ArrayList<>(sort.keySet())).containsExactly("_triggerBucket", "createdAt", "_id");
+        assertThat(new ArrayList<>(sort.keySet())).containsExactly("_triggerBucket", "startAt", "_id");
         assertThat(sort.get("_triggerBucket")).isEqualTo(1);
-        assertThat(sort.get("createdAt")).isEqualTo(-1);
+        assertThat(sort.get("startAt")).isEqualTo(-1);
         assertThat(sort.get("_id")).isEqualTo(-1);
+    }
+
+    @Test
+    void startAtSort_ascending_bucketStillAscending_deviceOnlineLast() {
+        Document sort = (Document) stage(startAtPipeline(Sort.Direction.ASC, null), "$sort").get("$sort");
+        assertThat(sort.get("_triggerBucket")).isEqualTo(1);   // bucket never flips — DEVICE_ONLINE always last
+        assertThat(sort.get("startAt")).isEqualTo(1);
     }
 
     @Test
     void backwardPaging_flipsEveryKeyIncludingBucket_soReversalKeepsDeviceOnlineLast() {
         // Backward paging reverses the whole sort (the service re-reverses the page). The bucket must
         // flip too — otherwise DEVICE_ONLINE would surface first on backward pages.
-        Document sort = (Document) stage(
-                pipelineForDateSort("createdAt", Sort.Direction.DESC, null, true), "$sort").get("$sort");
+        Document sort = (Document) stage(startAtPipeline(Sort.Direction.DESC, null, true), "$sort").get("$sort");
         assertThat(sort.get("_triggerBucket")).isEqualTo(-1);   // flipped to DESC under backward
-        assertThat(sort.get("createdAt")).isEqualTo(1);          // flip of requested DESC
+        assertThat(sort.get("startAt")).isEqualTo(1);            // flip of requested DESC
         assertThat(sort.get("_id")).isEqualTo(1);
     }
 
     @Test
     void backwardCursor_bucketKeysetComparatorFlipsToLt() {
-        List<Document> pipeline = pipelineForDateSort("createdAt", Sort.Direction.DESC,
-                "1|1735689600000|507f1f77bcf86cd799439011", true);
-        Document match = pipeline.stream()
-                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
-                .findFirst().orElseThrow();
-        @SuppressWarnings("unchecked")
-        List<Document> or = (List<Document>) ((Document) match.get("$match")).get("$or");
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.DESC,
+                "0|1735689600000|507f1f77bcf86cd799439011", true));
         Document bucketArm = (Document) or.get(0).get("_triggerBucket");
         assertThat(bucketArm).containsKey("$lt");   // bucket walks DESC under backward
     }
 
     @Test
-    void startAtSort_deviceOnlineLast_bucketThenStartAtThenId() {
-        Document sort = (Document) stage(pipelineForDateSort("startAt", Sort.Direction.ASC, null), "$sort").get("$sort");
-        assertThat(new ArrayList<>(sort.keySet())).containsExactly("_triggerBucket", "startAt", "_id");
-        assertThat(sort.get("_triggerBucket")).isEqualTo(1);   // DEVICE_ONLINE always last
-        assertThat(sort.get("startAt")).isEqualTo(1);
+    void startAtCursor_appliesBucketKeyset() {
+        Document match = startAtPipeline(Sort.Direction.DESC, "0|1735689600000|507f1f77bcf86cd799439011").stream()
+                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
+                .findFirst().orElseThrow();
+        assertThat(match.toJson()).contains("_triggerBucket");
     }
 
     @Test
-    void encodeCursor_startAtSort_dateTime_usesStartAtMillis_bucketZero() {
+    void startAtCursor_nullDatedBucket_keysetMatchesNullNotSentinel_soDeviceOnlineTailPaginates() {
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.ASC, "1||507f1f77bcf86cd799439011"));
+        Document tieArm = or.get(1);
+        assertThat(tieArm.get("_triggerBucket")).isEqualTo(1);
+        assertThat(tieArm.containsKey("startAt")).isTrue();
+        assertThat(tieArm.get("startAt")).isNull();                 // matches null, not Date(0)
+        assertThat((Document) tieArm.get("_id")).containsKey("$gt");
+    }
+
+    @Test
+    void encodeCursor_dateTime_usesStartAtMillis_bucketZero() {
         Instant startAt = Instant.parse("2026-03-15T00:00:00Z");
         ScriptSchedule s = new ScriptSchedule();
         s.setId("507f1f77bcf86cd799439011");
@@ -107,7 +139,7 @@ class CustomScriptScheduleRepositoryImplSortTest {
     }
 
     @Test
-    void encodeCursor_startAtSort_deviceOnline_nullStartAt_isEmptyMillisBucketOne() {
+    void encodeCursor_deviceOnline_nullStartAt_isEmptyMillisBucketOne() {
         // DEVICE_ONLINE always has null startAt (invariant); the millis segment must be empty,
         // not a 0 sentinel, so the keyset can match on null instead of Date(0).
         ScriptSchedule s = new ScriptSchedule();
@@ -118,61 +150,83 @@ class CustomScriptScheduleRepositoryImplSortTest {
     }
 
     @Test
-    void startAtCursor_nullDatedBucket_keysetMatchesNullNotSentinel_soDeviceOnlineTailPaginates() {
-        // Regression: a cursor sitting inside the DEVICE_ONLINE tail (null startAt) must continue
-        // by _id within bucket 1. Matching startAt == Date(0) would hit nothing and drop the rest.
-        List<Document> pipeline = pipelineForDateSort("startAt", Sort.Direction.ASC,
-                "1||507f1f77bcf86cd799439011");
-        Document match = pipeline.stream()
-                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
-                .findFirst().orElseThrow();
-        @SuppressWarnings("unchecked")
-        List<Document> or = (List<Document>) ((Document) match.get("$match")).get("$or");
-        Document tieArm = or.get(1);
-        assertThat(tieArm.get("_triggerBucket")).isEqualTo(1);
-        assertThat(tieArm.containsKey("startAt")).isTrue();
-        assertThat(tieArm.get("startAt")).isNull();                 // matches null, not Date(0)
-        assertThat((Document) tieArm.get("_id")).containsKey("$gt");
+    void forwardCursor_dateTimeBucket_ascending_isGtThreeArmKeyset() {
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.ASC, "0|1735689600000|507f1f77bcf86cd799439011"));
+        assertThat(or).hasSize(3);
+        // arm0: next bucket (bucket > 0)
+        assertThat((Document) or.get(0).get("_triggerBucket")).containsEntry("$gt", 0);
+        // arm1: same bucket, later startAt (startAt > cursor date)
+        assertThat(or.get(1).get("_triggerBucket")).isEqualTo(0);
+        assertThat((Document) or.get(1).get("startAt")).containsKey("$gt");
+        // arm2: same bucket, same startAt, later _id
+        assertThat(or.get(2).get("_triggerBucket")).isEqualTo(0);
+        assertThat(or.get(2).get("startAt")).isInstanceOf(Date.class);
+        assertThat((Document) or.get(2).get("_id")).containsKey("$gt");
     }
 
     @Test
-    void updatedAtSort_ascending_bucketStillAscending() {
-        Document sort = (Document) stage(pipelineForDateSort("updatedAt", Sort.Direction.ASC, null), "$sort").get("$sort");
-        assertThat(sort.get("_triggerBucket")).isEqualTo(1);   // bucket never flips — DEVICE_ONLINE always last
-        assertThat(sort.get("updatedAt")).isEqualTo(1);
+    void forwardCursor_dateTimeBucket_descending_flipsKeysetToLt() {
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.DESC, "0|1735689600000|507f1f77bcf86cd799439011"));
+        assertThat((Document) or.get(1).get("startAt")).containsKey("$lt");
+        assertThat((Document) or.get(2).get("_id")).containsKey("$lt");
     }
 
     @Test
-    void dateCursor_appliesBucketKeyset() {
-        List<Document> pipeline = pipelineForDateSort("createdAt", Sort.Direction.DESC,
-                "0|1735689600000|507f1f77bcf86cd799439011");
-
-        // A $match with an $or keyset over the trigger bucket is inserted before the $sort.
-        Document match = pipeline.stream()
-                .filter(d -> d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or"))
-                .findFirst().orElseThrow();
-        assertThat(match.toJson()).contains("_triggerBucket");
+    void invalidCursor_wrongPartCount_fallsBackToFirstPage_noKeyset() {
+        assertThat(hasKeysetStage(startAtPipeline(Sort.Direction.ASC, "not-a-valid-cursor"))).isFalse();
     }
 
     @Test
-    void encodeCursor_dateSort_isBucketMillisId_deviceOnlineBucketOne() {
-        Instant created = Instant.parse("2026-01-01T00:00:00Z");
-        ScriptSchedule s = new ScriptSchedule();
-        s.setId("507f1f77bcf86cd799439011");
-        s.setCreatedAt(created);
-        s.setTrigger(ScriptScheduleTrigger.DEVICE_ONLINE);
-
-        assertThat(repo.encodeCursor(s, "createdAt"))
-                .isEqualTo("1|" + created.toEpochMilli() + "|507f1f77bcf86cd799439011");
+    void invalidCursor_badObjectId_fallsBackToFirstPage_noKeyset() {
+        assertThat(hasKeysetStage(startAtPipeline(Sort.Direction.ASC, "0|1735689600000|not-an-objectid"))).isFalse();
     }
 
     @Test
-    void encodeCursor_dateSort_dateTimeIsBucketZero() {
-        ScriptSchedule s = new ScriptSchedule();
-        s.setId("id-1");
-        s.setUpdatedAt(Instant.parse("2026-02-01T00:00:00Z"));
-        s.setTrigger(ScriptScheduleTrigger.DATE_TIME);
+    void invalidCursor_unparseableMillis_fallsBackToFirstPage_noKeyset() {
+        assertThat(hasKeysetStage(startAtPipeline(Sort.Direction.ASC, "0|abc|507f1f77bcf86cd799439011"))).isFalse();
+    }
 
-        assertThat(repo.encodeCursor(s, "updatedAt")).startsWith("0|");
+    @Test
+    void keysetMatchIsInsertedBeforeSort() {
+        List<Document> pipeline = startAtPipeline(Sort.Direction.ASC, "0|1735689600000|507f1f77bcf86cd799439011");
+        int keysetIdx = -1;
+        int sortIdx = -1;
+        for (int i = 0; i < pipeline.size(); i++) {
+            Document d = pipeline.get(i);
+            if (keysetIdx < 0 && d.containsKey("$match") && d.get("$match") instanceof Document m && m.containsKey("$or")) {
+                keysetIdx = i;
+            }
+            if (sortIdx < 0 && d.containsKey("$sort")) {
+                sortIdx = i;
+            }
+        }
+        assertThat(keysetIdx).isGreaterThanOrEqualTo(0);
+        assertThat(keysetIdx).isLessThan(sortIdx);
+    }
+
+    @Test
+    void firstPage_noCursor_hasNoKeysetStage() {
+        assertThat(hasKeysetStage(startAtPipeline(Sort.Direction.ASC, null))).isFalse();
+    }
+
+    @Test
+    void startAtFilter_isAppliedInAggregateBaseMatch_whenSortingByStartAt() {
+        Instant from = Instant.parse("2026-04-01T00:00:00Z");
+        List<Document> pipeline = startAtPipeline(Sort.Direction.ASC, null, false,
+                ScriptScheduleQueryFilter.builder().startAtFrom(from).build());
+
+        // The first $match is the base tenant+filter predicate (the keyset $or is a later stage).
+        Document baseMatch = (Document) stage(pipeline, "$match").get("$match");
+        assertThat(baseMatch).containsKey("startAt");
+        assertThat((Document) baseMatch.get("startAt")).containsKey("$gte");
+    }
+
+    @Test
+    void isSortableField_startAtTrue_createdAtAndUpdatedAtRemoved() {
+        assertThat(repo.isSortableField("startAt")).isTrue();
+        assertThat(repo.isSortableField("createdAt")).isFalse();
+        assertThat(repo.isSortableField("updatedAt")).isFalse();
+        assertThat(repo.isSortableField("bogus")).isFalse();
+        assertThat(repo.isSortableField(null)).isFalse();
     }
 }

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/rmm/CustomScriptScheduleRepositoryImplSortTest.java
@@ -172,6 +172,24 @@ class CustomScriptScheduleRepositoryImplSortTest {
     }
 
     @Test
+    void ascendingCursor_nullStartAt_alsoSweepsDatedRowsAheadInSameBucket() {
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.ASC, "0||507f1f77bcf86cd799439011"));
+        boolean sweepsDated = or.stream().anyMatch(a ->
+                Integer.valueOf(0).equals(a.get("_triggerBucket"))
+                        && a.get("startAt") instanceof Document sd && sd.containsKey("$ne"));
+        assertThat(sweepsDated).isTrue();
+    }
+
+    @Test
+    void descendingCursor_datedStartAt_alsoSweepsNullTailInSameBucket() {
+        List<Document> or = keysetArms(startAtPipeline(Sort.Direction.DESC, "0|1735689600000|507f1f77bcf86cd799439011"));
+        boolean sweepsNullTail = or.stream().anyMatch(a ->
+                Integer.valueOf(0).equals(a.get("_triggerBucket"))
+                        && a.containsKey("startAt") && a.get("startAt") == null && !a.containsKey("_id"));
+        assertThat(sweepsNullTail).isTrue();
+    }
+
+    @Test
     void invalidCursor_wrongPartCount_fallsBackToFirstPage_noKeyset() {
         assertThat(hasKeysetStage(startAtPipeline(Sort.Direction.ASC, "not-a-valid-cursor"))).isFalse();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated script schedule filtering to use start-time ranges.
  * Updated schedule sorting to use start time instead of creation or update timestamps.
  * Improved pagination for schedules, including handling schedules without a start time.
  * Schedules triggered by device-online events are ordered last when sorting by start time.
* **Bug Fixes**
  * Improved cursor handling and validation for reliable forward and backward pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->