### PR TITLE
[AUTH] Never expose AppleNativeGrantAuthenticationProvider as a bean (breaks password login)

### DIFF
--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/config/AuthorizationServerConfig.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/config/AuthorizationServerConfig.java
@@ -73,7 +73,20 @@ public class AuthorizationServerConfig {
     public SecurityFilterChain authorizationServerSecurityFilterChain(
             HttpSecurity http,
             SsoProviderRegistry ssoProviderRegistry,
-            AppleNativeGrantAuthenticationProvider appleNativeGrantAuthenticationProvider) throws Exception {
+            AppleNativeTokenVerifier appleNativeTokenVerifier,
+            AppleAuthorizationCodeClient appleAuthorizationCodeClient,
+            SsoOidcUserService ssoOidcUserService,
+            UserService userService,
+            OAuth2AuthorizationService authorizationService,
+            OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator) throws Exception {
+
+        // Constructed inline ON PURPOSE — never expose an AuthenticationProvider as a bean: Spring
+        // Boot then makes it the global AuthenticationManager's ONLY provider and skips wiring the
+        // UserDetailsService DaoAuthenticationProvider, which silently breaks every password login
+        // with an instant ProviderNotFoundException.
+        var appleNativeGrantAuthenticationProvider = new AppleNativeGrantAuthenticationProvider(
+                appleNativeTokenVerifier, appleAuthorizationCodeClient, ssoOidcUserService,
+                userService, authorizationService, tokenGenerator);
 
         var as = new OAuth2AuthorizationServerConfigurer();
         AuthorizationServerSettings settings = AuthorizationServerSettings
@@ -146,18 +159,6 @@ public class AuthorizationServerConfig {
         jwtGenerator.setJwtCustomizer(tokenCustomizer);
         return new DelegatingOAuth2TokenGenerator(
                 jwtGenerator, new OAuth2AccessTokenGenerator(), new OAuth2RefreshTokenGenerator());
-    }
-
-    @Bean
-    public AppleNativeGrantAuthenticationProvider appleNativeGrantAuthenticationProvider(
-            AppleNativeTokenVerifier tokenVerifier,
-            AppleAuthorizationCodeClient codeClient,
-            SsoOidcUserService ssoOidcUserService,
-            UserService userService,
-            OAuth2AuthorizationService authorizationService,
-            OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator) {
-        return new AppleNativeGrantAuthenticationProvider(
-                tokenVerifier, codeClient, ssoOidcUserService, userService, authorizationService, tokenGenerator);
     }
 
     @Bean


### PR DESCRIPTION
QA regression after the native Apple SSO release: every password login fails as "incorrect credentials".

Root cause: `AppleNativeGrantAuthenticationProvider` was exposed as a `@Bean`. When any `AuthenticationProvider` bean exists, Spring Boot's `InitializeUserDetailsBeanManagerConfigurer` skips wiring the `UserDetailsService`-backed `DaoAuthenticationProvider` into the global `AuthenticationManager` — form login is left with a manager that only supports the Apple grant and rejects `UsernamePasswordAuthenticationToken` instantly.

Evidence from QA: correct password verified against the stored bcrypt hash offline; login POST fails in 22ms (bcrypt alone takes ~60–100ms — the password was never compared); TRACE showed no provider activity between "Securing POST /login" and the error redirect.

Fix: construct the provider inline in the token-endpoint wiring from its dependency beans (verifier, code client, user services, authorization service, token generator — all still beans). Comment added so nobody re-beans it. Companion PR updates the SaaS chain the same way.

Note: #1702 (CSRF revert) was a wrong-theory fix for this same regression and should be closed, not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Apple native grant authentication during authorization and token issuance.
  * Apple native sign-in now uses the required token verification, authorization, user, and token services directly within the authorization flow.
* **Security**
  * Existing JWT access and refresh token generation remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->