### PR TITLE
fix(data-mongo-sync): quote user input in Mongo regex filters (ReDoS)

### DIFF
--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/user/filter/UserQueryFilter.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/user/filter/UserQueryFilter.java
@@ -6,6 +6,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Despite the {@code Regex} field names — retained for API compatibility — both values are
+ * matched as literal case-insensitive substrings. The repository quotes them before they
+ * reach the Mongo regex engine, so metacharacters carry no special meaning.
+ */
 @Data
 @Builder
 @NoArgsConstructor

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/assignment/CustomItemAssignmentRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/assignment/CustomItemAssignmentRepositoryImpl.java
@@ -18,6 +18,7 @@ import org.springframework.data.mongodb.core.query.Query;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Slf4j
 @ConditionalOnProperty(name = "openframe.tenant-isolation.enabled", havingValue = "true")
@@ -131,7 +132,7 @@ public class CustomItemAssignmentRepositoryImpl extends TenantAwareRepositorySup
         query.addCriteria(Criteria.where(FIELD_TARGET_TYPE).is(targetType));
 
         if (StringUtils.hasText(search)) {
-            query.addCriteria(Criteria.where(FIELD_DISPLAY_NAME).regex(search.trim(), "i"));
+            query.addCriteria(Criteria.where(FIELD_DISPLAY_NAME).regex(Pattern.quote(search.trim()), "i"));
         }
 
         return query;

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/device/CustomMachineRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/device/CustomMachineRepositoryImpl.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class CustomMachineRepositoryImpl implements CustomMachineRepository {
@@ -301,13 +302,14 @@ public class CustomMachineRepositoryImpl implements CustomMachineRepository {
         }
 
         if (search != null && !search.isEmpty()) {
+            String quoted = Pattern.quote(search);
             criteriaList.add(new Criteria().orOperator(
-                    Criteria.where("hostname").regex(search, "i"),
-                    Criteria.where("displayName").regex(search, "i"),
-                    Criteria.where("ip").regex(search, "i"),
-                    Criteria.where("serialNumber").regex(search, "i"),
-                    Criteria.where("manufacturer").regex(search, "i"),
-                    Criteria.where("model").regex(search, "i")
+                    Criteria.where("hostname").regex(quoted, "i"),
+                    Criteria.where("displayName").regex(quoted, "i"),
+                    Criteria.where("ip").regex(quoted, "i"),
+                    Criteria.where("serialNumber").regex(quoted, "i"),
+                    Criteria.where("manufacturer").regex(quoted, "i"),
+                    Criteria.where("model").regex(quoted, "i")
             ));
         }
 

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/event/impl/CustomEventRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/event/impl/CustomEventRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Repository
@@ -72,9 +73,10 @@ public class CustomEventRepositoryImpl implements CustomEventRepository {
         }
 
         if (search != null && !search.trim().isEmpty()) {
+            String quoted = Pattern.quote(search);
             Criteria searchCriteria = new Criteria().orOperator(
-                    Criteria.where("type").regex(search, "i"),
-                    Criteria.where("data").regex(search, "i")
+                    Criteria.where("type").regex(quoted, "i"),
+                    Criteria.where("data").regex(quoted, "i")
             );
             query.addCriteria(searchCriteria);
         }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/CustomKnowledgeBaseItemRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/knowledgebase/CustomKnowledgeBaseItemRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Slf4j
 public class CustomKnowledgeBaseItemRepositoryImpl implements CustomKnowledgeBaseItemRepository {
@@ -44,7 +45,7 @@ public class CustomKnowledgeBaseItemRepositoryImpl implements CustomKnowledgeBas
         query.addCriteria(Criteria.where(FIELD_TYPE).is(KnowledgeBaseItemType.FOLDER));
 
         if (StringUtils.hasText(search)) {
-            query.addCriteria(Criteria.where(FIELD_NAME).regex(search, "i"));
+            query.addCriteria(Criteria.where(FIELD_NAME).regex(Pattern.quote(search), "i"));
         }
 
         if (itemIds != null) {
@@ -147,9 +148,10 @@ public class CustomKnowledgeBaseItemRepositoryImpl implements CustomKnowledgeBas
         List<Criteria> composites = new ArrayList<>();
 
         if (StringUtils.hasText(search)) {
+            String quoted = Pattern.quote(search);
             composites.add(new Criteria().orOperator(
-                    Criteria.where(FIELD_NAME).regex(search, "i"),
-                    Criteria.where(FIELD_SUMMARY).regex(search, "i")));
+                    Criteria.where(FIELD_NAME).regex(quoted, "i"),
+                    Criteria.where(FIELD_SUMMARY).regex(quoted, "i")));
         }
 
         Criteria cursorCriteria = buildCursorCriteria(cursor);

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/organization/CustomOrganizationRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/organization/CustomOrganizationRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Custom repository implementation for organization queries with MongoDB filtering.
@@ -61,7 +62,8 @@ public class CustomOrganizationRepositoryImpl implements CustomOrganizationRepos
 
             // Category filter
             if (filter.getCategory() != null) {
-                criteriaList.add(Criteria.where("category").regex("^" + filter.getCategory() + "$", "i"));
+                criteriaList.add(Criteria.where("category")
+                        .regex("^" + Pattern.quote(filter.getCategory()) + "$", "i"));
             }
 
             // Employee range filters
@@ -108,10 +110,11 @@ public class CustomOrganizationRepositoryImpl implements CustomOrganizationRepos
 
         // Search filter (name, organizationId or category)
         if (search != null && !search.trim().isEmpty()) {
+            String quoted = Pattern.quote(search);
             criteriaList.add(new Criteria().orOperator(
-                    Criteria.where("name").regex(search, "i"),
-                    Criteria.where("organizationId").regex(search, "i"),
-                    Criteria.where("category").regex(search, "i")
+                    Criteria.where("name").regex(quoted, "i"),
+                    Criteria.where("organizationId").regex(quoted, "i"),
+                    Criteria.where("category").regex(quoted, "i")
             ));
         }
 

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/ticket/CustomTicketRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/ticket/CustomTicketRepositoryImpl.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 @Slf4j
 @ConditionalOnProperty(name = "openframe.tenant-isolation.enabled", havingValue = "true")
@@ -108,7 +109,7 @@ public class CustomTicketRepositoryImpl extends TenantAwareRepositorySupport imp
         if (search == null || search.trim().isEmpty()) {
             return;
         }
-        String searchTrimmed = search.trim();
+        String searchTrimmed = Pattern.quote(search.trim());
         Criteria searchCriteria = new Criteria().orOperator(
                 Criteria.where(FIELD_TITLE).regex(searchTrimmed, "i"),
                 Criteria.where(FIELD_DEVICE_HOSTNAME).regex(searchTrimmed, "i"),

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/tool/CustomIntegratedToolRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/tool/CustomIntegratedToolRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Repository
@@ -56,9 +57,10 @@ public class CustomIntegratedToolRepositoryImpl implements CustomIntegratedToolR
         }
 
         if (search != null && !search.trim().isEmpty()) {
+            String quoted = Pattern.quote(search);
             Criteria searchCriteria = new Criteria().orOperator(
-                    Criteria.where("name").regex(search, "i"),
-                    Criteria.where("description").regex(search, "i")
+                    Criteria.where("name").regex(quoted, "i"),
+                    Criteria.where("description").regex(quoted, "i")
             );
             query.addCriteria(searchCriteria);
         }

--- a/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/CustomUserRepositoryImpl.java
+++ b/openframe-data-mongo-sync/src/main/java/com/openframe/data/repository/user/CustomUserRepositoryImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.springframework.util.StringUtils.hasText;
 
@@ -45,10 +46,10 @@ public class CustomUserRepositoryImpl implements CustomUserRepository {
         }
         if (hasText(filter.getEmailRegex())) {
             query.addCriteria(Criteria.where(FIELD_EMAIL)
-                    .regex(filter.getEmailRegex(), REGEX_FLAG_CASE_INSENSITIVE));
+                    .regex(Pattern.quote(filter.getEmailRegex()), REGEX_FLAG_CASE_INSENSITIVE));
         }
         if (hasText(filter.getNameRegex())) {
-            String pattern = filter.getNameRegex();
+            String pattern = Pattern.quote(filter.getNameRegex());
             query.addCriteria(new Criteria().orOperator(
                     Criteria.where(FIELD_FIRST_NAME).regex(pattern, REGEX_FLAG_CASE_INSENSITIVE),
                     Criteria.where(FIELD_LAST_NAME).regex(pattern, REGEX_FLAG_CASE_INSENSITIVE)

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/SearchInputQuotingTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/SearchInputQuotingTest.java
@@ -1,0 +1,145 @@
+package com.openframe.data.repository;
+
+import com.openframe.data.document.knowledgebase.KnowledgeBaseItem;
+import com.openframe.data.document.organization.filter.OrganizationQueryFilter;
+import com.openframe.data.document.user.User;
+import com.openframe.data.document.user.filter.UserQueryFilter;
+import com.openframe.data.repository.event.impl.CustomEventRepositoryImpl;
+import com.openframe.data.repository.knowledgebase.CustomKnowledgeBaseItemRepositoryImpl;
+import com.openframe.data.repository.organization.CustomOrganizationRepositoryImpl;
+import com.openframe.data.repository.tool.CustomIntegratedToolRepositoryImpl;
+import com.openframe.data.repository.user.CustomUserRepositoryImpl;
+import org.bson.Document;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * User-supplied search input must never reach the Mongo regex engine unescaped:
+ * unquoted patterns allow ReDoS inside mongod and force unindexed scans. Every
+ * search site quotes with Pattern.quote (\Q...\E), so metacharacters match
+ * literally. These tests pin that contract for the query builders.
+ */
+class SearchInputQuotingTest {
+
+    private static final String HOSTILE = "(a+)+$";
+    private static final String QUOTED = Pattern.quote(HOSTILE);
+
+    private static Pattern fieldPattern(Object node, String field) {
+        if (node instanceof Document doc) {
+            if (doc.get(field) instanceof Pattern pattern) {
+                return pattern;
+            }
+            return doc.values().stream()
+                    .map(v -> fieldPattern(v, field))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (node instanceof List<?> list) {
+            return list.stream()
+                    .map(v -> fieldPattern(v, field))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+
+    private static void assertQuoted(Document query, String... fields) {
+        for (String field : fields) {
+            Pattern pattern = fieldPattern(query, field);
+            assertThat(pattern).as(field).isNotNull();
+            assertThat(pattern.pattern()).as(field).isEqualTo(QUOTED);
+        }
+    }
+
+    @Test
+    @DisplayName("organization search: name/organizationId/category clauses quote the input")
+    void organizationSearchIsQuoted() {
+        CustomOrganizationRepositoryImpl repo =
+                new CustomOrganizationRepositoryImpl(mock(MongoTemplate.class));
+
+        Document q = repo.buildOrganizationQuery(null, HOSTILE).getQueryObject();
+
+        assertQuoted(q, "name", "organizationId", "category");
+    }
+
+    @Test
+    @DisplayName("organization category filter: exact match stays anchored (^\\Q...\\E$) with the value quoted")
+    void organizationCategoryFilterIsQuotedAndAnchored() {
+        CustomOrganizationRepositoryImpl repo =
+                new CustomOrganizationRepositoryImpl(mock(MongoTemplate.class));
+        OrganizationQueryFilter filter = OrganizationQueryFilter.builder()
+                .category(HOSTILE)
+                .build();
+
+        Document q = repo.buildOrganizationQuery(filter, null).getQueryObject();
+
+        Pattern pattern = fieldPattern(q, "category");
+        assertThat(pattern).isNotNull();
+        assertThat(pattern.pattern()).isEqualTo("^" + QUOTED + "$");
+    }
+
+    @Test
+    @DisplayName("event search: type and data clauses quote the input")
+    void eventSearchIsQuoted() {
+        CustomEventRepositoryImpl repo = new CustomEventRepositoryImpl(mock(MongoTemplate.class));
+
+        Document q = repo.buildEventQuery(null, HOSTILE).getQueryObject();
+
+        assertQuoted(q, "type", "data");
+    }
+
+    @Test
+    @DisplayName("integrated tool search: name and description clauses quote the input")
+    void toolSearchIsQuoted() {
+        CustomIntegratedToolRepositoryImpl repo =
+                new CustomIntegratedToolRepositoryImpl(mock(MongoTemplate.class));
+
+        Document q = repo.buildToolQuery(null, HOSTILE).getQueryObject();
+
+        assertQuoted(q, "name", "description");
+    }
+
+    @Test
+    @DisplayName("user search: the email/name filters are quoted before hitting the regex engine, despite their legacy Regex names")
+    void userSearchIsQuoted() {
+        MongoTemplate template = mock(MongoTemplate.class);
+        CustomUserRepositoryImpl repo = new CustomUserRepositoryImpl(template);
+        UserQueryFilter filter = UserQueryFilter.builder()
+                .emailRegex(HOSTILE)
+                .nameRegex(HOSTILE)
+                .build();
+
+        repo.findUsersBySearch(filter, 10);
+
+        ArgumentCaptor<Query> captor = ArgumentCaptor.forClass(Query.class);
+        verify(template).find(captor.capture(), eq(User.class));
+        assertQuoted(captor.getValue().getQueryObject(), "email", "firstName", "lastName");
+    }
+
+    @Test
+    @DisplayName("knowledge base folder search: name clause quotes the input")
+    void knowledgeBaseSearchIsQuoted() {
+        MongoTemplate template = mock(MongoTemplate.class);
+        CustomKnowledgeBaseItemRepositoryImpl repo = new CustomKnowledgeBaseItemRepositoryImpl(template);
+
+        repo.findFoldersForParent(null, HOSTILE, null);
+
+        ArgumentCaptor<Query> captor = ArgumentCaptor.forClass(Query.class);
+        verify(template).find(captor.capture(), eq(KnowledgeBaseItem.class));
+        assertQuoted(captor.getValue().getQueryObject(), "name");
+    }
+}

--- a/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/device/CustomMachineRepositoryImplTest.java
+++ b/openframe-data-mongo-sync/src/test/java/com/openframe/data/repository/device/CustomMachineRepositoryImplTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -153,5 +155,40 @@ class CustomMachineRepositoryImplTest {
         Document q = repo.buildDeviceQuery(filter, null, "status").getQueryObject();
 
         assertThat(mentionsField(q, "machineId")).isTrue();
+    }
+
+    private static Pattern fieldPattern(Object node, String field) {
+        if (node instanceof Document doc) {
+            if (doc.get(field) instanceof Pattern pattern) {
+                return pattern;
+            }
+            return doc.values().stream()
+                    .map(v -> fieldPattern(v, field))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
+        if (node instanceof List<?> list) {
+            return list.stream()
+                    .map(v -> fieldPattern(v, field))
+                    .filter(Objects::nonNull)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+
+    @Test
+    @DisplayName("buildDeviceQuery: search input is regex-quoted — metacharacters match literally and hostile patterns like (a+)+$ never reach the regex engine unescaped")
+    void searchInputIsRegexQuoted() {
+        String hostile = "(a+)+$";
+
+        Document q = repo.buildDeviceQuery(null, hostile).getQueryObject();
+
+        for (String field : List.of("hostname", "displayName", "ip", "serialNumber", "manufacturer", "model")) {
+            Pattern pattern = fieldPattern(q, field);
+            assertThat(pattern).as(field).isNotNull();
+            assertThat(pattern.pattern()).as(field).isEqualTo(Pattern.quote(hostile));
+        }
     }
 }


### PR DESCRIPTION
## Problem

Search filters across seven repositories passed user input straight into `Criteria.regex()`. Field names are constants and values are properly bound, so this is **not** query injection — but the regex *pattern* was attacker-controlled, which caused three problems:

1. **ReDoS (the driver).** A search string like `(a+)+$` triggers catastrophic backtracking inside `mongod`. One request from any authenticated user pins database CPU; a handful can make a tenant's database unresponsive. The AI agent's search tools relay tenant chat input into the same code paths, so it is also reachable from a chat message.
2. **Unindexed scans.** Unanchored user regexes can never use an index, so every search was a full collection scan — a performance amplifier even with benign input.
3. **Wrong results for literal searches.** Ordinary inputs like `C++`, `192.168.1.1`, or `john.doe@acme.com (admin)` were interpreted as regex and returned wrong or empty results.

Severity: Medium — remote DoS by an authenticated user; no data exposure.

## Fix

Wrap the value in `Pattern.quote()` at every search site — the idiom already used elsewhere in this module (`CustomScriptExecutionRepositoryImpl`, `CustomTimeEntryRepositoryImpl`, `CustomDialogRepositoryImpl`, and others). `\Q…\E` is valid PCRE, so Mongo honours it.

21 call sites across 7 files:

| file | note |
|---|---|
| `CustomMachineRepositoryImpl` | 6 search fields |
| `CustomTicketRepositoryImpl` | 4 search fields |
| `CustomOrganizationRepositoryImpl` | 3 search fields + category filter |
| `CustomKnowledgeBaseItemRepositoryImpl` | 3 sites |
| `CustomEventRepositoryImpl` | 2 sites |
| `CustomIntegratedToolRepositoryImpl` | 2 sites |
| `CustomItemAssignmentRepositoryImpl` | 1 site |

The organization **category filter** keeps its anchored, case-insensitive exact match — now `^\Q…\E$` rather than switching to `.is()`, since categories come from free-form input and dropping case-insensitivity would silently change matching behaviour.

## Compatibility

**Source-, binary- and wire-compatible.** No field, parameter, or method signature changes. `UserQueryFilter.emailRegex` / `nameRegex` keep their names — a javadoc now records that the names are legacy and the values are matched literally. The only behaviour change is the intended one: user-supplied search text is matched as a literal substring instead of as a regex.

## Tests

- New `SearchInputQuotingTest` — asserts `(a+)+$` is quoted in the built queries for the organization, event, tool, user, and knowledge-base repositories, and that the category filter stays anchored.
- New case in `CustomMachineRepositoryImplTest` covering all six machine search fields.
- `mvn test -pl openframe-data-mongo-sync` green.
- `CustomOrganizationRepositoryImplIT` (Testcontainers, real MongoDB) 8/8 — this IT exercises search directly.

Note: a full `mvn verify -pl openframe-data-mongo-sync -Dintegration.tests=true` also surfaces 4 failures + 42 errors in the notification (`bulkInsertUnordered` context-load cascade) and RMM ScriptSchedule device-count-sort suites. Those reproduce identically on `main` with this branch's changes stashed — pre-existing, unrelated to this PR.

## Follow-ups (not in this PR)

- `CustomEventRepositoryImpl` still regex-searches the whole `data` blob. Quoting fixes the ReDoS, but event search remains a full scan; it wants a text index or removal from the search `$or`.
- No mechanical gate prevents the next unquoted `.regex()` call. The new test is a regression test for these sites, not a rule for new code — a Semgrep taint rule (sanitizer `Pattern.quote`) or an ArchUnit ban paired with a quoting helper would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Search inputs are now treated as literal text across users, devices, events, tickets, organizations, tools, knowledge-base content, and assignments.
  - Special characters no longer act as regular-expression operators, improving search accuracy and safety.
  - Case-insensitive matching is preserved.

- **Tests**
  - Added coverage confirming special characters are escaped consistently across supported search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->