### PR TITLE
Auth: apple provider on the SSO auth forms

### DIFF
--- a/openframe-frontend-core/src/components/features/auth/sso-providers.tsx
+++ b/openframe-frontend-core/src/components/features/auth/sso-providers.tsx
@@ -2,12 +2,13 @@
 
 import * as React from 'react'
 import { OpenFrameLogo } from '../../icons'
+import { AppleLogoIcon } from '../../icons-v2-generated/brand-logos/apple-logo-icon'
 import { GoogleLogoIcon } from '../../icons-v2-generated/brand-logos/google-logo-icon'
 import { MicrosoftLogoIcon } from '../../icons-v2-generated/brand-logos/microsoft-logo-icon'
 import { Button } from '../../ui/button'
 
 /** SSO providers offered on the auth forms. */
-export type AuthSsoProvider = 'openframe' | 'google' | 'microsoft'
+export type AuthSsoProvider = 'openframe' | 'google' | 'microsoft' | 'apple'
 
 export const PROVIDER_META: Record<
   AuthSsoProvider,
@@ -25,6 +26,7 @@ export const PROVIDER_META: Record<
   },
   google: { name: 'Google', Icon: GoogleLogoIcon },
   microsoft: { name: 'Microsoft', Icon: MicrosoftLogoIcon },
+  apple: { name: 'Apple', Icon: AppleLogoIcon },
 }
 
 export interface SsoProviderButtonsProps {

--- a/openframe-frontend-core/src/stories/auth/Login.stories.tsx
+++ b/openframe-frontend-core/src/stories/auth/Login.stories.tsx
@@ -72,7 +72,7 @@ export const Filled: Story = {
   render: () => <LoginPage email="roman@mail.com" />,
 }
 
-const SSO_PROVIDERS: AuthSsoProvider[] = ['openframe', 'google', 'microsoft']
+const SSO_PROVIDERS: AuthSsoProvider[] = ['openframe', 'google', 'microsoft', 'apple']
 
 /** SSO configured: email filled, submit replaced by provider buttons. */
 export const SSO: Story = {


### PR DESCRIPTION
Adds 'apple' to AuthSsoProvider with the AppleLogoIcon brand icon, so LoginForm / CompleteAccountForm / CreateOrganizationForm can render the "Continue with Apple" button (BE support landed in #1598).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple as an available single sign-on option.
  * Apple sign-in is now included on the login screen alongside existing providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->