### PR TITLE
fix(chat+tickets): stale card status (NEW-on-CLOSED) + search clear leaving stale URL params

### DIFF
--- a/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
@@ -73,13 +73,19 @@ export function useChatCardItem<T = unknown>(
     // user toggles back to the tab is wasteful (the row's id-keyed
     // payload is effectively immutable).
     refetchOnWindowFocus: false,
-    // The id-keyed payload is effectively immutable, and a fetch-mode card
-    // inside a STREAMING assistant message re-mounts on every chunk as the
-    // surrounding markdown re-parses. Without a staleTime that meant a fresh
-    // network fetch + loading-skeleton flash on every single chunk. Treat the
-    // row as fresh for 5 min (matches the public pages) and keep it cached
-    // long after unmount so remounts resolve synchronously from cache — no
-    // refetch, no skeleton flash.
+    // A fetch-mode card inside a STREAMING assistant message re-mounts on
+    // every chunk as the surrounding markdown re-parses. Without a staleTime
+    // that meant a fresh network fetch + loading-skeleton flash on every
+    // single chunk. Treat the row as fresh for 5 min (matches the public
+    // pages) and keep it cached long after unmount so remounts resolve
+    // synchronously from cache — no refetch, no skeleton flash.
+    //
+    // MUTABLE ENTITIES (tickets, tasks): the 5-min freshness is NOT an
+    // immutability claim. When a confirmed tool action mutates an entity,
+    // `use-chat-stream-reducer` invalidates every ['chat-card-item', *, id]
+    // entry for it on the `approval-resolved` event — the receipt card (and
+    // any earlier card of the same entity) refetches the post-mutation row.
+    // Keep that invalidation in sync with this queryKey shape.
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
   })

--- a/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
+++ b/openframe-frontend-core/src/components/chat/hooks/use-chat-card-item.ts
@@ -10,9 +10,9 @@
  * `/case-studies`, `/podcasts`, `/roadmap`, etc.
  *
  * Batching: every compact card with the same `(type, id)` shares one
- * TanStack-Query entry; multiple refs of the same type in the same
- * chat message produce ONE network request (TanStack dedups by
- * queryKey). 5-minute staleTime matches `RelatedContentSection`.
+ * TanStack-Query entry; CONCURRENT refs of the same type in the same
+ * chat message produce ONE network request (TanStack dedups in-flight
+ * fetches by queryKey). Data is always stale — see the query options.
  *
  * URL builder is read from `runtime.endpoints.buildListUrl` so the
  * embedded app can supply a per-type URL builder against the reverse
@@ -68,25 +68,15 @@ export function useChatCardItem<T = unknown>(
       return (match ?? null) as T | null
     },
     enabled: !!url && id.length > 0,
-    // Don't refetch on window focus inside the chat — the chat panel
-    // is opened and closed frequently, and re-fetching every time the
-    // user toggles back to the tab is wasteful (the row's id-keyed
-    // payload is effectively immutable).
-    refetchOnWindowFocus: false,
-    // A fetch-mode card inside a STREAMING assistant message re-mounts on
-    // every chunk as the surrounding markdown re-parses. Without a staleTime
-    // that meant a fresh network fetch + loading-skeleton flash on every
-    // single chunk. Treat the row as fresh for 5 min (matches the public
-    // pages) and keep it cached long after unmount so remounts resolve
-    // synchronously from cache — no refetch, no skeleton flash.
-    //
-    // MUTABLE ENTITIES (tickets, tasks): the 5-min freshness is NOT an
-    // immutability claim. When a confirmed tool action mutates an entity,
-    // `use-chat-stream-reducer` invalidates every ['chat-card-item', *, id]
-    // entry for it on the `approval-resolved` event — the receipt card (and
-    // any earlier card of the same entity) refetches the post-mutation row.
-    // Keep that invalidation in sync with this queryKey shape.
-    staleTime: 5 * 60 * 1000,
+    // ALWAYS FRESH — no freshness window. Card entities are mutable
+    // (tickets, tasks change status), so a cached row is a lie waiting to
+    // render: a 5-min staleTime shipped a "NEW" badge on a ticket the
+    // receipt right above it said was just CLOSED (2026-08-18). Every
+    // mount refetches. `gcTime` is kept ONLY as render continuity: a card
+    // inside a STREAMING assistant message re-mounts on every chunk as the
+    // surrounding markdown re-parses, and the previous data renders while
+    // the refetch is in flight — no skeleton flash, never stale-forever.
+    staleTime: 0,
     gcTime: 30 * 60 * 1000,
   })
   return {

--- a/openframe-frontend-core/src/components/chat/stream/use-chat-stream-reducer.ts
+++ b/openframe-frontend-core/src/components/chat/stream/use-chat-stream-reducer.ts
@@ -16,7 +16,6 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
-import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import type { ChatStreamEvent } from '../../../chat-protocol/events'
 import {
   DEFAULT_DIALOG_SIDE,
@@ -33,35 +32,6 @@ import type {
 interface DialogKey {
   dialogId: string
   side: ChatDialogSide
-}
-
-/** QueryClient when a provider is mounted, null otherwise. The chat shell
- *  does not REQUIRE react-query (a provider-less embedder can still chat) —
- *  but when cards are in play a provider is always present (their
- *  `useChatCardItem` hard-depends on it), so mutation invalidation works
- *  exactly where it matters. Unconditional hook call → order-stable. */
-function useOptionalQueryClient(): QueryClient | null {
-  try {
-    return useQueryClient()
-  } catch {
-    return null
-  }
-}
-
-/** A confirmed tool action mutated this entity — mark every cached card
- *  row for that id stale so receipt cards (and any earlier card of the
- *  same entity in the transcript) refetch the post-mutation state.
- *  Without this, `useChatCardItem`'s 5-min staleTime serves the
- *  PRE-mutation row: observed live 2026-08-18 as a "NEW" badge on a
- *  ticket the receipt itself said was just CLOSED. */
-function invalidateMutatedEntityCards(queryClient: QueryClient | null, event: ChatStreamEvent): void {
-  if (!queryClient) return
-  if (event.type !== 'approval-resolved' || event.status !== 'approved') return
-  const mutatedId = (event.result as { ticket_id?: string } | undefined)?.ticket_id
-  if (!mutatedId) return
-  void queryClient.invalidateQueries({
-    predicate: (q) => q.queryKey[0] === 'chat-card-item' && q.queryKey[2] === mutatedId,
-  })
 }
 
 export interface UseChatStreamReducerOptions {
@@ -129,7 +99,6 @@ export function useChatStreamReducer({
 
   const flushDeltas = useCallback(() => batcher.flush(), [batcher])
 
-  const queryClient = useOptionalQueryClient()
   const applyEvent = useCallback(
     (event: ChatStreamEvent) => {
       // `push` flushes on key change and returns false for non-delta events;
@@ -138,12 +107,8 @@ export function useChatStreamReducer({
       if (batcher.push(event, keyRef.current)) return
       batcher.flush()
       store.apply(dialogId, side, event)
-      // Post-apply side effect: an approved tool action invalidates the
-      // mutated entity's cached card rows (see helper above). Runs at the
-      // applyEvent boundary so BOTH transports (SSE + NATS) get it.
-      invalidateMutatedEntityCards(queryClient, event)
     },
-    [batcher, store, dialogId, side, queryClient],
+    [batcher, store, dialogId, side],
   )
 
   // Flush on unmount so a torn-down panel doesn't drop its tail deltas.

--- a/openframe-frontend-core/src/components/chat/stream/use-chat-stream-reducer.ts
+++ b/openframe-frontend-core/src/components/chat/stream/use-chat-stream-reducer.ts
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
 import type { ChatStreamEvent } from '../../../chat-protocol/events'
 import {
   DEFAULT_DIALOG_SIDE,
@@ -32,6 +33,35 @@ import type {
 interface DialogKey {
   dialogId: string
   side: ChatDialogSide
+}
+
+/** QueryClient when a provider is mounted, null otherwise. The chat shell
+ *  does not REQUIRE react-query (a provider-less embedder can still chat) —
+ *  but when cards are in play a provider is always present (their
+ *  `useChatCardItem` hard-depends on it), so mutation invalidation works
+ *  exactly where it matters. Unconditional hook call → order-stable. */
+function useOptionalQueryClient(): QueryClient | null {
+  try {
+    return useQueryClient()
+  } catch {
+    return null
+  }
+}
+
+/** A confirmed tool action mutated this entity — mark every cached card
+ *  row for that id stale so receipt cards (and any earlier card of the
+ *  same entity in the transcript) refetch the post-mutation state.
+ *  Without this, `useChatCardItem`'s 5-min staleTime serves the
+ *  PRE-mutation row: observed live 2026-08-18 as a "NEW" badge on a
+ *  ticket the receipt itself said was just CLOSED. */
+function invalidateMutatedEntityCards(queryClient: QueryClient | null, event: ChatStreamEvent): void {
+  if (!queryClient) return
+  if (event.type !== 'approval-resolved' || event.status !== 'approved') return
+  const mutatedId = (event.result as { ticket_id?: string } | undefined)?.ticket_id
+  if (!mutatedId) return
+  void queryClient.invalidateQueries({
+    predicate: (q) => q.queryKey[0] === 'chat-card-item' && q.queryKey[2] === mutatedId,
+  })
 }
 
 export interface UseChatStreamReducerOptions {
@@ -99,6 +129,7 @@ export function useChatStreamReducer({
 
   const flushDeltas = useCallback(() => batcher.flush(), [batcher])
 
+  const queryClient = useOptionalQueryClient()
   const applyEvent = useCallback(
     (event: ChatStreamEvent) => {
       // `push` flushes on key change and returns false for non-delta events;
@@ -107,8 +138,12 @@ export function useChatStreamReducer({
       if (batcher.push(event, keyRef.current)) return
       batcher.flush()
       store.apply(dialogId, side, event)
+      // Post-apply side effect: an approved tool action invalidates the
+      // mutated entity's cached card rows (see helper above). Runs at the
+      // applyEvent boundary so BOTH transports (SSE + NATS) get it.
+      invalidateMutatedEntityCards(queryClient, event)
     },
-    [batcher, store, dialogId, side],
+    [batcher, store, dialogId, side, queryClient],
   )
 
   // Flush on unmount so a torn-down panel doesn't drop its tail deltas.

--- a/openframe-frontend-core/src/components/shared/dev-section/dev-section-view.tsx
+++ b/openframe-frontend-core/src/components/shared/dev-section/dev-section-view.tsx
@@ -21,6 +21,7 @@ import { SearchInput } from '../../ui';
 import { StatusFilterComponent } from '../../features';
 import {
   OPENFRAME_DEV_SECTIONS,
+  type OpenframeDevSection,
   type OpenframeDevSectionKey,
 } from '../../../utils/dev-sections/openframe-dev-sections';
 
@@ -65,7 +66,11 @@ export function DevSectionView({ sectionKey, hero, preControls, children, showHe
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const search = section.search;
+  // Widen from the registry's per-section literal types to the interface —
+  // optional fields (`clearParamKeys`) exist on the interface but not on
+  // every section's inferred literal. Sound: the registry `satisfies`
+  // `Record<string, OpenframeDevSection>`.
+  const search: OpenframeDevSection['search'] = section.search;
   const filter = section.filter;
 
   const currentSearch = search ? searchParams.get(search.paramKey) || '' : '';
@@ -73,8 +78,11 @@ export function DevSectionView({ sectionKey, hero, preControls, children, showHe
     ? searchParams.get(filter.paramKey) || filter.defaultValue
     : '';
 
-  // Controlled search-input state — input commits to the URL only on
-  // Enter (not on every keystroke), preserving the legacy behavior.
+  // Controlled search-input state — TYPING commits to the URL only on
+  // Enter (not on every keystroke), but CLEARING commits immediately:
+  // an emptied input must not keep filtering the list (the URL param —
+  // and any linked `clearParamKeys` companion like the tickets
+  // `?ticket=` drawer param — previously survived until Enter).
   // Lazy init from URL avoids a brief flash of stale value on first
   // paint after URL-driven re-render (e.g. tab switch).
   const [searchValue, setSearchValue] = useState(() => currentSearch);
@@ -85,9 +93,21 @@ export function DevSectionView({ sectionKey, hero, preControls, children, showHe
   const handleSearchSubmit = (value: string) => {
     if (!search) return;
     const params = new URLSearchParams(searchParams.toString());
-    if (value.trim()) params.set(search.paramKey, value.trim());
-    else params.delete(search.paramKey);
-    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    if (value.trim()) {
+      params.set(search.paramKey, value.trim());
+    } else {
+      params.delete(search.paramKey);
+      // Empty commit tears down the search's linked companion params too
+      // (deep links set them TOGETHER — see the config field docs).
+      for (const key of search.clearParamKeys ?? []) params.delete(key);
+    }
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  };
+
+  const handleSearchChange = (value: string) => {
+    setSearchValue(value);
+    if (value === '' && currentSearch !== '') handleSearchSubmit('');
   };
 
   const handleFilterChange = (value: string) => {
@@ -129,7 +149,7 @@ export function DevSectionView({ sectionKey, hero, preControls, children, showHe
               showDropdown={false}
               placeholder={search.placeholder}
               value={searchValue}
-              onChange={setSearchValue}
+              onChange={handleSearchChange}
               onSubmit={handleSearchSubmit}
             />
           )}

--- a/openframe-frontend-core/src/utils/dev-sections/openframe-dev-sections.ts
+++ b/openframe-frontend-core/src/utils/dev-sections/openframe-dev-sections.ts
@@ -30,7 +30,7 @@
 
 import { Map as MapIcon, Wrench, Rocket, GraduationCap, LifeBuoy, type LucideIcon } from 'lucide-react'
 import { releaseStatusOptions } from '../../types'
-import { DEV_SECTION_PARAM_KEYS } from './dev-section-param-keys'
+import { DEV_SECTION_PARAM_KEYS, TICKET_OPEN_PARAM } from './dev-section-param-keys'
 
 // Roadmap status options — `as const` preserves readonly tuple typing
 // across the registry boundary.
@@ -78,6 +78,12 @@ export interface OpenframeDevSection {
     placeholder: string
     /** URL search param the input writes on submit and the list reads on fetch. */
     paramKey: string
+    /** Companion URL params torn down whenever the search commits EMPTY.
+     *  For params that deep-links set TOGETHER with the search (e.g. the
+     *  tickets `?ticket=<id>&search=<id>` pair from chat cards) — clearing
+     *  the search must clear the whole linked context, not leave a stale
+     *  companion param filtering the view. */
+    clearParamKeys?: readonly string[]
   } | null
   /** Filter pill row configuration. `null` when the section has no filter (e.g. onboarding-guides). */
   filter: {
@@ -173,7 +179,14 @@ export const OPENFRAME_DEV_SECTIONS = {
       description:
         'Open new tickets, follow up on existing ones, and track responses from the team — all in one place.',
     },
-    search: { placeholder: 'Search your tickets...', paramKey: DEV_SECTION_PARAM_KEYS.search },
+    search: {
+      placeholder: 'Search your tickets...',
+      paramKey: DEV_SECTION_PARAM_KEYS.search,
+      // Chat-card deep links arrive as `?ticket=<id>&search=<id>`
+      // (buildTicketOpenHref) — clearing the search resets the whole
+      // linked context, drawer param included.
+      clearParamKeys: [TICKET_OPEN_PARAM],
+    },
     filter: {
       label: 'Status',
       paramKey: DEV_SECTION_PARAM_KEYS.status,


### PR DESCRIPTION
## Bug 1 — receipt says CLOSED, card badge says NEW (openframe chat, 2026-08-18)

Cards hydrate API-driven by id (`useChatCardItem`), but the hook cached each `(type, id)` row with a 5-minute `staleTime` under the assumption the payload is *"effectively immutable"* — false for tickets/tasks. A card fetched earlier in the conversation (ticket still NEW) kept serving the pre-mutation row when the update receipt rendered the same entity.

**Fix: no freshness window at all.** `staleTime: 0` — every card mount refetches; `gcTime` is kept ONLY as render continuity (a card inside a streaming message re-mounts per chunk; previous data renders while the refetch is in flight — no skeleton flash, never stale). No invalidation choreography, nothing to keep in sync — cards are simply always fresh. (An earlier revision of this PR wired event-driven cache invalidation through the stream reducer; replaced wholesale by this — reviewer call: no query-cache cleverness.)

## Bug 2 — clearing the tickets search leaves `?ticket=…&search=…` filtering the list

Two defects in `DevSectionView`:
1. The search input committed to the URL **only on Enter** — clearing the input changed local state only; the `search` param and the filtered results survived.
2. Even a committed empty search deleted only `search` — never the companion `ticket` drawer param that chat-card deep links set together with it (`buildTicketOpenHref` → `?ticket=<id>&search=<id>`).

**Fix:** clearing the input commits immediately (typing still commits on Enter), and an empty commit also tears down the section's declared `search.clearParamKeys` companions — config-driven, the tickets section declares `[TICKET_OPEN_PARAM]`. Also stops leaving a dangling `?` when the last param goes.

## Verification
- `tsc --noEmit`: clean
- `vitest run src`: **4817/4817 pass**

Hub counterpart context: flamingo-stack/multi-platform-hub#1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)