### PR TITLE
fix(): escalation actions

### DIFF
--- a/openframe-frontend-core/src/components/chat/approval-request-message.tsx
+++ b/openframe-frontend-core/src/components/chat/approval-request-message.tsx
@@ -77,7 +77,7 @@ function ApprovalCardBody({
 const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessageProps>(
   // `assistantType` is accepted for prop-parity with the batch card (so hosts
   // can forward it uniformly); the viewer variant is driven by `variant`.
-  ({ className, data, onApprove, onReject, status = 'pending', assistantType: _assistantType, variant = 'admin', resolvedByName, ...props }, ref) => {
+  ({ className, data, onApprove, onReject, status = 'pending', assistantType: _assistantType, variant = 'admin', resolvedByName, showFooterActions = true, ...props }, ref) => {
     const [isProcessing, setIsProcessing] = useState(false)
 
     const handleApprove = async () => {
@@ -114,7 +114,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
           <p className="text-h4 text-ods-text-primary whitespace-pre-line break-words w-full">
             {data.explanation?.trim() || "Approval required"}
           </p>
-          {status === 'pending' ? (
+          {!showFooterActions ? null : status === 'pending' ? (
             <div className="flex gap-[var(--spacing-system-mf)] items-center w-full">
               <Button
                 size="small-legacy"
@@ -162,7 +162,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
         {...props}
       >
         <ApprovalCardBody data={data} />
-        {status === 'pending' ? (
+        {!showFooterActions ? null : status === 'pending' ? (
           <div className="flex gap-[var(--spacing-system-mf)] items-center">
             <Button
               size="small-legacy"

--- a/openframe-frontend-core/src/components/chat/approval-request-message.tsx
+++ b/openframe-frontend-core/src/components/chat/approval-request-message.tsx
@@ -120,7 +120,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
                 size="small-legacy"
                 variant="accent"
                 onClick={handleApprove}
-                disabled={isProcessing}
+                disabled={isProcessing || !onApprove}
                 className={cn(
                   "bg-ods-accent hover:bg-ods-accent/90",
                   "text-h5 text-ods-bg",
@@ -133,7 +133,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
                 size="small-legacy"
                 variant="outline"
                 onClick={handleReject}
-                disabled={isProcessing}
+                disabled={isProcessing || !onReject}
                 className={cn(
                   "bg-ods-card border-ods-border",
                   "text-h5 text-ods-text-primary",
@@ -168,7 +168,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
               size="small-legacy"
               variant="accent"
               onClick={handleApprove}
-              disabled={isProcessing}
+              disabled={isProcessing || !onApprove}
               className={cn(
                 "bg-ods-accent hover:bg-ods-accent/90",
                 "text-h5 text-ods-bg",
@@ -181,7 +181,7 @@ const ApprovalRequestMessage = forwardRef<HTMLDivElement, ApprovalRequestMessage
               size="small-legacy"
               variant="outline"
               onClick={handleReject}
-              disabled={isProcessing}
+              disabled={isProcessing || !onReject}
               className={cn(
                 "bg-ods-card border-ods-border",
                 "text-h5 text-ods-text-primary",

--- a/openframe-frontend-core/src/components/chat/escalation-offer-message.tsx
+++ b/openframe-frontend-core/src/components/chat/escalation-offer-message.tsx
@@ -33,10 +33,11 @@ const EscalationOfferMessage = forwardRef<HTMLDivElement, EscalationOfferMessage
       <ApprovalRequestMessage
         variant="client"
         // Only the client may resolve an offer — the backend rejects every
-        // other actor — so a viewer with no handlers wired (the admin ticket
-        // view) sees the prompt read-only rather than dead buttons. A resolved
-        // offer still shows its "Approved by {name}" pill for everyone.
-        showFooterActions={!!onApprove || !!onReject || status !== 'pending'}
+        // other actor — so a viewer without BOTH handlers wired (the admin
+        // ticket view) sees the prompt read-only rather than dead buttons. The
+        // card renders Approve and Reject as a pair, so one handler is not a
+        // usable state. A resolved offer still shows its pill for everyone.
+        showFooterActions={(!!onApprove && !!onReject) || status !== 'pending'}
         // The client card renders `explanation` as its body and never shows
         // `command`; the offer's whole payload is that one backend-fixed line.
         data={{ command: '', explanation: data.text, requestId: data.offerId }}

--- a/openframe-frontend-core/src/components/chat/escalation-offer-message.tsx
+++ b/openframe-frontend-core/src/components/chat/escalation-offer-message.tsx
@@ -32,6 +32,11 @@ const EscalationOfferMessage = forwardRef<HTMLDivElement, EscalationOfferMessage
     <div ref={ref} className={cn("flex flex-col", className)} {...props}>
       <ApprovalRequestMessage
         variant="client"
+        // Only the client may resolve an offer — the backend rejects every
+        // other actor — so a viewer with no handlers wired (the admin ticket
+        // view) sees the prompt read-only rather than dead buttons. A resolved
+        // offer still shows its "Approved by {name}" pill for everyone.
+        showFooterActions={!!onApprove || !!onReject || status !== 'pending'}
         // The client card renders `explanation` as its body and never shows
         // `command`; the offer's whole payload is that one backend-fixed line.
         data={{ command: '', explanation: data.text, requestId: data.offerId }}

--- a/openframe-frontend-core/src/components/chat/types/component.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/component.types.ts
@@ -544,6 +544,10 @@ export interface ApprovalRequestMessageProps extends HTMLAttributes<HTMLDivEleme
    *  `'client'` = end-client (Fae desktop app) card with only the
    *  BE-generated title (`explanation`) + actions/status pill. */
   variant?: ApprovalBlockVariant
+  /** Render the footer Approve/Reject row (or the resolved-status tag).
+   *  Turn off when the viewer cannot resolve this card — matches
+   *  `ApprovalBatchMessageProps.showFooterActions`. Default true. */
+  showFooterActions?: boolean
   /** Display name of the user who resolved the request; baked into the
    *  client variant's full-text status pill ("Approved by {name}"). */
   resolvedByName?: string | null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to display approval messages without footer actions or resolved-status indicators.
  * Escalation offers can now appear in a read-only state when approval controls are unavailable.
  * Approval and rejection buttons are disabled when their corresponding actions aren’t available.
  * Existing approval and rejection controls remain available when configured or when an offer has been resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->