### PR TITLE
fix(ui): FieldWrapper label matches Field's label scale

### DIFF
--- a/openframe-frontend-core/src/components/ui/field-wrapper.tsx
+++ b/openframe-frontend-core/src/components/ui/field-wrapper.tsx
@@ -38,7 +38,12 @@ const FieldWrapper = React.forwardRef<HTMLDivElement, FieldWrapperProps>(
     return (
       <div ref={ref} className={cn(hasChrome ? "relative flex w-full flex-col" : "contents", className)}>
         {label && (
-          <label className="text-h4 text-ods-text-primary mb-1">
+          // text-h6, NOT text-h4: `Field` (ui/field.tsx) renders its label via
+          // `Label variant="small"` = text-h6, and every form that mixes
+          // Field-wrapped controls with `label=`-prop controls showed two label
+          // sizes side by side — the exact inconsistency the admin editors kept
+          // reporting. One label scale, owned here and in Field together.
+          <label className="text-h6 text-ods-text-primary mb-1">
             {label}
           </label>
         )}

--- a/openframe-frontend-core/src/components/ui/label.tsx
+++ b/openframe-frontend-core/src/components/ui/label.tsx
@@ -11,7 +11,11 @@ const labelVariants = cva(
   {
     variants: {
       variant: {
-        default: "text-h4",
+        // default is text-h6, matching `Field`'s label (Label variant="small")
+        // and FieldWrapper — every bare <Label> is a form label, and the three
+        // primitives must agree on ONE label scale. Use variant="large" for an
+        // intentionally bigger label.
+        default: "text-h6",
         small: "text-h6",
         medium: "text-h6",
         large: "text-h4"


### PR DESCRIPTION
Two one-line fixes killing the last label-inconsistency root causes. `Field` (the canonical form label) renders `Label variant="small"` = **text-h6 / 14px**, but two sibling primitives disagreed:

1. **FieldWrapper** (chrome behind every `<Input label=…>` / `<Textarea label=…>`) hardcoded `text-h4` (18px) → now `text-h6`.
2. **Label's default variant** was `text-h4` (18px). All 43 bare `<Label>` call sites in the lib are form labels (booking form, contact form, SEO/OG editors, video/transcript/subtitles sections, changelog manager) — only one call site ever passes a variant. Default is now `text-h6`; `variant="large"` remains for intentionally big labels.

Measured on the onboarding-guide admin modal: form fields at 14px but 'Uploaded Video' / 'Video Summary' / 'Video Transcript' / 'Subtitles (SRT)' / 'Video Clips' / 'Highlight Video' at 18px in the same dialog — all traced to these two defaults. After the fix the dialog renders ONE label size.

Blast radius: every bare-Label and label=-prop consumer gets the 14px form-label scale — that is the point. `tsc --noEmit`: 0 errors. Needs release + hub pin bump for previews; local dev rides yalc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)