### PR TITLE
feat(client): optional userId on agent registration

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/dto/agent/AgentRegistrationRequest.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/dto/agent/AgentRegistrationRequest.java
@@ -16,6 +16,8 @@ public class AgentRegistrationRequest {
     private String hostname;
     @NotBlank
     private String organizationId;
+    // User who installed the agent; optional — older agents don't send it
+    private String userId;
 
     // Network information
     private String ip;

--- a/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/AgentRegistrationService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/agentregistration/AgentRegistrationService.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import static com.openframe.client.service.AgentAuthService.CLIENT_CREDENTIALS_GRANT_TYPE;
 import static com.openframe.core.exception.ErrorCode.CLIENT_SECRET_INVALID;
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
 @RequiredArgsConstructor
@@ -165,6 +166,10 @@ public class AgentRegistrationService {
         machine.setOsType(normalizeOsType(request.getOsType()));
         machine.setAgentVersion(request.getAgentVersion());
         machine.setLastSeen(Instant.now());
+        // Optional; keep the existing value on reinstall when the agent doesn't send it
+        if (isNotBlank(request.getUserId())) {
+            machine.setUserId(request.getUserId());
+        }
     }
 
     private static OsType normalizeOsType(String rawOsType) {

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/device/Machine.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/device/Machine.java
@@ -29,6 +29,7 @@ public class Machine implements TenantScoped {
     private Instant lastSeen;
     @Indexed
     private String organizationId;
+    private String userId;      // User who installed the agent; optional, absent for older registrations
     private String hostname;
     private String displayName;
     private String nickname;


### PR DESCRIPTION
Extends the agent registration flow with an **optional** `userId` so we can capture which user installed the agent:

- `AgentRegistrationRequest` — new optional `userId` field (no validation constraint; older agents that don't send it keep working)
- `Machine` document — new `userId` field
- `AgentRegistrationService` — copies `userId` onto the machine on register/reinstall, only when non-blank, so a reinstall from an agent that doesn't send it does not wipe an existing value

🤖 Generated with [Claude Code](https://claude.com/claude-code)