### PR TITLE
fix(ods): skeleton token must contrast with the card it loads on

### DIFF
--- a/openframe-frontend-core/src/styles/ods-colors.css
+++ b/openframe-frontend-core/src/styles/ods-colors.css
@@ -275,7 +275,13 @@
   --color-bg-hover: var(--ods-system-greys-black-hover);
   --color-bg-active: var(--ods-system-greys-black-action);
   --color-bg-overlay: rgba(33, 33, 33, 0.8);
-  --color-bg-skeleton: var(--ods-system-greys-black);
+  /* Skeletons must CONTRAST with the surface they load on. `greys-black` here
+     was byte-identical to --color-bg-card, so every `bg-ods-skeleton` pulse
+     sitting on a card was invisible — it only appeared while the row's hover
+     tint lightened the ground beneath it (people-hub score table, 2026-08).
+     `soft-grey` is what `ui/Skeleton` (bg-ods-border) already pulses with, so
+     the two skeleton primitives now read as one, in both themes. */
+  --color-bg-skeleton: var(--ods-system-greys-soft-grey);
   --color-bg-surface: var(--ods-system-greys-soft-grey);
   --color-bg-surface-hover: var(--ods-system-greys-soft-grey-hover);
   --color-bg-surface-active: var(--ods-system-greys-soft-grey-action);


### PR DESCRIPTION
## The bug

`--color-bg-skeleton` has pointed at `var(--ods-system-greys-black)` since the file was created — and `--color-bg-card` points at the **same** variable. Every `bg-ods-skeleton` pulse sitting on a card surface is therefore invisible: same color as its ground, `animate-pulse` oscillating opacity over a perfect camouflage.

Where it bit: the people-hub performance table. During the phase-2 "Loading scores…" fetch, every row renders `UnifiedSkeleton` circles/bars — all present in the DOM, all animating, all `#212121` on `#212121`. They only became visible when a row was hovered, because the hover tint lightens the ground beneath them. Measured live: skeleton `srgb(0.1294…)`, row background `srgb(0.1294…)` — byte-identical.

The lib's *other* skeleton (`ui/Skeleton`) never had this problem because it pulses with `bg-ods-border` → `soft-grey`.

## The fix

One line: `--color-bg-skeleton` now points at `var(--ods-system-greys-soft-grey)` — the same grey `ui/Skeleton` already uses. The two skeleton primitives now read as one, and both theme blocks are covered automatically since the semantic layer references the per-theme grey.

## Verification

Live on the people-hub score table with the scores fetch artificially frozen: skeleton `#3a3a3a` on row `#212121`, distinct, 150 pulses across every row — previously only visible under hover.

Blast radius: 23 `bg-ods-skeleton` call sites in the lib, 18 in the hub. All of them get *more* visible, none can get less — the previous value was the definition of invisible on cards, and on the page background (`#161616`) the new grey has strictly more contrast than the old one.

Needs a release + hub pin bump to reach previews/prod; local dev sees it via yalc already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)