### PR TITLE
feat(nats): CLIENT_UNINSTALL stream and per-machine uninstall command publisher

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/controller/ForceAgentController.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/controller/ForceAgentController.java
@@ -1,14 +1,17 @@
 package com.openframe.api.controller;
 
+import com.openframe.api.dto.force.request.ForceClientUninstallRequest;
 import com.openframe.api.dto.force.request.ForceToolInstallationAllRequest;
 import com.openframe.api.dto.force.request.ForceToolInstallationRequest;
 import com.openframe.api.dto.force.request.ForceToolReinstallationRequest;
+import com.openframe.api.dto.force.response.ForceClientUninstallResponse;
 import com.openframe.api.dto.force.response.ForceClientUpdateResponse;
 import com.openframe.api.dto.force.response.ForceToolAgentInstallationResponse;
 import com.openframe.api.dto.update.ForceClientUpdateRequest;
 import com.openframe.api.dto.update.ForceToolAgentUpdateAllRequest;
 import com.openframe.api.dto.update.ForceToolAgentUpdateRequest;
 import com.openframe.api.dto.update.ForceToolAgentUpdateResponse;
+import com.openframe.api.service.ForceClientUninstallService;
 import com.openframe.api.service.ForceClientUpdateService;
 import com.openframe.api.service.ForceToolAgentUpdateService;
 import com.openframe.api.service.ForceToolInstallationService;
@@ -23,6 +26,7 @@ public class ForceAgentController {
     private final ForceToolInstallationService toolInstallationService;
     private final ForceClientUpdateService clientUpdateService;
     private final ForceToolAgentUpdateService toolAgentUpdateService;
+    private final ForceClientUninstallService clientUninstallService;
 
     @PostMapping("tool-agent/install")
     public ForceToolAgentInstallationResponse forceToolInstallation(@RequestBody ForceToolInstallationRequest request) {
@@ -37,6 +41,11 @@ public class ForceAgentController {
     @PostMapping("tool-agent/update")
     public ForceToolAgentUpdateResponse forceToolAgentUpdate(@RequestBody ForceToolAgentUpdateRequest request) {
         return toolAgentUpdateService.process(request);
+    }
+
+    @PostMapping("client/uninstall")
+    public ForceClientUninstallResponse forceClientUninstall(@RequestBody ForceClientUninstallRequest request) {
+        return clientUninstallService.process(request);
     }
 
     @PostMapping("client/update/all")

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/request/ForceClientUninstallRequest.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/request/ForceClientUninstallRequest.java
@@ -1,0 +1,12 @@
+package com.openframe.api.dto.force.request;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ForceClientUninstallRequest {
+
+    private List<String> machineIds;
+
+}

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/response/ForceClientUninstallResponse.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/response/ForceClientUninstallResponse.java
@@ -1,0 +1,12 @@
+package com.openframe.api.dto.force.response;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ForceClientUninstallResponse {
+
+    private List<ForceClientUninstallResponseItem> items;
+
+}

--- a/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/response/ForceClientUninstallResponseItem.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/dto/force/response/ForceClientUninstallResponseItem.java
@@ -1,0 +1,11 @@
+package com.openframe.api.dto.force.response;
+
+import lombok.Data;
+
+@Data
+public class ForceClientUninstallResponseItem {
+
+    private String machineId;
+    private ForceAgentStatus status;
+
+}

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
@@ -1,0 +1,72 @@
+package com.openframe.api.service;
+
+import com.openframe.api.dto.force.request.ForceClientUninstallRequest;
+import com.openframe.api.dto.force.response.ForceAgentStatus;
+import com.openframe.api.dto.force.response.ForceClientUninstallResponse;
+import com.openframe.api.dto.force.response.ForceClientUninstallResponseItem;
+import com.openframe.data.nats.publisher.ClientUninstallNatsPublisher;
+import com.openframe.data.repository.device.MachineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ForceClientUninstallService {
+
+    private final ClientUninstallNatsPublisher clientUninstallNatsPublisher;
+    private final MachineRepository machineRepository;
+
+    public ForceClientUninstallResponse process(ForceClientUninstallRequest request) {
+        List<String> machineIds = request.getMachineIds();
+
+        validateMachineIds(machineIds);
+
+        log.info("Process force client uninstall request for machines {}", machineIds);
+
+        List<ForceClientUninstallResponseItem> responseItems = machineIds.stream()
+                .map(this::processMachine)
+                .toList();
+
+        ForceClientUninstallResponse response = new ForceClientUninstallResponse();
+        response.setItems(responseItems);
+
+        return response;
+    }
+
+    private ForceClientUninstallResponseItem processMachine(String machineId) {
+        try {
+            if (machineRepository.findByMachineId(machineId).isEmpty()) {
+                log.warn("Skipping client uninstall for unknown machine {}", machineId);
+                return buildResponseItem(machineId, ForceAgentStatus.FAILED);
+            }
+
+            clientUninstallNatsPublisher.publish(machineId);
+
+            return buildResponseItem(machineId, ForceAgentStatus.PROCESSED);
+        } catch (Exception e) {
+            log.error("Failed to publish client uninstall command for machine {}", machineId, e);
+            return buildResponseItem(machineId, ForceAgentStatus.FAILED);
+        }
+    }
+
+    private void validateMachineIds(List<String> machineIds) {
+        if (isEmpty(machineIds)) {
+            throw new IllegalArgumentException("No machine ids provided");
+        }
+    }
+
+    private ForceClientUninstallResponseItem buildResponseItem(String machineId, ForceAgentStatus status) {
+        ForceClientUninstallResponseItem responseItem = new ForceClientUninstallResponseItem();
+        responseItem.setMachineId(machineId);
+        responseItem.setStatus(status);
+
+        return responseItem;
+    }
+
+}

--- a/openframe-client-core/src/main/java/com/openframe/client/controller/AgentController.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/controller/AgentController.java
@@ -2,6 +2,7 @@ package com.openframe.client.controller;
 
 
 import com.openframe.client.dto.agent.*;
+import com.openframe.client.service.AgentUninstallService;
 import com.openframe.client.service.agentregistration.AgentRegistrationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class AgentController {
     private static final String CLIENT_SECRET_HEADER = "X-Client-Secret";
 
     private final AgentRegistrationService agentRegistrationService;
+    private final AgentUninstallService agentUninstallService;
 
     @PostMapping("/register")
     public AgentRegistrationResponse register(
@@ -35,6 +37,15 @@ public class AgentController {
             @Valid @RequestBody AgentRegistrationRequest request
     ) {
         return agentRegistrationService.reinstall(initialKey, machineId, clientSecret, request);
+    }
+
+    @PostMapping("/uninstall")
+    public ResponseEntity<Void> uninstall(
+            @RequestHeader(MACHINE_ID_HEADER) String machineId,
+            @RequestHeader(CLIENT_SECRET_HEADER) String clientSecret
+    ) {
+        agentUninstallService.uninstall(machineId, clientSecret);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/openframe-client-core/src/main/java/com/openframe/client/service/AgentUninstallService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/AgentUninstallService.java
@@ -1,0 +1,54 @@
+package com.openframe.client.service;
+
+import com.openframe.client.service.validator.ClientSecretValidator;
+import com.openframe.data.document.device.DeviceStatus;
+import com.openframe.data.document.device.Machine;
+import com.openframe.data.document.oauth.OAuthClient;
+import com.openframe.data.repository.device.MachineRepository;
+import com.openframe.data.repository.oauth.OAuthClientRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AgentUninstallService {
+
+    private final OAuthClientRepository oauthClientRepository;
+    private final ClientSecretValidator clientSecretValidator;
+    private final MachineRepository machineRepository;
+    private final ToolConnectionService toolConnectionService;
+    private final InstalledAgentService installedAgentService;
+
+    public void uninstall(String machineId, String clientSecret) {
+        Optional<OAuthClient> client = oauthClientRepository.findByMachineId(machineId);
+        if (client.isEmpty()) {
+            log.info("Uninstall requested for unknown machine {}, treating as already deregistered", machineId);
+            return;
+        }
+        clientSecretValidator.validate(client.get(), clientSecret);
+
+        Optional<Machine> foundMachine = machineRepository.findByMachineId(machineId);
+        if (foundMachine.isEmpty()) {
+            log.info("Uninstall requested for machine {} without machine document, treating as already deregistered", machineId);
+            return;
+        }
+
+        Machine machine = foundMachine.get();
+        if (machine.getStatus() == DeviceStatus.DELETED) {
+            log.info("Machine {} is already deleted, uninstall is a no-op", machineId);
+            return;
+        }
+
+        machine.setStatus(DeviceStatus.DELETED);
+        machineRepository.save(machine);
+
+        toolConnectionService.disconnectAll(machineId);
+        installedAgentService.disconnectAll(machineId);
+
+        log.info("Machine {} deregistered on uninstall", machineId);
+    }
+}

--- a/openframe-client-core/src/test/java/com/openframe/client/controller/AgentControllerTest.java
+++ b/openframe-client-core/src/test/java/com/openframe/client/controller/AgentControllerTest.java
@@ -6,6 +6,7 @@ import com.openframe.client.exception.DuplicateConnectionException;
 import com.openframe.client.exception.InvalidClientSecretException;
 import com.openframe.core.exception.BaseGlobalExceptionHandler;
 import com.openframe.core.exception.ErrorCode;
+import com.openframe.client.service.AgentUninstallService;
 import com.openframe.client.service.agentregistration.AgentRegistrationService;
 import com.openframe.client.util.TestAuthenticationManager;
 import com.openframe.client.dto.agent.*;
@@ -36,13 +37,16 @@ class AgentControllerTest {
     @Mock
     private AgentRegistrationService agentRegistrationService;
 
+    @Mock
+    private AgentUninstallService agentUninstallService;
+
     private AgentRegistrationRequest registrationRequest;
     private AgentRegistrationResponse registrationResponse;
     private ObjectMapper objectMapper;
 
     @BeforeEach
     void setup() {
-        AgentController controller = new AgentController(agentRegistrationService);
+        AgentController controller = new AgentController(agentRegistrationService, agentUninstallService);
 
         mockMvc = MockMvcBuilders.standaloneSetup(controller)
                 .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/model/ClientUninstallMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/model/ClientUninstallMessage.java
@@ -1,0 +1,14 @@
+package com.openframe.data.nats.model;
+
+import lombok.Data;
+
+@Data
+public class ClientUninstallMessage {
+
+    /**
+     * When the command was issued (ISO-8601 instant). Lets the agent ignore
+     * stale commands replayed from the stream, e.g. after a reinstall.
+     */
+    private String issuedAt;
+
+}

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/publisher/ClientUninstallNatsPublisher.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/publisher/ClientUninstallNatsPublisher.java
@@ -1,0 +1,29 @@
+package com.openframe.data.nats.publisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty("spring.cloud.stream.enabled")
+@Slf4j
+public class ClientUninstallNatsPublisher {
+
+    private final static String TOPIC_NAME_TEMPLATE = "machine.%s.client-uninstall";
+
+    private final NatsMessagePublisher natsMessagePublisher;
+
+    public void publish(String machineId) {
+        String topicName = format(TOPIC_NAME_TEMPLATE, machineId);
+        // the message itself is the command — no payload contract, empty JSON body
+        natsMessagePublisher.publishPersistent(topicName, Map.of());
+
+        log.info("Published client uninstall command for machine {}", machineId);
+    }
+}

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/publisher/ClientUninstallNatsPublisher.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/publisher/ClientUninstallNatsPublisher.java
@@ -1,11 +1,12 @@
 package com.openframe.data.nats.publisher;
 
+import com.openframe.data.nats.model.ClientUninstallMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
+import java.time.Instant;
 
 import static java.lang.String.format;
 
@@ -21,9 +22,15 @@ public class ClientUninstallNatsPublisher {
 
     public void publish(String machineId) {
         String topicName = format(TOPIC_NAME_TEMPLATE, machineId);
-        // the message itself is the command — no payload contract, empty JSON body
-        natsMessagePublisher.publishPersistent(topicName, Map.of());
+        ClientUninstallMessage message = buildMessage();
+        natsMessagePublisher.publishPersistent(topicName, message);
 
         log.info("Published client uninstall command for machine {}", machineId);
+    }
+
+    private ClientUninstallMessage buildMessage() {
+        ClientUninstallMessage message = new ClientUninstallMessage();
+        message.setIssuedAt(Instant.now().toString());
+        return message;
     }
 }

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/security/GatewaySecurityConfig.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/security/GatewaySecurityConfig.java
@@ -90,6 +90,7 @@ public class GatewaySecurityConfig {
                                 CLIENTS_PREFIX + "/metrics/**",
                                 CLIENTS_PREFIX + "/api/agents/register",
                                 CLIENTS_PREFIX + "/api/agents/reinstall",
+                                CLIENTS_PREFIX + "/api/agents/uninstall",
                                 CLIENTS_PREFIX + "/api/release-version",
                                 CLIENTS_PREFIX + "/oauth/token",
                                 // TODO: removxxe after migration artifacts to GitHub

--- a/openframe-gateway-service-core/src/main/java/com/openframe/gateway/security/filter/AddAuthorizationHeaderFilter.java
+++ b/openframe-gateway-service-core/src/main/java/com/openframe/gateway/security/filter/AddAuthorizationHeaderFilter.java
@@ -62,6 +62,7 @@ public class AddAuthorizationHeaderFilter implements WebFilter {
                 path.startsWith(CLIENTS_PREFIX + "/metrics/")
                         || path.equals(CLIENTS_PREFIX + "/api/agents/register")
                         || path.equals(CLIENTS_PREFIX + "/api/agents/reinstall")
+                        || path.equals(CLIENTS_PREFIX + "/api/agents/uninstall")
                         || path.equals(CLIENTS_PREFIX + "/api/release-version")
                         || path.equals(CLIENTS_PREFIX + "/oauth/token")
                         || path.startsWith(CLIENTS_PREFIX + "/tool-agent/")

--- a/openframe-management-service-core/src/main/java/com/openframe/management/initializer/NatsStreamConfigurationInitializer.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/initializer/NatsStreamConfigurationInitializer.java
@@ -34,6 +34,13 @@ public class NatsStreamConfigurationInitializer implements ApplicationRunner {
                     .storageType(StorageType.File)
                     .retentionPolicy(RetentionPolicy.Limits)
                     .build(),
+            // client uninstall stream (the message itself is the command, empty payload)
+            StreamConfiguration.builder()
+                    .name("CLIENT_UNINSTALL")
+                    .subjects(List.of("machine.*.client-uninstall"))
+                    .storageType(StorageType.File)
+                    .retentionPolicy(RetentionPolicy.Limits)
+                    .build(),
             // tool agent update stream
             StreamConfiguration.builder()
                     .name("TOOL_UPDATE")


### PR DESCRIPTION
## Summary
Adds the backend side of the client uninstall command over NATS, end to end from the frontend-facing API to agent deregistration:

- **`CLIENT_UNINSTALL`** JetStream stream (File storage, Limits retention) carrying `machine.*.client-uninstall`, registered in `NatsStreamConfigurationInitializer`.
- **`ClientUninstallNatsPublisher`** (openframe-data-nats): publishes `ClientUninstallMessage` (`{"issuedAt": "<ISO-8601>"}`) to `machine.{machineId}.client-uninstall`. The message itself is the command; `issuedAt` lets the agent ignore stale commands replayed from the durable stream (e.g. after a reinstall under the same machineId).
- **`POST /force/client/uninstall`** (openframe-api-service-core): `{"machineIds": [...]}` → per-machine `PROCESSED`/`FAILED` items, mirroring `/force/client/update`; validates ids and machine existence before publishing.
- **`POST /clients/api/agents/uninstall`** (openframe-client-core): called by the agent when local deletion completes. Auth via `X-Machine-Id` + `X-Client-Secret` (validated against the machine's OAuth client, same as `/reinstall`), no body. Sets device status to `DELETED`, marks tool connections and installed agents disconnected. Idempotent: unknown or already-deleted machine → 204, never an error. Gateway permit-list + auth-header filter updated for the path.

The agent consumes its own subject (same model as `TOOL_INSTALLATION`/`CLIENT_UPDATE`); the agent-side subscription and local uninstall live in the Rust client and are not part of this PR.

## Related
Companion device-permission configmap PRs: flamingo-stack/openframe-saas-tenant#2576, flamingo-stack/openframe-oss-tenant#2293.

## Testing
- Verified compilation (`mvn compile`) for all touched modules (data-nats, management-service-core, api-service-core, client-core, gateway-service-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)