### PR TITLE
[AUTH] Rejected refresh must not clear auth cookies (prod kick-out fix)

### DIFF
--- a/openframe-security-oauth/src/main/java/com/openframe/security/oauth/controller/OAuthBffController.java
+++ b/openframe-security-oauth/src/main/java/com/openframe/security/oauth/controller/OAuthBffController.java
@@ -116,11 +116,23 @@ public class OAuthBffController {
 
         return tokensMono
                 .map(tokens -> buildNoContentWithCookies(tokens, includeHeaders))
-                .switchIfEmpty(Mono.fromSupplier(this::unauthorizedWithClearedCookies))
+                // A rejected/unknown refresh token must NOT clear cookies. With rotation
+                // (reuseRefreshTokens=false), concurrent refreshes race: the winner rotates the
+                // token and Set-Cookies the new one; the loser's stale token lands here — and
+                // wiping cookies in that response destroys the winner's freshly established
+                // session (observed in prod: a login killed 150ms after completion by a stale
+                // refresh from the previous session). A plain 401 leaves the browser's current —
+                // possibly newer and valid — cookies intact; explicit /logout remains the only
+                // place that clears an established session.
+                .switchIfEmpty(Mono.fromSupplier(this::unauthorized))
                 .onErrorResume(InvalidRefreshTokenException.class, e -> {
-                    log.warn("Refresh rejected: {}", e.getMessage());
-                    return Mono.just(unauthorizedWithClearedCookies());
+                    log.warn("Refresh rejected (cookies preserved): {}", e.getMessage());
+                    return Mono.just(unauthorized());
                 });
+    }
+
+    private ResponseEntity<Void> unauthorized() {
+        return ResponseEntity.status(401).build();
     }
 
     @GetMapping("/logout")


### PR DESCRIPTION
Root cause of the recurring "users kicked out of prod" reports.

**Mechanism** — three interlocking parts:
1. Refresh rotation (`reuseRefreshTokens=false`): every refresh invalidates the previous token, so stale copies exist by design (parallel tabs, in-flight requests, WS-reconnect refresh triggers).
2. Concurrent refreshes race; the loser presents a rotated-away token → `invalid_grant`.
3. The BFF answered that with `unauthorizedWithClearedCookies()` — wiping the winner's freshly rotated, valid cookie and destroying a healthy session.

**Prod evidence** (`oauth2_authorizations` + gateway logs, tenant `2f9fdf74…`): user logs in at `17:35:14.475`; a stale refresh from their previous session lands at `17:35:14.622` — 150ms later — and its response wipes the brand-new cookies. User is kicked immediately after logging in. Repeats ~daily across tenants.

**Change**: rejected (`invalid_grant`) or unknown refresh tokens return a plain 401 with cookies preserved. The no-token branch still clears (nothing valid to protect), and explicit `/oauth/logout` remains the only path that clears an established session.

**Follow-ups** (separate): refresh coalescing in the BFF (Redis-backed, dedupes concurrent refreshes across replicas) and/or frontend single-flight refresh — either removes the race itself; this PR removes its blast damage.

**Verification after deploy**: the log correlation that defines a kick — `invalid_grant` refresh followed within minutes by a fresh `authorization_code` login from the same tenant — should disappear; `Refresh rejected (cookies preserved)` entries may remain and are harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)