### PR TITLE
feat(data-nats): add AssetsBaseUrlProvider for dynamic assets base URL resolution

### DIFF
--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/.AssetsBaseUrlProvider.md
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/.AssetsBaseUrlProvider.md
@@ -1,0 +1,16 @@
+<!-- source-hash: 8817cd009a19c65b38193682728c7c1e -->
+Strategy interface for supplying the base URL substituted for `{assetsBaseUrl}` in download link templates. This library ships **no implementation**: absent a bean, `DownloadConfigurationLinkResolver` falls back to the static `openframe.assets.base-url` property, so existing OSS and shared-plane deployments are unaffected.
+
+## Key Components
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `getAssetsBaseUrl()` | Method | Returns the base URL (e.g. `https://tenant1.openframe.build`), or blank/null to defer to the property |
+
+## Contract
+
+- Called on every link resolution — implementations should be cheap (cache if backed by a datastore).
+- Returning blank or null is the "no opinion" signal, never an error: the resolver silently falls back to the property. Implementations must not throw for a missing value.
+- Trailing slashes are stripped by the resolver; implementations need not normalize.
+
+Intended downstream implementation: the SaaS tenant plane derives the URL from the tenant's own `tenants.domain` document, so published download links carry the tenant subdomain and the shared gateway resolves the tenant's registered client version.

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/.DownloadConfigurationLinkResolver.md
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/.DownloadConfigurationLinkResolver.md
@@ -1,13 +1,18 @@
-<!-- source-hash: bafc18467df1ad4ce3b2d339f7a48410 -->
-Resolves versioned download URLs from `DownloadConfiguration` link templates by substituting a `{version}` placeholder with a runtime-provided version string.
+<!-- source-hash: a2dcea7958c72c551d2a51b6a89e4b79 -->
+Resolves download URLs from `DownloadConfiguration` link templates by substituting the `{version}` and `{assetsBaseUrl}` placeholders.
 
 ## Key Components
 
 | Member | Type | Description |
 |--------|------|-------------|
-| `VERSION_PLACEHOLDER` | `String` constant | The placeholder token `{version}` replaced in URL templates |
+| `VERSION_PLACEHOLDER` | `String` constant | `{version}` — always substituted with the runtime-provided version string |
+| `ASSETS_BASE_URL_PLACEHOLDER` | `String` constant | `{assetsBaseUrl}` — substituted with the resolved base URL when one is available |
 | `resolve()` | Public method | Accepts a `DownloadConfiguration` and version string, returns the resolved URL |
-| `resolveLink()` | Private method | Performs the string substitution of the version placeholder |
+| `resolveAssetsBaseUrl()` | Private method | Base-URL precedence, evaluated **per call**: optional `AssetsBaseUrlProvider` bean (when present and non-blank) → `openframe.assets.base-url` property → none (placeholder left untouched) |
+
+## Base URL Resolution
+
+The `AssetsBaseUrlProvider` constructor parameter is `@Nullable` — with the single constructor, Spring treats it as an optional dependency, so contexts without such a bean (OSS self-hosted, shared plane) fall back to the static property with no configuration change. The provider is consulted on every `resolve()` call, not captured at construction, so a value that changes at runtime (e.g. a tenant domain assigned after startup) is picked up. Trailing slashes are stripped from both sources before substitution.
 
 ## Usage Example
 
@@ -15,11 +20,10 @@ Resolves versioned download URLs from `DownloadConfiguration` link templates by 
 @Autowired
 private DownloadConfigurationLinkResolver resolver;
 
-// Given a DownloadConfiguration with linkTemplate:
-// "https://releases.example.com/agent/{version}/agent-installer.exe"
-
+// linkTemplate: "{assetsBaseUrl}/v0/api/assets/download?agent=client&platform=macos"
 String downloadUrl = resolver.resolve(downloadConfig, "2.4.1");
-// Returns: "https://releases.example.com/agent/2.4.1/agent-installer.exe"
+// With a provider returning https://tenant1.openframe.build:
+// "https://tenant1.openframe.build/v0/api/assets/download?agent=client&platform=macos"
 ```
 
-> **Note:** The link template must contain the literal string `{version}` as a placeholder. If the placeholder is absent, the template is returned unchanged. Debug-level logging captures both the original template and the resolved URL for traceability.
+> **Note:** Templates without placeholders are returned unchanged. When no base URL is available from either source, `{assetsBaseUrl}` is left in the link untouched. Debug-level logging captures both the original template and the resolved URL for traceability.

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/AssetsBaseUrlProvider.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/AssetsBaseUrlProvider.java
@@ -1,0 +1,17 @@
+package com.openframe.data.nats.resolver;
+
+/**
+ * Supplies the base URL substituted for the {@code {assetsBaseUrl}} placeholder in download link
+ * templates. No implementation is provided in this library: when no bean is present,
+ * {@link DownloadConfigurationLinkResolver} falls back to the static
+ * {@code openframe.assets.base-url} property. Downstream deployments contribute a bean to resolve
+ * the base URL dynamically (e.g. the SaaS tenant plane derives it from the tenant's domain).
+ */
+public interface AssetsBaseUrlProvider {
+
+    /**
+     * @return the assets base URL (e.g. {@code https://tenant1.openframe.build}), or blank/null to
+     * defer to the {@code openframe.assets.base-url} property
+     */
+    String getAssetsBaseUrl();
+}

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolver.java
@@ -3,6 +3,7 @@ package com.openframe.data.nats.resolver;
 import com.openframe.data.document.clientconfiguration.DownloadConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import static org.springframework.util.StringUtils.hasText;
@@ -15,9 +16,13 @@ public class DownloadConfigurationLinkResolver {
     private static final String ASSETS_BASE_URL_PLACEHOLDER = "{assetsBaseUrl}";
 
     private final String assetsBaseUrl;
+    private final AssetsBaseUrlProvider assetsBaseUrlProvider;
 
-    public DownloadConfigurationLinkResolver(@Value("${openframe.assets.base-url:}") String assetsBaseUrl) {
+    public DownloadConfigurationLinkResolver(
+            @Value("${openframe.assets.base-url:}") String assetsBaseUrl,
+            @Nullable AssetsBaseUrlProvider assetsBaseUrlProvider) {
         this.assetsBaseUrl = stripTrailingSlashes(assetsBaseUrl);
+        this.assetsBaseUrlProvider = assetsBaseUrlProvider;
     }
 
     public String resolve(DownloadConfiguration config, String version) {
@@ -29,10 +34,25 @@ public class DownloadConfigurationLinkResolver {
 
     private String resolveLink(String linkTemplate, String version) {
         String link = linkTemplate.replace(VERSION_PLACEHOLDER, version);
-        if (hasText(assetsBaseUrl)) {
-            link = link.replace(ASSETS_BASE_URL_PLACEHOLDER, assetsBaseUrl);
+        String baseUrl = resolveAssetsBaseUrl();
+        if (hasText(baseUrl)) {
+            link = link.replace(ASSETS_BASE_URL_PLACEHOLDER, baseUrl);
         }
         return link;
+    }
+
+    /**
+     * Resolved per call, not at construction: a provider's value may change at runtime
+     * (e.g. a tenant domain assigned after startup).
+     */
+    private String resolveAssetsBaseUrl() {
+        if (assetsBaseUrlProvider != null) {
+            String provided = stripTrailingSlashes(assetsBaseUrlProvider.getAssetsBaseUrl());
+            if (hasText(provided)) {
+                return provided;
+            }
+        }
+        return assetsBaseUrl;
     }
 
     private static String stripTrailingSlashes(String value) {

--- a/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
+++ b/openframe-data-nats/src/test/java/com/openframe/data/nats/resolver/DownloadConfigurationLinkResolverTest.java
@@ -3,6 +3,8 @@ package com.openframe.data.nats.resolver;
 import com.openframe.data.document.clientconfiguration.DownloadConfiguration;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DownloadConfigurationLinkResolverTest {
@@ -14,7 +16,7 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldSubstituteVersionPlaceholder() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("", null);
 
         String resolved = resolver.resolve(config(GITHUB_TEMPLATE), "1.0.19");
 
@@ -24,7 +26,7 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldSubstituteAssetsBaseUrlPlaceholder() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build", null);
 
         String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
 
@@ -33,7 +35,7 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldStripTrailingSlashFromConfiguredBaseUrl() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build/");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build/", null);
 
         String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
 
@@ -42,7 +44,7 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldStripAllConsecutiveTrailingSlashesFromConfiguredBaseUrl() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build///");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build///", null);
 
         String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
 
@@ -51,7 +53,7 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldLeavePlaceholderUntouchedWhenBaseUrlNotConfigured() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("", null);
 
         String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
 
@@ -60,11 +62,66 @@ class DownloadConfigurationLinkResolverTest {
 
     @Test
     void shouldLeaveTemplatesWithoutPlaceholdersUnchanged() {
-        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver("https://openframe.build", null);
 
         String plain = "https://example.com/static/openframe-client_macos.tar.gz";
 
         assertThat(resolver.resolve(config(plain), "1.0.19")).isEqualTo(plain);
+    }
+
+    @Test
+    void shouldPreferProviderBaseUrlOverProperty() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver(
+                "https://openframe.build", () -> "https://tenant1.openframe.build");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://tenant1.openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldStripTrailingSlashesFromProviderBaseUrl() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver(
+                "", () -> "https://tenant1.openframe.build//");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://tenant1.openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldFallBackToPropertyWhenProviderReturnsBlank() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver(
+                "https://openframe.build", () -> "");
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldFallBackToPropertyWhenProviderReturnsNull() {
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver(
+                "https://openframe.build", () -> null);
+
+        String resolved = resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19");
+
+        assertThat(resolved).isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+    }
+
+    @Test
+    void shouldConsultProviderOnEveryResolution() {
+        AtomicReference<String> providerValue = new AtomicReference<>("");
+        DownloadConfigurationLinkResolver resolver = new DownloadConfigurationLinkResolver(
+                "https://openframe.build", providerValue::get);
+
+        assertThat(resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19"))
+                .isEqualTo("https://openframe.build/v0/api/assets/download?agent=chat&platform=macos");
+
+        providerValue.set("https://tenant1.openframe.build");
+
+        assertThat(resolver.resolve(config(GATEWAY_TEMPLATE), "1.0.19"))
+                .isEqualTo("https://tenant1.openframe.build/v0/api/assets/download?agent=chat&platform=macos");
     }
 
     private DownloadConfiguration config(String linkTemplate) {


### PR DESCRIPTION
## Summary

Adds an optional strategy interface for resolving the `{assetsBaseUrl}` placeholder in download link templates dynamically, instead of only from the static `openframe.assets.base-url` property.

- **`AssetsBaseUrlProvider`** (new, functional interface): returns the assets base URL, or blank/null to defer to the property. No implementation ships in this library.
- **`DownloadConfigurationLinkResolver`**: constructor gains a `@Nullable AssetsBaseUrlProvider` parameter (optional dependency with the single constructor). The base URL is now resolved **per `resolve()` call** with precedence: provider (present and non-blank) → `openframe.assets.base-url` property → placeholder left untouched. Trailing slashes are stripped from both sources.

## Backward compatibility

Fully backward compatible: no `AssetsBaseUrlProvider` bean exists anywhere yet, so every current consumer (OSS self-hosted, SaaS shared and tenant planes) takes the property path exactly as before. The only direct constructor call across all repos was this module's own test.

## Why

SaaS tenant services will contribute a provider that derives the URL from the tenant's own `tenants.domain` document. Published NATS download links then carry the tenant subdomain (`https://2490.dev.openframe.build/v0/api/assets/download?...`), which the shared gateway resolves to that tenant's registered client version (flamingo-stack/openframe-saas-shared#1750) — eliminating version skew during rolling releases. Per-call resolution matters because a tenant's domain can be assigned/changed after service startup.

## Tests

`DownloadConfigurationLinkResolverTest` grew from 6 to 11 cases: provider precedence, blank/null provider fallback, trailing-slash stripping of provider values, and per-call (dynamic) provider consultation. `openframe-data-nats` builds green; `openframe-management-service-core` (main consumer) compiles clean against the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)