### PR TITLE
feat(presence): openframe-presence module + recordPresence mutation in api-service-core

### DIFF
--- a/openframe-api-service-core/pom.xml
+++ b/openframe-api-service-core/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>openframe-security-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.openframe.oss</groupId>
+            <artifactId>openframe-presence</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.netflix.graphql.dgs</groupId>
             <artifactId>graphql-dgs-spring-boot-starter</artifactId>
             <version>${netflix.dgs.version}</version>

--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/PresenceDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/PresenceDataFetcher.java
@@ -15,7 +15,6 @@ public class PresenceDataFetcher {
 
     private final UserPresenceService presenceService;
 
-    // Boolean is the GraphQL idiom for a payload-less mutation: true = accepted, failures surface as GraphQL errors, never as false.
     @DgsMutation
     public boolean recordPresence(@AuthenticationPrincipal AuthPrincipal principal) {
         String userId = requireHumanUserId(principal);

--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/PresenceDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/PresenceDataFetcher.java
@@ -1,0 +1,25 @@
+package com.openframe.api.datafetcher;
+
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsMutation;
+import com.openframe.data.service.presence.UserPresenceService;
+import com.openframe.security.authentication.AuthPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+import static com.openframe.api.support.CurrentPrincipalSupport.requireHumanUserId;
+
+@DgsComponent
+@RequiredArgsConstructor
+public class PresenceDataFetcher {
+
+    private final UserPresenceService presenceService;
+
+    // Boolean is the GraphQL idiom for a payload-less mutation: true = accepted, failures surface as GraphQL errors, never as false.
+    @DgsMutation
+    public boolean recordPresence(@AuthenticationPrincipal AuthPrincipal principal) {
+        String userId = requireHumanUserId(principal);
+        presenceService.markPresent(userId);
+        return true;
+    }
+}

--- a/openframe-api-service-core/src/main/resources/schema/presence.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/presence.graphqls
@@ -1,0 +1,8 @@
+extend type Mutation {
+    """
+    Heartbeat from an active human session: marks the caller present for the presence TTL.
+    Sent by the frontend while the tab/app is visible, plus immediately on regaining focus.
+    An optional context argument can be added later without breaking existing clients.
+    """
+    recordPresence: Boolean!
+}

--- a/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/PresenceDataFetcherTest.java
+++ b/openframe-api-service-core/src/test/java/com/openframe/api/datafetcher/PresenceDataFetcherTest.java
@@ -1,0 +1,68 @@
+package com.openframe.api.datafetcher;
+
+import com.openframe.core.exception.UnauthorizedException;
+import com.openframe.data.service.presence.UserPresenceService;
+import com.openframe.security.authentication.ActorType;
+import com.openframe.security.authentication.AuthPrincipal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class PresenceDataFetcherTest {
+
+    @Mock
+    private UserPresenceService presenceService;
+
+    @InjectMocks
+    private PresenceDataFetcher dataFetcher;
+
+    @Test
+    void record_presence_marks_the_caller_present() {
+        AuthPrincipal principal = AuthPrincipal.builder()
+                .id("user-1")
+                .actorType(ActorType.ADMIN)
+                .build();
+
+        assertTrue(dataFetcher.recordPresence(principal));
+
+        verify(presenceService).markPresent("user-1");
+    }
+
+    @Test
+    void agent_principal_is_rejected() {
+        AuthPrincipal principal = AuthPrincipal.builder()
+                .id("machine-1")
+                .actorType(ActorType.AGENT)
+                .build();
+
+        assertThrows(UnauthorizedException.class, () -> dataFetcher.recordPresence(principal));
+
+        verifyNoInteractions(presenceService);
+    }
+
+    @Test
+    void missing_principal_is_rejected() {
+        assertThrows(UnauthorizedException.class, () -> dataFetcher.recordPresence(null));
+
+        verifyNoInteractions(presenceService);
+    }
+
+    @Test
+    void principal_without_user_id_is_rejected() {
+        AuthPrincipal principal = AuthPrincipal.builder()
+                .actorType(ActorType.ADMIN)
+                .build();
+
+        assertThrows(UnauthorizedException.class, () -> dataFetcher.recordPresence(principal));
+
+        verifyNoInteractions(presenceService);
+    }
+}

--- a/openframe-presence/pom.xml
+++ b/openframe-presence/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.openframe.oss</groupId>
+        <artifactId>openframe-oss-lib</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>openframe-presence</artifactId>
+    <packaging>jar</packaging>
+    <name>OpenFrame Presence</name>
+    <description>User presence facts in Redis: heartbeat-written keys read by delivery pipelines to tell an active user from an absent one</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.openframe.oss</groupId>
+            <artifactId>openframe-data-redis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/openframe-presence/src/main/java/com/openframe/data/config/PresenceProperties.java
+++ b/openframe-presence/src/main/java/com/openframe/data/config/PresenceProperties.java
@@ -1,0 +1,22 @@
+package com.openframe.data.config;
+
+import lombok.Data;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "openframe.presence")
+public class PresenceProperties implements InitializingBean {
+
+    private long ttlSeconds;
+
+    @Override
+    public void afterPropertiesSet() {
+        if (ttlSeconds <= 0) {
+            throw new IllegalStateException(
+                    "openframe.presence.ttl-seconds must be set to a positive number of seconds — there is no default");
+        }
+    }
+}

--- a/openframe-presence/src/main/java/com/openframe/data/repository/presence/UserPresenceRepository.java
+++ b/openframe-presence/src/main/java/com/openframe/data/repository/presence/UserPresenceRepository.java
@@ -1,0 +1,53 @@
+package com.openframe.data.repository.presence;
+
+import com.openframe.data.config.PresenceProperties;
+import com.openframe.data.redis.OpenframeRedisKeyBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+// Cross-writer contract: presence:user:{userId} via tenantKey(), value = lastSeen epoch millis, idempotent SET only (never RMW); :ctx:{key} suffix reserved for context presence.
+@Repository
+@RequiredArgsConstructor
+public class UserPresenceRepository {
+
+    private static final String USER_KEY_PREFIX = "presence:user:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final OpenframeRedisKeyBuilder keyBuilder;
+    private final PresenceProperties properties;
+
+    public void markPresent(String userId) {
+        String key = userKey(userId);
+        long nowMillis = System.currentTimeMillis();
+        String lastSeen = String.valueOf(nowMillis);
+        long ttlSeconds = properties.getTtlSeconds();
+        Duration ttl = Duration.ofSeconds(ttlSeconds);
+        redisTemplate.opsForValue().set(key, lastSeen, ttl);
+    }
+
+    public boolean isPresent(String userId) {
+        String key = userKey(userId);
+        Boolean keyExists = redisTemplate.hasKey(key);
+        return Boolean.TRUE.equals(keyExists);
+    }
+
+    public Optional<Instant> findLastSeen(String userId) {
+        String key = userKey(userId);
+        String lastSeenMillis = redisTemplate.opsForValue().get(key);
+        if (lastSeenMillis == null) {
+            return Optional.empty();
+        }
+        long epochMillis = Long.parseLong(lastSeenMillis);
+        Instant lastSeen = Instant.ofEpochMilli(epochMillis);
+        return Optional.of(lastSeen);
+    }
+
+    private String userKey(String userId) {
+        return keyBuilder.tenantKey(USER_KEY_PREFIX + userId);
+    }
+}

--- a/openframe-presence/src/main/java/com/openframe/data/repository/presence/UserPresenceRepository.java
+++ b/openframe-presence/src/main/java/com/openframe/data/repository/presence/UserPresenceRepository.java
@@ -10,7 +10,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
-// Cross-writer contract: presence:user:{userId} via tenantKey(), value = lastSeen epoch millis, idempotent SET only (never RMW); :ctx:{key} suffix reserved for context presence.
 @Repository
 @RequiredArgsConstructor
 public class UserPresenceRepository {

--- a/openframe-presence/src/main/java/com/openframe/data/service/presence/UserPresenceService.java
+++ b/openframe-presence/src/main/java/com/openframe/data/service/presence/UserPresenceService.java
@@ -1,0 +1,27 @@
+package com.openframe.data.service.presence;
+
+import com.openframe.data.repository.presence.UserPresenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserPresenceService {
+
+    private final UserPresenceRepository presenceRepository;
+
+    public void markPresent(String userId) {
+        presenceRepository.markPresent(userId);
+    }
+
+    public boolean isPresentCurrently(String userId) {
+        return presenceRepository.isPresent(userId);
+    }
+
+    public Optional<Instant> findLastPresenceTime(String userId) {
+        return presenceRepository.findLastSeen(userId);
+    }
+}

--- a/openframe-presence/src/test/java/com/openframe/data/config/PresencePropertiesTest.java
+++ b/openframe-presence/src/test/java/com/openframe/data/config/PresencePropertiesTest.java
@@ -1,0 +1,24 @@
+package com.openframe.data.config;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PresencePropertiesTest {
+
+    @Test
+    void missing_ttl_fails_fast_on_startup() {
+        PresenceProperties properties = new PresenceProperties();
+
+        assertThrows(IllegalStateException.class, properties::afterPropertiesSet);
+    }
+
+    @Test
+    void configured_ttl_passes() {
+        PresenceProperties properties = new PresenceProperties();
+        properties.setTtlSeconds(30);
+
+        assertDoesNotThrow(properties::afterPropertiesSet);
+    }
+}

--- a/openframe-presence/src/test/java/com/openframe/data/repository/presence/UserPresenceRepositoryTest.java
+++ b/openframe-presence/src/test/java/com/openframe/data/repository/presence/UserPresenceRepositoryTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class UserPresenceRepositoryTest {
 
-    // The full key shape is the cross-writer contract — assert it literally, not via the builder.
     private static final String EXPECTED_KEY = "of:{tenant-1}:presence:user:user-1";
 
     @Mock

--- a/openframe-presence/src/test/java/com/openframe/data/repository/presence/UserPresenceRepositoryTest.java
+++ b/openframe-presence/src/test/java/com/openframe/data/repository/presence/UserPresenceRepositoryTest.java
@@ -1,0 +1,99 @@
+package com.openframe.data.repository.presence;
+
+import com.openframe.data.config.PresenceProperties;
+import com.openframe.data.redis.OpenframeRedisKeyBuilder;
+import com.openframe.data.redis.OpenframeRedisProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserPresenceRepositoryTest {
+
+    // The full key shape is the cross-writer contract — assert it literally, not via the builder.
+    private static final String EXPECTED_KEY = "of:{tenant-1}:presence:user:user-1";
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private UserPresenceRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        OpenframeRedisProperties redisProperties = new OpenframeRedisProperties();
+        redisProperties.setTenantId("tenant-1");
+        OpenframeRedisKeyBuilder keyBuilder = new OpenframeRedisKeyBuilder(redisProperties);
+        PresenceProperties presenceProperties = new PresenceProperties();
+        presenceProperties.setTtlSeconds(30);
+        repository = new UserPresenceRepository(redisTemplate, keyBuilder, presenceProperties);
+    }
+
+    @Test
+    void mark_present_writes_epoch_value_under_tenant_key_with_configured_ttl() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+        repository.markPresent("user-1");
+
+        ArgumentCaptor<String> value = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(eq(EXPECTED_KEY), value.capture(), eq(Duration.ofSeconds(30)));
+        assertTrue(Long.parseLong(value.getValue()) > 0);
+    }
+
+    @Test
+    void is_present_when_key_exists() {
+        when(redisTemplate.hasKey(EXPECTED_KEY)).thenReturn(true);
+
+        assertTrue(repository.isPresent("user-1"));
+    }
+
+    @Test
+    void is_absent_when_key_missing() {
+        when(redisTemplate.hasKey(EXPECTED_KEY)).thenReturn(false);
+
+        assertFalse(repository.isPresent("user-1"));
+    }
+
+    @Test
+    void is_absent_when_redis_returns_null() {
+        when(redisTemplate.hasKey(EXPECTED_KEY)).thenReturn(null);
+
+        assertFalse(repository.isPresent("user-1"));
+    }
+
+    @Test
+    void find_last_seen_parses_the_stored_epoch_millis() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(EXPECTED_KEY)).thenReturn("1700000000000");
+
+        Optional<Instant> lastSeen = repository.findLastSeen("user-1");
+
+        assertEquals(Optional.of(Instant.ofEpochMilli(1_700_000_000_000L)), lastSeen);
+    }
+
+    @Test
+    void find_last_seen_is_empty_when_key_missing() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(EXPECTED_KEY)).thenReturn(null);
+
+        assertEquals(Optional.empty(), repository.findLastSeen("user-1"));
+    }
+}

--- a/openframe-presence/src/test/java/com/openframe/data/service/presence/UserPresenceServiceTest.java
+++ b/openframe-presence/src/test/java/com/openframe/data/service/presence/UserPresenceServiceTest.java
@@ -1,0 +1,57 @@
+package com.openframe.data.service.presence;
+
+import com.openframe.data.repository.presence.UserPresenceRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserPresenceServiceTest {
+
+    @Mock
+    private UserPresenceRepository presenceRepository;
+
+    @InjectMocks
+    private UserPresenceService service;
+
+    @Test
+    void mark_present_delegates_to_the_repository() {
+        service.markPresent("user-1");
+
+        verify(presenceRepository).markPresent("user-1");
+    }
+
+    @Test
+    void is_present_currently_reflects_the_repository() {
+        when(presenceRepository.isPresent("user-1")).thenReturn(true);
+
+        assertTrue(service.isPresentCurrently("user-1"));
+        assertFalse(service.isPresentCurrently("user-2"));
+    }
+
+    @Test
+    void find_last_presence_time_returns_the_stored_instant() {
+        Instant lastSeen = Instant.ofEpochMilli(1_700_000_000_000L);
+        when(presenceRepository.findLastSeen("user-1")).thenReturn(Optional.of(lastSeen));
+
+        assertEquals(Optional.of(lastSeen), service.findLastPresenceTime("user-1"));
+    }
+
+    @Test
+    void find_last_presence_time_is_empty_for_an_absent_user() {
+        when(presenceRepository.findLastSeen("user-1")).thenReturn(Optional.empty());
+
+        assertEquals(Optional.empty(), service.findLastPresenceTime("user-1"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>openframe-data-mongo-sync</module>
         <module>openframe-data-mongo-reactive</module>
         <module>openframe-data-redis</module>
+        <module>openframe-presence</module>
         <module>openframe-notification-mail</module>
         <module>openframe-data-kafka</module>
         <module>openframe-api-lib</module>
@@ -123,6 +124,11 @@
             <dependency>
                 <groupId>com.openframe.oss</groupId>
                 <artifactId>openframe-data-redis</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.openframe.oss</groupId>
+                <artifactId>openframe-presence</artifactId>
                 <version>${revision}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Supersedes flamingo-stack/openframe-saas-lib#731 — presence moves to oss per review: the data side is a lib module any pipeline can depend on, and the GraphQL surface ships with the API lib, never as a transitive of a delivery dependency.

## What

**New module `openframe-presence`** (dep: `openframe-data-redis`) — user-level presence facts in Redis, layer packages:

- `data.repository.presence.UserPresenceRepository` — `markPresent` = idempotent `SET .. EX ttl`, `isPresent` = `EXISTS` (no key = absent), `findLastSeen` = stored lastSeen epoch millis as `Optional<Instant>`. Keys only via `OpenframeRedisKeyBuilder.tenantKey()`: `of:{tenantId}:presence:user:{userId}`; the key schema is the cross-writer contract, `...:ctx:{key}` reserved for future context presence.
- `data.service.presence.UserPresenceService` — the consumer layer: `markPresent`, `isPresentCurrently`, `findLastPresenceTime` (`Optional` on purpose — presence keys self-expire, so absence is a normal outcome and check-then-get would race the TTL).
- `data.config.PresenceProperties` — `openframe.presence.ttl-seconds`, **required, no default**: startup fails unless every environment declares it. Planned value 30s against the ~10s frontend heartbeat.

**`openframe-api-service-core`** — `PresenceDataFetcher` (`recordPresence: Boolean!`, AGENT principals rejected via `CurrentPrincipalSupport.requireHumanUserId`) + `schema/presence.graphqls`, next to the other shared datafetchers.

## Why

First step of context presence for the push pipeline: the saas push outbox will check `isPresentCurrently` at enqueue — an absent recipient skips the grace window (push goes out immediately), a present one keeps today's grace + cancel-on-read. A future dedicated WS writer is just a second `markPresent` caller (idempotent SET → writers can overlap during migration); per-context presence is new reserved keys, not a redesign.

## Tests

16/16 module + datafetcher (key-shape contract incl. hashtag namespace, TTL, null-safe EXISTS, lastSeen parsing, delegation, fail-fast config, AGENT/missing-principal rejection); full api-service-core suite green (309 tests).

## Rollout

Inert until a service declares `openframe.presence.ttl-seconds` (consumers of api-service-core will fail fast on startup after the bump until their configs declare it — the tenant wiring PR adds it). Push behavior changes only with the saas outbox flag, after the FE heartbeat ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKdcCJmnHipDNZe1qYqp9H