### PR TITLE
feat(board): status-description tooltip in board column headers

### DIFF
--- a/openframe-frontend-core/src/components/features/board/board-column-header.tsx
+++ b/openframe-frontend-core/src/components/features/board/board-column-header.tsx
@@ -2,7 +2,8 @@
 
 import { Button } from '../../ui/button/button'
 import { TicketStatusTag, resolveTicketStatus } from '../../ui/ticket-status-tag'
-import { Arrow02LeftIcon, Arrow02RightIcon, BoxArchiveIcon, PlusIcon } from '../../icons-v2-generated'
+import { TouchFriendlyTooltip } from '../../ui/touch-friendly-tooltip'
+import { Arrow02LeftIcon, Arrow02RightIcon, BoxArchiveIcon, InfoCircleIcon, PlusIcon } from '../../icons-v2-generated'
 import type { BoardColumnDef } from './types'
 
 export interface BoardColumnHeaderProps {
@@ -60,6 +61,18 @@ export function BoardColumnHeader({
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-[var(--spacing-system-xxs)]">
+        {column.tooltip && (
+          <TouchFriendlyTooltip content={column.tooltip} side="bottom">
+            <Button
+              variant="transparent"
+              size="icon"
+              className="h-8 w-8 md:h-8 md:w-8 p-0"
+              aria-label={column.tooltip}
+            >
+              <InfoCircleIcon className="h-6 w-6 text-ods-text-secondary" />
+            </Button>
+          </TouchFriendlyTooltip>
+        )}
         <Button
           variant="transparent"
           size="icon"

--- a/openframe-frontend-core/src/components/features/board/types.ts
+++ b/openframe-frontend-core/src/components/features/board/types.ts
@@ -76,6 +76,12 @@ export interface BoardColumnDef {
   statusKey?: string
   label: string
   color: string
+  /**
+   * What this column's status means, shown from an info icon in the header
+   * (e.g. the system-status descriptions from the status settings page). No
+   * icon is rendered when absent.
+   */
+  tooltip?: string
   tickets: BoardTicket[]
 
   total?: number
@@ -117,6 +123,7 @@ export function columnFromTicketStatus(
     id: status,
     label: overrides.label ?? defaults.label,
     color: overrides.color ?? defaults.color,
+    tooltip: overrides.tooltip,
     tickets,
     total: overrides.total,
     hasMore: overrides.hasMore,

--- a/openframe-frontend-core/src/components/ui/index.ts
+++ b/openframe-frontend-core/src/components/ui/index.ts
@@ -116,6 +116,7 @@ export * from './tag'
 export * from './title-content-block'
 export * from './toggle'
 export * from './tooltip'
+export * from './touch-friendly-tooltip'
 export * from './error-state'
 export * from './content-loader'
 

--- a/openframe-frontend-core/src/components/ui/ticket-status-config-row.tsx
+++ b/openframe-frontend-core/src/components/ui/ticket-status-config-row.tsx
@@ -11,7 +11,7 @@ import { ColorPresetSelect, ColorPickerInput } from './color-preset-select'
 import { Input } from './input'
 import { type TagProps } from './tag'
 import { TicketStatusTag } from './ticket-status-tag'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
+import { TouchFriendlyTooltip } from './touch-friendly-tooltip'
 
 type SystemTagVariant = Extract<TagProps['variant'], 'outline' | 'primary'>
 
@@ -35,56 +35,6 @@ export interface TicketStatusConfigRowProps {
   dragHandleProps?: DraggableSyntheticListeners
   dragHandleAttributes?: DraggableAttributes
   isDragging?: boolean
-}
-
-let dismissOpenTooltip: (() => void) | null = null
-
-function WithLeftTooltip({ content, children }: { content?: string; children: React.ReactElement }) {
-  const [open, setOpen] = React.useState(false)
-  const isTouchRef = React.useRef(false)
-  const close = React.useCallback(() => setOpen(false), [])
-
-  if (!content) return children
-
-  const toggleFromTouch = () => {
-    setOpen(prev => {
-      const next = !prev
-      if (next) {
-        if (dismissOpenTooltip && dismissOpenTooltip !== close) dismissOpenTooltip()
-        dismissOpenTooltip = close
-      } else if (dismissOpenTooltip === close) {
-        dismissOpenTooltip = null
-      }
-      return next
-    })
-  }
-
-  return (
-    <TooltipProvider delayDuration={150}>
-      <Tooltip open={open} onOpenChange={setOpen}>
-        <TooltipTrigger
-          asChild
-          onPointerDown={e => {
-            isTouchRef.current = e.pointerType === 'touch'
-            if (!isTouchRef.current) return
-            e.preventDefault()
-            toggleFromTouch()
-          }}
-          onFocus={e => {
-            if (isTouchRef.current) e.preventDefault()
-          }}
-          onClick={e => {
-            if (isTouchRef.current) e.preventDefault()
-          }}
-        >
-          {children}
-        </TooltipTrigger>
-        <TooltipContent side="left" className="max-w-xs">
-          {content}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  )
 }
 
 export function TicketStatusConfigRow({
@@ -179,7 +129,7 @@ export function TicketStatusConfigRow({
 
       <div className="flex h-11 w-12 shrink-0 items-center justify-center md:h-12">
         {isSystem ? (
-          <WithLeftTooltip content={systemTooltip}>
+          <TouchFriendlyTooltip content={systemTooltip}>
             <button
               type="button"
               aria-label={systemTooltip ?? 'System status'}
@@ -187,9 +137,9 @@ export function TicketStatusConfigRow({
             >
               <InfoCircleIcon size={24} />
             </button>
-          </WithLeftTooltip>
+          </TouchFriendlyTooltip>
         ) : (
-          <WithLeftTooltip content={deleteDisabled ? deleteDisabledReason : undefined}>
+          <TouchFriendlyTooltip content={deleteDisabled ? deleteDisabledReason : undefined}>
             <span className="inline-flex">
               <Button
                 type="button"
@@ -203,7 +153,7 @@ export function TicketStatusConfigRow({
                 <TrashIcon className="text-ods-error"/>
               </Button>
             </span>
-          </WithLeftTooltip>
+          </TouchFriendlyTooltip>
         )}
       </div>
     </div>

--- a/openframe-frontend-core/src/components/ui/touch-friendly-tooltip.tsx
+++ b/openframe-frontend-core/src/components/ui/touch-friendly-tooltip.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import * as React from 'react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
+
+/**
+ * The one tooltip allowed open at a time, across every instance — tapping a
+ * second trigger dismisses the first, since touch has no "mouse left" to close
+ * it. Module-level on purpose: instances live in unrelated subtrees.
+ */
+let dismissOpenTooltip: (() => void) | null = null
+
+export interface TouchFriendlyTooltipProps {
+  /** Tooltip text; when absent the children render bare, with no trigger wiring. */
+  content?: string
+  side?: 'top' | 'right' | 'bottom' | 'left'
+  children: React.ReactElement
+}
+
+/**
+ * Hover tooltip that also works on touch, where Radix's hover/focus model never
+ * opens: a tap toggles it instead. Wraps its own `TooltipProvider`, so it can be
+ * dropped anywhere without a provider up the tree.
+ */
+export function TouchFriendlyTooltip({ content, side = 'left', children }: TouchFriendlyTooltipProps) {
+  const [open, setOpen] = React.useState(false)
+  const isTouchRef = React.useRef(false)
+  const close = React.useCallback(() => setOpen(false), [])
+
+  if (!content) return children
+
+  const toggleFromTouch = () => {
+    setOpen(prev => {
+      const next = !prev
+      if (next) {
+        if (dismissOpenTooltip && dismissOpenTooltip !== close) dismissOpenTooltip()
+        dismissOpenTooltip = close
+      } else if (dismissOpenTooltip === close) {
+        dismissOpenTooltip = null
+      }
+      return next
+    })
+  }
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger
+          asChild
+          onPointerDown={e => {
+            isTouchRef.current = e.pointerType === 'touch'
+            if (!isTouchRef.current) return
+            e.preventDefault()
+            toggleFromTouch()
+          }}
+          onFocus={e => {
+            if (isTouchRef.current) e.preventDefault()
+          }}
+          onClick={e => {
+            if (isTouchRef.current) e.preventDefault()
+          }}
+        >
+          {children}
+        </TooltipTrigger>
+        <TooltipContent side={side} className="max-w-xs">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}


### PR DESCRIPTION
## Summary

ClickUp: https://app.clickup.com/t/9013925967/86ajnycnq

Adds an optional `tooltip` field to `BoardColumnDef`, rendered by `BoardColumnHeader` as an info-circle icon button in the expanded header's right-hand action group, before the collapse arrow — matching the tickets Figma (desktop 8001-90111, tablet 8002-271985, mobile 8002-272207: a 32px `transparent`/`icon` button with a 24px `InfoCircleIcon`, identical on every breakpoint, same as the existing collapse/archive/add header buttons). Hovering shows the description; on touch devices a tap toggles it. Columns without a `tooltip` render exactly as before, and `columnFromTicketStatus` passes the new override through.

The touch-toggle tooltip that `ticket-status-config-row` carried as a local `WithLeftTooltip` helper is extracted into a shared `ui/TouchFriendlyTooltip` (same behavior, plus a configurable `side`, default `left`) and both call sites now use it — the config row unchanged at `side="left"`, the board header at `side="bottom"`.

## Consumer

The consuming change in openframe-oss-frontend passes the system-status descriptions (`SYSTEM_KIND_META`, the same texts as the status settings page) into the tickets board lanes:

- flamingo-stack/openframe-oss-frontend#255 — needs this published and the dependency bumped there to take effect.
