### PR TITLE
fix(video): move Mux viewer identity out of a cookie into localStorage

### DIFF
--- a/openframe-frontend-core/src/components/features/video.tsx
+++ b/openframe-frontend-core/src/components/features/video.tsx
@@ -930,6 +930,16 @@ function FilePlayer({
       playsInline
       muted={muted}
       preferCmcd="header"
+      // Mux Data writes a first-party `muxData` cookie on the registrable
+      // domain to keep one viewer id across sessions. It rides on every request
+      // to the app origin, and its punctuation density trips Cloud Armor's
+      // restricted-SQL-character cookie counters (CRS 942420/942421) — 245
+      // preview-DENY events in a 6-hour census, 233 of them on tenant hosts
+      // where the player never even renders. Playback and per-session QoE
+      // metrics are unaffected; what is lost is cross-session viewer identity,
+      // so "unique viewers" becomes "unique sessions". That is the right trade
+      // for a player used on onboarding steps and help-center releases.
+      disableCookies
       // MuxPlayer's built-in default is `#fa50b5` (Mux brand pink) — when
       // its `--media-accent-color` resolves to nothing the player falls
       // through to that hardcoded pink. The `var(--ods-accent,

--- a/openframe-frontend-core/src/components/features/video.tsx
+++ b/openframe-frontend-core/src/components/features/video.tsx
@@ -51,6 +51,60 @@ function videoPerfDebugEnabled(): boolean {
 }
 
 // =============================================================================
+// Mux viewer identity without a cookie
+// =============================================================================
+//
+// Mux Data keeps `mux_viewer_id` (stable viewer) and a rolling session id in a
+// `muxData` cookie, 365-day expiry. That cookie rides on EVERY request to the
+// origin, and its punctuation trips Cloud Armor's restricted-SQL-character
+// cookie counters (CRS 942420/942421) — 245 preview-DENY events in a 6-hour
+// census. `disableCookies` alone stops the beacons carrying any viewer id at
+// all (`viewerData = disableCookies ? {} : Ae()` in mux-embed), which would
+// turn every page load into a new "unique viewer".
+//
+// So we keep the identity and drop the cookie: the id lives in localStorage and
+// is handed to Mux as `metadata.viewer_user_id`. No coverage is lost — Mux's
+// cookie is host-only (`Cookies.set` with `{path:'/'}` and no `domain`), and
+// localStorage is origin-scoped, so the two cover exactly the same surface.
+//
+// What does NOT come back: `session_id`/`session_start`, which group views into
+// a 25-minute session — mux-embed derives those internally and exposes no way
+// to supply them. Per-view metrics, QoE and viewer counts are unaffected.
+// `mux_sample_number` is also dropped, which is harmless at the default
+// `sampleRate: 1` (the beacon check is `(sample ?? 0) >= sampleRate`).
+const MUX_VIEWER_ID_KEY = 'mux:viewer_id';
+
+function muxViewerId(): string | undefined {
+  try {
+    if (typeof localStorage === 'undefined') return undefined;
+    const existing = localStorage.getItem(MUX_VIEWER_ID_KEY);
+    if (existing) return existing;
+    const generated =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    localStorage.setItem(MUX_VIEWER_ID_KEY, generated);
+    return generated;
+  } catch {
+    // Private mode / storage disabled — Mux falls back to per-view identity.
+    return undefined;
+  }
+}
+
+// One-time removal of the legacy `muxData` cookie. `disableCookies` stops NEW
+// writes but never clears what was already issued, and at 365 days those
+// browsers would keep tripping 942420/942421 for a year. Module-level so it runs
+// on import, before any player mounts. Host-only, so no `domain` attribute —
+// that is what Mux set. Remove this once the census reads zero.
+if (typeof document !== 'undefined') {
+  try {
+    document.cookie = 'muxData=; path=/; max-age=0';
+  } catch {
+    // Non-blocking: a failed cleanup only means the census decays slower.
+  }
+}
+
+// =============================================================================
 // Suppress Google Cast SDK loading (CSP-friendly)
 // =============================================================================
 //
@@ -930,16 +984,11 @@ function FilePlayer({
       playsInline
       muted={muted}
       preferCmcd="header"
-      // Mux Data writes a first-party `muxData` cookie on the registrable
-      // domain to keep one viewer id across sessions. It rides on every request
-      // to the app origin, and its punctuation density trips Cloud Armor's
-      // restricted-SQL-character cookie counters (CRS 942420/942421) — 245
-      // preview-DENY events in a 6-hour census, 233 of them on tenant hosts
-      // where the player never even renders. Playback and per-session QoE
-      // metrics are unaffected; what is lost is cross-session viewer identity,
-      // so "unique viewers" becomes "unique sessions". That is the right trade
-      // for a player used on onboarding steps and help-center releases.
+      // No `muxData` cookie — the viewer id moves to localStorage and rides in
+      // `metadata` below instead. See the "Mux viewer identity without a
+      // cookie" block at the top of this file.
       disableCookies
+      metadata={{ viewer_user_id: muxViewerId() }}
       // MuxPlayer's built-in default is `#fa50b5` (Mux brand pink) — when
       // its `--media-accent-color` resolves to nothing the player falls
       // through to that hardcoded pink. The `var(--ods-accent,


### PR DESCRIPTION
## What

Three changes in `video.tsx`, one file:

1. `disableCookies` on `<MuxPlayer>` — Mux Data stops writing the `muxData` cookie.
2. The viewer id moves to `localStorage` and is passed as `metadata.viewer_user_id`.
3. A one-time removal of the legacy cookie, at module level.

## Why

The `muxData` cookie rides on **every** request to the origin, and its punctuation density trips
Cloud Armor's cumulative restricted-SQL-character cookie counters (CRS 942420/942421) — **245
preview-DENY events in a 6-hour census, 0.77% of all WAF false positives**. All OWASP CRS rules are
still `preview = true` and cannot be enforced until the false positives clear.

## Why `disableCookies` alone was not enough

mux-embed does:

```js
this.viewerData = this.disableCookies ? {} : Ae()
```

So the flag on its own stops beacons carrying *any* viewer id — every page load would read as a new
unique viewer. Passing the id through `metadata` restores it: mux-embed maps `user_id` /
`viewer_user_id` onto the same field it would have filled from the cookie.

**No coverage is lost.** Mux's cookie is host-only (`Cookies.set` with `{path: '/'}` and no
`domain`), and `localStorage` is origin-scoped — the two span exactly the same surface.

What does *not* come back: `session_id` / `session_start`, which group views into a 25-minute
session. mux-embed derives those internally and exposes no way to supply them. Per-view metrics,
QoE and viewer counts are unaffected. `mux_sample_number` also goes, harmless at the default
`sampleRate: 1` since the beacon check is `(sample ?? 0) >= sampleRate`.

## Why the cookie kill is needed

Mux writes it with `expires: 365`, and `disableCookies` never clears what was already issued. Same
trap that required an explicit kill line in the GTM container for PostHog: without it this family
decays over a year instead of dropping. Module-level so it runs on import, before any player mounts.
Remove once the census reads zero.

## Correction to an earlier claim

The first revision of this PR said the 233 tenant-host hits were on hosts "where the player never
renders". That is wrong. `FloatingWalkthroughVideo` picks `kind={video.youtubeUrl ? 'youtube' :
'file'}`, and the `file` branch is MuxPlayer — the player does run inside the product, alongside
help-center releases. The onboarding steps pass `kind="youtube"` and never touch Mux. The cookie is
set where the player runs, which is consistent with it being host-only.

## Verification

`tsc --noEmit` clean. After release, `muxData` should stop appearing in
`jsonPayload.previewSecurityPolicy.matchedFieldName` for rules 942420/942421, and Mux "unique
viewers" should stay stable rather than inflating.