### PR TITLE
feat(tickets): rename "AI Assistance" status label to "AI Handling"

### DIFF
--- a/openframe-frontend-core/src/components/features/board/types.ts
+++ b/openframe-frontend-core/src/components/features/board/types.ts
@@ -106,7 +106,7 @@ export interface BoardChange {
 
 const STATUS_DEFAULTS: Record<TicketStatus, { label: string; color: string }> = {
   ACTIVE: { label: 'Active', color: '#5ea62e' },
-  AI_ASSISTANCE: { label: 'AI Assistance', color: '#888888' },
+  AI_ASSISTANCE: { label: 'AI Handling', color: '#888888' },
   TECH_REQUIRED: { label: 'Tech Required', color: '#e1b32f' },
   ON_HOLD: { label: 'On Hold', color: '#f36666' },
   RESOLVED: { label: 'Resolved', color: '#888888' },

--- a/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
+++ b/openframe-frontend-core/src/components/ui/dashboard-info-card.tsx
@@ -34,7 +34,7 @@ export interface DashboardInfoCardProps {
   titleSlot?: React.ReactNode
   /**
    * Tag rendered in the title row, after the title (Figma "status" variant) —
-   * e.g. `<Tag variant="outline" label="AI-Assistance" />` or a TicketStatusTag.
+   * e.g. `<Tag variant="outline" label="AI Handling" />` or a TicketStatusTag.
    * Works with or without a `title`.
    */
   titleTag?: React.ReactNode

--- a/openframe-frontend-core/src/components/ui/ticket-status-tag.tsx
+++ b/openframe-frontend-core/src/components/ui/ticket-status-tag.tsx
@@ -28,7 +28,7 @@ const STATUS_CONFIG: Record<TicketStatus, TicketStatusConfig> = {
     variant: 'success',
   },
   AI_ASSISTANCE: {
-    label: 'AI Assistance',
+    label: 'AI Handling',
     variant: 'outline',
   },
   TECH_REQUIRED: {

--- a/openframe-frontend-core/src/stories/.Board.stories.md
+++ b/openframe-frontend-core/src/stories/.Board.stories.md
@@ -16,7 +16,7 @@ Storybook stories for the `Board` component, covering all major interaction stat
 | Story | Description |
 |---|---|
 | `Default` | Five canonical-status columns with full DnD wired up |
-| `SystemAndCustom` | Mixed system + custom columns; AI-Assistance refuses drops, Resolved tickets are pinned |
+| `SystemAndCustom` | Mixed system + custom columns; AI Handling refuses drops, Resolved tickets are pinned |
 | `CustomColumns` | Fully custom columns decoupled from `TicketStatus` (Backlog, In Review, Blocked, Done) |
 | `Collapsible` | Column collapse/expand with `localStorage` persistence via `collapseStorageKey` |
 | `Pagination` | One column loads 10 of 50 tickets; `onLoadMore` appends pages after a 600ms simulated delay |

--- a/openframe-frontend-core/src/stories/Board.stories.tsx
+++ b/openframe-frontend-core/src/stories/Board.stories.tsx
@@ -112,11 +112,11 @@ export const Default: Story = {
 
 /**
  * Mixed system + custom columns matching the OpenFrame Tickets layout:
- * AI-Assistance and Tech Required are system columns (default surface, joined
+ * AI Handling and Tech Required are system columns (default surface, joined
  * with no gap), middle columns are custom (tinted by color), Resolved is a
  * system column whose `RESOLVED` status gives the green-checkmark tag.
  *
- * DnD restrictions: AI-Assistance refuses drops (tickets enter via the AI
+ * DnD restrictions: AI Handling refuses drops (tickets enter via the AI
  * pipeline, not by dragging), but tickets in it can still be dragged out.
  * Resolved tickets are pinned (`dragDisabled`).
  */
@@ -124,8 +124,8 @@ export const SystemAndCustom: Story = {
   render: function Render() {
     const [columns, setColumns] = React.useState<BoardColumnDef[]>([
       {
-        id: 'ai-assistance',
-        label: 'AI-Assistance',
+        id: 'ai-handling',
+        label: 'AI Handling',
         color: '#f357bb',
         system: true,
         dropDisabled: true,

--- a/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
+++ b/openframe-frontend-core/src/stories/DashboardInfoCard.stories.tsx
@@ -356,7 +356,7 @@ export const ProgressSizeComparison: Story = {
 export const WithTitleTag: Story = {
   args: {
     value: 75,
-    titleTag: <Tag variant="outline" label="AI-Assistance" />,
+    titleTag: <Tag variant="outline" label="AI Handling" />,
   },
   parameters: {
     docs: {

--- a/openframe-frontend-core/src/stories/InfoSection.stories.tsx
+++ b/openframe-frontend-core/src/stories/InfoSection.stories.tsx
@@ -35,7 +35,7 @@ const assigneeOptions = [
 ];
 
 const statusOptions = [
-  { id: 's1', name: 'AI Assistance', color: '#3a3a3a' },
+  { id: 's1', name: 'AI Handling', color: '#3a3a3a' },
   { id: 's2', name: 'Tech Required', color: '#f59e0b' },
   { id: 's3', name: 'Resolved', color: '#5ea62e' },
 ];

--- a/openframe-frontend-core/src/stories/TicketEventMessage.stories.tsx
+++ b/openframe-frontend-core/src/stories/TicketEventMessage.stories.tsx
@@ -71,7 +71,7 @@ export const ReopenedWithReason: Story = {
 	},
 };
 
-/** Reopened into AI Assistance (targetStatusKind decides) — Figma type=reopened-fae. */
+/** Reopened into AI Handling (targetStatusKind decides) — Figma type=reopened-fae. */
 export const ReopenedFaeContinues: Story = {
 	args: {
 		data: { kind: "REOPENED", actorId: "u-7", actorName: "John Smith", actorType: "CLIENT", targetStatusKind: "AI_ASSISTANCE" },


### PR DESCRIPTION
Renames the AI ticket status display label from "AI Assistance" to "AI Handling" across the library fallbacks and Storybook.

ClickUp: https://app.clickup.com/t/86ak3dvzt

## Changes

- `ticket-status-tag.tsx` - `STATUS_CONFIG.AI_ASSISTANCE.label` -> `AI Handling` (fallback label used when no backend `statusName` is present: dashboard Tickets Overview card, optimistic status transitions in chat)
- `board/types.ts` - `STATUS_DEFAULTS.AI_ASSISTANCE.label` -> `AI Handling` (cold-start board column fallback)
- Stories/docs mentions: `Board.stories.tsx` (label, column id, comments), `.Board.stories.md`, `DashboardInfoCard.stories.tsx` + doc comment in `dashboard-info-card.tsx`, `InfoSection.stories.tsx`, comment in `TicketEventMessage.stories.tsx`

## Out of scope (intentional)

- The `AI_ASSISTANCE` kind token, `TicketStatus` value, and `STATUS_ALIASES` are unchanged - they are wire contract (transitions, board styling, chat composer locking, TICKET_EVENT `targetStatusKind`).
- Tenant-facing status names come from backend status definitions and were renamed on the BE side separately (already live on dev).

## Verification

- `tsc --noEmit` clean, `vitest run` 63 files / 4898 tests green
- No "AI Assistance"/"AI-Assistance" literals left in `src` (only `AI_ASSISTANCE` tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)