### PR TITLE
[AUTH] Revert CSRF on POST /login — breaks the SPA credential POST

### DIFF
--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/config/SecurityConfig.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/config/SecurityConfig.java
@@ -31,7 +31,6 @@ import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -61,10 +60,11 @@ public class SecurityConfig {
                                                           JwtDecoderFactory<ClientRegistration> ssoJwtDecoderFactory,
                                                           SsoProviderRegistry ssoProviderRegistry) throws Exception {
         return http
-                // Scoped to the one cookie-authenticated form POST on this chain. Everything else is
-                // either OAuth (client-authenticated or GET) or JSON-only, which a cross-site form
-                // cannot reach: it can't set application/json, and fetch preflights against disabled CORS.
-                .csrf(csrf -> csrf.requireCsrfProtectionMatcher(new AntPathRequestMatcher("/login", "POST")))
+                // CSRF disabled: the login POST is submitted programmatically by the React auth page
+                // (no server-rendered form, so no _csrf token available) — protecting it broke every
+                // password login. Re-enabling requires the SPA pattern (CookieCsrfTokenRepository +
+                // X-XSRF-TOKEN header in the frontend) shipped together with a frontend release.
+                .csrf(AbstractHttpConfigurer::disable)
                 .cors(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
QA regression after 1.0.32: every email/password login fails as "incorrect credentials".

Root cause: CSRF was scoped to `POST /login` assuming the server-rendered Thymeleaf form (which auto-carries `_csrf`) is the only client. The real login UI is the React auth page, which POSTs credentials to `/sas/login` programmatically — no rendered form, no token, every login rejected. Verified on QA: token-less POST dies; the same POST with a scraped token behaves normally.

This reverts to `csrf disabled` (pre-existing behavior). Re-enabling properly = `CookieCsrfTokenRepository` + `X-XSRF-TOKEN` header in the frontend, shipped together — tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login security handling for single-page application sign-ins.
  * Disabled CSRF protection for the current authentication flow to prevent login issues.
  * Added guidance for re-enabling CSRF protection when token-based authentication is introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->