### PR TITLE
feat(notification-core): typed notification seeds — a seed class per spec replaces the raw attrs map

### DIFF
--- a/.github/workflows/changes.yaml
+++ b/.github/workflows/changes.yaml
@@ -59,6 +59,7 @@ jobs:
                 "openframe-gateway-service-core/**",
                 "openframe-idp-configuration/**",
                 "openframe-management-service-core/**",
+                "openframe-notification-core/**",
                 "openframe-notification-mail/**",
                 "openframe-notification-push/**",
                 "openframe-pinot-initializer/**",

--- a/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
@@ -35,7 +35,7 @@ public class NotificationEmitter {
         NotificationType type = seed.type();
         try {
             NotificationTypeSpec<?> spec = registry.require(type);
-            Attrs attrs = enrich(spec, seed);
+            Attrs attrs = mapToAttrs(spec, seed);
 
             Audience declared = spec.audience(attrs);
             NotificationCommand command = buildCommand(correlationId, spec, attrs, declared);
@@ -47,12 +47,12 @@ public class NotificationEmitter {
     }
 
     // The cast is the wiring check: a seed whose type() routes to a spec built for another
-    // seed class fails loudly here, not with a mystery deep inside enrich().
-    private static <S extends NotificationSeed> Attrs enrich(NotificationTypeSpec<S> spec,
-                                                             NotificationSeed seed) {
+    // seed class fails loudly here, not with a mystery deep inside the spec.
+    private static <S extends NotificationSeed> Attrs mapToAttrs(NotificationTypeSpec<S> spec,
+                                                                 NotificationSeed seed) {
         Class<S> seedClass = spec.getSeedClass();
         S typed = seedClass.cast(seed);
-        return spec.enrich(typed);
+        return spec.attrs(typed);
     }
 
     private static NotificationCommand buildCommand(String correlationId,

--- a/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
@@ -1,11 +1,11 @@
 package com.openframe.notification;
 
-import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSeverity;
 import com.openframe.notification.service.NotificationBroadcaster;
 import com.openframe.notification.service.NotificationCommand;
 import com.openframe.notification.spec.Attrs;
 import com.openframe.notification.spec.Audience;
+import com.openframe.notification.spec.NotificationContext;
 import com.openframe.notification.spec.NotificationText;
 import com.openframe.notification.spec.NotificationType;
 import com.openframe.notification.spec.NotificationTypeRegistry;
@@ -30,10 +30,11 @@ public class NotificationEmitter {
 
     // Never throws: a notification bug must not fail the business flow that emitted it.
     public void notify(NotificationRequest request, String correlationId) {
-        NotificationType type = request.getType();
+        NotificationContext context = request.getContext();
+        NotificationType type = context.type();
         try {
-            NotificationTypeSpec spec = registry.require(type);
-            Attrs attrs = Attrs.validated(spec, request.getAttrs());
+            NotificationTypeSpec<?> spec = registry.require(type);
+            Attrs attrs = enrich(spec, context);
 
             Audience declared = spec.audience(attrs);
             NotificationCommand command = buildCommand(correlationId, spec, attrs, declared);
@@ -44,8 +45,17 @@ public class NotificationEmitter {
         }
     }
 
+    // The cast is the wiring check: a context whose type() routes to a spec built for another
+    // context class fails loudly here, not with a mystery deep inside enrich().
+    private static <C extends NotificationContext> Attrs enrich(NotificationTypeSpec<C> spec,
+                                                                NotificationContext context) {
+        Class<C> contextClass = spec.getContextClass();
+        C typed = contextClass.cast(context);
+        return spec.enrich(typed);
+    }
+
     private static NotificationCommand buildCommand(String correlationId,
-                                                    NotificationTypeSpec spec,
+                                                    NotificationTypeSpec<?> spec,
                                                     Attrs attrs,
                                                     Audience audience) {
         NotificationText text = spec.compose(attrs);
@@ -54,7 +64,7 @@ public class NotificationEmitter {
 
         Map<String, String> attributes = attrs.asMap();
         NotificationSeverity severity = spec.getSeverity();
-        NotificationContext legacyContext = spec.buildLegacyContext(attrs);
+        com.openframe.data.document.notification.NotificationContext legacyContext = spec.buildLegacyContext(attrs);
         NotificationType specType = spec.getType();
         return NotificationCommand.builder()
                 .type(specType)

--- a/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/NotificationEmitter.java
@@ -1,11 +1,12 @@
 package com.openframe.notification;
 
+import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSeverity;
 import com.openframe.notification.service.NotificationBroadcaster;
 import com.openframe.notification.service.NotificationCommand;
 import com.openframe.notification.spec.Attrs;
 import com.openframe.notification.spec.Audience;
-import com.openframe.notification.spec.NotificationContext;
+import com.openframe.notification.spec.NotificationSeed;
 import com.openframe.notification.spec.NotificationText;
 import com.openframe.notification.spec.NotificationType;
 import com.openframe.notification.spec.NotificationTypeRegistry;
@@ -30,11 +31,11 @@ public class NotificationEmitter {
 
     // Never throws: a notification bug must not fail the business flow that emitted it.
     public void notify(NotificationRequest request, String correlationId) {
-        NotificationContext context = request.getContext();
-        NotificationType type = context.type();
+        NotificationSeed seed = request.getSeed();
+        NotificationType type = seed.type();
         try {
             NotificationTypeSpec<?> spec = registry.require(type);
-            Attrs attrs = enrich(spec, context);
+            Attrs attrs = enrich(spec, seed);
 
             Audience declared = spec.audience(attrs);
             NotificationCommand command = buildCommand(correlationId, spec, attrs, declared);
@@ -45,12 +46,12 @@ public class NotificationEmitter {
         }
     }
 
-    // The cast is the wiring check: a context whose type() routes to a spec built for another
-    // context class fails loudly here, not with a mystery deep inside enrich().
-    private static <C extends NotificationContext> Attrs enrich(NotificationTypeSpec<C> spec,
-                                                                NotificationContext context) {
-        Class<C> contextClass = spec.getContextClass();
-        C typed = contextClass.cast(context);
+    // The cast is the wiring check: a seed whose type() routes to a spec built for another
+    // seed class fails loudly here, not with a mystery deep inside enrich().
+    private static <S extends NotificationSeed> Attrs enrich(NotificationTypeSpec<S> spec,
+                                                             NotificationSeed seed) {
+        Class<S> seedClass = spec.getSeedClass();
+        S typed = seedClass.cast(seed);
         return spec.enrich(typed);
     }
 
@@ -64,7 +65,7 @@ public class NotificationEmitter {
 
         Map<String, String> attributes = attrs.asMap();
         NotificationSeverity severity = spec.getSeverity();
-        com.openframe.data.document.notification.NotificationContext legacyContext = spec.buildLegacyContext(attrs);
+        NotificationContext legacyContext = spec.buildLegacyContext(attrs);
         NotificationType specType = spec.getType();
         return NotificationCommand.builder()
                 .type(specType)

--- a/openframe-notification-core/src/main/java/com/openframe/notification/NotificationRequest.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/NotificationRequest.java
@@ -1,50 +1,21 @@
 package com.openframe.notification;
 
-import com.openframe.notification.spec.AttrKey;
-import com.openframe.notification.spec.NotificationType;
+import com.openframe.notification.spec.NotificationContext;
 import lombok.Getter;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Objects;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Getter
 public final class NotificationRequest {
 
-    private final NotificationType type;
-    private final Map<String, String> attrs;
+    private final NotificationContext context;
 
-    private NotificationRequest(NotificationType type, Map<String, String> attrs) {
-        this.type = type;
-        this.attrs = attrs;
+    private NotificationRequest(NotificationContext context) {
+        this.context = context;
     }
 
-    public static Builder of(NotificationType type) {
-        Objects.requireNonNull(type, "type must not be null");
-        return new Builder(type);
-    }
-
-    public static final class Builder {
-
-        private final NotificationType type;
-        private final Map<String, String> attrs = new LinkedHashMap<>();
-
-        private Builder(NotificationType type) {
-            this.type = type;
-        }
-
-        // Null/blank leaves the attribute absent — an optional fact simply isn't there.
-        public Builder attr(AttrKey key, String value) {
-            if (!isBlank(value)) {
-                attrs.put(key.getName(), value);
-            }
-            return this;
-        }
-
-        public NotificationRequest build() {
-            return new NotificationRequest(type, Map.copyOf(attrs));
-        }
+    public static NotificationRequest of(NotificationContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        return new NotificationRequest(context);
     }
 }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/NotificationRequest.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/NotificationRequest.java
@@ -1,6 +1,6 @@
 package com.openframe.notification;
 
-import com.openframe.notification.spec.NotificationContext;
+import com.openframe.notification.spec.NotificationSeed;
 import lombok.Getter;
 
 import java.util.Objects;
@@ -8,14 +8,14 @@ import java.util.Objects;
 @Getter
 public final class NotificationRequest {
 
-    private final NotificationContext context;
+    private final NotificationSeed seed;
 
-    private NotificationRequest(NotificationContext context) {
-        this.context = context;
+    private NotificationRequest(NotificationSeed seed) {
+        this.seed = seed;
     }
 
-    public static NotificationRequest of(NotificationContext context) {
-        Objects.requireNonNull(context, "context must not be null");
-        return new NotificationRequest(context);
+    public static NotificationRequest of(NotificationSeed seed) {
+        Objects.requireNonNull(seed, "seed must not be null");
+        return new NotificationRequest(seed);
     }
 }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/Attrs.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/Attrs.java
@@ -2,19 +2,14 @@ package com.openframe.notification.spec;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
-import java.util.TreeSet;
 
-import static java.util.stream.Collectors.toUnmodifiableSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-@Slf4j
 public final class Attrs {
 
     private static final ObjectMapper JSON = new ObjectMapper();
@@ -23,12 +18,6 @@ public final class Attrs {
 
     private Attrs(Map<String, String> values) {
         this.values = values;
-    }
-
-    public static Attrs validated(NotificationTypeSpec spec, Map<String, String> raw) {
-        rejectMissingRequiredKeys(spec, raw);
-        Map<String, String> declared = dropUndeclaredKeys(spec, raw);
-        return new Attrs(declared);
     }
 
     public static Attrs of(Map<String, String> values) {
@@ -80,46 +69,5 @@ public final class Attrs {
 
     public Map<String, String> asMap() {
         return values;
-    }
-
-    private static void rejectMissingRequiredKeys(NotificationTypeSpec spec, Map<String, String> raw) {
-        for (AttrKey key : spec.getRequiredKeys()) {
-            String name = key.getName();
-            String value = raw.get(name);
-            if (isBlank(value)) {
-                String type = spec.getType().name();
-                throw new IllegalArgumentException(
-                        type + ": required attribute '" + name + "' is missing or blank");
-            }
-        }
-    }
-
-    // Undeclared keys are dropped, not rejected: a producer may start emitting a fact before the
-    // catalog consumes it. The WARN is what keeps a typo in an optional key from hiding forever.
-    private static Map<String, String> dropUndeclaredKeys(NotificationTypeSpec spec, Map<String, String> raw) {
-        Set<String> declared = declaredKeyNames(spec);
-        Map<String, String> kept = new HashMap<>();
-        Set<String> dropped = new TreeSet<>();
-        for (Map.Entry<String, String> entry : raw.entrySet()) {
-            String key = entry.getKey();
-            if (declared.contains(key)) {
-                kept.put(key, entry.getValue());
-            } else {
-                dropped.add(key);
-            }
-        }
-        if (!dropped.isEmpty()) {
-            String type = spec.getType().name();
-            log.warn("{}: ignoring undeclared attribute(s) {}", type, dropped);
-        }
-        return Map.copyOf(kept);
-    }
-
-    private static Set<String> declaredKeyNames(NotificationTypeSpec spec) {
-        Set<String> required = spec.getRequiredKeys().stream().map(AttrKey::getName).collect(toUnmodifiableSet());
-        Set<String> optional = spec.getOptionalKeys().stream().map(AttrKey::getName).collect(toUnmodifiableSet());
-        Set<String> declared = new TreeSet<>(required);
-        declared.addAll(optional);
-        return declared;
     }
 }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationContext.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationContext.java
@@ -1,0 +1,9 @@
+package com.openframe.notification.spec;
+
+// A context carries ids + event-only facts (things only the emitting moment knows: the actor, the
+// previous status). Snapshot facts (titles, names, …) are the spec's enrich() job — a snapshot
+// field added here duplicates enrich and goes stale the moment the entity changes.
+public interface NotificationContext {
+
+    NotificationType type();
+}

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationSeed.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationSeed.java
@@ -1,9 +1,9 @@
 package com.openframe.notification.spec;
 
-// A context carries ids + event-only facts (things only the emitting moment knows: the actor, the
+// A seed carries ids + event-only facts (things only the emitting moment knows: the actor, the
 // previous status). Snapshot facts (titles, names, …) are the spec's enrich() job — a snapshot
 // field added here duplicates enrich and goes stale the moment the entity changes.
-public interface NotificationContext {
+public interface NotificationSeed {
 
     NotificationType type();
 }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationSeed.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationSeed.java
@@ -1,8 +1,7 @@
 package com.openframe.notification.spec;
 
-// A seed carries ids + event-only facts (things only the emitting moment knows: the actor, the
-// previous status). Snapshot facts (titles, names, …) are the spec's enrich() job — a snapshot
-// field added here duplicates enrich and goes stale the moment the entity changes.
+// A seed carries everything its notification needs — the seed class is the compile-checked
+// contract, and the producer fills it from entities it already holds at the emitting moment.
 public interface NotificationSeed {
 
     NotificationType type();

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeRegistry.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeRegistry.java
@@ -14,19 +14,19 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 @Component
 public class NotificationTypeRegistry {
 
-    private final Map<String, NotificationTypeSpec> byTypeName;
+    private final Map<String, NotificationTypeSpec<?>> byTypeName;
 
     // ObjectProvider, not List: a service with zero specs on the classpath must still boot.
     // toUnmodifiableMap throws IllegalStateException on a duplicate type — the wanted fail-fast.
-    public NotificationTypeRegistry(ObjectProvider<NotificationTypeSpec> specs) {
+    public NotificationTypeRegistry(ObjectProvider<NotificationTypeSpec<?>> specs) {
         this.byTypeName = specs.stream()
                 .collect(toUnmodifiableMap(spec -> spec.getType().name(), identity()));
         TreeSet<String> sortedTypes = new TreeSet<>(byTypeName.keySet());
         log.info("Registered {} notification type(s): {}", byTypeName.size(), sortedTypes);
     }
 
-    public NotificationTypeSpec require(NotificationType type) {
-        NotificationTypeSpec spec = byTypeName.get(type.name());
+    public NotificationTypeSpec<?> require(NotificationType type) {
+        NotificationTypeSpec<?> spec = byTypeName.get(type.name());
         if (spec == null) {
             throw new IllegalArgumentException("No spec registered for notification type: " + type.name());
         }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
@@ -1,21 +1,22 @@
 package com.openframe.notification.spec;
 
 import com.openframe.data.document.notification.NotificationCategory;
+import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSettingGroup;
 import com.openframe.data.document.notification.NotificationSeverity;
 
 import java.util.Optional;
 import java.util.Set;
 
-public interface NotificationTypeSpec<C extends NotificationContext> {
+public interface NotificationTypeSpec<S extends NotificationSeed> {
 
     NotificationType getType();
 
-    Class<C> getContextClass();
+    Class<S> getSeedClass();
 
-    // The single I/O method: resolves the context's ids into the full attribute snapshot.
+    // The single I/O method: resolves the seed's ids into the full attribute snapshot.
     // Everything below runs on its result and must stay pure.
-    Attrs enrich(C context);
+    Attrs enrich(S seed);
 
     Optional<NotificationSettingGroup> getSettingsGroup();
 
@@ -36,5 +37,5 @@ public interface NotificationTypeSpec<C extends NotificationContext> {
     }
 
     // Transitional — deleted together with the legacy context classes; do not build on it.
-    com.openframe.data.document.notification.NotificationContext buildLegacyContext(Attrs attrs);
+    NotificationContext buildLegacyContext(Attrs attrs);
 }

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
@@ -14,9 +14,9 @@ public interface NotificationTypeSpec<S extends NotificationSeed> {
 
     Class<S> getSeedClass();
 
-    // The single I/O method: resolves the seed's ids into the full attribute snapshot.
-    // Everything below runs on its result and must stay pure.
-    Attrs enrich(S seed);
+    // Pure seed → stored-attributes mapping. No I/O in specs: the seed arrives self-contained,
+    // and a fetch here would re-read what the producer already held at the emitting moment.
+    Attrs attrs(S seed);
 
     Optional<NotificationSettingGroup> getSettingsGroup();
 

--- a/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
+++ b/openframe-notification-core/src/main/java/com/openframe/notification/spec/NotificationTypeSpec.java
@@ -1,22 +1,21 @@
 package com.openframe.notification.spec;
 
 import com.openframe.data.document.notification.NotificationCategory;
-import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSettingGroup;
 import com.openframe.data.document.notification.NotificationSeverity;
 
 import java.util.Optional;
 import java.util.Set;
 
-public interface NotificationTypeSpec {
+public interface NotificationTypeSpec<C extends NotificationContext> {
 
     NotificationType getType();
 
-    Set<AttrKey> getRequiredKeys();
+    Class<C> getContextClass();
 
-    default Set<AttrKey> getOptionalKeys() {
-        return Set.of();
-    }
+    // The single I/O method: resolves the context's ids into the full attribute snapshot.
+    // Everything below runs on its result and must stay pure.
+    Attrs enrich(C context);
 
     Optional<NotificationSettingGroup> getSettingsGroup();
 
@@ -36,6 +35,6 @@ public interface NotificationTypeSpec {
         return Set.of();
     }
 
-    // Transitional — deleted together with the context classes; do not build on it.
-    NotificationContext buildLegacyContext(Attrs attrs);
+    // Transitional — deleted together with the legacy context classes; do not build on it.
+    com.openframe.data.document.notification.NotificationContext buildLegacyContext(Attrs attrs);
 }

--- a/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
+++ b/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
@@ -40,7 +40,7 @@ class NotificationEmitterTest {
 
     private enum TestType implements NotificationType { TEST_TYPE, UNREGISTERED }
 
-    private record TestSeed(String ticketId) implements NotificationSeed {
+    private record TestSeed(String ticketId, String assigneeUserId) implements NotificationSeed {
         @Override public NotificationType type() { return TestType.TEST_TYPE; }
     }
 
@@ -66,9 +66,9 @@ class NotificationEmitterTest {
     }
 
     @Test
-    @DisplayName("The pipeline in one pass: typed seed → enrich → compose/audience → command with type, attributes and legacy context")
+    @DisplayName("The pipeline in one pass: typed seed → attrs mapping → compose/audience → command with type, attributes and legacy context")
     void happy_path_builds_the_full_command() {
-        NotificationRequest request = NotificationRequest.of(new TestSeed("t-1"));
+        NotificationRequest request = NotificationRequest.of(new TestSeed("t-1", "u-9"));
 
         emitter.notify(request, "corr-1");
 
@@ -77,7 +77,7 @@ class NotificationEmitterTest {
         NotificationCommand sent = command.getValue();
         assertThat(sent.getType()).isEqualTo(TestType.TEST_TYPE);
         assertThat(sent.getAttributes())
-                .as("enrich() laid the snapshot fact on top of the seed's event fact")
+                .as("attrs() mapped the self-contained seed to the stored snapshot")
                 .containsEntry("ticketId", "t-1")
                 .containsEntry("assigneeUserId", "u-9");
         assertThat(sent.getTitle()).isEqualTo("Ticket t-1");
@@ -118,8 +118,8 @@ class NotificationEmitterTest {
         @Override public NotificationSeverity getSeverity() { return NotificationSeverity.INFO; }
         @Override public Audience audience(Attrs attrs) { return audience; }
 
-        @Override public Attrs enrich(TestSeed seed) {
-            return Attrs.of(Map.of("ticketId", seed.ticketId())).with(ASSIGNEE, "u-9");
+        @Override public Attrs attrs(TestSeed seed) {
+            return Attrs.of(Map.of("ticketId", seed.ticketId())).with(ASSIGNEE, seed.assigneeUserId());
         }
 
         @Override public NotificationText compose(Attrs attrs) {

--- a/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
+++ b/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
@@ -2,6 +2,7 @@ package com.openframe.notification;
 
 import com.openframe.data.document.notification.GenericContext;
 import com.openframe.data.document.notification.NotificationCategory;
+import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSettingGroup;
 import com.openframe.data.document.notification.NotificationSeverity;
 import com.openframe.notification.service.NotificationBroadcaster;
@@ -9,7 +10,7 @@ import com.openframe.notification.service.NotificationCommand;
 import com.openframe.notification.spec.AttrKey;
 import com.openframe.notification.spec.Attrs;
 import com.openframe.notification.spec.Audience;
-import com.openframe.notification.spec.NotificationContext;
+import com.openframe.notification.spec.NotificationSeed;
 import com.openframe.notification.spec.NotificationText;
 import com.openframe.notification.spec.NotificationType;
 import com.openframe.notification.spec.NotificationTypeRegistry;
@@ -39,16 +40,16 @@ class NotificationEmitterTest {
 
     private enum TestType implements NotificationType { TEST_TYPE, UNREGISTERED }
 
-    private record TestContext(String ticketId) implements NotificationContext {
+    private record TestSeed(String ticketId) implements NotificationSeed {
         @Override public NotificationType type() { return TestType.TEST_TYPE; }
     }
 
-    private record UnregisteredContext() implements NotificationContext {
+    private record UnregisteredSeed() implements NotificationSeed {
         @Override public NotificationType type() { return TestType.UNREGISTERED; }
     }
 
     // Claims TEST_TYPE but is not the class TestSpec was built for — a wiring bug, not bad input.
-    private record ForeignContext() implements NotificationContext {
+    private record ForeignSeed() implements NotificationSeed {
         @Override public NotificationType type() { return TestType.TEST_TYPE; }
     }
 
@@ -65,9 +66,9 @@ class NotificationEmitterTest {
     }
 
     @Test
-    @DisplayName("The pipeline in one pass: typed context → enrich → compose/audience → command with type, attributes and legacy context")
+    @DisplayName("The pipeline in one pass: typed seed → enrich → compose/audience → command with type, attributes and legacy context")
     void happy_path_builds_the_full_command() {
-        NotificationRequest request = NotificationRequest.of(new TestContext("t-1"));
+        NotificationRequest request = NotificationRequest.of(new TestSeed("t-1"));
 
         emitter.notify(request, "corr-1");
 
@@ -76,7 +77,7 @@ class NotificationEmitterTest {
         NotificationCommand sent = command.getValue();
         assertThat(sent.getType()).isEqualTo(TestType.TEST_TYPE);
         assertThat(sent.getAttributes())
-                .as("enrich() laid the snapshot fact on top of the context's event fact")
+                .as("enrich() laid the snapshot fact on top of the seed's event fact")
                 .containsEntry("ticketId", "t-1")
                 .containsEntry("assigneeUserId", "u-9");
         assertThat(sent.getTitle()).isEqualTo("Ticket t-1");
@@ -90,11 +91,11 @@ class NotificationEmitterTest {
     @Test
     @DisplayName("Producer bugs are swallowed with an ERROR log — a notification must never fail the business flow")
     void producer_bugs_are_swallowed() {
-        NotificationRequest unregistered = NotificationRequest.of(new UnregisteredContext());
-        NotificationRequest wrongContextClass = NotificationRequest.of(new ForeignContext());
+        NotificationRequest unregistered = NotificationRequest.of(new UnregisteredSeed());
+        NotificationRequest wrongSeedClass = NotificationRequest.of(new ForeignSeed());
 
         assertThatCode(() -> emitter.notify(unregistered)).doesNotThrowAnyException();
-        assertThatCode(() -> emitter.notify(wrongContextClass)).doesNotThrowAnyException();
+        assertThatCode(() -> emitter.notify(wrongSeedClass)).doesNotThrowAnyException();
         verify(broadcaster, never()).broadcast(any());
     }
 
@@ -106,26 +107,26 @@ class NotificationEmitterTest {
     }
 
     // Hand-rolled, not a mock: the pipeline calls every spec method and a mock would silently null.
-    private static class TestSpec implements NotificationTypeSpec<TestContext> {
+    private static class TestSpec implements NotificationTypeSpec<TestSeed> {
 
         Audience audience = Audience.users("u-9");
 
         @Override public NotificationType getType() { return TestType.TEST_TYPE; }
-        @Override public Class<TestContext> getContextClass() { return TestContext.class; }
+        @Override public Class<TestSeed> getSeedClass() { return TestSeed.class; }
         @Override public Optional<NotificationSettingGroup> getSettingsGroup() { return Optional.empty(); }
         @Override public NotificationCategory getCategory() { return NotificationCategory.TICKETS; }
         @Override public NotificationSeverity getSeverity() { return NotificationSeverity.INFO; }
         @Override public Audience audience(Attrs attrs) { return audience; }
 
-        @Override public Attrs enrich(TestContext context) {
-            return Attrs.of(Map.of("ticketId", context.ticketId())).with(ASSIGNEE, "u-9");
+        @Override public Attrs enrich(TestSeed seed) {
+            return Attrs.of(Map.of("ticketId", seed.ticketId())).with(ASSIGNEE, "u-9");
         }
 
         @Override public NotificationText compose(Attrs attrs) {
             return new NotificationText("Ticket " + attrs.get(TICKET_ID), "Assigned to " + attrs.get(ASSIGNEE));
         }
 
-        @Override public com.openframe.data.document.notification.NotificationContext buildLegacyContext(Attrs attrs) {
+        @Override public NotificationContext buildLegacyContext(Attrs attrs) {
             return GenericContext.builder().type(getType().name()).payload("{}").build();
         }
     }

--- a/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
+++ b/openframe-notification-core/src/test/java/com/openframe/notification/NotificationEmitterTest.java
@@ -2,7 +2,6 @@ package com.openframe.notification;
 
 import com.openframe.data.document.notification.GenericContext;
 import com.openframe.data.document.notification.NotificationCategory;
-import com.openframe.data.document.notification.NotificationContext;
 import com.openframe.data.document.notification.NotificationSettingGroup;
 import com.openframe.data.document.notification.NotificationSeverity;
 import com.openframe.notification.service.NotificationBroadcaster;
@@ -10,6 +9,7 @@ import com.openframe.notification.service.NotificationCommand;
 import com.openframe.notification.spec.AttrKey;
 import com.openframe.notification.spec.Attrs;
 import com.openframe.notification.spec.Audience;
+import com.openframe.notification.spec.NotificationContext;
 import com.openframe.notification.spec.NotificationText;
 import com.openframe.notification.spec.NotificationType;
 import com.openframe.notification.spec.NotificationTypeRegistry;
@@ -20,8 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.ObjectProvider;
 
+import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +39,19 @@ class NotificationEmitterTest {
 
     private enum TestType implements NotificationType { TEST_TYPE, UNREGISTERED }
 
+    private record TestContext(String ticketId) implements NotificationContext {
+        @Override public NotificationType type() { return TestType.TEST_TYPE; }
+    }
+
+    private record UnregisteredContext() implements NotificationContext {
+        @Override public NotificationType type() { return TestType.UNREGISTERED; }
+    }
+
+    // Claims TEST_TYPE but is not the class TestSpec was built for — a wiring bug, not bad input.
+    private record ForeignContext() implements NotificationContext {
+        @Override public NotificationType type() { return TestType.TEST_TYPE; }
+    }
+
     private NotificationBroadcaster broadcaster;
     private NotificationEmitter emitter;
     private TestSpec spec;
@@ -52,12 +65,9 @@ class NotificationEmitterTest {
     }
 
     @Test
-    @DisplayName("The pipeline in one pass: validate → compose/audience → command with type, attributes and legacy context")
+    @DisplayName("The pipeline in one pass: typed context → enrich → compose/audience → command with type, attributes and legacy context")
     void happy_path_builds_the_full_command() {
-        NotificationRequest request = NotificationRequest.of(TestType.TEST_TYPE)
-                .attr(TICKET_ID, "t-1")
-                .attr(ASSIGNEE, "u-9")
-                .build();
+        NotificationRequest request = NotificationRequest.of(new TestContext("t-1"));
 
         emitter.notify(request, "corr-1");
 
@@ -65,7 +75,10 @@ class NotificationEmitterTest {
         verify(broadcaster).broadcast(command.capture());
         NotificationCommand sent = command.getValue();
         assertThat(sent.getType()).isEqualTo(TestType.TEST_TYPE);
-        assertThat(sent.getAttributes()).containsEntry("ticketId", "t-1").containsEntry("assigneeUserId", "u-9");
+        assertThat(sent.getAttributes())
+                .as("enrich() laid the snapshot fact on top of the context's event fact")
+                .containsEntry("ticketId", "t-1")
+                .containsEntry("assigneeUserId", "u-9");
         assertThat(sent.getTitle()).isEqualTo("Ticket t-1");
         assertThat(sent.getDescription()).isEqualTo("Assigned to u-9");
         assertThat(sent.getSeverity()).isEqualTo(NotificationSeverity.INFO);
@@ -77,39 +90,42 @@ class NotificationEmitterTest {
     @Test
     @DisplayName("Producer bugs are swallowed with an ERROR log — a notification must never fail the business flow")
     void producer_bugs_are_swallowed() {
-        NotificationRequest unregistered = NotificationRequest.of(TestType.UNREGISTERED).build();
-        NotificationRequest missingRequired = NotificationRequest.of(TestType.TEST_TYPE).build();
+        NotificationRequest unregistered = NotificationRequest.of(new UnregisteredContext());
+        NotificationRequest wrongContextClass = NotificationRequest.of(new ForeignContext());
 
         assertThatCode(() -> emitter.notify(unregistered)).doesNotThrowAnyException();
-        assertThatCode(() -> emitter.notify(missingRequired)).doesNotThrowAnyException();
+        assertThatCode(() -> emitter.notify(wrongContextClass)).doesNotThrowAnyException();
         verify(broadcaster, never()).broadcast(any());
     }
 
     @SuppressWarnings("unchecked")
-    private static ObjectProvider<NotificationTypeSpec> provider(NotificationTypeSpec... specs) {
-        ObjectProvider<NotificationTypeSpec> provider = mock(ObjectProvider.class);
+    private static ObjectProvider<NotificationTypeSpec<?>> provider(NotificationTypeSpec<?>... specs) {
+        ObjectProvider<NotificationTypeSpec<?>> provider = mock(ObjectProvider.class);
         when(provider.stream()).thenReturn(Stream.of(specs));
         return provider;
     }
 
     // Hand-rolled, not a mock: the pipeline calls every spec method and a mock would silently null.
-    private static class TestSpec implements NotificationTypeSpec {
+    private static class TestSpec implements NotificationTypeSpec<TestContext> {
 
         Audience audience = Audience.users("u-9");
 
         @Override public NotificationType getType() { return TestType.TEST_TYPE; }
-        @Override public Set<AttrKey> getRequiredKeys() { return Set.of(TICKET_ID); }
-        @Override public Set<AttrKey> getOptionalKeys() { return Set.of(ASSIGNEE); }
+        @Override public Class<TestContext> getContextClass() { return TestContext.class; }
         @Override public Optional<NotificationSettingGroup> getSettingsGroup() { return Optional.empty(); }
         @Override public NotificationCategory getCategory() { return NotificationCategory.TICKETS; }
         @Override public NotificationSeverity getSeverity() { return NotificationSeverity.INFO; }
         @Override public Audience audience(Attrs attrs) { return audience; }
 
+        @Override public Attrs enrich(TestContext context) {
+            return Attrs.of(Map.of("ticketId", context.ticketId())).with(ASSIGNEE, "u-9");
+        }
+
         @Override public NotificationText compose(Attrs attrs) {
             return new NotificationText("Ticket " + attrs.get(TICKET_ID), "Assigned to " + attrs.get(ASSIGNEE));
         }
 
-        @Override public NotificationContext buildLegacyContext(Attrs attrs) {
+        @Override public com.openframe.data.document.notification.NotificationContext buildLegacyContext(Attrs attrs) {
             return GenericContext.builder().type(getType().name()).payload("{}").build();
         }
     }

--- a/openframe-notification-core/src/test/java/com/openframe/notification/spec/AttrsTest.java
+++ b/openframe-notification-core/src/test/java/com/openframe/notification/spec/AttrsTest.java
@@ -8,12 +8,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class AttrsTest {
 
@@ -21,53 +18,20 @@ class AttrsTest {
     private static final AttrKey ACTOR_ID = AttrKey.of("actorId");
     private static final AttrKey TOOL_CALLS = AttrKey.of("toolCalls");
 
-    private enum TestType implements NotificationType { TEST_TYPE }
-
     @Test
-    @DisplayName("Given all required keys present, when validated, then values are readable")
-    void valid_attrs_pass() {
-        Attrs attrs = Attrs.validated(spec(Set.of(TICKET_ID)), Map.of("ticketId", "t-1"));
+    @DisplayName("of() snapshots the map; values are readable by key")
+    void values_readable() {
+        Attrs attrs = Attrs.of(Map.of("ticketId", "t-1"));
 
         assertThat(attrs.get(TICKET_ID)).isEqualTo("t-1");
         assertThat(attrs.has(TICKET_ID)).isTrue();
-    }
-
-    @Test
-    @DisplayName("Given a missing or blank required key, when validated, then the producer's bug is named")
-    void missing_or_blank_required_key_rejected() {
-        assertThatThrownBy(() -> Attrs.validated(spec(Set.of(TICKET_ID)), Map.of()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("ticketId");
-        assertThatThrownBy(() -> Attrs.validated(spec(Set.of(TICKET_ID)), Map.of("ticketId", "  ")))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("ticketId");
-    }
-
-    @Test
-    @DisplayName("Undeclared keys are dropped, not rejected — a producer may emit a fact before the catalog consumes it")
-    void undeclared_key_dropped() {
-        Attrs attrs = Attrs.validated(spec(Set.of(TICKET_ID)), Map.of("ticketId", "t-1", "futureFact", "x"));
-
         assertThat(attrs.asMap()).containsOnlyKeys("ticketId");
-    }
-
-    @Test
-    @DisplayName("A declared optional key is kept when present and legal to omit")
-    void optional_key_kept_or_omitted() {
-        NotificationTypeSpec spec = spec(Set.of(TICKET_ID));
-        when(spec.getOptionalKeys()).thenReturn(Set.of(ACTOR_ID));
-
-        Attrs present = Attrs.validated(spec, Map.of("ticketId", "t-1", "actorId", "u-1"));
-        Attrs absent = Attrs.validated(spec, Map.of("ticketId", "t-1"));
-
-        assertThat(present.get(ACTOR_ID)).isEqualTo("u-1");
-        assertThat(absent.has(ACTOR_ID)).isFalse();
     }
 
     @Test
     @DisplayName("with() lays values on top; null and blank leave the attribute absent")
     void with_adds_values_and_ignores_blanks() {
-        Attrs base = Attrs.validated(spec(Set.of(TICKET_ID)), Map.of("ticketId", "t-1"));
+        Attrs base = Attrs.of(Map.of("ticketId", "t-1"));
 
         Attrs extended = base.with(ACTOR_ID, "u-1").with(TOOL_CALLS, null).with(AttrKey.of("x"), "  ");
 
@@ -80,10 +44,19 @@ class AttrsTest {
     @Test
     @DisplayName("get() on an absent attribute throws; optional() is the null-safe road")
     void absent_attribute_access() {
-        Attrs attrs = Attrs.validated(spec(Set.of(TICKET_ID)), Map.of("ticketId", "t-1"));
+        Attrs attrs = Attrs.of(Map.of("ticketId", "t-1"));
 
         assertThatThrownBy(() -> attrs.get(ACTOR_ID)).isInstanceOf(NoSuchElementException.class);
         assertThat(attrs.optional(ACTOR_ID)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a blank value counts as absent — get() throws, has() is false")
+    void blank_value_counts_as_absent() {
+        Attrs attrs = Attrs.of(Map.of("ticketId", "  "));
+
+        assertThat(attrs.has(TICKET_ID)).isFalse();
+        assertThatThrownBy(() -> attrs.get(TICKET_ID)).isInstanceOf(NoSuchElementException.class);
     }
 
     @Test
@@ -101,13 +74,5 @@ class AttrsTest {
     void blank_key_rejected() {
         assertThatThrownBy(() -> AttrKey.of(" ")).isInstanceOf(IllegalArgumentException.class);
         assertThat(Optional.of(AttrKey.of("ok").getName())).contains("ok");
-    }
-
-    private static NotificationTypeSpec spec(Set<AttrKey> requiredKeys) {
-        NotificationTypeSpec spec = mock(NotificationTypeSpec.class);
-        when(spec.getType()).thenReturn(TestType.TEST_TYPE);
-        when(spec.getRequiredKeys()).thenReturn(requiredKeys);
-        when(spec.getOptionalKeys()).thenReturn(Set.of());
-        return spec;
     }
 }

--- a/openframe-notification-core/src/test/java/com/openframe/notification/spec/NotificationTypeRegistryTest.java
+++ b/openframe-notification-core/src/test/java/com/openframe/notification/spec/NotificationTypeRegistryTest.java
@@ -17,7 +17,7 @@ class NotificationTypeRegistryTest {
 
     @Test
     void resolves_registered_spec_by_type() {
-        NotificationTypeSpec spec = spec(TestType.TICKET_ASSIGNED);
+        NotificationTypeSpec<?> spec = spec(TestType.TICKET_ASSIGNED);
 
         NotificationTypeRegistry registry = new NotificationTypeRegistry(provider(spec));
 
@@ -37,7 +37,7 @@ class NotificationTypeRegistryTest {
     @Test
     @DisplayName("Two specs claiming one type kill the context at startup, not a random one at runtime")
     void duplicate_type_fails_fast() {
-        ObjectProvider<NotificationTypeSpec> duplicates =
+        ObjectProvider<NotificationTypeSpec<?>> duplicates =
                 provider(spec(TestType.TICKET_ASSIGNED), spec(TestType.TICKET_ASSIGNED));
 
         assertThatThrownBy(() -> new NotificationTypeRegistry(duplicates))
@@ -46,14 +46,14 @@ class NotificationTypeRegistryTest {
     }
 
     @SuppressWarnings("unchecked")
-    private static ObjectProvider<NotificationTypeSpec> provider(NotificationTypeSpec... specs) {
-        ObjectProvider<NotificationTypeSpec> provider = mock(ObjectProvider.class);
+    private static ObjectProvider<NotificationTypeSpec<?>> provider(NotificationTypeSpec<?>... specs) {
+        ObjectProvider<NotificationTypeSpec<?>> provider = mock(ObjectProvider.class);
         when(provider.stream()).thenReturn(Stream.of(specs));
         return provider;
     }
 
-    private static NotificationTypeSpec spec(NotificationType type) {
-        NotificationTypeSpec spec = mock(NotificationTypeSpec.class);
+    private static NotificationTypeSpec<?> spec(NotificationType type) {
+        NotificationTypeSpec<?> spec = mock(NotificationTypeSpec.class);
         when(spec.getType()).thenReturn(type);
         return spec;
     }


### PR DESCRIPTION
## What

Reworks the emission side of the notification SPI (decisions by Semen + Kirill, 2026-08-19/20): producers no longer fill a raw `Map<String,String>` — they emit a **typed seed** (naming picked over "context" to avoid colliding with the legacy stored-context classes).

- **New `spec/NotificationSeed`** — interface with `type()`. Each spec will declare its own seed class (nested in the spec file, PR-3 in tenant). A seed arrives **self-contained**: the producer fills it from entities it already holds at the emitting moment; the seed class is the compile-checked contract of what the notification needs.
- **`NotificationRequest`** — now a single field: `seed` (extensible later without touching call sites). The attr-builder dies.
- **`NotificationTypeSpec<S extends NotificationSeed>`** — gains `getSeedClass()` and `attrs(S) → Attrs`, a **pure** seed → stored-attributes mapping (no I/O in specs — a fetch would re-read what the producer already held; keeps specs repository-free and the legacy-vs-new comparison tests trivial). `getRequiredKeys()/getOptionalKeys()` are gone: a field present in the per-type seed class *is* required, at compile time.
- **`Attrs`** — `validated()` and the declared-keys machinery die with the raw map; `of/get/optional/has/json/with/asMap` stay.
- **`NotificationEmitter`** — `seed.type()` → spec lookup → `getSeedClass().cast(seed)` (the wiring check: a seed routed to a spec built for another class fails loud) → `attrs` → audience/compose → command. Still never throws.
- **CI fix ridden along**: `openframe-notification-core` was missing from the java change filter in `changes.yaml`, so PRs touching only this module (e.g. #1834) skipped Test Java entirely. One line added.

## What this is NOT

Not a return of the legacy typed contexts: those are the **stored/wire** format (Mongo + NATS + GraphQL) and are still on their deletion path. Seeds live only at the emission call site and die inside the spec — stored shape stays `type` + `attributes` map.

## Blast radius

Zero consumers: verified no usages of `NotificationEmitter`/`NotificationTypeSpec`/`NotificationRequest` outside `openframe-notification-core` on oss-lib, saas-lib and tenant mains; #2552 doesn't touch the SPI either. Only this module's own tests changed.

## Tests

`openframe-notification-core` suite green locally on JDK 21: 78 run, 0 failed (13 skipped = Mongo ITs, failsafe-only). Emitter test proves the self-contained seed maps to the stored snapshot; swallow test covers both an unregistered type and a seed-class mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCDHWY4aLtcZfA2kBTpVsk