### PR TITLE
feat(chat): imperative startNewChat() handle on EmbeddableChat

### DIFF
--- a/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
+++ b/openframe-frontend-core/src/components/chat/embeddable-chat.tsx
@@ -30,7 +30,7 @@
  * host-supplied builders (program configs, product-release prop builder).
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { cn } from '../../utils/cn'
 import { useControllableState } from '@radix-ui/react-use-controllable-state'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
@@ -904,9 +904,31 @@ function SourceChips({
  * EmbeddableChat — the floating "Ask AI" button + Mingo chat panel.
  * Lib-portable port of the hub's `<GlobalAskAI>`.
  */
-export function EmbeddableChat(props: EmbeddableChatProps) {
-  return <EmbeddableChatInner {...props} />
+/**
+ * Imperative escape hatch for the ONE thing a host can't express as a prop:
+ * "put the panel on a new chat, now". Everything else the host drives is state
+ * it already owns (open, active dialog, mode); this is a command, and it has to
+ * work whether the panel was just mounted or has been open on the chat list for
+ * a while — which a mount-time prop or a `view` prop can't do (re-asserting the
+ * same value is not a change).
+ */
+export interface EmbeddableChatHandle {
+  /**
+   * Same as the panel's own "Start New Chat": clears the open conversation and
+   * its messages, force-closes the archive, and — in the narrow single-column
+   * layout — navigates from the "Current Chats" list to the composer. Wide
+   * layouts already show the new-chat welcome once nothing is open, so there
+   * the compose flag is inert.
+   */
+  startNewChat: () => void
 }
+
+export const EmbeddableChat = React.forwardRef<
+  EmbeddableChatHandle,
+  EmbeddableChatProps
+>(function EmbeddableChat(props, ref) {
+  return <EmbeddableChatInner {...props} handleRef={ref} />
+})
 
 function EmbeddableChatInner({
   baseRoute,
@@ -942,7 +964,8 @@ function EmbeddableChatInner({
   guidePendingPrompt,
   onGuidePromptConsumed,
   contextMemory,
-}: EmbeddableChatProps) {
+  handleRef,
+}: EmbeddableChatProps & { handleRef?: React.Ref<EmbeddableChatHandle> }) {
   // `shell === 'none'` means the consumer hosts us inside their own panel
   // (e.g. AppLayoutDrawer in openframe-frontend). Several drawer-shell
   // concerns are unconditional in this codebase — gate them off here so
@@ -1993,6 +2016,20 @@ function EmbeddableChatInner({
   const handleNewChat = useCallback(() => {
     resetToNewChat()
   }, [resetToNewChat])
+
+  // Host-driven "Start New Chat" (see EmbeddableChatHandle). Same reset as the
+  // rail button, plus the narrow layout's list→compose navigation that the
+  // in-panel button gets from the list itself — a host has no other way in.
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      startNewChat: () => {
+        resetToNewChat()
+        setComposeOpen(true)
+      },
+    }),
+    [resetToNewChat],
+  )
 
   // Desktop split header ⋯ menu (active, non-archived conversation only).
   const splitHeaderMenuItems = [

--- a/openframe-frontend-core/src/components/chat/index.ts
+++ b/openframe-frontend-core/src/components/chat/index.ts
@@ -92,4 +92,8 @@ export * from './utils'
 // EmbeddableChat — full chat orchestrator (lib-portable port of hub's
 // `<GlobalAskAI>`). Hosts mount it once at the root after providing a
 // <ChatRuntimeContext.Provider>.
-export { EmbeddableChat, type EmbeddableChatProps } from './embeddable-chat'
+export {
+  EmbeddableChat,
+  type EmbeddableChatHandle,
+  type EmbeddableChatProps,
+} from './embeddable-chat'


### PR DESCRIPTION
## Problem

The onboarding "Meet Mingo" step has a **Start New Chat** button. It opened the in-layout Mingo drawer with the active dialog cleared — and the visitor landed on the **"Current Chats" list** (usually the empty "No Current Chats" state), not on a chat.

That is the panel behaving correctly: with no conversation open, the narrow single-column layout shows the chat list, and "Start New Chat" *inside* it navigates to the composer. A host has no way to reach that navigation — it is the panel's own view state.

## Change

`EmbeddableChat` now accepts a `ref` exposing one method:

```ts
export interface EmbeddableChatHandle {
  startNewChat: () => void
}
```

It reuses the panel's existing reset (`resetToNewChat` — clear conversation + messages, force-close the archive, exactly what the rail's "Start New Chat" does) and adds the narrow layout's list → compose navigation.

## Why a ref and not a prop

- `initialView` only applies if the panel **mounts** on the request. The drawer can already be open on the list, and then nothing happens.
- A `view` prop can't re-assert the same value: open compose → user goes back to the list → the host asks for compose again → no prop change → no effect.

This is a command, not state, so it gets the standard React escape hatch. `forwardRef` (not React 19's ref-as-prop) because the package still lists React 18 as a supported peer.

## Notes

- Inert in wide layouts — they already show the new-chat welcome once nothing is open, and `composeOpen` only gates the narrow `stackedListView`.
- No behaviour change for any existing consumer; the ref is optional.
- Consumer side: openframe-oss-frontend#262.