### PR TITLE
Chat: onTicketEvent reducer effect + safe ticket-event dedupe

### DIFF
--- a/openframe-frontend-core/src/components/chat/__tests__/ticket-event.test.ts
+++ b/openframe-frontend-core/src/components/chat/__tests__/ticket-event.test.ts
@@ -161,6 +161,58 @@ describe('accumulator — hydrate/catch-up overlap', () => {
     )
     expect(events(segments)).toHaveLength(2)
   })
+
+  it('renders a payload-identical REPEATED event whose first occurrence is seq-less', () => {
+    // The observed swallow: resolve -> reopen -> resolve by the SAME actor
+    // with no reason. The first resolve hydrated from history without a seq,
+    // so payload equality matched it against the NEW resolve and the final
+    // card never rendered. Only the LATEST ticket event may payload-match.
+    const accumulator = new MessageSegmentAccumulator()
+    accumulator.addTicketEvent({ kind: 'RESOLVED', actorId: 'u-1', actorName: 'Yevhenii', actorType: 'TECHNICIAN' })
+    accumulator.addTicketEvent(
+      { kind: 'REOPENED', actorId: 'u-1', actorName: 'Yevhenii', actorType: 'TECHNICIAN', targetStatusKind: 'TECH_REQUIRED' },
+      79,
+    )
+    const segments = accumulator.addTicketEvent(
+      { kind: 'RESOLVED', actorId: 'u-1', actorName: 'Yevhenii', actorType: 'TECHNICIAN' },
+      80,
+    )
+    const rendered = events(segments)
+    expect(rendered).toHaveLength(3)
+    expect(rendered[2].data.kind).toBe('RESOLVED')
+  })
+
+  it('renders an entirely seq-less repeated cycle (no sequences anywhere)', () => {
+    const accumulator = new MessageSegmentAccumulator()
+    accumulator.addTicketEvent({ kind: 'RESOLVED', actorName: 'Fae', actorType: 'AI' })
+    accumulator.addTicketEvent({ kind: 'REOPENED', actorName: 'Fae', actorType: 'AI' })
+    const segments = accumulator.addTicketEvent({ kind: 'RESOLVED', actorName: 'Fae', actorType: 'AI' })
+    expect(events(segments)).toHaveLength(3)
+  })
+})
+
+describe('chat stream reducer — onTicketEvent effect', () => {
+  it('emits the event payload so hosts can move ticket state with the card', () => {
+    const seen: unknown[] = []
+    const reducer = createChatStreamReducer({
+      transport: 'nats',
+      onEffect: (effect) => {
+        if (effect.name === 'onTicketEvent') seen.push(effect.args[0])
+      },
+    })
+    const event = decodeNatsChunk({
+      type: 'TICKET_EVENT',
+      kind: 'REOPENED',
+      actorId: 'u-1',
+      actorName: 'Yevhenii',
+      actorType: 'TECHNICIAN',
+      targetStatusKind: 'TECH_REQUIRED',
+      streamSeq: 5,
+    })
+    if (event) reducer.apply(event)
+    expect(seen).toHaveLength(1)
+    expect(seen[0]).toMatchObject({ kind: 'REOPENED', targetStatusKind: 'TECH_REQUIRED' })
+  })
 })
 
 describe('processHistoricalMessages — ticket event', () => {

--- a/openframe-frontend-core/src/components/chat/stream/chat-stream-reducer.ts
+++ b/openframe-frontend-core/src/components/chat/stream/chat-stream-reducer.ts
@@ -209,6 +209,7 @@ export interface ChatReducerEffect {
     | 'onToolExecuted'
     | 'onAgentBusy'
     | 'onDialogClosed'
+    | 'onTicketEvent'
     | 'segments-after-approval-result'
   args: unknown[]
 }
@@ -1369,18 +1370,21 @@ export function createChatStreamReducer(
         // `ticket-escalated`. `seq` rides onto the segment: it is the event's
         // dedupe identity (see `addTicketEvent`).
         const before = accumulator.getSegments().length
-        const segments = accumulator.addTicketEvent(
-          {
-            kind: event.kind,
-            actorId: event.actorId,
-            actorName: event.actorName,
-            actorType: event.actorType,
-            reason: event.reason,
-            targetStatusKind: event.targetStatusKind,
-          },
-          seq,
-        )
+        const data = {
+          kind: event.kind,
+          actorId: event.actorId,
+          actorName: event.actorName,
+          actorType: event.actorType,
+          reason: event.reason,
+          targetStatusKind: event.targetStatusKind,
+        }
+        const segments = accumulator.addTicketEvent(data, seq)
         applyAccumulated(before, segments)
+        // The card alone is not enough for a host that also tracks the
+        // ticket's state: a RESOLVED/REOPENED arriving live must move the
+        // composer lock/status chip on the same render as the card, not on
+        // the next status poll. Hosts that don't wire it lose nothing.
+        emit('onTicketEvent', data)
         break
       }
 

--- a/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
+++ b/openframe-frontend-core/src/components/chat/utils/message-segment-accumulator.ts
@@ -540,13 +540,15 @@ export class MessageSegmentAccumulator {
   /**
    * Add a ticket lifecycle receipt (resolved / reopened / unknown kind).
    *
-   * Upsert identity is the chunk's stream sequence when BOTH sides know it;
-   * otherwise full payload equality. History-hydrated segments come back
+   * Upsert identity is the chunk's stream sequence when BOTH sides know it.
+   * The payload fallback exists for one overlap only: history hydration is
    * seq-less (the persisted row's seq lives on the message, not the
    * `messageData`), so a JetStream catch-up redelivery of the same event must
-   * still match its hydrated twin — payload equality is what catches that.
-   * Two genuinely distinct events (resolve → reopen → resolve) differ in seq
-   * or payload and both render.
+   * still match its hydrated twin. That twin is necessarily the LATEST ticket
+   * event, so the fallback may consider only that one — scanning older
+   * segments swallowed a genuinely REPEATED event: resolve → reopen → resolve
+   * by the same actor is payload-identical to the first resolve, and matching
+   * the old card meant the final one never rendered.
    */
   addTicketEvent(data: TicketEventData, streamSeq?: number): MessageSegment[] {
     const segment: TicketEventSegment = {
@@ -554,18 +556,30 @@ export class MessageSegmentAccumulator {
       data,
       ...(streamSeq !== undefined ? { streamSeq } : {}),
     }
-    const existingIndex = this.segments.findIndex((s) => {
-      if (s.type !== 'ticket_event') return false
-      if (s.streamSeq !== undefined && streamSeq !== undefined) return s.streamSeq === streamSeq
-      return (
-        s.data.kind === data.kind &&
-        s.data.actorId === data.actorId &&
-        s.data.actorName === data.actorName &&
-        s.data.actorType === data.actorType &&
-        s.data.reason === data.reason &&
-        s.data.targetStatusKind === data.targetStatusKind
-      )
-    })
+    let existingIndex =
+      streamSeq !== undefined
+        ? this.segments.findIndex((s) => s.type === 'ticket_event' && s.streamSeq === streamSeq)
+        : -1
+    if (existingIndex === -1) {
+      for (let i = this.segments.length - 1; i >= 0; i--) {
+        const s = this.segments[i]
+        if (s.type !== 'ticket_event') continue
+        // Both seqs known and unequal: proven distinct, never payload-match.
+        const seqsDistinguish = s.streamSeq !== undefined && streamSeq !== undefined
+        if (
+          !seqsDistinguish &&
+          s.data.kind === data.kind &&
+          s.data.actorId === data.actorId &&
+          s.data.actorName === data.actorName &&
+          s.data.actorType === data.actorType &&
+          s.data.reason === data.reason &&
+          s.data.targetStatusKind === data.targetStatusKind
+        ) {
+          existingIndex = i
+        }
+        break
+      }
+    }
     if (existingIndex !== -1) {
       this.segments[existingIndex] = segment
       return this.getSegments()


### PR DESCRIPTION
## Summary

Two live-path fixes behind the ticket resolution/reopen story, found while QA-ing the client chat:

**1. New `onTicketEvent` reducer effect.** A `TICKET_EVENT` chunk arriving live only rendered the card; a host that also tracks the ticket's state (composer lock, status chip) had to wait for its next status poll - up to 15s of a "resolved" chat that still accepts input, and an admin-side reopen that never unlocks at all (the terminal-state pin stops the poll). The reducer now emits `onTicketEvent` with the event payload (`kind`, `targetStatusKind`, actor fields) so hosts can move state on the same render as the card. Purely additive: the effect sink forwards by name, hosts that don't wire it lose nothing.

**2. Safe ticket-event dedupe.** `addTicketEvent`'s payload-equality fallback scanned ALL ticket-event segments, so a genuinely repeated event - resolve -> reopen -> resolve by the same actor with no reason - payload-matched the FIRST resolve (seq-less, hydrated from history) and the final card never rendered (observed on a live tenant: history had seq 78/79/80, the feed ended at 79). The fallback now considers only the LATEST ticket event: a JetStream redelivery matching its seq-less hydrated twin (the fallback's actual job) is always the latest event, while a repeated real event always has another ticket event in between and now renders.

## Testing

- 3 new regression tests: payload-identical repeat with a seq-less first occurrence, an entirely seq-less repeated cycle, and the `onTicketEvent` emission.
- Full suite: 4820 passed. type-check + build clean.

Consumer wiring (openframe-chat) follows in openframe-saas-tenant once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)