### PR TITLE
feat(authz): carry authMobile through SSO registration and invite flows

### DIFF
--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/dto/SsoInvitationAcceptRequest.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/dto/SsoInvitationAcceptRequest.java
@@ -15,4 +15,6 @@ public class SsoInvitationAcceptRequest {
     private String provider;
     private Boolean switchTenant;
     private String redirectTo;
+    /** Mobile-app flow: forwarded to {@code /oauth/continue} — see {@link SsoTenantRegistrationInitRequest#isAuthMobile()}. */
+    private boolean authMobile;
 }

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/dto/SsoTenantRegistrationInitRequest.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/dto/SsoTenantRegistrationInitRequest.java
@@ -38,6 +38,13 @@ public class SsoTenantRegistrationInitRequest {
     // Optional final redirect target (absolute or allowed host)
     private String redirectTo;
 
+    /**
+     * Mobile-app flow: forwarded to the BFF {@code /oauth/continue} after finalization so the
+     * callback attaches the one-time ticket the app exchanges for tokens (same contract as
+     * {@code /oauth/login?authMobile=true}).
+     */
+    private boolean authMobile;
+
     private RegistrationAttribution attribution;
 }
 

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/SsoInviteCookiePayload.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/SsoInviteCookiePayload.java
@@ -6,6 +6,7 @@ public record SsoInviteCookiePayload(
         Boolean switchTenant,
         String provider,
         String redirectTo,
+        boolean authMobile,
         long iat,
         long exp
 ) implements SsoCookiePayload {

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/SsoTenantRegCookiePayload.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/SsoTenantRegCookiePayload.java
@@ -8,6 +8,7 @@ public record SsoTenantRegCookiePayload(
         String tenantDomain,
         String provider,
         String redirectTo,
+        boolean authMobile,
         String accessCode,
         RegistrationAttribution attribution,
         long iat,

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/InviteSsoHandler.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/InviteSsoHandler.java
@@ -60,7 +60,7 @@ public class InviteSsoHandler implements SsoFlowHandler {
         String targetTenantId = userCreated.getTenantId();
 
         // Clear SSO flow cookie but KEEP session to allow OAuth continue
-        clearFlowCookieAndRedirect(response, cookie, targetTenantId, payload.redirectTo());
+        clearFlowCookieAndRedirect(response, cookie, targetTenantId, payload.redirectTo(), payload.authMobile());
     }
 
 }

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/SsoFlowHandler.java
@@ -91,12 +91,16 @@ public interface SsoFlowHandler {
     default void clearFlowCookieAndRedirect(HttpServletResponse response,
                                             Cookie flowCookie,
                                             String tenantId,
-                                            String redirectTo) {
+                                            String redirectTo,
+                                            boolean authMobile) {
         clearCookie(response, flowCookie.getName());
         String path = "/oauth/continue?tenantId=" +
                 encode(tenantId, UTF_8);
         if (hasText(redirectTo)) {
             path += "&redirectTo=" + encode(redirectTo, UTF_8);
+        }
+        if (authMobile) {
+            path += "&authMobile=true";
         }
         foundAtRoot(response, path);
     }

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/TenantRegSsoHandler.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/security/flow/TenantRegSsoHandler.java
@@ -70,7 +70,7 @@ public class TenantRegSsoHandler implements SsoFlowHandler {
 
         var tenant = registrationService.registerTenant(reg);
 
-        clearFlowCookieAndRedirect(response, cookie, tenant.getId(), payload.redirectTo());
+        clearFlowCookieAndRedirect(response, cookie, tenant.getId(), payload.redirectTo(), payload.authMobile());
     }
 
 }

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/sso/SsoInvitationService.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/sso/SsoInvitationService.java
@@ -36,6 +36,7 @@ public class SsoInvitationService {
                 request.getSwitchTenant(),
                 provider,
                 request.getRedirectTo(),
+                request.isAuthMobile(),
                 now,
                 now + COOKIE_TTL_SECONDS
         );

--- a/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/sso/SsoTenantRegistrationService.java
+++ b/openframe-authorization-service-core/src/main/java/com/openframe/authz/service/sso/SsoTenantRegistrationService.java
@@ -77,6 +77,7 @@ public class SsoTenantRegistrationService {
                 request.getTenantDomain(),
                 provider,
                 request.getRedirectTo(),
+                request.isAuthMobile(),
                 request.getAccessCode(),
                 boundedAttribution(request.getAttribution()),
                 issuedAt,


### PR DESCRIPTION
## Problem
Mobile registration/invitation via browser SSO with `redirectTo=com.openframe.app://auth` can redirect back to the app (after #1841), but the app never gets a session: on prod `dev-ticket-enabled: false`, so the one-time ticket is only attached when the BFF flow runs with `authMobile=true` — and unlike `/oauth/login?authMobile=true`, the registration/invite flows had no way to say it.

## Fix
Wire `authMobile` end-to-end, mirroring the login contract:
- `SsoTenantRegistrationInitRequest` / `SsoInvitationAcceptRequest`: new optional `authMobile` param
- carried in the signed `of_sso_reg` / `of_sso_invite` cookie payloads (Jackson decode of old cookies defaults to `false`)
- finalize appends `&authMobile=true` to the `/oauth/continue` redirect; `continueFlow` already accepts it and gates on `mobile-auth-enabled`

Frontend follow-up: the app-shell registration/invite calls must send `authMobile=true` alongside `redirectTo=com.openframe.app://auth` (same as `loginUrl` does).

Cross-compiled against openframe-saas-shared auth-server (999-SNAPSHOT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)