### PR TITLE
feat(client): NATS listener on machine.*.hostname — update device hostname on change

### DIFF
--- a/openframe-client-core/src/main/java/com/openframe/client/listener/MachineHostnameListener.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/listener/MachineHostnameListener.java
@@ -1,0 +1,90 @@
+package com.openframe.client.listener;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openframe.client.service.MachineHostnameService;
+import com.openframe.client.service.NatsTopicMachineIdExtractor;
+import com.openframe.data.nats.listener.AbstractJetStreamPushListener;
+import com.openframe.data.nats.model.MachineHostnameMessage;
+import io.nats.client.Connection;
+import io.nats.client.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+@Component
+@Slf4j
+public class MachineHostnameListener extends AbstractJetStreamPushListener {
+
+    private final ObjectMapper objectMapper;
+    private final MachineHostnameService machineHostnameService;
+    private final NatsTopicMachineIdExtractor machineIdExtractor;
+
+    public MachineHostnameListener(
+            Connection natsConnection,
+            ObjectMapper objectMapper,
+            MachineHostnameService machineHostnameService,
+            NatsTopicMachineIdExtractor machineIdExtractor
+    ) {
+        super(natsConnection);
+        this.objectMapper = objectMapper;
+        this.machineHostnameService = machineHostnameService;
+        this.machineIdExtractor = machineIdExtractor;
+    }
+
+    @Override
+    protected String getStreamName() {
+        return "MACHINE_HOSTNAME";
+    }
+
+    @Override
+    protected String getSubject() {
+        return "machine.*.hostname";
+    }
+
+    @Override
+    protected String getConsumerName() {
+        return "machine-hostname-processor-v1";
+    }
+
+    @Override
+    protected String getDeliveryGroup() {
+        return "machine-hostname";
+    }
+
+    @Override
+    protected String getDeliverySubject() {
+        return "machine.hostname.delivery";
+    }
+
+    @Override
+    protected void handleMessage(Message message) {
+        String messagePayload = new String(message.getData(), StandardCharsets.UTF_8);
+        String subject = message.getSubject();
+
+        try {
+            String machineId = machineIdExtractor.extract(subject);
+            MachineHostnameMessage hostnameMessage = objectMapper.readValue(messagePayload, MachineHostnameMessage.class);
+
+            String hostname = hostnameMessage.getHostname();
+            if (isBlank(hostname)) {
+                log.warn("Hostname message without hostname for machineId={}, acking without update", machineId);
+                message.ack();
+                return;
+            }
+
+            log.info("Processing hostname update: machineId={} hostname={}", machineId, hostname);
+
+            machineHostnameService.updateHostname(machineId, hostname);
+
+            message.ack();
+            log.debug("Hostname update processed successfully and acked");
+        } catch (Exception e) {
+            log.error("Unexpected error processing hostname update: {}", messagePayload, e);
+            // Don't ack the message and let it be redelivered
+            log.info("Leaving message unacked for potential redelivery: hostname update");
+        }
+    }
+}

--- a/openframe-client-core/src/main/java/com/openframe/client/service/MachineHostnameService.java
+++ b/openframe-client-core/src/main/java/com/openframe/client/service/MachineHostnameService.java
@@ -1,0 +1,46 @@
+package com.openframe.client.service;
+
+import com.openframe.data.document.device.DeviceStatus;
+import com.openframe.data.document.device.Machine;
+import com.openframe.data.repository.device.MachineRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+import static com.openframe.data.document.device.DeviceStatus.DELETED;
+import static com.openframe.data.document.device.DeviceStatus.PENDING_DELETION;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MachineHostnameService {
+
+    private final MachineRepository machineRepository;
+
+    public void updateHostname(String machineId, String hostname) {
+        Optional<Machine> foundMachine = machineRepository.findByMachineId(machineId);
+        if (foundMachine.isEmpty()) {
+            log.warn("Hostname update for unknown machine {}, ignoring", machineId);
+            return;
+        }
+
+        Machine machine = foundMachine.get();
+        DeviceStatus status = machine.getStatus();
+        if (status == PENDING_DELETION || status == DELETED) {
+            log.debug("Ignoring hostname update for machineId={} in status {}", machineId, status);
+            return;
+        }
+
+        if (hostname.equals(machine.getHostname())) {
+            log.debug("Hostname for machineId={} is already {}, nothing to update", machineId, hostname);
+            return;
+        }
+
+        machine.setHostname(hostname);
+        machineRepository.save(machine);
+
+        log.info("Updated hostname for machineId={} to {}", machineId, hostname);
+    }
+}

--- a/openframe-data-nats/src/main/java/com/openframe/data/nats/model/MachineHostnameMessage.java
+++ b/openframe-data-nats/src/main/java/com/openframe/data/nats/model/MachineHostnameMessage.java
@@ -1,0 +1,10 @@
+package com.openframe.data.nats.model;
+
+import lombok.Data;
+
+@Data
+public class MachineHostnameMessage {
+
+    private String hostname;
+
+}

--- a/openframe-management-service-core/src/main/java/com/openframe/management/initializer/NatsStreamConfigurationInitializer.java
+++ b/openframe-management-service-core/src/main/java/com/openframe/management/initializer/NatsStreamConfigurationInitializer.java
@@ -61,6 +61,13 @@ public class NatsStreamConfigurationInitializer implements ApplicationRunner {
                     .subjects(List.of("machine.*.installed-agent", "user.*.installed-agent"))
                     .storageType(StorageType.File)
                     .retentionPolicy(RetentionPolicy.Limits)
+                    .build(),
+            // machine hostname change stream
+            StreamConfiguration.builder()
+                    .name("MACHINE_HOSTNAME")
+                    .subjects(List.of("machine.*.hostname"))
+                    .storageType(StorageType.File)
+                    .retentionPolicy(RetentionPolicy.Limits)
                     .build()
     );
 


### PR DESCRIPTION
Adds a durable JetStream listener so agents can report hostname changes and the device document follows:

- **`MACHINE_HOSTNAME` stream** (`machine.*.hostname`) registered in `NatsStreamConfigurationInitializer`
- **`MachineHostnameListener`** (client-core) — durable push consumer (`machine-hostname-processor-v1`), payload `{"hostname": "<current>"}`; machineId comes from the subject. Acks on success and on blank-hostname payloads; leaves unacked for redelivery on errors
- **`MachineHostnameService`** — loads the machine, no-ops for unknown machines, machines in `PENDING_DELETION`/`DELETED` (consistent with heartbeat handling), or unchanged hostname; otherwise updates `Machine.hostname`
- **`MachineHostnameMessage`** DTO in openframe-data-nats

🤖 Generated with [Claude Code](https://claude.com/claude-code)