### PR TITLE
Agent proxy returns 404

### DIFF
--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
@@ -14,9 +14,7 @@ import org.springframework.http.*;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
@@ -24,7 +22,9 @@ import javax.net.ssl.SSLException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import static com.openframe.core.constants.HttpHeaders.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -36,6 +36,18 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class RestProxyService {
 
     private static final AttributeKey<URI> TARGET_URI_KEY = AttributeKey.valueOf("target_uri");
+
+    /**
+     * Upstream response headers relayed to the caller, lower-cased. Allowlist, not a hop-by-hop
+     * denylist: this proxy fronts many tenants, so {@code Set-Cookie} (lands on the gateway's own
+     * domain) and {@code Access-Control-*} (silently replaces this gateway's CorsWebFilter, since
+     * the result handler merges with putAll) must not leak through. Length headers are omitted —
+     * the body is re-encoded here.
+     */
+    private static final Set<String> FORWARDED_RESPONSE_HEADERS = Set.of(
+            "content-type",
+            "content-disposition",
+            "x-fleet-capabilities");
 
     private final ReactiveIntegratedToolRepository toolRepository;
     private final ToolUpstreamResolverRegistry upstreamRegistry;
@@ -52,6 +64,7 @@ public class RestProxyService {
 
     public Mono<ResponseEntity<String>> proxyApiRequest(String toolId, ServerHttpRequest request, String body) {
         return findTool(toolId, request)
+                .switchIfEmpty(Mono.error(new ToolNotFoundException(toolId)))
                 .flatMap(tool -> {
                     if (!tool.isEnabled()) {
                         return Mono
@@ -72,8 +85,8 @@ public class RestProxyService {
 
                     return proxy(tool, targetUri, method, headers, body);
                 })
-                .switchIfEmpty(
-                        Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND).body("Tool not found: " + toolId)));
+                .onErrorResume(ToolNotFoundException.class, e -> Mono.just(
+                        ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage())));
     }
 
     /**
@@ -144,6 +157,7 @@ public class RestProxyService {
      */
     public Mono<ResponseEntity<String>> proxyAgentRequest(String toolId, ServerHttpRequest request, String body) {
         return findTool(toolId, request)
+                .switchIfEmpty(Mono.error(new ToolNotFoundException(toolId)))
                 .flatMap(tool -> {
                     if (!tool.isEnabled()) {
                         ResponseEntity<String> response = ResponseEntity.badRequest()
@@ -159,8 +173,8 @@ public class RestProxyService {
 
                     return proxy(tool, targetUri, method, headers, body);
                 })
-                .switchIfEmpty(
-                        Mono.just(ResponseEntity.status(HttpStatus.NOT_FOUND).body("Tool not found: " + toolId)));
+                .onErrorResume(ToolNotFoundException.class, e -> Mono.just(
+                        ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage())));
     }
 
     private Map<String, String> buildAgentRequestHeaders(ServerHttpRequest request) {
@@ -182,16 +196,7 @@ public class RestProxyService {
             HttpMethod method,
             Map<String, String> proxyHeaders,
             String body) {
-        HttpClient httpClient = buildHttpClient(targetUri);
-
-        WebClient webClient = WebClient.builder()
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .codecs(configurer -> configurer
-                        .defaultCodecs()
-                        .maxInMemorySize(16 * 1024 * 1024)) // Increase to 16MB
-                .build();
-
-        WebClient.RequestBodySpec requestSpec = webClient
+        WebClient.RequestBodySpec requestSpec = webClient(targetUri)
                 .method(method)
                 .uri(targetUri)
                 .headers(headers -> headers.setAll(proxyHeaders));
@@ -203,11 +208,16 @@ public class RestProxyService {
         Mono<ResponseEntity<String>> monoResponseEntity;
         try {
             monoResponseEntity = requestSpec
-                    .retrieve()
-                    .onStatus(this::isErrorStatusCode, this::processErrorResponse)
-                    .bodyToMono(String.class)
+                    // exchangeToMono, not retrieve(): a proxy relays the upstream status, headers
+                    // and body verbatim. retrieve() turns 4xx/5xx into exceptions, and bodyToMono
+                    // emits NOTHING for an empty body — which the callers' switchIfEmpty then
+                    // reported as 404 "Tool not found". Fleet's HEAD /api/fleet/orbit/ping is
+                    // header-only by design, so it 404'd on every poll.
+                    .exchangeToMono(response -> response.toEntity(String.class))
                     .timeout(Duration.ofSeconds(60))
-                    .map(ResponseEntity::ok)
+                    .map(upstream -> ResponseEntity.status(upstream.getStatusCode())
+                            .headers(headers -> forwardHeaders(upstream.getHeaders(), headers))
+                            .body(upstream.getBody()))
                     .onErrorResume(this::buildErrorResponse)
                     .doOnSuccess(response -> log.debug("Successfully proxied request to {}", tool.getName()))
                     .doOnError(error -> log.error("Failed to proxy request to {}: {}", tool.getName(),
@@ -217,6 +227,24 @@ public class RestProxyService {
             return Mono.just(ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage()));
         }
         return monoResponseEntity;
+    }
+
+    private static void forwardHeaders(HttpHeaders from, HttpHeaders to) {
+        from.forEach((name, values) -> {
+            if (FORWARDED_RESPONSE_HEADERS.contains(name.toLowerCase(Locale.ROOT))) {
+                to.addAll(name, values);
+            }
+        });
+    }
+
+    /** Package-private so tests can stub the upstream exchange. */
+    WebClient webClient(URI targetUri) {
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(buildHttpClient(targetUri)))
+                .codecs(configurer -> configurer
+                        .defaultCodecs()
+                        .maxInMemorySize(16 * 1024 * 1024)) // Increase to 16MB
+                .build();
     }
 
     private HttpClient buildHttpClient(URI targetUri) {
@@ -244,28 +272,14 @@ public class RestProxyService {
                 });
     }
 
-    private boolean isErrorStatusCode(HttpStatusCode statusCode) {
-        return statusCode.is4xxClientError() || statusCode.is5xxServerError();
-    }
-
-    private Mono<Throwable> processErrorResponse(ClientResponse response) {
-        return response.bodyToMono(String.class)
-                .flatMap(errorBody -> Mono.error(
-                        WebClientResponseException.create(
-                                response.statusCode().value(),
-                                response.statusCode().toString(),
-                                response.headers().asHttpHeaders(),
-                                errorBody.getBytes(),
-                                null)));
-    }
-
+    /** Transport failure only — upstream HTTP statuses are relayed as ordinary responses. */
     private Mono<ResponseEntity<String>> buildErrorResponse(Throwable e) {
-        if (e instanceof WebClientResponseException responseException) {
-            ResponseEntity<String> response = ResponseEntity.status(responseException.getStatusCode())
-                    .body(responseException.getResponseBodyAsString());
-            return Mono.just(response);
+        return Mono.just(ResponseEntity.status(500).body(e.getMessage()));
+    }
+
+    private static class ToolNotFoundException extends RuntimeException {
+        ToolNotFoundException(String toolId) {
+            super("Tool not found: " + toolId);
         }
-        ResponseEntity<String> response = ResponseEntity.status(500).body(e.getMessage());
-        return Mono.just(response);
     }
 }

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/service/RestProxyService.java
@@ -37,16 +37,11 @@ public class RestProxyService {
 
     private static final AttributeKey<URI> TARGET_URI_KEY = AttributeKey.valueOf("target_uri");
 
-    /**
-     * Upstream response headers relayed to the caller, lower-cased. Allowlist, not a hop-by-hop
-     * denylist: this proxy fronts many tenants, so {@code Set-Cookie} (lands on the gateway's own
-     * domain) and {@code Access-Control-*} (silently replaces this gateway's CorsWebFilter, since
-     * the result handler merges with putAll) must not leak through. Length headers are omitted —
-     * the body is re-encoded here.
-     */
     private static final Set<String> FORWARDED_RESPONSE_HEADERS = Set.of(
             "content-type",
             "content-disposition",
+            "location",
+            "retry-after",
             "x-fleet-capabilities");
 
     private final ReactiveIntegratedToolRepository toolRepository;
@@ -208,11 +203,6 @@ public class RestProxyService {
         Mono<ResponseEntity<String>> monoResponseEntity;
         try {
             monoResponseEntity = requestSpec
-                    // exchangeToMono, not retrieve(): a proxy relays the upstream status, headers
-                    // and body verbatim. retrieve() turns 4xx/5xx into exceptions, and bodyToMono
-                    // emits NOTHING for an empty body — which the callers' switchIfEmpty then
-                    // reported as 404 "Tool not found". Fleet's HEAD /api/fleet/orbit/ping is
-                    // header-only by design, so it 404'd on every poll.
                     .exchangeToMono(response -> response.toEntity(String.class))
                     .timeout(Duration.ofSeconds(60))
                     .map(upstream -> ResponseEntity.status(upstream.getStatusCode())
@@ -237,7 +227,6 @@ public class RestProxyService {
         });
     }
 
-    /** Package-private so tests can stub the upstream exchange. */
     WebClient webClient(URI targetUri) {
         return WebClient.builder()
                 .clientConnector(new ReactorClientHttpConnector(buildHttpClient(targetUri)))
@@ -272,7 +261,6 @@ public class RestProxyService {
                 });
     }
 
-    /** Transport failure only — upstream HTTP statuses are relayed as ordinary responses. */
     private Mono<ResponseEntity<String>> buildErrorResponse(Throwable e) {
         return Mono.just(ResponseEntity.status(500).body(e.getMessage()));
     }

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceResponseRelayTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceResponseRelayTest.java
@@ -27,12 +27,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-/**
- * The agent proxy must relay the upstream response as-is. Regression cover for orbit's
- * {@code HEAD /api/fleet/orbit/ping}, which Fleet answers 200 with a capabilities header and no
- * body: the old {@code bodyToMono(String.class)} emitted nothing there, so every poll surfaced as
- * a 404 "Tool not found".
- */
 class RestProxyServiceResponseRelayTest {
 
     private static final String FLEET = "fleetmdm-server";
@@ -61,7 +55,6 @@ class RestProxyServiceResponseRelayTest {
                 new FleetEndpointAllowlist(props)));
     }
 
-    /** Stubs the upstream exchange, bypassing the real connector. */
     private void upstreamResponds(ClientResponse response) {
         WebClient stub = WebClient.builder()
                 .exchangeFunction(request -> Mono.just(response))
@@ -116,13 +109,39 @@ class RestProxyServiceResponseRelayTest {
         assertThat(response.getBody()).isEqualTo("{\"error\":\"gone\"}");
     }
 
-    /** An empty-bodied upstream error used to collapse into the same bogus 404. */
     @Test
     void relaysEmptyBodiedUpstreamError() {
         toolExists(true);
         upstreamResponds(ClientResponse.create(HttpStatus.UNAUTHORIZED).build());
 
         assertThat(proxyPing().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void relaysRedirectLocation() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.TEMPORARY_REDIRECT)
+                .header(HttpHeaders.LOCATION, "https://storage.example/package.pkg")
+                .build());
+
+        ResponseEntity<String> response = proxyPing();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.LOCATION))
+                .isEqualTo("https://storage.example/package.pkg");
+    }
+
+    @Test
+    void relaysRetryAfterOnThrottledUpstream() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.TOO_MANY_REQUESTS)
+                .header(HttpHeaders.RETRY_AFTER, "120")
+                .build());
+
+        ResponseEntity<String> response = proxyPing();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("120");
     }
 
     @Test
@@ -142,7 +161,6 @@ class RestProxyServiceResponseRelayTest {
         assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
     }
 
-    /** A genuinely missing tool must still 404 — that path moved off the response chain. */
     @Test
     void stillReportsMissingTool() {
         when(toolRepository.findByKey(FLEET)).thenReturn(Mono.empty());

--- a/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceResponseRelayTest.java
+++ b/openframe-gateway-service-core/src/test/java/com/openframe/gateway/service/RestProxyServiceResponseRelayTest.java
@@ -1,0 +1,162 @@
+package com.openframe.gateway.service;
+
+import com.openframe.data.document.tool.IntegratedTool;
+import com.openframe.data.reactive.repository.tool.ReactiveIntegratedToolRepository;
+import com.openframe.gateway.config.prop.FleetMultiTenancyProperties;
+import com.openframe.gateway.upstream.ToolUpstreamResolver;
+import com.openframe.gateway.upstream.ToolUpstreamResolverRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * The agent proxy must relay the upstream response as-is. Regression cover for orbit's
+ * {@code HEAD /api/fleet/orbit/ping}, which Fleet answers 200 with a capabilities header and no
+ * body: the old {@code bodyToMono(String.class)} emitted nothing there, so every poll surfaced as
+ * a 404 "Tool not found".
+ */
+class RestProxyServiceResponseRelayTest {
+
+    private static final String FLEET = "fleetmdm-server";
+    private static final String CAPABILITIES = "X-Fleet-Capabilities";
+
+    private ReactiveIntegratedToolRepository toolRepository;
+    private RestProxyService service;
+
+    @BeforeEach
+    void setUp() {
+        toolRepository = mock(ReactiveIntegratedToolRepository.class);
+
+        ToolUpstreamResolver resolver = mock(ToolUpstreamResolver.class);
+        when(resolver.resolveRest(any(), any(), any()))
+                .thenReturn(URI.create("http://fleet:8080/api/fleet/orbit/ping"));
+        ToolUpstreamResolverRegistry registry = mock(ToolUpstreamResolverRegistry.class);
+        when(registry.resolve(FLEET)).thenReturn(resolver);
+
+        FleetMultiTenancyProperties props = new FleetMultiTenancyProperties();
+        props.setAllowedEndpoints(List.of("GET /api/{v}/fleet/hosts"));
+
+        service = spy(new RestProxyService(
+                toolRepository,
+                registry,
+                mock(ToolApiKeyHeadersResolver.class),
+                new FleetEndpointAllowlist(props)));
+    }
+
+    /** Stubs the upstream exchange, bypassing the real connector. */
+    private void upstreamResponds(ClientResponse response) {
+        WebClient stub = WebClient.builder()
+                .exchangeFunction(request -> Mono.just(response))
+                .build();
+        doReturn(stub).when(service).webClient(any());
+    }
+
+    private void toolExists(boolean enabled) {
+        IntegratedTool tool = new IntegratedTool();
+        tool.setName("Fleet");
+        tool.setEnabled(enabled);
+        when(toolRepository.findByKey(FLEET)).thenReturn(Mono.just(tool));
+    }
+
+    private ServerHttpRequest ping() {
+        return MockServerHttpRequest
+                .head("/tools/agent/" + FLEET + "/api/fleet/orbit/ping")
+                .build();
+    }
+
+    private ResponseEntity<String> proxyPing() {
+        ResponseEntity<String> response = service.proxyAgentRequest(FLEET, ping(), null).block();
+        assertThat(response).as("proxy must always produce a response").isNotNull();
+        return response;
+    }
+
+    @Test
+    void relaysEmptyBodiedSuccessInsteadOfReportingToolNotFound() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.OK)
+                .header(CAPABILITIES, "orbit_endpoints,token_rotation")
+                .build());
+
+        ResponseEntity<String> response = proxyPing();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNull();
+        assertThat(response.getHeaders().getFirst(CAPABILITIES)).isEqualTo("orbit_endpoints,token_rotation");
+    }
+
+    @Test
+    void relaysUpstreamErrorStatusAndBody() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.GONE)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body("{\"error\":\"gone\"}")
+                .build());
+
+        ResponseEntity<String> response = proxyPing();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.GONE);
+        assertThat(response.getBody()).isEqualTo("{\"error\":\"gone\"}");
+    }
+
+    /** An empty-bodied upstream error used to collapse into the same bogus 404. */
+    @Test
+    void relaysEmptyBodiedUpstreamError() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.UNAUTHORIZED).build());
+
+        assertThat(proxyPing().getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void doesNotLeakUpstreamCookiesOrCorsHeaders() {
+        toolExists(true);
+        upstreamResponds(ClientResponse.create(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, "session=upstream")
+                .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, "https://upstream.example")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .body("{}")
+                .build());
+
+        HttpHeaders headers = proxyPing().getHeaders();
+
+        assertThat(headers.containsKey(HttpHeaders.SET_COOKIE)).isFalse();
+        assertThat(headers.containsKey(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN)).isFalse();
+        assertThat(headers.getContentType()).isEqualTo(MediaType.APPLICATION_JSON);
+    }
+
+    /** A genuinely missing tool must still 404 — that path moved off the response chain. */
+    @Test
+    void stillReportsMissingTool() {
+        when(toolRepository.findByKey(FLEET)).thenReturn(Mono.empty());
+
+        ResponseEntity<String> response = proxyPing();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getBody()).isEqualTo("Tool not found: " + FLEET);
+    }
+
+    @Test
+    void reportsDisabledTool() {
+        toolExists(false);
+
+        assertThat(proxyPing().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxied responses now preserve upstream status codes, response bodies, and permitted headers.
  * Empty upstream responses are handled correctly.
  * Missing tools return 404 responses, while disabled tools continue to return 400 responses.
  * Transport failures continue to return 500 responses.
  * Sensitive upstream headers, including cookies and CORS headers, are filtered from responses.
  * Behavior is consistent across API and agent request flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->