### PR TITLE
feat(onboarding): Meet Mingo replaces Company & Team; trim the user tour enum

### DIFF
--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/onboarding/TenantOnboardingStep.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/onboarding/TenantOnboardingStep.java
@@ -9,5 +9,5 @@ public enum TenantOnboardingStep {
     MSP_SETUP,
     CUSTOMERS_SETUP,
     DEVICE_MANAGEMENT,
-    COMPANY_TEAM
+    MEET_MINGO
 }

--- a/openframe-data-mongo-common/src/main/java/com/openframe/data/document/onboarding/UserOnboardingStep.java
+++ b/openframe-data-mongo-common/src/main/java/com/openframe/data/document/onboarding/UserOnboardingStep.java
@@ -3,16 +3,14 @@ package com.openframe.data.document.onboarding;
 /**
  * Steps of the per-user "Get Started" onboarding flow.
  * One {@link UserOnboardingProgress} record per (userId, tenantId) tracks which of these are done.
- * Order mirrors the Figma design; the UI grouping (Get set up / Run your operations / Work smarter
- * with AI) is presentational only and not persisted.
+ * Order mirrors the Figma design; the UI grouping (Work smarter with AI / Run your operations) is
+ * presentational only and not persisted.
  */
 public enum UserOnboardingStep {
-    CUSTOMERS_SETUP,
-    DEVICE_MANAGEMENT,
+    MEET_MINGO,
     TICKETS,
     SCRIPTING,
     MONITORING,
     LOGGING,
-    KNOWLEDGE_MANAGEMENT,
-    MEET_MINGO
+    KNOWLEDGE_MANAGEMENT
 }

--- a/openframe-management-service-core/src/main/java/com/openframe/management/migration/PruneRetiredOnboardingStepsChangeUnit.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/migration/PruneRetiredOnboardingStepsChangeUnit.java
@@ -1,0 +1,52 @@
+package com.openframe.management.migration;
+
+import com.mongodb.client.result.UpdateResult;
+import com.openframe.data.service.TenantIdProvider;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.util.List;
+
+/**
+ * Removes steps the onboarding enums no longer declare from the stored {@code completedSteps}:
+ * {@code COMPANY_TEAM} (tenant) and {@code CUSTOMERS_SETUP} / {@code DEVICE_MANAGEMENT} (user).
+ * A document still holding one cannot deserialise into a {@code Set<enum>}, so this ships with the
+ * enum change. Raw collections for the same reason; idempotent; rollback would re-break reads.
+ */
+@Slf4j
+@ChangeUnit(id = "prune-retired-onboarding-steps", order = "010", author = "openframe")
+public class PruneRetiredOnboardingStepsChangeUnit {
+
+    private static final String TENANT_COLLECTION = "tenant_onboarding_progress";
+    private static final String USER_COLLECTION = "user_onboarding_progress";
+    private static final String TENANT_ID_FIELD = "tenantId";
+    private static final String COMPLETED_STEPS_FIELD = "completedSteps";
+
+    private static final List<String> RETIRED_TENANT_STEPS = List.of("COMPANY_TEAM");
+    private static final List<String> RETIRED_USER_STEPS = List.of("CUSTOMERS_SETUP", "DEVICE_MANAGEMENT");
+
+    @Execution
+    public void execution(MongoTemplate mongoTemplate, TenantIdProvider tenantIdProvider) {
+        String tenantId = tenantIdProvider.getTenantId();
+        prune(mongoTemplate, TENANT_COLLECTION, RETIRED_TENANT_STEPS, tenantId);
+        prune(mongoTemplate, USER_COLLECTION, RETIRED_USER_STEPS, tenantId);
+    }
+
+    @RollbackExecution
+    public void rollback() {
+    }
+
+    private void prune(MongoTemplate mongoTemplate, String collection, List<String> retiredSteps, String tenantId) {
+        UpdateResult result = mongoTemplate.getCollection(collection).updateMany(
+                new Document(TENANT_ID_FIELD, tenantId)
+                        .append(COMPLETED_STEPS_FIELD, new Document("$in", retiredSteps)),
+                new Document("$pull", new Document(COMPLETED_STEPS_FIELD, new Document("$in", retiredSteps)))
+        );
+        log.info("Pruned retired onboarding step(s) {} from {} document(s) in {}, tenantId={}",
+                retiredSteps, result.getModifiedCount(), collection, tenantId);
+    }
+}

--- a/openframe-management-service-core/src/main/java/com/openframe/management/migration/PruneRetiredOnboardingStepsChangeUnit.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/migration/PruneRetiredOnboardingStepsChangeUnit.java
@@ -18,7 +18,7 @@ import java.util.List;
  * enum change. Raw collections for the same reason; idempotent; rollback would re-break reads.
  */
 @Slf4j
-@ChangeUnit(id = "prune-retired-onboarding-steps", order = "010", author = "openframe")
+@ChangeUnit(id = "prune-retired-onboarding-steps", order = "011", author = "openframe")
 public class PruneRetiredOnboardingStepsChangeUnit {
 
     private static final String TENANT_COLLECTION = "tenant_onboarding_progress";


### PR DESCRIPTION
Brings both onboarding step enums in line with the current Figma. The frontend already renders this shape (openframe-oss-frontend), running on a cast until these values exist.

## What changes

**`TenantOnboardingStep`** — `COMPANY_TEAM` → `MEET_MINGO`.
The design's fourth Initial Setup row is the Mingo intro ([Figma](https://www.figma.com/design/YQttTEQP9lQIP92VGHBwvy/openframe---dashboard?node-id=10014-85482&m=dev)); inviting teammates lives in Settings → Company & Users, not in setup.

**`UserOnboardingStep`** — drops `CUSTOMERS_SETUP` and `DEVICE_MANAGEMENT`.
Both are *tenant* Initial Setup steps, and the Get Started tour only unlocks once Initial Setup is complete — so the workspace already has a customer and a device by the time a user sees the tour. The frontend has skipped them for a while.

## Migration ships with it

`completedSteps` is a `Set<enum>`, so a document still holding `"COMPANY_TEAM"` (or the two retired user steps) cannot deserialise once the constant is gone. `PruneRetiredOnboardingStepsChangeUnit` (order `010`) `$pull`s them from `tenant_onboarding_progress` and `user_onboarding_progress` — raw collections, since the entities can no longer represent what it removes, the same approach `009` took for the identical problem. Idempotent, tenant-scoped, rollback deliberately empty.

**Deploy note:** the migration runs in the management service, the documents are read by the API service — a tenant whose management service hasn't run this yet will fail the onboarding query. The failure is graceful on the client (the onboarding chrome just doesn't render, no broken dashboard) and it only affects tenants that already used the retired steps, but it is worth making sure the migration lands everywhere.

**Effect on data:** a retired step stops counting toward "X/Y done". A tenant that finished all four Initial Setup steps but never pressed Complete drops to 3/4 with Meet Mingo outstanding — the honest state, nobody has met Mingo yet. Tenants already flagged `completed` are unaffected: separate field, and the card hides on it without reading `completedSteps`. For the user tour the visible effect is zero — those two steps were never rendered.

## Merge order

This PR, then the SDL companion flamingo-stack/openframe-saas-tenant#2688 once this is released and `openframe.oss.libs.version` is bumped there. Landing the SDL first would expose `MEET_MINGO` with no Java constant behind it.

## Not verified locally

No Maven toolchain on this machine, so nothing was compiled. CI is the first real compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)