### PR TITLE
fix(modal-v2): focus containment must not fight portaled Radix layers (multi-item select highlight)

### DIFF
--- a/openframe-frontend-core/src/components/ui/modal-v2.tsx
+++ b/openframe-frontend-core/src/components/ui/modal-v2.tsx
@@ -43,6 +43,20 @@ interface ModalFooterProps {
 // TOP one may contain focus, or they fight each other.
 const modalStack: symbol[] = []
 
+// Radix popups (Select/DropdownMenu/Popover content) PORTAL to <body>, so a
+// dropdown opened from inside the modal focuses nodes OUTSIDE the panel.
+// Focus landing there is NOT an escape — yanking it back (containFocus /
+// reasserts / Tab trap) fights Radix's own item-focus management and strands
+// stale `data-highlighted` on items it never got to blur-clean (observed:
+// two or three select options painted "hovered" simultaneously). Popper-based
+// layers carry `data-radix-popper-content-wrapper`; the default item-aligned
+// Select content doesn't, hence the role fallbacks.
+const isInPortaledLayer = (node: Node | null): boolean =>
+  node instanceof Element &&
+  node.closest(
+    '[data-radix-popper-content-wrapper], [role="listbox"], [role="menu"]',
+  ) !== null
+
 const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
   ({ isOpen, onClose, children, className }, ref) => {
     // Keep the modal mounted while the exit animation plays.
@@ -79,7 +93,7 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         const panel = panelRef.current
         if (!panel) return
         const target = event.target as Node | null
-        if (target && panel.contains(target)) return
+        if (target && (panel.contains(target) || isInPortaledLayer(target))) return
         panel.focus()
       }
       document.addEventListener('focusin', containFocus)
@@ -90,7 +104,11 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
           if (modalStack[modalStack.length - 1] !== stackId) return
           const panel = panelRef.current
           if (!panel) return
-          if (!panel.contains(document.activeElement)) panel.focus()
+          if (
+            !panel.contains(document.activeElement) &&
+            !isInPortaledLayer(document.activeElement)
+          )
+            panel.focus()
         }, ms),
       )
       return () => {
@@ -110,6 +128,10 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
         if (event.key !== 'Tab') return
         const panel = panelRef.current
         if (!panel) return
+        // Focus inside a portaled Radix layer (open Select/menu): Tab is that
+        // layer's affair — trapping it back into the panel closes nothing and
+        // steals focus mid-interaction.
+        if (isInPortaledLayer(document.activeElement)) return
         const focusables = Array.from(
           panel.querySelectorAll<HTMLElement>(
             'a[href], button:not([disabled]), input:not([disabled]):not([type="hidden"]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',


### PR DESCRIPTION
## Symptom (owner-reported regression, landed with #1675 / 0.0.525)

Selects inside ModalV2 dialogs (product-hub repo settings modal, rule modal) paint **two or even three options as simultaneously hovered/highlighted**. Deterministically reproduced in clean headless Chromium: after hovering one option, a second (and in one capture a third) option still carried `data-highlighted`.

## Root cause

`#1675` added focus containment to ModalV2 (`containFocus` on `focusin`, bounded re-asserts, Tab trap). Radix Select/DropdownMenu/Popover content **portals to `document.body`** — outside the modal panel — so when a dropdown opened from inside the modal focuses an option, the containment sees "focus escaped" and yanks it back with `panel.focus()`. That fights Radix's own item-focus management: options never get a clean blur, stranding stale `data-highlighted` on items the pointer left (it even broke the initial selected-item highlight on open).

## Fix

`isInPortaledLayer()` — focus landing inside `[data-radix-popper-content-wrapper]`, `[role="listbox"]` or `[role="menu"]` is treated as inside the dialog's interaction, not an escape. Applied to all three containment paths: `containFocus`, the bounded re-asserts, and the Tab trap (Tab inside an open portaled layer is that layer's affair).

## Verification (live, product-hub dev server, headless Chromium + real mouse moves)

Before: rule modal Severity — hover item 0 → items 0 **and** 1 both `data-highlighted` (both painted `#3a3a3a`); repo modal model selector mid-move → items 0, 1, 2 **all** highlighted. Selected item NOT highlighted on open.

After: exactly one highlighted item at every phase in both modals — selected item highlighted alone on open, highlight moves atomically to the hovered item, triggers unaffected (`:hover` only on the hovered trigger). Escape/scroll-lock behavior from #1675 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus behavior when interacting with popovers, dropdowns, listboxes, and menus inside modal dialogs.
  * Prevented modal focus trapping from interrupting active layered controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->