### PR TITLE
fix(notification-core): exclude the NATS SCS binder from data-nats — leak kills tenant-stream boot

### DIFF
--- a/openframe-notification-core/pom.xml
+++ b/openframe-notification-core/pom.xml
@@ -27,6 +27,19 @@
         <dependency>
             <groupId>com.openframe.oss</groupId>
             <artifactId>openframe-data-nats</artifactId>
+            <!--
+              The NATS Spring Cloud Stream binder must not leak to consumers of this module: with SCS on
+              the classpath, any bean extending java.util.function.* (e.g. MongoConversionsContributor)
+              gets auto-bound as a stream function and boots die without NATS binder config
+              (tenant-stream). Same leak was already killed once in saas-lib #732. Apps that consume via
+              SCS declare data-nats (and its binder) directly.
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>io.nats</groupId>
+                    <artifactId>nats-spring-cloud-stream-binder</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Problem

Boot-check of tenant main on a feature tenant (openframe-saas-tenant #2660): every service starts on the 6.25.28/3.27.20 pair **except `tenant-stream` — CrashLoopBackOff**:

```
Creating binder: nats → NatsChannelBinder: no server properties found
Failed to start bean 'inputBindingLifecycle'
APPLICATION FAILED TO START: A component required a bean of type Binder
```

The chain: `openframe-saas-mongo-sync 3.27.20 → openframe-notification-core → openframe-data-nats → io.nats:nats-spring-cloud-stream-binder → spring-cloud-stream`. With SCS suddenly on the classpath, its functional auto-binding picks up `notificationContextConversionsContributor` (a `MongoConversionsContributor`, which extends `java.util.function.Consumer`) and tries to bind `…-in-0` through the NATS binder — tenant-stream has no NATS binder config, boot dies. On 6.25.2x tenant-stream had no SCS at all, so the Consumer-shaped bean was harmless.

This is the same leak saas-lib already killed once in #732 (drop data-nats from saas-mongo-sync); notification-core re-introduced it transitively.

## Fix

Exclude the binder on notification-core's `data-nats` dependency. The module itself publishes through `NatsMessagePublisher` (raw `io.nats.client.Connection`) — no SCS classes involved. Apps that consume via SCS (api, gateway) declare `data-nats` directly and keep the binder.

Verified: `mvn test` green on `-pl openframe-notification-core -am`; in tenant-stream's dependency tree this edge is the single path to spring-cloud-stream, so the exclusion removes SCS there entirely.

## Rollout

Release train after merge: oss `6.25.29` → saas-lib bump + `3.27.21` → bump PRs to tenant and shared (both currently carry the armed pair). Re-check on feature tenant #2660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCDHWY4aLtcZfA2kBTpVsk