### PR TITLE
fix(client): surface OS error codes in SCM failure logs and add agentId-timeout context

### DIFF
--- a/clients/openframe-client/src/platform/system_service.rs
+++ b/clients/openframe-client/src/platform/system_service.rs
@@ -36,6 +36,15 @@ where
         .await
 }
 
+/// Display for `Error::Winapi` hides the io::Error ("IO error in winapi call"); surface it so logs carry the OS error code.
+#[cfg(target_os = "windows")]
+fn scm_error_detail(e: &windows_service::Error) -> String {
+    match e {
+        windows_service::Error::Winapi(io) => io.to_string(),
+        other => other.to_string(),
+    }
+}
+
 /// `query_service_status_windows` off-runtime with a timeout; the outer Err is an unresponsive SCM.
 #[cfg(target_os = "windows")]
 async fn query_service_status_timed(
@@ -163,13 +172,13 @@ fn try_start_service_windows(service_name: &str) -> std::result::Result<(), Stri
     use windows_service::service_manager::{ServiceManager, ServiceManagerAccess};
 
     let manager = ServiceManager::local_computer(None::<&str>, ServiceManagerAccess::CONNECT)
-        .map_err(|e| format!("connect to SCM: {}", e))?;
+        .map_err(|e| format!("connect to SCM: {}", scm_error_detail(&e)))?;
     let service = manager
         .open_service(
             service_name,
             ServiceAccess::START | ServiceAccess::QUERY_STATUS,
         )
-        .map_err(|e| format!("open service: {}", e))?;
+        .map_err(|e| format!("open service: {}", scm_error_detail(&e)))?;
 
     match service.start::<&std::ffi::OsStr>(&[]) {
         Ok(()) => Ok(()),
@@ -178,7 +187,7 @@ fn try_start_service_windows(service_name: &str) -> std::result::Result<(), Stri
         {
             Ok(())
         }
-        Err(e) => Err(format!("{}", e)),
+        Err(e) => Err(format!("start call: {}", scm_error_detail(&e))),
     }
 }
 
@@ -354,7 +363,8 @@ async fn stop_service_windows(service_name: &str, allow_delete: bool) -> Result<
         Err(e) => {
             error!(
                 "Failed to stop service {} via SCM: {}; force-killing service process",
-                service_name, e
+                service_name,
+                scm_error_detail(&e)
             );
             force_stop_service_windows(service_name, allow_delete).await
         }
@@ -692,6 +702,16 @@ pub fn service_not_stopped(service_name: &str) -> bool {
     match query_service_status_windows(service_name) {
         Ok(status) => status.current_state != ServiceState::Stopped,
         Err(_) => false,
+    }
+}
+
+/// Pooled, timeboxed running check; None = SCM busy/unresponsive or errored (e.g. service missing).
+#[cfg(target_os = "windows")]
+pub async fn service_running_state(service_name: &str) -> Option<bool> {
+    use windows_service::service::ServiceState;
+    match query_service_status_timed(service_name).await {
+        Ok(Ok(status)) => Some(status.current_state != ServiceState::Stopped),
+        _ => None,
     }
 }
 

--- a/clients/openframe-client/src/services/tool_connection_processing_manager.rs
+++ b/clients/openframe-client/src/services/tool_connection_processing_manager.rs
@@ -247,13 +247,23 @@ impl ToolConnectionProcessingManager {
                         }
                         // Command returned an error before timeout
                         Ok(Err(e)) => {
-                            error!("Failed to execute agentId command: {:#} – retrying", e);
+                            error!(
+                                tool_id = %tool.tool_id,
+                                command_path = %command_path,
+                                "Failed to execute agentId command: {:#} – retrying", e
+                            );
                             backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
                         // Timeout expired
                         Err(_) => {
-                            error!("agentId command timed out after {AGENT_ID_COMMAND_TIMEOUT_SECONDS} seconds – killed it, retrying");
+                            let service_running = tool_service_running(&tool).await;
+                            error!(
+                                tool_id = %tool.tool_id,
+                                command_path = %command_path,
+                                service_running = ?service_running,
+                                "agentId command timed out after {AGENT_ID_COMMAND_TIMEOUT_SECONDS} seconds – killed it, retrying"
+                            );
                             backoff_agent_id_failure(&tool.tool_id, &mut agent_id_failures).await;
                             continue;
                         }
@@ -340,6 +350,18 @@ impl ToolConnectionProcessingManager {
 
         Ok(())
     }
+}
+
+/// Some(true) = the tool's service instance is live (likely holding its db); None = non-Windows, non-service install, or SCM unavailable.
+async fn tool_service_running(tool: &InstalledTool) -> Option<bool> {
+    #[cfg(target_os = "windows")]
+    if let crate::models::installed_tool::Installation::Service { service_name, .. } =
+        &tool.installation
+    {
+        return crate::platform::system_service::service_running_state(service_name).await;
+    }
+    let _ = tool;
+    None
 }
 
 /// Sleep between agentId-resolution attempts, escalating to a longer back-off once failures


### PR DESCRIPTION
## Motivation

Investigating the fleet-wide "Mesh offline" reports showed ~88 machines across 32 tenants stuck in a mesh restart loop logging only:

> Start attempt 1/3 for service Mesh Agent failed: open service: IO error in winapi call

`windows-service`'s `Display` for `Error::Winapi` hides the wrapped `io::Error`, so the logs cannot distinguish a missing service (os error 1060 — e.g. mesh uninstalled out from under the client, the confirmed icmtel case) from access denied (5) or anything else. Each cause needs a different remediation.

The same machines also log `agentId command timed out after 15 seconds` with no context on which binary hung or whether the tool's service instance was concurrently running (the suspected DB-contention cause of the hang).

## Changes

- `system_service.rs`: new `scm_error_detail()` unwraps the `io::Error` (whose Display carries the OS error code and message) and is applied at the four sites that formatted a `windows_service::Error` with bare `{}` — SCM connect, open service, start call, and the stop-path catchall. The anyhow-wrapped `{:#}` sites already chain the source and are unchanged.
- `system_service.rs`: new `pub async fn service_running_state()` — a running check routed through the existing `scm_call_timed` / `TimedPermitPool`, returning `None` on SCM busy/unresponsive/error instead of a misleading `false`.
- `tool_connection_processing_manager.rs`: agentId failure/timeout logs now carry `tool_id` and `command_path`; the timeout log additionally records `service_running` (via the pooled check above, Windows `Service` installs only) so the hung-`-nodeid` / service-holds-db theory can be confirmed per device from Loki.

Example of the new failure line:

> Start attempt 1/3 for service Mesh Agent failed: open service: The specified service does not exist as an installed service. (os error 1060)

## Verification

- `cargo check` + `cargo clippy` clean on host (macOS) and `x86_64-pc-windows-gnu` (only pre-existing warnings in untouched files)
- `cargo fmt --check` clean
- 137/137 tests pass (`--skip test_ensure_admin` per repo convention)

Logging-only change: no control-flow or behavior changes beyond the added timeboxed SCM status query on the (already-failing, backed-off) agentId timeout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1EzGzzvDrtZRGpkikURuT