### PR TITLE
fix(tab-navigation): underline width in real pixels, not scaleX

### DIFF
--- a/openframe-frontend-core/src/components/ui/__tests__/tab-navigation.test.tsx
+++ b/openframe-frontend-core/src/components/ui/__tests__/tab-navigation.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from 'vitest'
+import { describe, it, expect, beforeAll, vi } from 'vitest'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { mockReplace, setMockSearchParams } from '../../../../vitest.setup'
 import { TabNavigation, type TabItem } from '../tab-navigation'
@@ -154,6 +154,38 @@ describe('TabNavigation with urlSync', () => {
       setMockSearchParams(new URLSearchParams('tab=nonsense'))
       nav.rerenderWith(TABS)
       expect(nav.active).toBe('general')
+    })
+  })
+  describe('the underline', () => {
+    it('is sized in real pixels rather than a scaled 1px bar', () => {
+      // Regression guard. The underline used to be `w-px` stretched with
+      // `scaleX(width)`, which is only exact when one CSS pixel lands on a whole
+      // device pixel. At 125%/150% OS scaling or any browser zoom the base is
+      // rasterized to the nearest whole device pixel and `scaleX` multiplies
+      // that rounding by the tab's width, so the bar rendered visibly shorter or
+      // longer than the tab it underlines — while `offsetWidth` had been right
+      // all along. Asserting the STYLE (not the pixels, which jsdom has none of)
+      // is what keeps the multiplier from coming back.
+      const widthSpy = vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockReturnValue(120)
+      const leftSpy = vi.spyOn(HTMLElement.prototype, 'offsetLeft', 'get').mockReturnValue(40)
+
+      try {
+        setMockSearchParams(new URLSearchParams('tab=general'))
+        const { container } = render(
+          <TabNavigation tabs={TABS} urlSync>
+            {() => null}
+          </TabNavigation>
+        )
+
+        const underline = container.querySelector('[aria-hidden]') as HTMLElement
+        expect(underline.style.width).toBe('120px')
+        expect(underline.style.transform).toBe('translateX(40px)')
+        expect(underline.style.transform).not.toContain('scaleX')
+        expect(underline.className).not.toContain('w-px')
+      } finally {
+        widthSpy.mockRestore()
+        leftSpy.mockRestore()
+      }
     })
   })
 })

--- a/openframe-frontend-core/src/components/ui/tab-navigation.tsx
+++ b/openframe-frontend-core/src/components/ui/tab-navigation.tsx
@@ -231,12 +231,29 @@ const TabBar = memo(function TabBar({
     return { background: c }
   }, [leftFade, rightFade])
 
-  // A 1px bar scaled to width, rather than an animated `left`/`width` pair:
-  // transform and opacity are the only two properties the compositor can
-  // animate without laying the strip out again on every frame.
+  // Real width, moved by `translateX`. This used to be a 1px bar stretched with
+  // `scaleX(width)` — transform and opacity being the only properties the
+  // compositor can animate without laying out again — but scaling from a ONE
+  // PIXEL base turns that pixel into an error multiplier.
+  //
+  // A CSS pixel only lands on a whole device pixel at integer scale factors. At
+  // 125% / 150% OS scaling, a scaled Mac resolution, or any browser zoom, the
+  // base is rasterized at the nearest whole device pixel — call it 0.8 or 1.33
+  // CSS px — and `scaleX(150)` multiplies that rounding by 150. The underline
+  // then renders a fifth short or a third long, per tab, with `measureIndicator`
+  // having been perfectly correct all along. It shows up from the SECOND tab
+  // change on, because that is when the transition promotes the bar into its own
+  // composited layer, where it is rasterized in its own 1×4 coordinate space and
+  // only then stretched.
+  //
+  // Animating `width` costs a layout per frame for this one element — it is
+  // `absolute`, so nothing else in the strip is laid out with it, and 200ms of
+  // that for a 4px-tall bar is not measurable. Correctness at every zoom level
+  // is worth more than keeping one property on the compositor.
   const isPlaced = indicator.width > 0
   const indicatorStyle: React.CSSProperties = {
-    transform: `translateX(${indicator.left}px) scaleX(${indicator.width})`,
+    width: `${indicator.width}px`,
+    transform: `translateX(${indicator.left}px)`,
     opacity: isPlaced ? 1 : 0,
   }
   const shouldAnimateIndicator = hasPlacedIndicatorRef.current
@@ -302,13 +319,13 @@ const TabBar = memo(function TabBar({
         })}
 
         {/* One underline for the whole strip, sliding between tabs. Inside the
-            scroll container so it travels with the content; `origin-left` +
-            `w-px` make scaleX(n) read as "n pixels wide". */}
+            scroll container so it travels with the content. Width comes from the
+            style below in real pixels — see why it is not a scaled 1px bar. */}
         <div
           aria-hidden
           className={cn(
-            "pointer-events-none absolute bottom-0 left-0 h-1 w-px origin-left bg-ods-accent",
-            shouldAnimateIndicator && "transition-[transform,opacity] duration-200 ease-out motion-reduce:transition-none"
+            "pointer-events-none absolute bottom-0 left-0 h-1 bg-ods-accent",
+            shouldAnimateIndicator && "transition-[transform,width,opacity] duration-200 ease-out motion-reduce:transition-none"
           )}
           style={indicatorStyle}
         />


### PR DESCRIPTION
## Problem

The active-tab underline was a `w-px` bar stretched with `scaleX(width)`.

A CSS pixel only lands on a whole device pixel at integer scale factors. At 125%/150% OS scaling, a scaled Mac resolution, or any browser zoom, the 1px base is rasterized to the nearest whole device pixel and `scaleX(n)` multiplies that rounding by `n`. The bar then renders visibly shorter or longer than the tab it underlines.

`measureIndicator` was correct all along — only the rendering was off, and only from the **second** tab change on: that is when the transition promotes the bar into its own composited layer, where it is rasterized in its own 1×4 coordinate space and only then stretched.

## Fix

- `width` is set in real pixels; position stays on `translateX`
- the transition now includes `width`

That is a layout per frame, yes — but for a single `absolute` element 4px tall, with nothing else in the strip relaying out alongside it. Correctness at every zoom level is worth more than keeping one property on the compositor.

## Test

Adds a regression test asserting the **style** (px width, no `scaleX`, no `w-px`) rather than pixels — jsdom has none.

## Verified

- `npm run test` — 11/11 in `tab-navigation.test.tsx`
- `npm run type-check` — 0 errors