### PR TITLE
test: fix device-details selector, scope mutating device filters to the pipeline org

### DIFF
--- a/openframe-test-service-core/src/main/java/com/openframe/test/data/generator/DeviceGenerator.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/data/generator/DeviceGenerator.java
@@ -21,6 +21,20 @@ public class DeviceGenerator {
         return statusDevicesFilter(DeviceStatus.ARCHIVED);
     }
 
+    /**
+     * Narrows a filter to one organization, in place.
+     *
+     * <p>Load-bearing for any case that <em>mutates</em> what it finds. A status-only filter spans the
+     * whole tenant, which is harmless on a single-device fixture tenant and destructive on a shared one:
+     * the archive cases picked an unrelated OFFLINE device out of a long-lived QA tenant, archived and
+     * deleted it, and left the pipeline's own device assigned to the org it was about to archive — which
+     * then failed with a 409.
+     */
+    public static DeviceFilterInput inOrganization(DeviceFilterInput filter, String organizationId) {
+        filter.setOrganizationIds(List.of(organizationId));
+        return filter;
+    }
+
     public static DeviceFilterInput osDevicesFilter(String os) {
         return DeviceFilterInput.builder()
                 .osTypes(List.of(os))

--- a/openframe-test-service-core/src/main/java/com/openframe/test/pages/DeviceDetailsPage.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/pages/DeviceDetailsPage.java
@@ -16,30 +16,28 @@ public class DeviceDetailsPage {
 
     private static final String DEVICE_NAME_HEADING = "main h1";
 
-    // The status badge is an ODS `Tag` — its markup is owned by the design
-    // system (openframe-frontend-core src/components/ui/tag.tsx) and is the one
-    // part of this header that does not drift:
+    // The status badge is an ODS `Tag` (openframe-frontend-core src/components/ui/tag.tsx). Match the
+    // pill's own container and take the first one in <main>: the status badge precedes all tab content.
+    //
+    // Everything about this header's *layout* drifts, so do not anchor on it. Three attempts have now
+    // broken here, each for a different reason:
+    //
+    //   1. Sibling-of-h1 ("main h1 + span span.truncate") — `TitleBlock` wraps the <h1> in
+    //      FloatingTooltip's own <div ref=setReference>, so the <h1> has no element sibling at all.
+    //   2. Scoped to a "div.flex.items-center.flex-wrap.py-4" status row — that div no longer exists.
+    //   3. A `>` child combinator between the pill and its text span — Tag now nests the text one level
+    //      deeper, and a direct-child match silently returns nothing.
+    //
+    // (3) is the current shape, verified against a captured failure DOM:
     //   <div class="inline-flex items-center justify-center rounded-md …">
-    //     <span class="truncate" title="ONLINE">ONLINE</span>
-    //   </div>
+    //     <span class="min-w-0 max-w-full">
+    //       <span class="truncate block">ONLINE</span>   <-- was a direct child, now a grandchild
     //
-    // FIX: sibling-of-h1 anchoring ("main h1 + span span.truncate") cannot
-    // match. `TitleBlock` (frozen ODS chrome) wraps the <h1> in the
-    // FloatingTooltip's own <div ref=setReference> — see
-    // openframe-frontend-core src/components/layout/title-block.tsx and
-    // src/components/ui/floating-tooltip.tsx — so the <h1> has NO element
-    // sibling at all; a `titleAdornment` span is a sibling of that wrapper div,
-    // not of the h1. Hence the 30s innerText() timeout.
-    //
-    // Match the Tag pill itself instead. Two forms, tried in order: scoped to
-    // the status/tags row rendered under the title block, then the first pill
-    // anywhere in <main> (the status badge precedes all tab content). Both are
-    // parent-chain independent enough to survive header re-layouts, which the
-    // previous two attempts were not.
+    // Hence a descendant combinator, and no layout scope. The only structural assumption left is the
+    // Tag container's own utility classes, which come from the component rather than from this page.
+    // Measured on that DOM: this matches the ONLINE badge first, the log row's INFO pill second.
     private static final String STATUS_PILL =
-            "div.inline-flex.items-center.justify-center.rounded-md > span.truncate";
-    private static final String STATUS_BADGE =
-            "main div.flex.items-center.flex-wrap.py-4 " + STATUS_PILL;
+            "div.inline-flex.items-center.justify-center.rounded-md span.truncate";
     private static final String STATUS_BADGE_ANY = "main " + STATUS_PILL;
 
     // Radix `DropdownMenuContent` — a DIV with role="menu", portalled to the
@@ -309,17 +307,12 @@ public class DeviceDetailsPage {
     // ── Private helpers ───────────────────────────────────────────────────────
 
     /**
-     * Returns the first status-badge locator that currently resolves to an
-     * element, or {@code null} if none does. Never waits.
+     * Returns the status-badge locator if it currently resolves to an element, or {@code null}.
+     * Never waits — callers decide whether a miss means "not loaded yet" or "wait for it".
      */
     private Locator resolvedStatusBadge() {
-        for (String selector : new String[]{STATUS_BADGE, STATUS_BADGE_ANY}) {
-            Locator candidate = page.locator(selector).first();
-            if (candidate.count() > 0) {
-                return candidate;
-            }
-        }
-        return null;
+        Locator candidate = page.locator(STATUS_BADGE_ANY).first();
+        return candidate.count() > 0 ? candidate : null;
     }
 
     /**

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/BaseTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/BaseTest.java
@@ -1,12 +1,43 @@
 package com.openframe.test.tests;
 
+import com.openframe.test.context.PipelineContext;
+import com.openframe.test.data.dto.device.DeviceFilterInput;
 import com.openframe.test.helpers.AuthHelper;
 import org.junit.jupiter.api.BeforeAll;
+
+import static com.openframe.test.data.generator.DeviceGenerator.inOrganization;
 
 public abstract class BaseTest {
 
     @BeforeAll
     public static void setup() {
         AuthHelper.clearCookies();
+    }
+
+    /**
+     * Narrows a device filter to the organization this pipeline created, when there is one.
+     *
+     * <p>Status-only filters span the whole tenant. On the single-device fixture tenant a pipeline
+     * registers that is the same set either way — which is why the unscoped form went unnoticed for so
+     * long. On a shared tenant it is not: the archive cases selected an unrelated OFFLINE device out of
+     * a long-lived QA tenant, archived and deleted it, and left the pipeline's own device attached to
+     * the org it was about to archive, which then failed with a 409.
+     *
+     * <p>Use it wherever a case <em>acts</em> on the device it selects — mutating the device, or
+     * creating records against that device's organization. A read-only assertion about the tenant at
+     * large should not be scoped.
+     *
+     * <p>Outside a pipeline there is no org and the filter is returned unchanged, preserving the
+     * historical behaviour for standalone runs.
+     */
+    protected static DeviceFilterInput pipelineScoped(DeviceFilterInput filter) {
+        String orgId = PipelineContext.getOrgId();
+        return orgId == null || orgId.isBlank() ? filter : inOrganization(filter, orgId);
+    }
+
+    /** Names the scope a selection ran against, so a failure says which set was searched. */
+    protected static String orgSuffix() {
+        String orgId = PipelineContext.getOrgId();
+        return orgId == null || orgId.isBlank() ? " (tenant-wide: no pipeline org set)" : " in org " + orgId;
     }
 }

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/DevicesTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/DevicesTest.java
@@ -200,8 +200,10 @@ public class DevicesTest extends BaseTest {
     @Test
     @DisplayName("Archive device")
     public void testArchiveDevice() {
-        List<Machine> devices = DeviceApi.getDevices(offlineDevicesFilter());
-        assertThat(devices).as("Expected at least one OFFLINE device to archive").isNotEmpty();
+        List<Machine> devices = DeviceApi.getDevices(pipelineScoped(offlineDevicesFilter()));
+        assertThat(devices)
+                .as("Expected at least one OFFLINE device to archive%s", orgSuffix())
+                .isNotEmpty();
         Machine device = devices.getLast();
         DeviceApi.archiveDevice(device);
         List<String> ids = DeviceApi.getDeviceIds(listedStatusesDevicesFilter());
@@ -213,13 +215,16 @@ public class DevicesTest extends BaseTest {
     @Test
     @DisplayName("Delete device")
     public void testDeleteDevice() {
-        // Archive (@Order(1)) moves the single enrolled device to ARCHIVED, so it no longer appears
+        // Archive (@Order(1)) moves this pipeline's enrolled device to ARCHIVED, so it no longer appears
         // in the OFFLINE listing. Delete operates on that archived device.
-        List<Machine> devices = DeviceApi.getDevices(archivedDevicesFilter());
-        assertThat(devices).as("Expected at least one ARCHIVED device to delete").isNotEmpty();
+        List<Machine> devices = DeviceApi.getDevices(pipelineScoped(archivedDevicesFilter()));
+        assertThat(devices)
+                .as("Expected at least one ARCHIVED device to delete%s", orgSuffix())
+                .isNotEmpty();
         Machine device = devices.getLast();
         DeviceApi.deleteDevice(device);
         List<String> ids = DeviceApi.getDeviceIds(listedStatusesDevicesFilter());
         assertThat(ids).as("Deleted device should not be in listed devices").doesNotContain(device.getMachineId());
     }
+
 }

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/TicketsTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/TicketsTest.java
@@ -69,9 +69,12 @@ public class TicketsTest extends BaseTest {
         String reorderAssigneeId = TicketGenerator.assigneeId(reorderAdmins);
 
         // Pick a device first (prefer ONLINE) and create under that device's own organization —
-        // createTicket rejects a device from a different org.
-        Machine reorderDevice = DeviceApi.getAnyDevice(onlineDevicesFilter(), offlineDevicesFilter());
-        assertThat(reorderDevice).as("Expected at least one device").isNotNull();
+        // createTicket rejects a device from a different org. Scoped to the pipeline's org so the
+        // ticket lands on the device this run enrolled, rather than on whichever device a shared
+        // tenant happens to list first — and so the records it leaves behind stay in the fixture org.
+        Machine reorderDevice = DeviceApi.getAnyDevice(
+                pipelineScoped(onlineDevicesFilter()), pipelineScoped(offlineDevicesFilter()));
+        assertThat(reorderDevice).as("Expected at least one device%s", orgSuffix()).isNotNull();
 
         List<TicketLabel> reorderLabels = TicketApi.getTicketLabels();
         assertThat(reorderLabels).as("Expected at least one ticket label").isNotEmpty();
@@ -108,9 +111,10 @@ public class TicketsTest extends BaseTest {
         String assigneeId = TicketGenerator.assigneeId(users);
 
         // Pick a device first (prefer ONLINE) and create the ticket under that device's own organization —
-        // createTicket rejects a device that doesn't belong to the selected org.
-        Machine device = DeviceApi.getAnyDevice(onlineDevicesFilter(), offlineDevicesFilter());
-        assertThat(device).as("Expected at least one device").isNotNull();
+        // createTicket rejects a device that doesn't belong to the selected org. Scoped as above.
+        Machine device = DeviceApi.getAnyDevice(
+                pipelineScoped(onlineDevicesFilter()), pipelineScoped(offlineDevicesFilter()));
+        assertThat(device).as("Expected at least one device%s", orgSuffix()).isNotNull();
 
         List<TicketLabel> labels = TicketApi.getTicketLabels();
         assertThat(labels).as("Expected at least one ticket label").isNotEmpty();

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoDeviceTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoDeviceTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * resolves it via its own {@code searchMachines} tool — so no ticket binding is needed.
  */
 @Tag("ai")
+@Tag("mingo")
 @DisplayName("Mingo — device")
 public class MingoDeviceTest extends MingoBaseTest {
 

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoEntityMutationTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoEntityMutationTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Immune to the searchMachines online-flap — no machine is involved.
  */
 @Tag("ai")
+@Tag("mingo")
 @DisplayName("Mingo — scripts & KB")
 public class MingoEntityMutationTest extends MingoBaseTest {
 

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoEntityQueryTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoEntityQueryTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Immune to the searchMachines online-flap — no machine is involved.
  */
 @Tag("ai")
+@Tag("mingo")
 @DisplayName("Mingo — directory & web")
 public class MingoEntityQueryTest extends MingoBaseTest {
 
@@ -73,13 +74,12 @@ public class MingoEntityQueryTest extends MingoBaseTest {
     @Tag("directory")
     @DisplayName("Mingo lists Windows machines")
     public void testListWindowsMachines() {
-        // Ground truth from the device API: hostnames of the currently-ONLINE Windows machines.
-        List<String> onlineWindowsHosts = DeviceApi.getDevices(DeviceGenerator.onlineDevicesFilter()).stream()
+        // Ground truth from the device API: the currently-ONLINE Windows machines.
+        List<Machine> onlineWindows = DeviceApi.getDevices(DeviceGenerator.onlineDevicesFilter()).stream()
                 .filter(m -> m.getOsType() != null && m.getOsType().toLowerCase().contains("win"))
-                .map(Machine::getHostname)
-                .filter(h -> h != null && !h.isBlank())
+                .filter(m -> m.getHostname() != null && !m.getHostname().isBlank())
                 .toList();
-        assertThat(onlineWindowsHosts).as("Tenant should have at least one online Windows machine").isNotEmpty();
+        assertThat(onlineWindows).as("Tenant should have at least one online Windows machine").isNotEmpty();
 
         RunResult result = prompt("List all Windows machines that are currently online.");
 
@@ -87,11 +87,32 @@ public class MingoEntityQueryTest extends MingoBaseTest {
                 .as("Assistant should use the searchMachines tool.\n%s", result)
                 .isTrue();
         String reply = result.finalText() == null ? "" : result.finalText();
-        for (String hostname : onlineWindowsHosts) {
-            assertThat(reply)
-                    .as("Reply should include online Windows machine %s.\n%s", hostname, result)
-                    .containsIgnoringCase(hostname);
+        for (Machine machine : onlineWindows) {
+            assertThat(referencesMachine(reply, machine))
+                    .as("Reply should reference online Windows machine %s (hostname, or an "
+                                    + "@device: mention of id %s / machineId %s).\n%s",
+                            machine.getHostname(), machine.getId(), machine.getMachineId(), result)
+                    .isTrue();
         }
+    }
+
+    /**
+     * Whether a reply identifies this machine — by hostname, or by one of its ids.
+     *
+     * <p>The assistant renders a device either as its hostname or as an {@code @device:<id>} mention
+     * that the UI turns into a chip; both name the same machine, so either satisfies the case. Matching
+     * on the bare id rather than the {@code @device:} prefix keeps this working if the mention syntax
+     * changes again — what matters is that the right machine was named, not how it was decorated.
+     */
+    private static boolean referencesMachine(String reply, Machine machine) {
+        return containsIgnoringCase(reply, machine.getHostname())
+                || containsIgnoringCase(reply, machine.getId())
+                || containsIgnoringCase(reply, machine.getMachineId());
+    }
+
+    private static boolean containsIgnoringCase(String haystack, String needle) {
+        return needle != null && !needle.isBlank()
+                && haystack.toLowerCase().contains(needle.toLowerCase());
     }
 
     @Test

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoFleetTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoFleetTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * when none is configured. Both boxes are subject to the searchMachines online-flap (left unguarded).
  */
 @Tag("ai")
+@Tag("mingo")
 @Tag("fleet")
 @DisplayName("Mingo — multi-host")
 public class MingoFleetTest extends MingoBaseTest {

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoMdmTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoMdmTest.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * only to resolve its Fleet host id).
  */
 @Tag("ai")
+@Tag("mingo")
 @DisplayName("Mingo — Fleet MDM")
 public class MingoMdmTest extends MingoBaseTest {
 

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoSafetyTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoSafetyTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * than being masked — by design).
  */
 @Tag("ai")
+@Tag("mingo")
 @Tag("negative")
 @DisplayName("Mingo — safety")
 public class MingoSafetyTest extends MingoBaseTest {

--- a/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoTicketingTest.java
+++ b/openframe-test-service-core/src/main/java/com/openframe/test/tests/ai/MingoTicketingTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Immune to the searchMachines online-flap that affects device cases — these never touch a machine.
  */
 @Tag("ai")
+@Tag("mingo")
 @DisplayName("Mingo — ticketing")
 public class MingoTicketingTest extends MingoBaseTest {
 


### PR DESCRIPTION
Four fixes surfaced by running the E2E pipeline against a long-lived tenant instead of a fresh one, plus the tag the pipeline needs to stage Fae and Mingo separately.

## `DeviceDetailsPage` — three UI tests have been failing on a selector, not a product bug

The ODS `Tag` component nests its text one level deeper than the selector assumed:

```html
<div class="inline-flex items-center justify-center rounded-md …">
  <span class="min-w-0 max-w-full">
    <span class="truncate block">ONLINE</span>   <!-- was a direct child, now a grandchild -->
```

The `>` child combinator matched nothing, `resolvedStatusBadge()` returned null, `isLoaded()` never became true, and all three `DeviceRemoteTest` cases each burned a 30s timeout in the shared `@BeforeEach`.

Verified against the DOM captured from three real failures, then live: **all three pass, and the device phase drops from 4m54s to 1m29s.** A screenshot from the failing run shows the page rendering perfectly — heading, `ONLINE` badge, every tab — which is what ruled out a product bug.

The scoped `STATUS_BADGE` is deleted: the row it anchored on (`div.flex.items-center.flex-wrap.py-4`) no longer exists, so it was a wasted query that also implied a fallback that could never fire. This is the third distinct break in this selector, so the comment now records all three instead of claiming the markup does not drift.

## `DevicesTest` archive/delete — was deleting unrelated devices

The filter was status-only, spanning the whole tenant. On the single-device tenant a pipeline registers that is the same set either way, which is why this went unnoticed. On a long-lived one it is not: the cases selected an unrelated OFFLINE device, **archived and deleted it**, and left the pipeline's own device attached to the org it was about to archive — which then failed with a 409, correctly reporting a device still assigned.

Now scoped to `PipelineContext.getOrgId()` via a new `BaseTest.pipelineScoped`. Confirmed live: the phase acted on the run's own device and `Archive Organization` passed.

## `TicketsTest` — same unscoped selection

Read-only with respect to devices, so never destructive, but it created tickets against whichever device the tenant listed first, seeding fixture data into unrelated orgs. Both filters in the preference chain are scoped — scoping only the ONLINE one would leave the fallback open, and on a shared tenant the fallback is the likelier branch.

## `MingoEntityQueryTest` — assistant now emits `@device:` mentions

The assistant renders devices as `@device:<id>` mention tokens rather than hostnames, so a reply naming the right machine failed a literal hostname grep. The tool call itself succeeded and returned the right data.

Accepts hostname or either id, matching the **bare id** rather than the `@device:` prefix — what matters is that the right machine was named, not how the reference was decorated, so this survives the next syntax change.

⚠️ This slightly weakens the case: a reply listing only opaque UUIDs now passes. That is right *if* mention tokens are the intended output format. If they are not, raw `@device:<uuid>` reaching users as text is a UX regression this test would no longer catch — worth confirming with whoever owns the output format.

## `@Tag("mingo")` on the seven Mingo classes

So the pipeline can select the two assistant families separately. Both keep `@Tag("ai")`, so the functional phase's exclusion is unaffected.

Measured: `fae` selects **21** tests across 5 classes, `mingo` **39** across 7 — 60 total, matching what the single `ai` phase executed.

## Verification

Run end-to-end against qa from a local build of this branch. The five fixes above all confirmed. Other failures in that run were dominated by environment (8 gateway 5xx, 3 connect timeouts from the laptop, 2 AI-run ceilings) and are not evidence about this change either way.

## Consumer

`openframe-saas-shared` needs a release of this before its `fae`/`mingo` split can flip from `tag: ai` + `exclude-tags: [fae]` to `tag: mingo`. That config is gated behind a TODO until the version bump — `tag: mingo` against a lib without the tag selects zero tests and reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved device selection so archive, delete, ticket, and reorder validations target the correct pipeline organization.
  - Strengthened device status validation for updated page layouts.
  - Enhanced Windows-machine checks to verify all online machines using reliable identifiers.
  - Added clearer failure details for organization-scoped and tenant-wide scenarios.
  - Added a dedicated tag for grouping Mingo-related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->