### PR TITLE
feat(device): add PENDING_DELETION to DeviceStatus GraphQL enum

### DIFF
--- a/openframe-api-service-core/src/main/resources/schema/device.graphqls
+++ b/openframe-api-service-core/src/main/resources/schema/device.graphqls
@@ -86,6 +86,7 @@ enum DeviceStatus {
     DECOMMISSIONED,
     ONLINE,
     OFFLINE,
+    PENDING_DELETION,
     DELETED,
     ARCHIVED
 }


### PR DESCRIPTION
Follow-up to #1794, which added `PENDING_DELETION` to the Java `DeviceStatus` enum but not to the GraphQL schema. This adds the value to the `DeviceStatus` enum in `device.graphqls` (same position as in the Java enum) so devices in this status can be returned and filtered via GraphQL without schema validation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)