### PR TITLE
feat(client): doctor healing submodule — auto-install machine-wide WebView2

### DIFF
--- a/clients/openframe-client/src/cli.rs
+++ b/clients/openframe-client/src/cli.rs
@@ -91,12 +91,21 @@ pub fn run() -> Result<()> {
                 println!("\n{} warning(s). Installation will proceed, but the agent may have connectivity issues.", warns);
             }
 
-            println!("\nStarting installation...\n");
-
             if let Err(e) = crate::logging::init_file_only(None, None) {
                 eprintln!("Failed to initialize logging: {}", e);
                 process::exit(1);
             }
+
+            // Healing runs only on a fresh install; a reinstall (existing client present) skips it.
+            if !Service::is_installed()
+                && !crate::doctor::healing::pending(&report.results).is_empty()
+            {
+                println!("\nAttempting automatic fixes (this may take a few minutes)...");
+                let heals = rt.block_on(crate::doctor::healing::heal(&report.results));
+                print_heal_outcomes(&heals);
+            }
+
+            println!("\nStarting installation...\n");
 
             rt.block_on(async {
                 match Service::install(params).await {
@@ -218,5 +227,19 @@ fn init_logging() {
     if let Err(e) = crate::logging::init(None, None) {
         eprintln!("Failed to initialize logging: {}", e);
         process::exit(1);
+    }
+}
+
+fn print_heal_outcomes(heals: &[crate::doctor::healing::HealResult]) {
+    use crate::doctor::healing::HealOutcome;
+    use crate::doctor::Remediation;
+    for heal in heals {
+        let label = match heal.remediation {
+            Remediation::InstallWebview2 => "WebView2 Runtime install",
+        };
+        match &heal.outcome {
+            HealOutcome::Healed => println!("  [+] {} fixed", label),
+            HealOutcome::Failed(e) => println!("  [x] {} failed: {}", label, e),
+        }
     }
 }

--- a/clients/openframe-client/src/doctor/checks.rs
+++ b/clients/openframe-client/src/doctor/checks.rs
@@ -305,7 +305,37 @@ pub async fn check_websocket_upgrade(server_url: &str) -> CheckResult {
 // Detect the Edge WebView2 Runtime (required by the Tauri chat window) via its EdgeUpdate registry version.
 #[cfg(windows)]
 pub fn check_webview2_runtime() -> Option<CheckResult> {
-    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE, KEY_READ};
+    use super::Remediation;
+    use winreg::enums::{HKEY_CURRENT_USER, HKEY_LOCAL_MACHINE};
+
+    Some(match (webview2_version(HKEY_LOCAL_MACHINE), webview2_version(HKEY_CURRENT_USER)) {
+        (Some(v), _) => CheckResult::pass(
+            CheckCategory::Runtime,
+            &format!("Runtime: WebView2 Runtime {} installed machine-wide", v),
+        ),
+        (None, Some(v)) => CheckResult::warn(
+            CheckCategory::Runtime,
+            &format!("Runtime: WebView2 Runtime {} installed per-user only", v),
+            "A per-user WebView2 install is unavailable to other accounts on this machine and cannot be \
+             verified by the OpenFrame agent, so the chat window may fail to launch. \
+             A machine-wide install is required.",
+        )
+        .with_remediation(Remediation::InstallWebview2),
+        (None, None) => CheckResult::warn(
+            CheckCategory::Runtime,
+            "Runtime: WebView2 Runtime not installed",
+            "The OpenFrame chat window requires the Microsoft Edge WebView2 Runtime and will not launch without it. \
+             Install the Evergreen WebView2 Runtime from \
+             https://developer.microsoft.com/microsoft-edge/webview2/.",
+        )
+        .with_remediation(Remediation::InstallWebview2),
+    })
+}
+
+/// Reads the WebView2 EdgeUpdate client version ("pv") from the given registry hive.
+#[cfg(windows)]
+fn webview2_version(hive: winreg::HKEY) -> Option<String> {
+    use winreg::enums::KEY_READ;
     use winreg::RegKey;
 
     const CLIENT: &str =
@@ -313,33 +343,13 @@ pub fn check_webview2_runtime() -> Option<CheckResult> {
     const CLIENT_WOW: &str =
         r"SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
 
-    let candidates = [
-        (HKEY_LOCAL_MACHINE, CLIENT_WOW),
-        (HKEY_LOCAL_MACHINE, CLIENT),
-        (HKEY_CURRENT_USER, CLIENT),
-        (HKEY_CURRENT_USER, CLIENT_WOW),
-    ];
-
-    let version = candidates.iter().find_map(|(hive, path)| {
-        RegKey::predef(*hive)
+    [CLIENT_WOW, CLIENT].iter().find_map(|path| {
+        RegKey::predef(hive)
             .open_subkey_with_flags(path, KEY_READ)
             .ok()
             .and_then(|k| k.get_value::<String, _>("pv").ok())
-            .filter(|v| !v.trim().is_empty() && v.trim() != "0.0.0.0")
-    });
-
-    Some(match version {
-        Some(v) => CheckResult::pass(
-            CheckCategory::Runtime,
-            &format!("Runtime: WebView2 Runtime {} installed", v.trim()),
-        ),
-        None => CheckResult::warn(
-            CheckCategory::Runtime,
-            "Runtime: WebView2 Runtime not installed",
-            "The OpenFrame chat window requires the Microsoft Edge WebView2 Runtime and will not launch without it. \
-             Install the Evergreen WebView2 Runtime from \
-             https://developer.microsoft.com/microsoft-edge/webview2/.",
-        ),
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty() && v != "0.0.0.0")
     })
 }
 

--- a/clients/openframe-client/src/doctor/healing/healing_tests.rs
+++ b/clients/openframe-client/src/doctor/healing/healing_tests.rs
@@ -1,0 +1,51 @@
+use super::*;
+use crate::doctor::CheckCategory;
+
+fn warn_with_remediation(name: &str) -> CheckResult {
+    CheckResult::warn(CheckCategory::Runtime, name, "hint")
+        .with_remediation(Remediation::InstallWebview2)
+}
+
+#[test]
+fn pending_collects_flagged_remediations() {
+    let results = vec![
+        CheckResult::pass(CheckCategory::Admin, "admin"),
+        warn_with_remediation("webview2"),
+    ];
+
+    assert_eq!(pending(&results), vec![Remediation::InstallWebview2]);
+}
+
+#[test]
+fn pending_deduplicates() {
+    let results = vec![warn_with_remediation("a"), warn_with_remediation("b")];
+
+    assert_eq!(pending(&results), vec![Remediation::InstallWebview2]);
+}
+
+#[test]
+fn pending_is_empty_without_flags() {
+    let results = vec![
+        CheckResult::pass(CheckCategory::Admin, "admin"),
+        CheckResult::warn(CheckCategory::Network, "tcp", "hint"),
+        CheckResult::fail(CheckCategory::Disk, "disk", "hint"),
+    ];
+
+    assert!(pending(&results).is_empty());
+}
+
+#[test]
+fn constructors_leave_remediation_unset() {
+    assert_eq!(
+        CheckResult::pass(CheckCategory::Admin, "x").remediation,
+        None
+    );
+    assert_eq!(
+        CheckResult::info(CheckCategory::Network, "x").remediation,
+        None
+    );
+    assert_eq!(
+        warn_with_remediation("x").remediation,
+        Some(Remediation::InstallWebview2)
+    );
+}

--- a/clients/openframe-client/src/doctor/healing/mod.rs
+++ b/clients/openframe-client/src/doctor/healing/mod.rs
@@ -1,0 +1,60 @@
+mod webview2_installer;
+
+use tracing::{info, warn};
+
+use super::{CheckResult, Remediation};
+
+/// Outcome of a single healing action.
+#[derive(Debug)]
+pub enum HealOutcome {
+    Healed,
+    Failed(String),
+}
+
+/// One remediation attempt and how it ended.
+#[derive(Debug)]
+pub struct HealResult {
+    pub remediation: Remediation,
+    pub outcome: HealOutcome,
+}
+
+/// Remediations flagged in `results`, deduplicated in first-seen order.
+pub fn pending(results: &[CheckResult]) -> Vec<Remediation> {
+    let mut remediations = Vec::new();
+    for result in results {
+        if let Some(remediation) = result.remediation {
+            if !remediations.contains(&remediation) {
+                remediations.push(remediation);
+            }
+        }
+    }
+    remediations
+}
+
+/// Runs every remediation flagged in `results`; each action verifies its own fix.
+pub async fn heal(results: &[CheckResult]) -> Vec<HealResult> {
+    let mut heals = Vec::new();
+    for remediation in pending(results) {
+        info!("Doctor healing: running {:?}", remediation);
+        let outcome = run_action(remediation).await;
+        match &outcome {
+            HealOutcome::Healed => info!("Doctor healing: {:?} healed", remediation),
+            HealOutcome::Failed(e) => warn!("Doctor healing: {:?} failed: {}", remediation, e),
+        }
+        heals.push(HealResult {
+            remediation,
+            outcome,
+        });
+    }
+    heals
+}
+
+async fn run_action(remediation: Remediation) -> HealOutcome {
+    match remediation {
+        Remediation::InstallWebview2 => webview2_installer::install().await,
+    }
+}
+
+#[cfg(test)]
+#[path = "healing_tests.rs"]
+mod tests;

--- a/clients/openframe-client/src/doctor/healing/webview2_installer.rs
+++ b/clients/openframe-client/src/doctor/healing/webview2_installer.rs
@@ -145,18 +145,20 @@ async fn download_bootstrapper(path: &std::path::Path) -> anyhow::Result<()> {
         .with_context(|| format!("Failed to flush {}", path.display()))
 }
 
+/// PowerShell probe: exits 0 only for a valid Microsoft Authenticode signature; `{path}` is filled in at run time.
+#[cfg(windows)]
+const SIGNATURE_CHECK_SCRIPT: &str =
+    "$s = Get-AuthenticodeSignature -LiteralPath '{path}'; \
+     if ($s.Status -eq 'Valid' -and $s.SignerCertificate.Subject -like '*O=Microsoft Corporation*') { exit 0 }; \
+     Write-Output \"status=$($s.Status) subject=$($s.SignerCertificate.Subject)\"; exit 1";
+
 /// Rejects the download unless it carries a valid Microsoft Authenticode signature.
 #[cfg(windows)]
 async fn verify_microsoft_signature(path: &std::path::Path) -> anyhow::Result<()> {
     use anyhow::{anyhow, bail, Context};
 
     let powershell = crate::platform::get_powershell_path().map_err(|e| anyhow!(e))?;
-    let script = format!(
-        "$s = Get-AuthenticodeSignature -LiteralPath '{}'; \
-         if ($s.Status -eq 'Valid' -and $s.SignerCertificate.Subject -like '*O=Microsoft Corporation*') {{ exit 0 }}; \
-         Write-Output \"status=$($s.Status) subject=$($s.SignerCertificate.Subject)\"; exit 1",
-        path.display()
-    );
+    let script = SIGNATURE_CHECK_SCRIPT.replace("{path}", &path.display().to_string());
 
     let output = tokio::time::timeout(
         SIGNATURE_TIMEOUT,

--- a/clients/openframe-client/src/doctor/healing/webview2_installer.rs
+++ b/clients/openframe-client/src/doctor/healing/webview2_installer.rs
@@ -1,0 +1,196 @@
+use super::HealOutcome;
+
+/// Microsoft's permalink to the Evergreen WebView2 bootstrapper.
+#[cfg(windows)]
+const BOOTSTRAPPER_URL: &str = "https://go.microsoft.com/fwlink/p/?LinkId=2124703";
+
+/// The bootstrapper downloads the full runtime during install, so allow plenty of time.
+#[cfg(windows)]
+const INSTALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(600);
+
+#[cfg(windows)]
+const DOWNLOAD_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
+/// The bootstrapper is ~2 MB; anything larger is not the bootstrapper.
+#[cfg(windows)]
+const MAX_BOOTSTRAPPER_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Guards the PowerShell signature probe against hanging.
+#[cfg(windows)]
+const SIGNATURE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Runtime registration can land after the bootstrapper exits, so re-check this many times.
+#[cfg(windows)]
+const VERIFY_ATTEMPTS: u32 = 12;
+
+#[cfg(windows)]
+const VERIFY_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Installs the WebView2 Runtime machine-wide and re-runs the registry check to verify.
+#[cfg(windows)]
+pub async fn install() -> HealOutcome {
+    match try_install().await {
+        Ok(()) => HealOutcome::Healed,
+        Err(e) => HealOutcome::Failed(format!("{e:#}")),
+    }
+}
+
+#[cfg(not(windows))]
+pub async fn install() -> HealOutcome {
+    HealOutcome::Failed("WebView2 install is only applicable on Windows".to_string())
+}
+
+#[cfg(windows)]
+async fn try_install() -> anyhow::Result<()> {
+    use anyhow::{bail, Context};
+    use tracing::info;
+
+    // Staged under the admin-owned secured dir with an unguessable name; the signature check below guards what we execute.
+    let installer_path = crate::platform::DirectoryManager::new()
+        .secured_dir()
+        .join(format!(
+            "MicrosoftEdgeWebView2Setup-{}.exe",
+            uuid::Uuid::new_v4()
+        ));
+    if let Some(parent) = installer_path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+
+    info!(
+        "Downloading WebView2 bootstrapper from {}",
+        BOOTSTRAPPER_URL
+    );
+    if let Err(e) = download_bootstrapper(&installer_path).await {
+        let _ = tokio::fs::remove_file(&installer_path).await;
+        return Err(e);
+    }
+
+    if let Err(e) = verify_microsoft_signature(&installer_path).await {
+        let _ = tokio::fs::remove_file(&installer_path).await;
+        return Err(e);
+    }
+
+    // Running elevated (agent is SYSTEM), the bootstrapper installs machine-wide automatically.
+    info!("Running silent WebView2 install");
+    // kill_on_drop only reaps the bootstrapper on timeout; its updater child may still finish in the background (caught by the verification poll).
+    let run = tokio::time::timeout(
+        INSTALL_TIMEOUT,
+        tokio::process::Command::new(&installer_path)
+            .args(["/silent", "/install"])
+            .creation_flags(CREATE_NO_WINDOW)
+            .kill_on_drop(true)
+            .status(),
+    )
+    .await;
+
+    let healed = wait_for_machine_wide().await;
+    let _ = tokio::fs::remove_file(&installer_path).await;
+    if healed {
+        return Ok(());
+    }
+
+    let status = run
+        .context("WebView2 installer timed out")?
+        .context("Failed to run WebView2 installer")?;
+    if !status.success() {
+        bail!("WebView2 installer exited with {}", status);
+    }
+    bail!("Installer succeeded but machine-wide WebView2 runtime still not detected")
+}
+
+/// Streams the download to disk, capped so an oversized response cannot exhaust agent memory.
+#[cfg(windows)]
+async fn download_bootstrapper(path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::{bail, Context};
+    use tokio::io::AsyncWriteExt;
+
+    let mut response = reqwest::Client::builder()
+        .timeout(DOWNLOAD_TIMEOUT)
+        .build()
+        .context("Failed to create HTTP client")?
+        .get(BOOTSTRAPPER_URL)
+        .send()
+        .await
+        .context("Failed to download WebView2 bootstrapper")?
+        .error_for_status()
+        .context("WebView2 bootstrapper download failed")?;
+
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .with_context(|| format!("Failed to create {}", path.display()))?;
+    let mut written: u64 = 0;
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .context("Failed to read WebView2 bootstrapper body")?
+    {
+        written += chunk.len() as u64;
+        if written > MAX_BOOTSTRAPPER_BYTES {
+            bail!(
+                "WebView2 bootstrapper download exceeded {} MB",
+                MAX_BOOTSTRAPPER_BYTES / (1024 * 1024)
+            );
+        }
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+    }
+    file.flush()
+        .await
+        .with_context(|| format!("Failed to flush {}", path.display()))
+}
+
+/// Rejects the download unless it carries a valid Microsoft Authenticode signature.
+#[cfg(windows)]
+async fn verify_microsoft_signature(path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::{anyhow, bail, Context};
+
+    let powershell = crate::platform::get_powershell_path().map_err(|e| anyhow!(e))?;
+    let script = format!(
+        "$s = Get-AuthenticodeSignature -LiteralPath '{}'; \
+         if ($s.Status -eq 'Valid' -and $s.SignerCertificate.Subject -like '*O=Microsoft Corporation*') {{ exit 0 }}; \
+         Write-Output \"status=$($s.Status) subject=$($s.SignerCertificate.Subject)\"; exit 1",
+        path.display()
+    );
+
+    let output = tokio::time::timeout(
+        SIGNATURE_TIMEOUT,
+        tokio::process::Command::new(powershell)
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .creation_flags(CREATE_NO_WINDOW)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .context("Authenticode verification timed out")?
+    .context("Failed to run Authenticode verification")?;
+
+    if !output.status.success() {
+        bail!(
+            "WebView2 bootstrapper failed Authenticode verification: {}",
+            String::from_utf8_lossy(&output.stdout).trim()
+        );
+    }
+    Ok(())
+}
+
+/// Polls the registry check so registration landing shortly after the installer finishes still counts.
+#[cfg(windows)]
+async fn wait_for_machine_wide() -> bool {
+    use crate::doctor::{checks::check_webview2_runtime, CheckStatus};
+
+    for attempt in 0..VERIFY_ATTEMPTS {
+        if check_webview2_runtime().is_some_and(|r| r.status == CheckStatus::Pass) {
+            return true;
+        }
+        if attempt + 1 < VERIFY_ATTEMPTS {
+            tokio::time::sleep(VERIFY_POLL_INTERVAL).await;
+        }
+    }
+    false
+}

--- a/clients/openframe-client/src/doctor/mod.rs
+++ b/clients/openframe-client/src/doctor/mod.rs
@@ -1,4 +1,5 @@
 pub mod checks;
+pub mod healing;
 
 use crate::installation_initial_config_service::InstallConfigParams;
 use crate::platform::DirectoryManager;
@@ -22,12 +23,19 @@ pub enum CheckStatus {
     Info,
 }
 
+/// Automatic fix the healing submodule can run when a check flags it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Remediation {
+    InstallWebview2,
+}
+
 #[derive(Debug)]
 pub struct CheckResult {
     pub category: CheckCategory,
     pub status: CheckStatus,
     pub name: String,
     pub hint: Option<String>,
+    pub remediation: Option<Remediation>,
 }
 
 impl CheckResult {
@@ -37,6 +45,7 @@ impl CheckResult {
             status: CheckStatus::Pass,
             name: name.to_string(),
             hint: None,
+            remediation: None,
         }
     }
 
@@ -46,6 +55,7 @@ impl CheckResult {
             status: CheckStatus::Fail,
             name: name.to_string(),
             hint: Some(hint.into()),
+            remediation: None,
         }
     }
 
@@ -55,6 +65,7 @@ impl CheckResult {
             status: CheckStatus::Warn,
             name: name.to_string(),
             hint: Some(hint.into()),
+            remediation: None,
         }
     }
 
@@ -64,7 +75,13 @@ impl CheckResult {
             status: CheckStatus::Info,
             name: name.to_string(),
             hint: None,
+            remediation: None,
         }
+    }
+
+    pub fn with_remediation(mut self, remediation: Remediation) -> Self {
+        self.remediation = Some(remediation);
+        self
     }
 }
 


### PR DESCRIPTION
## Summary

Port of flamingo-stack/openframe-oss-tenant#2252 into oss-lib (moved here; the tenant PR is closed in its favor). Implements [86ajwjk4m — Bundle WebView2 in Windows client installer](https://app.clickup.com/t/9013925967/86ajwjk4m): the OpenFrame chat window needs the WebView2 Runtime installed **machine-wide**; a per-user-only install leaves other accounts (and agent verification) without it.

### 1. Doctor check — install scope detection
- `check_webview2_runtime` now reads the EdgeUpdate `pv` version per hive: **HKLM (machine-wide) → pass**; **HKCU-only (per-user) or missing → warn + flagged for remediation**.

### 2. New `doctor::healing` submodule — actions driven by doctor results
- `CheckResult` gains an optional machine-readable `Remediation` flag; checks set it where an automatic fix exists.
- `doctor/healing/` runs the flagged remediations (`healable_checks()` → `pending()` → `heal()`) and reports per-action `HealResult`s. First of its kind — new actions are one enum variant + one action module.
- First action `webview2_installer`: download Evergreen bootstrapper → stream to ACL-restricted secured dir under a UUID name with a 32 MB cap → **verify Authenticode signature (Valid + Microsoft signer)** → `/silent /install` with `CREATE_NO_WINDOW`, `kill_on_drop`, 600s timeout → poll the registry check (12×5s) so delayed registration still counts.

### 3. Healing trigger — fresh install only
- **`install` order: doctor → heal → install.** A doctor failure aborts with any existing client intact. Healing runs **only when no client is already installed** (fresh install) — reinstalls skip it — so chat's first launch always lands in a healed environment and nothing races the heal.
- The `doctor` command is strictly **read-only** (reports the scope warn + hint; no fix mode).
- To heal an existing broken machine: `uninstall`, then `install` (fresh → heals).

### Port notes (differences from the tenant PR)
- CLI changes land in `src/cli.rs` (this crate's entrypoint) instead of `src/main.rs`; `openframe::` paths became `crate::`.
- The `docs/reference/architecture/overview.md` hunk has no equivalent file in this repo and was dropped.
- Everything is rustfmt-formatted to match this repo (pre-commit enforces it).

### Design notes
- **Intended behavior change:** machines with per-user-only WebView2 now get a doctor **warn** (CLI exits 1) instead of pass — per the task ("per-user only → warn + flag for remediation").

## Test plan
- [x] `cargo test -- --skip test_ensure_admin` — 129 passed, incl. 4 `doctor::healing` unit tests
- [x] Native + `x86_64-pc-windows-gnu` release builds (`--features bin`) pass with no new warnings; lib-only (no `bin`) build also clean
- [x] `cargo clippy` (windows-gnu target, `--features bin`) clean; `cargo fmt --check` clean
- [x] Windows behavior verified end to end on the tenant branch this is ported from (byte-identical logic modulo formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)