### PR TITLE
feat(chat): "Open in ClickUp" action in the chat card overflow menu

### DIFF
--- a/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
+++ b/openframe-frontend-core/src/components/chat/entity-cards/dispatch.tsx
@@ -78,6 +78,8 @@ import { ArrowRightUpIcon } from '../../icons-v2-generated/arrows/arrow-right-up
 import { TagIcon } from '../../icons-v2-generated/shopping/tag-icon'
 import { QuestionCircleIcon } from '../../icons-v2-generated/signs-and-symbols/question-circle-icon'
 import { SlackLogoGreyIcon } from '../../icons-v2-generated/brand-logos/slack-logo-grey-icon'
+import { ClickupLogoIcon } from '../../icons-v2-generated/brand-logos/clickup-logo-icon'
+import { clickupTaskUrl } from '../utils/external-app-urls'
 import { FileContentIcon } from '../../icons-v2-generated/documents/file-content-icon'
 import { ChartBar01VerIcon } from '../../icons-v2-generated/charts/chart-bar-01-ver-icon'
 import { ChartPieIcon } from '../../icons-v2-generated/charts/chart-pie-icon'
@@ -260,12 +262,22 @@ export interface CardDiscussAction {
   run: () => void
 }
 
+/** External-app deep-link row for a card's "⋯" menu (e.g. "Open in ClickUp").
+ *  Always opens in a new tab — the destination is a third-party app, never a
+ *  hub route. */
+export interface CardExternalLink {
+  label: string
+  icon: React.ReactNode
+  href: string
+}
+
 /** Overflow-menu groups for a card (Figma `7740:55075`): the optional "Ask
  *  Mingo"/"Display" item (when the host supplied a handler) followed by "Open
  *  Details" — whose main row navigates to the card (same tab) and whose trailing
- *  ↗ side-button opens it in a new tab. Returns `undefined` when neither applies
- *  so the "⋯" button is omitted entirely. The href is already absolute
- *  (ChatCardLoader pre-resolves it). */
+ *  ↗ side-button opens it in a new tab — then the optional external-app
+ *  deep-link row (new tab). Returns `undefined` when none applies so the "⋯"
+ *  button is omitted entirely. The href is already absolute (ChatCardLoader
+ *  pre-resolves it). */
 function cardMenuGroups(
   href: string | null | undefined,
   discuss?: CardDiscussAction,
@@ -274,6 +286,9 @@ function cardMenuGroups(
    *  in the entity's own terms and mirrors the card's leading icon. Defaults to
    *  a generic "Open Details" + eye glyph. */
   openDetails?: { label: string; icon: React.ReactNode },
+  /** Optional trailing deep-link into the entity's own third-party app
+   *  (ClickUp task, …). Rendered after "Open Details", always new-tab. */
+  externalLink?: CardExternalLink,
 ) {
   const items: ActionsMenuGroup['items'] = []
   if (discuss) {
@@ -298,6 +313,15 @@ function cardMenuGroups(
         href,
         openInNewTab: true,
       },
+    })
+  }
+  if (externalLink) {
+    items.push({
+      id: 'open-external',
+      label: externalLink.label,
+      icon: externalLink.icon,
+      href: externalLink.href,
+      openInNewTab: true,
     })
   }
   return items.length ? [{ items }] : undefined
@@ -629,6 +653,8 @@ function EntityMingoCard({
   isNewTab,
   menuAriaLabel,
   discuss,
+  openDetails,
+  externalLink,
 }: {
   title: React.ReactNode
   description?: React.ReactNode
@@ -639,6 +665,10 @@ function EntityMingoCard({
   isNewTab: boolean
   menuAriaLabel: string
   discuss?: CardDiscussAction
+  /** See `cardMenuGroups` — per-entity "Open Details" row override. */
+  openDetails?: { label: string; icon: React.ReactNode }
+  /** See `cardMenuGroups` — trailing third-party-app deep-link row. */
+  externalLink?: CardExternalLink
 }) {
   return (
     <MingoInfoCard
@@ -649,7 +679,7 @@ function EntityMingoCard({
       icon={fallbackIcon}
       status={status}
       anchorProps={buildAnchorProps(chatRef.url, isNewTab)}
-      menuGroups={cardMenuGroups(chatRef.url, discuss)}
+      menuGroups={cardMenuGroups(chatRef.url, discuss, openDetails, externalLink)}
       menuAriaLabel={menuAriaLabel}
     />
   )
@@ -958,6 +988,14 @@ function RoadmapChatCard({
   ) : (
     defaultIcon
   )
+  // Every card here is a mirrored ClickUp task whose ref id IS the ClickUp
+  // task id, so the "⋯" menu deep-links into ClickUp. internal_task's card
+  // URL already IS that deep link (its mapper resolves no public
+  // destination) — there we relabel the existing "Open Details" row instead
+  // of adding a duplicate second ClickUp row.
+  const clickupHref = clickupTaskUrl(chatRef.id)
+  const clickupIcon = <ClickupLogoIcon size={20} />
+  const cardUrlIsClickup = cardType === 'internal_task'
   return (
     <EntityMingoCard
       title={item?.title ?? ''}
@@ -968,6 +1006,14 @@ function RoadmapChatCard({
       isNewTab={isNewTab}
       discuss={discuss}
       menuAriaLabel="Roadmap actions"
+      openDetails={
+        cardUrlIsClickup ? { label: 'Open in ClickUp', icon: clickupIcon } : undefined
+      }
+      externalLink={
+        !cardUrlIsClickup && clickupHref
+          ? { label: 'Open in ClickUp', icon: clickupIcon, href: clickupHref }
+          : undefined
+      }
     />
   )
 }

--- a/openframe-frontend-core/src/components/ui/actions-menu.tsx
+++ b/openframe-frontend-core/src/components/ui/actions-menu.tsx
@@ -52,6 +52,8 @@ export interface ActionsMenuItem {
 	danger?: boolean;
 	/** Optional URL for navigation items */
 	href?: string;
+	/** Open the main-row `href` in a new tab (external app deep-links). */
+	openInNewTab?: boolean;
 	/**
 	 * Optional secondary action — a 40px-wide button on the right of the row
 	 * with a vertical divider. The main row keeps its primary click target;
@@ -257,6 +259,8 @@ const MenuItem: React.FC<MenuItemProps> = ({ item, onItemClick }) => {
 				<Link
 					href={item.href}
 					prefetch={false}
+					target={item.openInNewTab ? "_blank" : undefined}
+					rel={item.openInNewTab ? "noopener noreferrer" : undefined}
 					className={itemClasses}
 					onClick={handleLinkClick}
 					aria-disabled={item.disabled}


### PR DESCRIPTION
## What

Adds an **"Open in ClickUp"** action to the "⋯" overflow menu on the AI-chat entity cards that are backed by mirrored ClickUp tasks.

- **Roadmap + delivery cards** get a new "Open in ClickUp" row (ClickUp logo, opens `app.clickup.com/t/<taskId>` in a new tab) after the existing "Ask Mingo" / "Open Details" rows. The ref id for these card types IS the ClickUp task id, so the link is built with the existing `clickupTaskUrl()` helper.
- **Internal task cards** — their card URL already IS the ClickUp deep link (the internal mapper resolves no public destination), so instead of a duplicate row the generic "Open Details" row is relabeled "Open in ClickUp" with the ClickUp logo (same pattern as HubSpot tickets' "Open Ticket Details").

## How

- `actions-menu.tsx`: `ActionsMenuItem` gains `openInNewTab` for main-row link items — promoted into the primitive (the secondary icon-action already supported it) instead of a `window.open` hack.
- `entity-cards/dispatch.tsx`:
  - `cardMenuGroups` accepts an optional `externalLink` (`CardExternalLink`) appended after "Open Details", always new-tab — a reusable seam for any future third-party deep link (Linear, HubSpot, …).
  - `EntityMingoCard` threads `externalLink` + the existing `openDetails` override through.
  - `RoadmapChatCard` wires the ClickUp link per card type as described above.

## Notes

- Roadmap/delivery cards also render in the public flamingo chat; visitors without workspace access hit ClickUp's login if they click the action. Task ids were already public in the DOM, so nothing new leaks. A per-source gate is a small follow-up if unwanted.
- `npm run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ClickUp branding and links to roadmap cards.
  * Internal tasks now offer an “Open in ClickUp” action.
  * Other roadmap cards include a separate ClickUp link.
  * External links from card menus can open in a new browser tab.
* **Improvements**
  * Card detail actions can now use custom labels and icons for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->