### PR TITLE
Client Chat: targetStatusKind on TICKET_EVENT - deterministic reopen subtitle

### DIFF
--- a/openframe-frontend-core/src/chat-protocol/__tests__/__snapshots__/nats-decoder-golden.test.ts.snap
+++ b/openframe-frontend-core/src/chat-protocol/__tests__/__snapshots__/nats-decoder-golden.test.ts.snap
@@ -412,9 +412,30 @@ exports[`decodeNatsChunk — golden corpus > maps the full recorded corpus to no
     "actorType": undefined,
     "kind": "RESOLVED",
     "reason": undefined,
+    "targetStatusKind": undefined,
+    "type": "ticket-event",
+  },
+  "ticket_event_blank_target_kind_dropped": {
+    "actorId": undefined,
+    "actorName": undefined,
+    "actorType": undefined,
+    "kind": "REOPENED",
+    "reason": undefined,
+    "seq": 415,
+    "targetStatusKind": undefined,
     "type": "ticket-event",
   },
   "ticket_event_missing_kind": null,
+  "ticket_event_reopened_target_kind": {
+    "actorId": "user-42",
+    "actorName": "John Smith",
+    "actorType": "CLIENT",
+    "kind": "REOPENED",
+    "reason": undefined,
+    "seq": 414,
+    "targetStatusKind": "AI_ASSISTANCE",
+    "type": "ticket-event",
+  },
   "ticket_event_reopened_with_reason": {
     "actorId": "user-42",
     "actorName": "John Smith",
@@ -422,6 +443,7 @@ exports[`decodeNatsChunk — golden corpus > maps the full recorded corpus to no
     "kind": "REOPENED",
     "reason": "The printer stopped working again",
     "seq": 413,
+    "targetStatusKind": undefined,
     "type": "ticket-event",
   },
   "ticket_event_resolved": {
@@ -431,6 +453,7 @@ exports[`decodeNatsChunk — golden corpus > maps the full recorded corpus to no
     "kind": "RESOLVED",
     "reason": undefined,
     "seq": 412,
+    "targetStatusKind": undefined,
     "type": "ticket-event",
   },
   "ticket_event_stream_seq_wins": {
@@ -440,6 +463,7 @@ exports[`decodeNatsChunk — golden corpus > maps the full recorded corpus to no
     "kind": "RESOLVED",
     "reason": undefined,
     "seq": 500,
+    "targetStatusKind": undefined,
     "type": "ticket-event",
   },
   "ticket_event_unknown_kind": {
@@ -448,6 +472,7 @@ exports[`decodeNatsChunk — golden corpus > maps the full recorded corpus to no
     "actorType": undefined,
     "kind": "ON_HOLD",
     "reason": undefined,
+    "targetStatusKind": undefined,
     "type": "ticket-event",
   },
   "token_usage": {

--- a/openframe-frontend-core/src/chat-protocol/__tests__/nats-decoder-golden.test.ts
+++ b/openframe-frontend-core/src/chat-protocol/__tests__/nats-decoder-golden.test.ts
@@ -279,6 +279,23 @@ const CORPUS: Record<string, unknown> = {
     sequenceId: 413,
   },
   ticket_event_unknown_kind: { type: 'TICKET_EVENT', kind: 'ON_HOLD', actorName: 'Roman Smith' },
+  // Where the ticket reopened INTO - decides the card's subtitle without
+  // guessing from the actor. Blank strings are folded to undefined.
+  ticket_event_reopened_target_kind: {
+    type: 'TICKET_EVENT',
+    kind: 'REOPENED',
+    actorId: 'user-42',
+    actorName: 'John Smith',
+    actorType: 'CLIENT',
+    targetStatusKind: 'AI_ASSISTANCE',
+    streamSeq: 414,
+  },
+  ticket_event_blank_target_kind_dropped: {
+    type: 'TICKET_EVENT',
+    kind: 'REOPENED',
+    targetStatusKind: '  ',
+    streamSeq: 415,
+  },
   ticket_event_missing_kind: { type: 'TICKET_EVENT', actorName: 'Fae' },
   ticket_event_blank_reason_dropped: { type: 'TICKET_EVENT', kind: 'RESOLVED', reason: '   ' },
   // Transport-stamped streamSeq wins over the payload's sequenceId copy.

--- a/openframe-frontend-core/src/chat-protocol/events.ts
+++ b/openframe-frontend-core/src/chat-protocol/events.ts
@@ -264,6 +264,8 @@ export interface TicketEventEvent extends ChatStreamEventBase {
   /** Who acted — e.g. an AI agent vs a human technician. Open string. */
   actorType?: string
   reason?: string
+  /** Kind-token the ticket reopened INTO (AI_ASSISTANCE / TECH_REQUIRED / ...). */
+  targetStatusKind?: string
 }
 
 /** Per-turn metadata. Raw wire values pass through UNVALIDATED — the

--- a/openframe-frontend-core/src/chat-protocol/nats-decoder.ts
+++ b/openframe-frontend-core/src/chat-protocol/nats-decoder.ts
@@ -393,6 +393,10 @@ export function decodeNatsChunk(chunk: unknown): ChatStreamEvent | null {
         actorType: typeof data.actorType === 'string' ? data.actorType : undefined,
         reason:
           typeof data.reason === 'string' && data.reason.trim() ? data.reason : undefined,
+        targetStatusKind:
+          typeof data.targetStatusKind === 'string' && data.targetStatusKind.trim()
+            ? data.targetStatusKind
+            : undefined,
         ...eventSeq,
       }
     }

--- a/openframe-frontend-core/src/components/chat/__tests__/ticket-event.test.ts
+++ b/openframe-frontend-core/src/components/chat/__tests__/ticket-event.test.ts
@@ -45,6 +45,7 @@ describe('decodeNatsChunk — TICKET_EVENT', () => {
       actorName: 'Fae',
       actorType: 'AI',
       reason: undefined,
+      targetStatusKind: undefined,
       seq: 7,
     })
   })
@@ -56,6 +57,15 @@ describe('decodeNatsChunk — TICKET_EVENT', () => {
 
   it('prefers the transport-stamped `streamSeq` over the payload copy', () => {
     expect(decodeNatsChunk(resolvedChunk(500, { sequenceId: 499 }))).toMatchObject({ seq: 500 })
+  })
+
+  it('decodes the reopen target kind and folds blanks to undefined', () => {
+    expect(
+      decodeNatsChunk({ type: 'TICKET_EVENT', kind: 'REOPENED', targetStatusKind: 'TECH_REQUIRED', streamSeq: 8 }),
+    ).toMatchObject({ targetStatusKind: 'TECH_REQUIRED' })
+    expect(
+      decodeNatsChunk({ type: 'TICKET_EVENT', kind: 'REOPENED', targetStatusKind: ' ', streamSeq: 9 }),
+    ).toMatchObject({ targetStatusKind: undefined })
   })
 
   it('keeps unknown kinds — the vocabulary is open', () => {
@@ -175,6 +185,15 @@ describe('processHistoricalMessages — ticket event', () => {
     expect(messages).toHaveLength(1)
     expect(events(messages[0].content)[0]).toMatchObject({
       data: { kind: 'REOPENED', reason: 'The printer stopped working again' },
+    })
+  })
+
+  it('replays the persisted reopen target kind', () => {
+    const { messages } = processHistoricalMessages([
+      historyRow('m1', { type: 'TICKET_EVENT', kind: 'REOPENED', targetStatusKind: 'AI_ASSISTANCE' }),
+    ])
+    expect(events(messages[0].content)[0]).toMatchObject({
+      data: { kind: 'REOPENED', targetStatusKind: 'AI_ASSISTANCE' },
     })
   })
 

--- a/openframe-frontend-core/src/components/chat/stream/chat-stream-reducer.ts
+++ b/openframe-frontend-core/src/components/chat/stream/chat-stream-reducer.ts
@@ -1376,6 +1376,7 @@ export function createChatStreamReducer(
             actorName: event.actorName,
             actorType: event.actorType,
             reason: event.reason,
+            targetStatusKind: event.targetStatusKind,
           },
           seq,
         )

--- a/openframe-frontend-core/src/components/chat/ticket-event-message.tsx
+++ b/openframe-frontend-core/src/components/chat/ticket-event-message.tsx
@@ -29,6 +29,14 @@ export interface TicketEventMessageProps extends HTMLAttributes<HTMLDivElement> 
   timestamp?: Date
 }
 
+/** Where the ticket reopened INTO → the "who picks it up next" line.
+ *  Kind-tokens per the lifecycle statuses; the vocabulary is open, so an
+ *  unrecognized target falls back to the actor heuristic below. */
+const REOPEN_TARGET_COPY: Record<string, string> = {
+  AI_ASSISTANCE: "The AI assistant will continue helping you in this conversation.",
+  TECH_REQUIRED: "A technician will reply when available.",
+}
+
 /**
  * Ticket lifecycle receipt — resolved / reopened / an unknown future kind.
  * Figma `ai-assistant-info` (type=resolved-fae | resolved-tech |
@@ -37,15 +45,16 @@ export interface TicketEventMessageProps extends HTMLAttributes<HTMLDivElement> 
  * Copy is composed client-side from the event's fields (unlike
  * `ticket_escalated`, whose body the backend authors):
  *   RESOLVED → "Resolved by {actorName}." under a green check;
- *   REOPENED → the reason when the wire carries one, otherwise who picks the
- *     conversation up next, inferred from `actorType` (an AI actor keeps
- *     assisting; anything else means a technician will reply);
+ *   REOPENED → the reason when the wire carries one; otherwise who picks the
+ *     conversation up next — `targetStatusKind` decides deterministically,
+ *     with the `actorType` heuristic as the fallback for older backends
+ *     that don't send the target;
  *   unknown kind → a neutral info line: humanized kind as the title, the
  *     reason or actor as the body. Never dropped — the vocabulary is open.
  */
 const TicketEventMessage = forwardRef<HTMLDivElement, TicketEventMessageProps>(
   ({ data, timestamp, ...props }, ref) => {
-    const { kind, actorName, actorType, reason } = data
+    const { kind, actorName, actorType, reason, targetStatusKind } = data
     const resolved = kind === TICKET_EVENT_KIND.RESOLVED
     const reopened = kind === TICKET_EVENT_KIND.REOPENED
 
@@ -55,11 +64,12 @@ const TicketEventMessage = forwardRef<HTMLDivElement, TicketEventMessageProps>(
     if (resolved) {
       body = actorName ? `Resolved by ${actorName}.` : "The ticket has been resolved."
     } else if (reopened) {
-      body = reason
-        ? `Reason: ${reason}`
-        : isAiActor(actorType)
+      body =
+        (reason ? `Reason: ${reason}` : undefined) ??
+        (targetStatusKind ? REOPEN_TARGET_COPY[targetStatusKind] : undefined) ??
+        (isAiActor(actorType)
           ? `${actorName || "Fae"} will continue assisting in this conversation.`
-          : "A technician will reply when available."
+          : "A technician will reply when available.")
     } else {
       body = reason || (actorName ? `By ${actorName}.` : undefined)
     }

--- a/openframe-frontend-core/src/components/chat/types/message.types.ts
+++ b/openframe-frontend-core/src/components/chat/types/message.types.ts
@@ -185,6 +185,11 @@ export interface TicketEventData {
   /** Who acted — e.g. an AI agent vs a human. Open string like `kind`. */
   actorType?: string
   reason?: string
+  /** Kind-token of the status the ticket reopened INTO (AI_ASSISTANCE /
+   *  TECH_REQUIRED / CUSTOM / ...) — same open vocabulary the lifecycle
+   *  statuses use. Picks the REOPENED card's subtitle deterministically;
+   *  absent on RESOLVED events and older backends. */
+  targetStatusKind?: string
 }
 
 /**
@@ -483,6 +488,7 @@ export interface TicketEventMessageData extends MessageDataBase {
   actorName?: string | null
   actorType?: string | null
   reason?: string | null
+  targetStatusKind?: string | null
 }
 
 export interface ErrorMessageData extends MessageDataBase {

--- a/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
+++ b/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
@@ -562,7 +562,8 @@ export class MessageSegmentAccumulator {
         s.data.actorId === data.actorId &&
         s.data.actorName === data.actorName &&
         s.data.actorType === data.actorType &&
-        s.data.reason === data.reason
+        s.data.reason === data.reason &&
+        s.data.targetStatusKind === data.targetStatusKind
       )
     })
     if (existingIndex !== -1) {

--- a/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
+++ b/openframe-frontend-core/src/components/chat/utils/process-historical-messages.ts
@@ -257,6 +257,10 @@ export function decodeHistoricalMessageData(data: MessageData): ChatStreamEvent 
         actorName: typeof data.actorName === 'string' ? data.actorName : undefined,
         actorType: typeof data.actorType === 'string' ? data.actorType : undefined,
         reason: typeof data.reason === 'string' && data.reason.trim() ? data.reason : undefined,
+        targetStatusKind:
+          typeof data.targetStatusKind === 'string' && data.targetStatusKind.trim()
+            ? data.targetStatusKind
+            : undefined,
       }
     }
 
@@ -364,6 +368,7 @@ function applyHistoryEvent(
         actorName: event.actorName,
         actorType: event.actorType,
         reason: event.reason,
+        targetStatusKind: event.targetStatusKind,
       })
       break
 

--- a/openframe-frontend-core/src/stories/TicketEventMessage.stories.tsx
+++ b/openframe-frontend-core/src/stories/TicketEventMessage.stories.tsx
@@ -71,18 +71,26 @@ export const ReopenedWithReason: Story = {
 	},
 };
 
-/** Reopened, no reason, AI keeps assisting — Figma type=reopened-fae. */
+/** Reopened into AI Assistance (targetStatusKind decides) — Figma type=reopened-fae. */
 export const ReopenedFaeContinues: Story = {
 	args: {
-		data: { kind: "REOPENED", actorId: "fae", actorName: "Fae", actorType: "AI" },
+		data: { kind: "REOPENED", actorId: "u-7", actorName: "John Smith", actorType: "CLIENT", targetStatusKind: "AI_ASSISTANCE" },
 		timestamp: TIMESTAMP,
 	},
 };
 
-/** Reopened, no reason, routed to a human — Figma type=reopened-tech. */
+/** Reopened into Tech Required (targetStatusKind decides) — Figma type=reopened-tech. */
 export const ReopenedTechnicianReplies: Story = {
 	args: {
-		data: { kind: "REOPENED", actorId: "u-42", actorName: "Roman Smith", actorType: "TECHNICIAN" },
+		data: { kind: "REOPENED", actorId: "u-7", actorName: "John Smith", actorType: "CLIENT", targetStatusKind: "TECH_REQUIRED" },
+		timestamp: TIMESTAMP,
+	},
+};
+
+/** Older backend without targetStatusKind — the actorType heuristic still decides. */
+export const ReopenedLegacyActorFallback: Story = {
+	args: {
+		data: { kind: "REOPENED", actorId: "fae", actorName: "Fae", actorType: "AI" },
 		timestamp: TIMESTAMP,
 	},
 };


### PR DESCRIPTION
## Summary

The backend now sends **where the ticket reopened INTO** (`targetStatusKind` kind-token: `AI_ASSISTANCE` / `TECH_REQUIRED` / ...) on the `TICKET_EVENT` chunk and the persisted `TicketEventData` row - agreed in ClickUp 86ajnyctz and already deployed. This closes the contract gap where the REOPENED card guessed who picks the conversation up from the actor: a customer reply can land in either stage, so the actor alone could not tell "the AI continues" from "a technician will reply".

- Field on `TicketEventData` / `TicketEventMessageData` / `TicketEventEvent`, parsed on both paths (blank strings fold to `undefined`), included in the dedupe payload-equality
- REOPENED subtitle priority: `reason` -> `targetStatusKind` mapping -> the legacy `actorType` heuristic (kept for older backends)
- Copy says **"The AI assistant"**, not "Fae": the assistant display name is tenant-branded, so the mock's hardcoded name would mislabel white-label tenants - flagged for the designer

Consumers already select the field (openframe-oss-frontend#228, openframe-saas-tenant#2614) - it renders once this releases and the apps bump.

## Testing

- 2 new golden-corpus decoder cases (target kind decoded, blank folded)
- decode/history cases in the ticket-event suite; full suite 4812/4812
- Stories: reopened variants now driven by `targetStatusKind` + a legacy actor-fallback story
- type-check + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)