### PR TITLE
fix(api): resolve ScriptSchedule through the Relay node query

### DIFF
--- a/openframe-api-lib/src/main/java/com/openframe/api/relay/NodeType.java
+++ b/openframe-api-lib/src/main/java/com/openframe/api/relay/NodeType.java
@@ -15,6 +15,7 @@ public enum NodeType {
     LOG_DETAILS("LogDetails"),
     SCRIPT("Script"),
     SCRIPT_EXECUTION("ScriptExecution"),
+    SCRIPT_SCHEDULE("ScriptSchedule"),
     SCHEDULE_RUN("ScheduleRun");
 
     private final String graphqlTypeName;

--- a/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/NodeDataFetcher.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/datafetcher/NodeDataFetcher.java
@@ -12,6 +12,7 @@ import com.openframe.api.service.ToolConnectionService;
 import com.openframe.api.service.ToolService;
 import com.openframe.api.service.rmm.ScheduleRunService;
 import com.openframe.api.service.rmm.ScriptExecutionService;
+import com.openframe.api.service.rmm.ScriptScheduleService;
 import com.openframe.api.service.rmm.ScriptService;
 import com.openframe.data.repository.tenant.TenantRepository;
 import com.openframe.data.service.OrganizationService;
@@ -38,6 +39,7 @@ public class NodeDataFetcher {
     private final InstalledAgentService installedAgentService;
     private final ScriptService scriptService;
     private final ScriptExecutionService scriptExecutionService;
+    private final ScriptScheduleService scriptScheduleService;
     private final ScheduleRunService scheduleRunService;
 
     @Autowired(required = false)
@@ -78,6 +80,7 @@ public class NodeDataFetcher {
             case INSTALLED_AGENT -> installedAgentService.getInstalledAgent(globalId.getId()).orElse(null);
             case SCRIPT -> scriptService.findById(globalId.getId()).orElse(null);
             case SCRIPT_EXECUTION -> scriptExecutionService.findById(globalId.getId()).orElse(null);
+            case SCRIPT_SCHEDULE -> scriptScheduleService.findById(globalId.getId()).orElse(null);
             case SCHEDULE_RUN -> scheduleRunService.findById(globalId.getId()).orElse(null);
             case TENANT -> tenantRepository != null
                     ? tenantRepository.findById(globalId.getId()).orElse(null)

--- a/openframe-api-service-core/src/main/java/com/openframe/api/relay/NodeTypeResolver.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/relay/NodeTypeResolver.java
@@ -3,6 +3,7 @@ package com.openframe.api.relay;
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsTypeResolver;
 import com.openframe.api.dto.rmm.execution.ScriptExecutionResponse;
+import com.openframe.api.dto.rmm.schedule.ScriptScheduleResponse;
 import com.openframe.api.dto.rmm.schedulerun.ScheduleRunResponse;
 import com.openframe.api.dto.rmm.script.ScriptResponse;
 import com.openframe.data.document.assignment.ItemAssignment;
@@ -52,6 +53,9 @@ public class NodeTypeResolver {
         }
         if (node instanceof ScriptExecutionResponse) {
             return "ScriptExecution";
+        }
+        if (node instanceof ScriptScheduleResponse) {
+            return "ScriptSchedule";
         }
         if (node instanceof ScheduleRunResponse) {
             return "ScheduleRun";


### PR DESCRIPTION
## Problem

Paginating the device lists on a script schedule fails with HTTP 400:

```json
{"errors":[{"message":"Unknown Node type: ScriptSchedule","extensions":{"httpStatus":400,"code":"VALIDATION_ERROR"}}],"data":{"node":null}}
```

The first page renders (it comes from `scriptSchedule(id:)`), but "load more" — and any refetch triggered by a filter or search change — returns the error above and the list breaks.

## Cause

`ScriptSchedule implements Node`, and the dashboard's device lists are `@refetchable` fragments on it:

```graphql
fragment scriptScheduleDevicesRelay_schedule on ScriptSchedule
  @refetchable(queryName: "scriptScheduleDevicesRelayPaginationQuery")
```

Relay refetches such a fragment through the standard `node(id:)` query, **not** through the field the first page came from:

```graphql
query scriptScheduleDevicesRelayPaginationQuery(...) {
  node(id: $id) { __typename ...scriptScheduleDevicesRelay_schedule_2zR4qx id }
}
```

`NodeDataFetcher` decodes the global id `ScriptSchedule:<id>` and hands the type name to `NodeType.fromTypeName()`, which had no `ScriptSchedule` constant and threw.

Three frontend pagination queries hit this, all on `ScriptSchedule`:

- `scriptScheduleDevicesRelayPaginationQuery` — Assigned Devices tab
- `scheduleDevicePickerRelayPaginationQuery` — Available side of the device picker
- `scheduleDevicePickerRelayAssignedPaginationQuery` — Selected side of the device picker

## Fix

- `NodeType` — add `SCRIPT_SCHEDULE("ScriptSchedule")`.
- `NodeDataFetcher` — route it to `ScriptScheduleService.findById()`. That method already existed and was unused; it is the non-throwing lookup that keeps the same tenant scoping and `DELETED` filtering as the `scriptSchedule` query, so `node` cannot leak another tenant's schedule.
- `NodeTypeResolver` — map `ScriptScheduleResponse` → `"ScriptSchedule"`, otherwise DGS cannot resolve the concrete type behind the `Node` interface.

No schema change and no frontend change: the query was always correct, the resolver registry was missing an entry.

## Testing

Not built locally — no `mvn` or maven-wrapper available in my environment. Please let CI compile it. Manual check afterwards: open a schedule with >20 assigned devices, scroll the Assigned Devices tab past the first page, and change a filter — both previously returned the 400.