### PR TITLE
ci: propagate released version to pom and dependent repos

### DIFF
--- a/.github/steps/bump-revision/action.yml
+++ b/.github/steps/bump-revision/action.yml
@@ -1,0 +1,63 @@
+name: "Bump Revision"
+description: "Opens an auto-merged PR aligning the <revision> property in pom.xml with the released version. Bails out if the diff is anything but that one line."
+
+inputs:
+  version:
+    description: "Released version to write into <revision>"
+    required: true
+  token:
+    description: "GitHub App token with contents:write and pull-requests:write on this repository"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout main
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        token: ${{ inputs.token }}
+        path: bump-revision-workspace
+
+    - name: Open and merge revision PR
+      shell: bash
+      working-directory: bump-revision-workspace
+      env:
+        NEW_VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions"
+        git config user.email "github-actions@users.noreply.github.com"
+
+        CURRENT=$(grep -m1 -oP '(?<=<revision>)[^<]+' pom.xml || true)
+        echo "revision: ${CURRENT:-<none>} -> ${NEW_VERSION}"
+        [ -n "$CURRENT" ] || { echo "::error::No <revision> property in pom.xml"; exit 1; }
+        if [ "$CURRENT" = "$NEW_VERSION" ]; then echo "Already up to date, nothing to do"; exit 0; fi
+
+        sed -i "0,/<revision>.*<\/revision>/s//<revision>${NEW_VERSION}<\/revision>/" pom.xml
+
+        ACTUAL=$(git diff -U0 | { grep -E '^[-+][^-+]' || true; } | tr -d '[:space:]')
+        EXPECTED="-<revision>${CURRENT}</revision>+<revision>${NEW_VERSION}</revision>"
+        if [ "$(git diff --name-only)" != pom.xml ] || [ "$ACTUAL" != "$EXPECTED" ]; then
+          echo "::error::Refusing to auto-merge, the diff is not just the revision line"
+          git diff
+          exit 1
+        fi
+
+        BRANCH="chore/revision-${NEW_VERSION}"
+        git checkout -qb "$BRANCH"
+        git commit -qam "chore: set revision to ${NEW_VERSION}"
+        git push -qu origin HEAD --force
+
+        if PR=$(gh pr view "$BRANCH" --json url --jq '.url' 2>/dev/null); then
+          echo "PR already open, branch updated"
+        else
+          PR=$(gh pr create --base main --head "$BRANCH" \
+            --title "Set revision to ${NEW_VERSION} (automatically generated PR)" \
+            --body "Align the \`revision\` property in pom.xml with the released version ${NEW_VERSION}.")
+        fi
+        gh pr merge "$PR" --squash --auto || {
+          echo "Auto-merge unavailable, merging directly"
+          gh pr merge "$PR" --squash
+        }

--- a/.github/steps/propagate-version/action.yml
+++ b/.github/steps/propagate-version/action.yml
@@ -1,0 +1,66 @@
+name: "Propagate Version"
+description: "Opens a PR in every listed downstream repository bumping the given Maven property to the version just released here. One failing repository does not stop the rest."
+
+inputs:
+  repositories:
+    description: "Downstream repository names, one per line"
+    required: true
+  version:
+    description: "Released version to write into the property"
+    required: true
+  property:
+    description: "Maven property holding this library's version downstream"
+    required: true
+  token:
+    description: "Token with write access to the downstream repositories"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Open version bump PRs
+      shell: bash
+      env:
+        REPOSITORIES: ${{ inputs.repositories }}
+        NEW_VERSION: ${{ inputs.version }}
+        PROPERTY: ${{ inputs.property }}
+        OWNER: ${{ github.repository_owner }}
+        LIB: ${{ github.event.repository.name }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -uo pipefail
+        BRANCH="chore/${LIB}-${NEW_VERSION}"
+        FAILED=""
+
+        for NAME in $REPOSITORIES; do
+          echo "::group::${NAME}"
+          (
+            set -euo pipefail
+            rm -rf "${RUNNER_TEMP:?}/${NAME}"
+            git clone -q --depth 1 -b main "https://x-access-token:${GH_TOKEN}@github.com/${OWNER}/${NAME}.git" "${RUNNER_TEMP}/${NAME}"
+            cd "${RUNNER_TEMP}/${NAME}"
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+
+            CURRENT=$(grep -m1 -oP "(?<=<${PROPERTY}>)[^<]+" pom.xml || true)
+            echo "${PROPERTY}: ${CURRENT:-<none>} -> ${NEW_VERSION}"
+            [ -n "$CURRENT" ] || { echo "::error::No <${PROPERTY}> property in ${NAME}/pom.xml"; exit 1; }
+            if [ "$CURRENT" = "$NEW_VERSION" ]; then echo "Already up to date, nothing to do"; exit 0; fi
+
+            sed -i "s|<${PROPERTY}>[^<]*</${PROPERTY}>|<${PROPERTY}>${NEW_VERSION}</${PROPERTY}>|g" pom.xml
+            CHANGED=$(git diff --name-only | tr '\n' ' ')
+            [ "$CHANGED" = "pom.xml " ] || { echo "::error::Unexpected files changed: ${CHANGED}"; exit 1; }
+
+            git checkout -qb "$BRANCH"
+            git commit -qam "chore(deps): ${LIB} ${NEW_VERSION}"
+            git push -qu origin HEAD --force
+            if gh pr view "$BRANCH" --json url --jq '.url' 2>/dev/null; then echo "PR already open, branch updated"; exit 0; fi
+            gh pr create --base main --head "$BRANCH" \
+              --title "${LIB} ${NEW_VERSION} (automatically generated PR)" \
+              --body "Bump \`${PROPERTY}\` to ${NEW_VERSION}, released from ${RUN_URL}."
+          ) || FAILED="${FAILED} ${NAME}"
+          echo "::endgroup::"
+        done
+
+        [ -z "$FAILED" ] || { echo "::error::Version bump failed for:${FAILED}"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,8 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'java') ||
       (github.event_name == 'push' && fromJSON(needs.changes.outputs.changes || '{}').java == 'true')
+    outputs:
+      version: ${{ steps.released_version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -119,6 +121,10 @@ jobs:
             --batch-mode \
             --no-transfer-progress
 
+      - name: Export Released Version
+        id: released_version
+        run: echo "version=${{ env.NEW_VERSION }}" >> $GITHUB_OUTPUT
+
       - name: Clean SNAPSHOT versions
         if: github.event_name == 'workflow_dispatch'
         continue-on-error: true
@@ -133,6 +139,47 @@ jobs:
               --jq '[.[] | select(.name | test("SNAPSHOT")) | select(.name | test("-[0-9]+-SNAPSHOT") | not)] | sort_by(.created_at) | reverse | .[3:] | .[].id' |
               xargs -r -n1 -I{} gh api -X DELETE "/orgs/${{ env.ORGANISATION }}/packages/maven/$PKG/versions/{}"
           done
+
+
+  propagate-release:
+    name: "Propagate ${{ needs.release-java.outputs.version }}"
+    runs-on: ubuntu-latest
+    needs: release-java
+    if: github.event_name == 'workflow_dispatch' && !inputs.snapshot
+
+    steps:
+      - name: Generate release token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            openframe-oss-lib
+            openframe-saas-lib
+            openframe-saas-tenant
+            openframe-saas-shared
+
+      - uses: actions/checkout@v4
+
+      - name: Bump revision in this repository
+        uses: ./.github/steps/bump-revision
+        with:
+          version: ${{ needs.release-java.outputs.version }}
+          token: ${{ steps.app_token.outputs.token }}
+
+      - name: Open version bump PRs downstream
+        if: '!cancelled()'
+        uses: ./.github/steps/propagate-version
+        with:
+          version: ${{ needs.release-java.outputs.version }}
+          property: openframe.oss.libs.version
+          token: ${{ steps.app_token.outputs.token }}
+          repositories: |
+            openframe-saas-lib
+            openframe-saas-tenant
+            openframe-saas-shared
 
 
   release-node:


### PR DESCRIPTION
## What
On a lib release, automatically:
1. Bump `<revision>` in this repo's `pom.xml` to the released version (auto-merged PR).
2. Open a version-bump PR in every dependent repo.

Closes [CU-86ajy9vtc](https://app.clickup.com/t/86ajy9vtc) — Renovate does not trigger the version-update + PR flow on lib releases.

## How
New `propagate-release` job (release `workflow_dispatch` only, skipped for snapshots), driven by two composite actions under `.github/steps/`:

- **bump-revision** — sets `<revision>` to the released version, opens a PR, enables squash auto-merge. Refuses to proceed unless the diff is exactly that one line.
- **propagate-version** — opens a PR bumping `openframe.oss.libs.version` downstream. One failing repo does not block the others.

Downstream targets: `openframe-saas-lib`, `openframe-saas-tenant`, `openframe-saas-shared`.

## Auth
GitHub App token via `actions/create-github-app-token` (same pattern as `SAAS_FLEET_DEV_APP`), scoped per run. No PAT, no rotation.

## Note
This repo's \`<revision>\` was the \`999-SNAPSHOT\` dev-default; after the first release it becomes the real version. README/docs still mention \`999-SNAPSHOT\` — not updated here.

## Before merge
- [ ] GitHub App created + installed, \`RELEASE_APP_ID\` / \`RELEASE_APP_KEY\` set
- [x] Allow auto-merge enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process Improvements**
  - Automated revision updates during manual releases.
  - Automatically prepares version-update pull requests for downstream projects after a successful non-snapshot release.
  - Added validation to prevent unintended file changes during automated version updates.
  - Release workflows now report the released version consistently and continue processing other projects when an individual update fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->