### PR TITLE
feat(device): PENDING_DELETION status while client uninstall is in flight

### DIFF
--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
@@ -4,6 +4,8 @@ import com.openframe.api.dto.force.request.ForceClientUninstallRequest;
 import com.openframe.api.dto.force.response.ForceAgentStatus;
 import com.openframe.api.dto.force.response.ForceClientUninstallResponse;
 import com.openframe.api.dto.force.response.ForceClientUninstallResponseItem;
+import com.openframe.data.document.device.DeviceStatus;
+import com.openframe.data.document.device.Machine;
 import com.openframe.data.nats.publisher.ClientUninstallNatsPublisher;
 import com.openframe.data.repository.device.MachineRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
@@ -41,18 +44,36 @@ public class ForceClientUninstallService {
 
     private ForceClientUninstallResponseItem processMachine(String machineId) {
         try {
-            if (machineRepository.findByMachineId(machineId).isEmpty()) {
+            Optional<Machine> foundMachine = machineRepository.findByMachineId(machineId);
+            if (foundMachine.isEmpty()) {
                 log.warn("Skipping client uninstall for unknown machine {}", machineId);
                 return buildResponseItem(machineId, ForceAgentStatus.FAILED);
             }
 
+            Machine machine = foundMachine.get();
+            if (machine.getStatus() == DeviceStatus.DELETED) {
+                log.warn("Skipping client uninstall for already deleted machine {}", machineId);
+                return buildResponseItem(machineId, ForceAgentStatus.FAILED);
+            }
+
             clientUninstallNatsPublisher.publish(machineId);
+
+            markPendingDeletion(machine);
 
             return buildResponseItem(machineId, ForceAgentStatus.PROCESSED);
         } catch (Exception e) {
             log.error("Failed to publish client uninstall command for machine {}", machineId, e);
             return buildResponseItem(machineId, ForceAgentStatus.FAILED);
         }
+    }
+
+    private void markPendingDeletion(Machine machine) {
+        if (machine.getStatus() == DeviceStatus.PENDING_DELETION) {
+            return;
+        }
+        machine.setStatus(DeviceStatus.PENDING_DELETION);
+        machineRepository.save(machine);
+        log.info("Machine {} marked PENDING_DELETION", machine.getMachineId());
     }
 
     private void validateMachineIds(List<String> machineIds) {

--- a/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
+++ b/openframe-api-service-core/src/main/java/com/openframe/api/service/ForceClientUninstallService.java
@@ -4,7 +4,6 @@ import com.openframe.api.dto.force.request.ForceClientUninstallRequest;
 import com.openframe.api.dto.force.response.ForceAgentStatus;
 import com.openframe.api.dto.force.response.ForceClientUninstallResponse;
 import com.openframe.api.dto.force.response.ForceClientUninstallResponseItem;
-import com.openframe.data.document.device.DeviceStatus;
 import com.openframe.data.document.device.Machine;
 import com.openframe.data.nats.publisher.ClientUninstallNatsPublisher;
 import com.openframe.data.repository.device.MachineRepository;
@@ -15,6 +14,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 
+import static com.openframe.data.document.device.DeviceStatus.DELETED;
+import static com.openframe.data.document.device.DeviceStatus.PENDING_DELETION;
 import static org.apache.commons.lang3.ObjectUtils.isEmpty;
 
 @Service
@@ -51,7 +52,7 @@ public class ForceClientUninstallService {
             }
 
             Machine machine = foundMachine.get();
-            if (machine.getStatus() == DeviceStatus.DELETED) {
+            if (machine.getStatus() == DELETED) {
                 log.warn("Skipping client uninstall for already deleted machine {}", machineId);
                 return buildResponseItem(machineId, ForceAgentStatus.FAILED);
             }
@@ -68,10 +69,10 @@ public class ForceClientUninstallService {
     }
 
     private void markPendingDeletion(Machine machine) {
-        if (machine.getStatus() == DeviceStatus.PENDING_DELETION) {
+        if (machine.getStatus() == PENDING_DELETION) {
             return;
         }
-        machine.setStatus(DeviceStatus.PENDING_DELETION);
+        machine.setStatus(PENDING_DELETION);
         machineRepository.save(machine);
         log.info("Machine {} marked PENDING_DELETION", machine.getMachineId());
     }

--- a/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
@@ -13,6 +13,12 @@ import org.springframework.stereotype.Service;
 
 import java.time.Instant;
 
+import static com.openframe.data.document.device.DeviceStatus.DELETED;
+import static com.openframe.data.document.device.DeviceStatus.OFFLINE;
+import static com.openframe.data.document.device.DeviceStatus.ONLINE;
+import static com.openframe.data.document.device.DeviceStatus.PENDING;
+import static com.openframe.data.document.device.DeviceStatus.PENDING_DELETION;
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -22,15 +28,15 @@ public class MachineStatusService {
     private final ApplicationEventPublisher eventPublisher;
 
     public void updateToOnline(String machineId, Instant eventTimestamp) {
-        update(machineId, DeviceStatus.ONLINE, eventTimestamp);
+        update(machineId, ONLINE, eventTimestamp);
     }
 
     public void updateToOffline(String machineId, Instant eventTimestamp) {
-        update(machineId, DeviceStatus.OFFLINE, eventTimestamp);
+        update(machineId, OFFLINE, eventTimestamp);
     }
 
     public void processHeartbeat(String machineId, Instant eventTimestamp) {
-        update(machineId, DeviceStatus.ONLINE, eventTimestamp);
+        update(machineId, ONLINE, eventTimestamp);
     }
 
     private void update(String machineId, DeviceStatus newStatus, Instant eventTimestamp) {
@@ -57,7 +63,7 @@ public class MachineStatusService {
 
     private boolean isDeletionInProgress(Machine machine) {
         DeviceStatus status = machine.getStatus();
-        return status == DeviceStatus.PENDING_DELETION || status == DeviceStatus.DELETED;
+        return status == PENDING_DELETION || status == DELETED;
     }
 
     private void applyStatusUpdate(Machine machine, DeviceStatus newStatus, Instant eventTimestamp) {
@@ -67,12 +73,12 @@ public class MachineStatusService {
         machineRepository.save(machine);
         log.debug("Updated machineId={} to status={} at {}", machine.getMachineId(), newStatus, eventTimestamp);
 
-        if (previousStatus == DeviceStatus.PENDING && (newStatus == DeviceStatus.ONLINE || newStatus == DeviceStatus.OFFLINE)) {
+        if (previousStatus == PENDING && (newStatus == ONLINE || newStatus == OFFLINE)) {
             log.info("Device first connected: machineId={}, transition {} -> {}", machine.getMachineId(), previousStatus, newStatus);
             eventPublisher.publishEvent(new DeviceFirstConnectedEvent(this, machine));
         }
 
-        if (previousStatus == DeviceStatus.OFFLINE && newStatus == DeviceStatus.ONLINE) {
+        if (previousStatus == OFFLINE && newStatus == ONLINE) {
             log.info("Device came online (offline->online): machineId={}", machine.getMachineId());
             eventPublisher.publishEvent(new DeviceCameOnlineEvent(this, machine));
         }

--- a/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/MachineStatusService.java
@@ -39,6 +39,11 @@ public class MachineStatusService {
         Machine machine = machineRepository.findByMachineId(machineId)
                 .orElseThrow(() -> new MachineNotFoundException(machineId));
 
+        if (isDeletionInProgress(machine)) {
+            log.debug("Ignoring {} event for machineId={} in status {}", newStatus, machineId, machine.getStatus());
+            return;
+        }
+
         if (isEventNewer(eventTimestamp, machine.getLastSeen())) {
             applyStatusUpdate(machine, newStatus, eventTimestamp);
         } else {
@@ -48,6 +53,11 @@ public class MachineStatusService {
 
     private boolean isEventNewer(Instant eventTimestamp, Instant lastSeen) {
         return lastSeen == null || eventTimestamp.isAfter(lastSeen);
+    }
+
+    private boolean isDeletionInProgress(Machine machine) {
+        DeviceStatus status = machine.getStatus();
+        return status == DeviceStatus.PENDING_DELETION || status == DeviceStatus.DELETED;
     }
 
     private void applyStatusUpdate(Machine machine, DeviceStatus newStatus, Instant eventTimestamp) {

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/device/DeviceStatus.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/device/DeviceStatus.java
@@ -8,6 +8,7 @@ public enum DeviceStatus {
     DECOMMISSIONED,
     ONLINE,
     OFFLINE,
+    PENDING_DELETION,
     DELETED,
     ARCHIVED
 } 


### PR DESCRIPTION
## Summary
Between "dashboard triggered uninstall" and "agent finished uninstalling and deregistered", the device is still alive and heartbeating — so it kept flipping back to ONLINE and looked healthy in the dashboard. This PR makes that window explicit:

- **`DeviceStatus.PENDING_DELETION`** — new status set by `ForceClientUninstallService` right after the uninstall command is published (machines already `DELETED` are skipped with a `FAILED` item instead of publishing a command that could only replay later).
- **`MachineStatusService`** now ignores connect/disconnect/heartbeat events for machines in `PENDING_DELETION` or `DELETED` — device-side signals can no longer resurrect a device that is being (or has been) deleted. This is the single funnel for all device-driven status flips (`ClientConnectionListener`, `MachineHeartbeatListener`); the management-side offline-detection job only queries `ONLINE` machines, so it needs no change.
- The agent's deregistration callback (`POST /api/agents/uninstall`) still transitions `PENDING_DELETION` → `DELETED` unchanged.

Deliberate escape hatch: an explicit `/register` or `/reinstall` still resets the status (to `PENDING`) — a human intentionally reinstalling the client on a machine outranks a stale pending deletion.

## Status flow
`ONLINE/OFFLINE` → (force uninstall published) → `PENDING_DELETION` → (agent deregisters) → `DELETED`

## Testing
- `mvn test-compile` clean across touched modules; no exhaustive switches over `DeviceStatus` exist, so the new enum value is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)