### PR TITLE
fix(authz): propagate redirectTo when finalizing SSO registration/invite flows

### DIFF
--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
@@ -16,6 +16,7 @@ import static com.openframe.authz.util.OidcUserUtils.resolveEmail;
 import static com.openframe.authz.web.AuthStateUtils.clearCookie;
 import static com.openframe.authz.web.Redirects.foundAtRoot;
 import static java.net.URLEncoder.encode;
+import static org.springframework.util.StringUtils.hasText;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ROOT;
 
@@ -94,7 +95,7 @@ public interface SsoFlowHandler {
         clearCookie(response, flowCookie.getName());
         String path = "/oauth/continue?tenantId=" +
                 encode(tenantId, UTF_8);
-        if (redirectTo != null && !redirectTo.isBlank()) {
+        if (hasText(redirectTo)) {
             path += "&redirectTo=" + encode(redirectTo, UTF_8);
         }
         foundAtRoot(response, path);

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
@@ -94,7 +94,9 @@ public interface SsoFlowHandler {
         clearCookie(response, flowCookie.getName());
         String path = "/oauth/continue?tenantId=" +
                 encode(tenantId, UTF_8);
-        // TODO: Add redirectTo support for local debugging
+        if (redirectTo != null && !redirectTo.isBlank()) {
+            path += "&redirectTo=" + encode(redirectTo, UTF_8);
+        }
         foundAtRoot(response, path);
     }
 }


### PR DESCRIPTION
## Problem
`redirectTo` works on login (`/oauth/login?redirectTo=`) but is ignored on SSO registration (and invitation acceptance).

## Root cause
The parameter survives the whole flow — `SsoTenantRegistrationInitRequest` → signed `of_sso_reg`/`of_sso_invite` cookie payload → `TenantRegSsoHandler`/`InviteSsoHandler` — and then `SsoFlowHandler.clearFlowCookieAndRedirect` drops it at the final hop (`// TODO: Add redirectTo support`): the redirect to the BFF `/oauth/continue` only carried `tenantId`.

## Fix
Append `redirectTo` (URL-encoded) to the `/oauth/continue` redirect when present. `OAuthBffController.continueFlow` already accepts the parameter and gives it the exact semantics login has: stored in the signed state cookie's `rt` claim, honored only for absolute URLs, otherwise the default post-login target. No BFF or frontend changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)