### PR TITLE
chore: track released version in revision (retire 999-SNAPSHOT default)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <url>https://github.com/flamingo-stack/openframe-oss-lib</url>
 
     <properties>
-        <revision>999-SNAPSHOT</revision>
+        <revision>6.25.22</revision>
         <java.version>21</java.version>
         <lombok.version>1.18.30</lombok.version>
         <spring-data-mongodb.version>4.2.0</spring-data-mongodb.version>


### PR DESCRIPTION
Revision should equal the released version so a local build of the lib matches what downstream references. Then: checkout oss-lib + saas-tenant, build the lib, build tenant — and tenant picks up the local lib build without manually switching versions to snapshot in two places.

999-SNAPSHOT broke this: it's higher than any release, so a local lib build never matches the pinned release version that saas-tenant references.

Set <revision> to the current release (6.25.22, same as saas-tenant / saas-lib reference). Renovate keeps it in sync on every release after, like saas-lib.