### PR TITLE
Switch mesh core module asset from hardcoded ARTIFACTORY to GITHUB release

### DIFF
--- a/openframe-management-service-core/src/main/java/com/openframe/management/initializer/IntegratedToolAgentInitializer.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/initializer/IntegratedToolAgentInitializer.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 public class IntegratedToolAgentInitializer implements ApplicationRunner {
 
     private static final String OSQUERY_ASSET_ID = "osqueryd";
+    private static final String MESHCENTRAL_CORE_MODULE_ASSET_ID = "meshcentral-core-module";
 
     private final ObjectMapper objectMapper;
     private final IntegratedToolAgentService integratedToolAgentService;
@@ -103,6 +104,7 @@ public class IntegratedToolAgentInitializer implements ApplicationRunner {
             @Override
             void apply(IntegratedToolAgentConfiguration configuration, ClientVersionsProperties versions) {
                 configuration.setVersion(versions.getMesh());
+                applyAssetVersion(configuration, MESHCENTRAL_CORE_MODULE_ASSET_ID, versions.getMesh());
             }
         },
         FLEETMDM("fleetmdm-agent") {

--- a/openframe-management-service-core/src/main/resources/agent-configurations/meshcentral-agent.json
+++ b/openframe-management-service-core/src/main/resources/agent-configurations/meshcentral-agent.json
@@ -40,6 +40,21 @@
   "assets": [
     {
       "id": "meshcentral-core-module",
+      "source": "GITHUB",
+      "downloadConfigurations": [
+        {
+          "os": "windows",
+          "linkTemplate": "https://github.com/flamingo-stack/meshagent/releases/download/{version}/meshagent-windows-amd64.zip",
+          "fileName": "meshagent-windows-amd64.zip",
+          "targetFileName": "CoreModule.js"
+        },
+        {
+          "os": "macos",
+          "linkTemplate": "https://github.com/flamingo-stack/meshagent/releases/download/{version}/meshagent-macos-universal.tar.gz",
+          "fileName": "meshagent-macos-universal.tar.gz",
+          "targetFileName": "CoreModule.js"
+        }
+      ],
       "localFilenameConfiguration": [
         {
           "filename": "CoreModule.js",
@@ -50,7 +65,6 @@
           "os": "macos"
         }
       ],
-      "source": "ARTIFACTORY",
       "executable": false
     },
     {


### PR DESCRIPTION
## Why

Deployed OpenFrame machines get the mesh agent's JS core from a frozen snapshot baked into this repo's JAR (`ToolAgentFileController` + `openframe-client-core/src/main/resources/meshcentral-core-module`, marked `TODO: remove after github artifact is implemented`). Edits to `CoreModule.js` in the meshagent repo never reach machines. The GITHUB asset mechanism this TODO was waiting for now exists and is proven by fleet's `osqueryd` asset — this PR migrates the mesh core module onto it.

## What

- `meshcentral-agent.json`: `meshcentral-core-module` asset flips `ARTIFACTORY` → `GITHUB`, with `downloadConfigurations` pointing at the **same meshagent release archives** that deliver the binary (`targetFileName: CoreModule.js`). One artifact, one tag — core/binary skew becomes impossible.
- `IntegratedToolAgentInitializer`: the asset's version is wired to `openframe.client-versions.mesh` (mirrors the osqueryd pattern), so every mesh version bump re-downloads the core on deployed machines via the standard asset-update path.

`ToolAgentFileController`, the JAR blob, and the client's ARTIFACTORY path are deliberately left in place — old installation messages sit on persistent NATS topics and can be replayed. Cleanup is a follow-up PR after the fleet migrates.

## ⚠️ Deployment ordering (load-bearing)

Do not deploy this against a mesh version whose release archives lack `CoreModule.js`:
- `CoreModule.js` ships in meshagent archives starting with the release cut from flamingo-stack/meshagent#79 (expected `0.1.1`). Releases ≤ `0.1.0` do **not** contain it.
- If `openframe.client-versions.mesh` points at an older release when this deploys, the asset download fails and **aborts fresh mesh installs** (existing machines are unaffected — `hasAssetChanges` treats the null→versioned transition as no change, so nothing is published until the next mesh version bump; that bump-driven rollout is the intended semantics).
- Correct order: meshagent#79 merged → release cut → `MESH_CLIENT_VERSION` bumped to it → this deploys.

## Known accepted trade-offs

- Install/update fetches the same archive twice (binary + asset). Few MB, 429→jsDelivr fallback exists; a shared-archive cache is a possible later optimization.
- Client builds pinned via the `meshcentral-agent-version` feature pin only the binary (`meshcentral-server` tool id), not this asset — a pinned build would take the asset from the server-sent version. Follow-up candidate in `tool_version_overrides`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MeshCentral agents now consistently apply the configured version to both the agent and its core module.
  * Windows and macOS core modules now download from the correct GitHub source.
  * Existing filenames and non-executable behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->