### PR TITLE
fix(): mobile view modals with software keyboard

### DIFF
--- a/openframe-frontend-core/src/components/ui/alert-dialog.tsx
+++ b/openframe-frontend-core/src/components/ui/alert-dialog.tsx
@@ -42,10 +42,10 @@ const AlertDialogContent = React.forwardRef<
         // max-height keeps that upward shift from pushing the top off-screen.
         // See modal-v2.tsx for the full reasoning; --of-keyboard-inset is
         // published by the app (keyboard-inset.ts) and 0 everywhere else.
-        // The cap is safe to pair with overflow here, and NOT in DialogContent,
-        // because this Content has no absolutely-positioned close button that a
-        // scroll container would carry off the top.
-        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-50 grid w-full max-w-lg max-h-[calc(100dvh_-_var(--of-keyboard-inset,0px)_-_2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
+        // Content scrolls directly here, where DialogContent has to hand that
+        // job to a wrapper: this Content has no absolutely-positioned close
+        // button for a scroll container to carry off the top.
+        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-50 grid w-full max-w-lg max-h-[calc(100dvh_-_var(--of-keyboard-inset,0px)_-_2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-[var(--spacing-system-mf)] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
         className
       )}
       {...props}

--- a/openframe-frontend-core/src/components/ui/alert-dialog.tsx
+++ b/openframe-frontend-core/src/components/ui/alert-dialog.tsx
@@ -36,7 +36,16 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
+        // Centered on the KEYBOARD-FREE area, not the layout viewport: nothing
+        // resizes the viewport when a mobile software keyboard opens, so a
+        // plain top-[50%] leaves the lower half of the dialog behind it. The
+        // max-height keeps that upward shift from pushing the top off-screen.
+        // See modal-v2.tsx for the full reasoning; --of-keyboard-inset is
+        // published by the app (keyboard-inset.ts) and 0 everywhere else.
+        // The cap is safe to pair with overflow here, and NOT in DialogContent,
+        // because this Content has no absolutely-positioned close button that a
+        // scroll container would carry off the top.
+        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-50 grid w-full max-w-lg max-h-[calc(100dvh_-_var(--of-keyboard-inset,0px)_-_2rem)] overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
         className
       )}
       {...props}

--- a/openframe-frontend-core/src/components/ui/dialog.tsx
+++ b/openframe-frontend-core/src/components/ui/dialog.tsx
@@ -44,17 +44,28 @@ const DialogContent = React.forwardRef<
         // modal-v2.tsx for the full reasoning; --of-keyboard-inset is published
         // by the app (keyboard-inset.ts) and 0 everywhere else.
         //
-        // Deliberately NO max-height/overflow here, unlike AlertDialogContent:
-        // the close button below is `absolute` against this box, so making it a
-        // scroll container scrolls the X away with the content. Capping the
-        // height needs the overflow to move to a wrapper around `children`, and
-        // that collapses the `gap-4` this grid gives header/body/footer.
-        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
+        // The cap is on THIS box but the scrolling is not: the close button
+        // below is `absolute` against it, so a scroll container here would
+        // carry the X off the top. The wrapper around `children` scrolls
+        // instead, and carries the section gap that used to sit here so
+        // header/body/footer keep their spacing.
+        //
+        // `grid-rows-[minmax(0,1fr)]` is what makes the cap bite. An implicit
+        // row track is `auto`-sized, so it grows to its content and overflows
+        // the max-height no matter what min-height the wrapper carries —
+        // measured at 1136px of rows inside an 843px box. Constraining the
+        // track is what hands the wrapper a scrollbar; `1fr` still collapses to
+        // max-content when the dialog is shorter than the cap, so short dialogs
+        // keep hugging their content.
+        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-[9999] grid grid-rows-[minmax(0,1fr)] w-full max-w-lg max-h-[calc(100dvh_-_var(--of-keyboard-inset,0px)_-_2rem)] translate-x-[-50%] translate-y-[-50%] border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
         className,
       )}
       {...props}
     >
-      {children}
+      {/* min-h-0 is load-bearing: a grid item defaults to min-height:auto and
+          would refuse to shrink below its content, so the cap above would push
+          past the viewport instead of handing this box a scrollbar. */}
+      <div className="grid min-h-0 gap-[var(--spacing-system-mf)] overflow-y-auto">{children}</div>
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>

--- a/openframe-frontend-core/src/components/ui/dialog.tsx
+++ b/openframe-frontend-core/src/components/ui/dialog.tsx
@@ -38,7 +38,18 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
+        // Centered on the KEYBOARD-FREE area, not the layout viewport: nothing
+        // resizes the viewport when a mobile software keyboard opens, so a
+        // plain top-[50%] leaves the lower half of the dialog behind it. See
+        // modal-v2.tsx for the full reasoning; --of-keyboard-inset is published
+        // by the app (keyboard-inset.ts) and 0 everywhere else.
+        //
+        // Deliberately NO max-height/overflow here, unlike AlertDialogContent:
+        // the close button below is `absolute` against this box, so making it a
+        // scroll container scrolls the X away with the content. Capping the
+        // height needs the overflow to move to a wrapper around `children`, and
+        // that collapses the `gap-4` this grid gives header/body/footer.
+        "fixed left-[50%] top-[calc(50%_-_var(--of-keyboard-inset,0px)/2)] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-1/2 md:rounded-lg",
         className,
       )}
       {...props}

--- a/openframe-frontend-core/src/components/ui/modal-v2.tsx
+++ b/openframe-frontend-core/src/components/ui/modal-v2.tsx
@@ -200,7 +200,22 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
 
     return (
       <RemoveScroll enabled={isOpen} removeScrollBar={false}>
-      <div className="fixed inset-0 z-[1300] flex items-end md:items-center justify-center">
+      {/* SOFTWARE KEYBOARD — padding, not a shrunken box. Neither mobile shell
+          shrinks the LAYOUT viewport when the keyboard opens (WKWebView keeps
+          its frame; Android's window is edge-to-edge so the IME arrives as a
+          WindowInsets type), so `inset-0` and every vh/% height keep reporting
+          the full screen and this bottom-anchored panel opened entirely BEHIND
+          the keyboard. Padding leaves the backdrop full-screen while the flex
+          CONTENT box — which is what `items-end` anchors to and what the
+          panel's percentage max-height resolves against — stops above it.
+          `--of-keyboard-inset` is published by the app (keyboard-inset.ts);
+          unset everywhere else, hence the 0px fallback. The 200ms below is
+          mirrored there as INSET_TRANSITION_MS — it delays the app's
+          scroll-the-focused-field re-assert until this transition settles. */}
+      <div
+        className="fixed inset-0 z-[1300] flex items-end md:items-center justify-center transition-[padding] duration-200"
+        style={{ paddingBottom: 'var(--of-keyboard-inset, 0px)' }}
+      >
         <div
           data-state={state}
           className={cn(
@@ -231,7 +246,14 @@ const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
             // max-w-* overrides via className still win at every breakpoint.
             "relative z-10 w-full min-w-0 max-w-[min(28rem,calc(100vw-2rem))] flex flex-col",
             "mx-4 mb-4 md:mb-0",
-            "max-h-[90vh]",
+            // dvh, not vh: vh ignores a mobile browser's retracting URL bar, so
+            // 90vh already overflowed behind Safari's toolbar. The `100%-2rem`
+            // arm resolves against the keyboard-padded wrapper above and caps
+            // the panel to what's left of it, less the 1rem `mb-4` and a
+            // matching 1rem of breathing room at the top — header and footer
+            // stay pinned, ModalV2Content scrolls. min() picks 90dvh on any
+            // viewport over 320px tall, so desktop is untouched.
+            "max-h-[min(90dvh,100%-2rem)]",
             "bg-ods-bg md:bg-ods-card",
             "border border-ods-border rounded-md shadow-xl",
             "p-[var(--spacing-system-xl)] gap-[var(--spacing-system-l)]",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog and modal positioning when the mobile keyboard is open.
  * Updated modal sizing to adapt to dynamic viewport space.
  * Added scrolling for oversized alert dialog content.
  * Added smooth spacing adjustments to keep modal content visible above the keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->