### PR TITLE
Board: activity/staleness indicator row on TicketCard

### DIFF
--- a/openframe-frontend-core/src/components/features/board/index.ts
+++ b/openframe-frontend-core/src/components/features/board/index.ts
@@ -24,6 +24,8 @@ export type {
   BoardColumnDef,
   BoardPriority,
   BoardTicket,
+  BoardTicketActivity,
+  BoardTicketActivityKind,
   BoardTicketAssignee,
   BoardTicketPendingApproval,
 } from './types'

--- a/openframe-frontend-core/src/components/features/board/ticket-card.tsx
+++ b/openframe-frontend-core/src/components/features/board/ticket-card.tsx
@@ -4,7 +4,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import Link from '../../../embed-shims/next-link'
 import * as React from 'react'
-import { LaptopIcon, Flag02Icon, MessagesIcon, UserCheckIcon } from '../../icons-v2-generated'
+import { ClockIcon, DotsLoaderIcon, LaptopIcon, Flag02Icon, MessagesIcon, UserCheckIcon } from '../../icons-v2-generated'
 import { DeletedUserAvatar } from '../../ui/deleted-user-avatar'
 import { SquareAvatar } from '../../ui/square-avatar'
 import { Tag } from '../../ui/tag'
@@ -13,7 +13,7 @@ import { cn } from '../../../utils/cn'
 import { getReadableTextColor } from '../../../utils/ods-color-utils'
 import { formatTicketRelativeTime, formatTicketFullTimestamp } from '../../../utils/date-utils'
 import { BoardTicketApproval } from './board-ticket-approval'
-import type { BoardPriority, BoardTicket } from './types'
+import type { BoardPriority, BoardTicket, BoardTicketActivityKind } from './types'
 
 const PRIORITY_COLOR_CLASS: Record<BoardPriority, string> = {
   low: 'text-ods-text-secondary',
@@ -24,6 +24,13 @@ const PRIORITY_COLOR_CLASS: Record<BoardPriority, string> = {
 
 const MAX_VISIBLE_TAGS = 2
 const MAX_VISIBLE_ASSIGNEES = 3
+
+const ACTIVITY_DEFAULT_LABEL: Record<BoardTicketActivityKind, string> = {
+  'ai-working': 'AI assistant is working',
+  'user-typing': 'User typing',
+  'waiting-external': 'Waiting for client response',
+  stale: 'No activity',
+}
 
 /** Shared card shell (border / padding / bg). Same footprint for the draggable
  *  board card and the static {@link TicketCardView}. */
@@ -123,6 +130,21 @@ export function TicketCardBody({ ticket, columnColor, renderAssignSlot, onApprov
         <div className="flex items-center gap-[var(--spacing-system-xxs)] text-h6 text-ods-open-yellow">
           <UserCheckIcon className="size-4 shrink-0" />
           <span className="truncate">Escalated by User</span>
+        </div>
+      )}
+      {ticket.activity && (
+        <div
+          className={cn(
+            'flex items-center gap-[var(--spacing-system-xxs)] text-h6',
+            ticket.activity.kind === 'stale' ? 'text-ods-open-yellow' : 'text-ods-text-secondary',
+          )}
+        >
+          {ticket.activity.kind === 'stale' ? (
+            <ClockIcon className="size-4 shrink-0" />
+          ) : (
+            <DotsLoaderIcon className="size-4 shrink-0" />
+          )}
+          <span className="truncate">{ticket.activity.label ?? ACTIVITY_DEFAULT_LABEL[ticket.activity.kind]}</span>
         </div>
       )}
       {showNewMessage && (

--- a/openframe-frontend-core/src/components/features/board/types.ts
+++ b/openframe-frontend-core/src/components/features/board/types.ts
@@ -22,6 +22,24 @@ export interface BoardTicketAssignee {
   deleted?: boolean
 }
 
+/**
+ * Live-activity footer indicator on a board card. Indicators are mutually
+ * exclusive by design — the consumer decides which single one a ticket shows
+ * (staleness has the lowest priority and must be suppressed when any other
+ * signal — new message, approval, escalation — is present).
+ */
+export type BoardTicketActivityKind = 'ai-working' | 'user-typing' | 'waiting-external' | 'stale'
+
+export interface BoardTicketActivity {
+  kind: BoardTicketActivityKind
+  /**
+   * Overrides the built-in label for the kind. Required in practice for
+   * 'stale', whose label carries the computed duration ("No activity for
+   * 2 hours") that only the consumer can know — and tick over time.
+   */
+  label?: string
+}
+
 export interface BoardTicket {
   id: string
   title: string
@@ -43,6 +61,8 @@ export interface BoardTicket {
    * technician should pick it up.
    */
   escalatedByUser?: boolean
+  /** Single live-activity indicator rendered as the card's footer row. */
+  activity?: BoardTicketActivity
 }
 
 export interface BoardColumnDef {

--- a/openframe-frontend-core/src/stories/TicketCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/TicketCard.stories.tsx
@@ -6,6 +6,7 @@ import {
   TicketCard,
   type TicketCardProps,
   type BoardTicket,
+  type BoardTicketActivityKind,
 } from '../components/features/board'
 import type { PendingToolCallData } from '../components/chat/types'
 
@@ -159,6 +160,44 @@ export const WithNewMessage: Story = {
 export const EscalatedByUser: Story = {
   args: {
     ticket: { ...BASE_TICKET, id: 'ticket-escalated', escalatedByUser: true },
+  },
+}
+
+/**
+ * The `activity` footer row, one card per kind. The three live kinds (animated
+ * dots loader + grey text) fall back to their built-in labels; `stale` (clock +
+ * amber text) carries a consumer-computed duration label, since only the
+ * consumer knows the ticket's idle time — and keeps it ticking.
+ */
+export const ActivityIndicators: Story = {
+  render: () => {
+    const activities: { kind: BoardTicketActivityKind; label?: string }[] = [
+      { kind: 'ai-working' },
+      { kind: 'user-typing' },
+      { kind: 'waiting-external' },
+      { kind: 'stale', label: 'No activity for 2 hours' },
+    ]
+    return (
+      <DndContext>
+        <SortableContext items={activities.map((a) => `ticket-activity-${a.kind}`)}>
+          <div className="flex w-[320px] flex-col gap-[var(--spacing-system-sf)] rounded-lg bg-ods-card p-[var(--spacing-system-sf)]">
+            {activities.map((activity) => (
+              <TicketCard
+                key={activity.kind}
+                columnId="ACTIVE"
+                ticket={{
+                  ...BASE_TICKET,
+                  id: `ticket-activity-${activity.kind}`,
+                  priority: undefined,
+                  tags: undefined,
+                  activity,
+                }}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    )
   },
 }
 


### PR DESCRIPTION
## Summary
- New `BoardTicket.activity` field (`BoardTicketActivity` / `BoardTicketActivityKind`) renders a single live-activity footer row on the board ticket card
- Kinds: `ai-working` / `user-typing` / `waiting-external` (animated dots loader + grey text with built-in labels) and `stale` (clock icon + yellow text, consumer-computed duration label, e.g. "No activity for 2 hours")
- Indicators are mutually exclusive by design; `stale` has the lowest display priority - the consumer decides which single indicator a ticket shows
- Storybook: `ActivityIndicators` story in `TicketCard.stories.tsx` covering all four kinds

## Context
Part of activity/staleness indicators for the tickets board view: https://app.clickup.com/t/86ajn8n1y (lib subtask: https://app.clickup.com/t/86ajy9fbp). Design: open-design-system, `ticket-card-column` component (node 2088:6274).

First consumer: openframe-frontend branch `hotfix/tickets-board-staleness` (FE-only staleness slice; the remaining kinds get wired once the backend ships `activityState`).

## Testing
- `tsc --noEmit` clean, lib builds
- Verified visually in Storybook (all four kinds match the Figma variants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)